### PR TITLE
fix(models): gate Phi 3.5 Perplexica coverage

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -80,6 +80,17 @@
           "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
+        },
+        "perplexica": {
+          "status": "unsupported_until_revalidated",
+          "label": "Perplexica orchestration unsupported",
+          "reason": "Fresh exact-commit release cycles loaded Phi-3.5 Mini through the browser UI on tower2 (Linux llama-server) and strix-halo (Lemonade), then passed challenge-bound ODS Talk, LiteLLM, Open WebUI, and OpenCode where deployed. Perplexica alone failed to complete within 180 seconds on both independent backends, while its baseline probes and the following Granite H-Micro cycle passed. Keep Phi-3.5 Mini out of all-app release coverage until Perplexica orchestration is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-24T09-22-58Z-release-product-4cd022b82609-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-001/{tower2,strix-halo}",
+          "recordedAt": "2026-07-24T10:09:00Z",
+          "productSha": "4cd022b826093913dda7137b2dd69502628d7f50",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "globalScope": true,
+          "expiresAt": "2026-08-24T00:00:00Z"
         }
       },
       "install_recommendation": false

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -196,14 +196,19 @@ def test_llama31_8b_is_not_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["llama3.1-8b-instruct-q4"])
 
 
-def test_phi35_mini_is_unsupported_on_windows_8gb_after_profile_revalidation():
+def test_phi35_mini_requires_perplexica_revalidation_globally_and_runtime_revalidation_on_windows():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     compatibility = by_id["phi3.5-mini-q4"]["app_compatibility"]
 
     assert compatibility["openai_chat"]["status"] == "unsupported_until_revalidated"
     assert compatibility["openai_chat"]["evidence"]
-    assert _agent_viable_for_release(by_id["phi3.5-mini-q4"])
+    assert compatibility["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert compatibility["perplexica"]["globalScope"] is True
+    assert "tower2" in compatibility["perplexica"]["reason"]
+    assert "strix-halo" in compatibility["perplexica"]["reason"]
+    assert "cycle-001/{tower2,strix-halo}" in compatibility["perplexica"]["evidence"]
+    assert not _agent_viable_for_release(by_id["phi3.5-mini-q4"])
     assert not _agent_viable_for_release(by_id["phi3.5-mini-q4"], host="windows-laptop")
 
 


### PR DESCRIPTION
## Summary

- record an expiring global Phi-3.5 Mini / Perplexica compatibility verdict from the fresh exact-commit six-host release run
- preserve Phi-3.5 for direct chat and other consumers while excluding it from all-application release planning
- add a regression assertion for the compatibility scope and immutable fleet evidence

## Fleet evidence

Run: `2026-07-24T09-22-58Z-release-product-4cd022b82609-harness-954deb755b07-hosts-six-scope-6cycle-switchboard`

On both `tower2` (Linux llama-server) and `strix-halo` (Lemonade), cycle 1 browser-loaded `phi3.5-mini-q4` and passed challenge-bound ODS Talk, LiteLLM, Open WebUI, and OpenCode where deployed. Perplexica alone failed to complete within 180 seconds. Baseline Perplexica probes passed on both hosts, and the following Granite H-Micro cycle passed Perplexica on Tower2, isolating the issue to the model/application pairing rather than install health, routing, or the probe.

## Validation

- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/tests/test-model-library-verdicts.py` (38 passed)
- `git diff --check`