### PR TITLE
fix(models): gate Qwen3 4B 128K Talk coverage

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -983,13 +983,13 @@
       "app_compatibility": {
         "hermes_talk": {
           "status": "unsupported_until_revalidated",
-          "label": "ODS Talk revalidation required on M5 and Windows",
-          "reason": "A fresh exact-commit release run loaded Qwen3 4B 128K through Apple llama-server on m5-mbp and Windows llama-server on windows-laptop. On M5, ODS Talk's final user-facing reply contained only a generated .MEDIA audio marker and omitted the required challenge text; on Windows, the exact model loaded and routed correctly but Talk did not finish within the enforced 180-second inference limit. Keep this model out of M5 and Windows Talk/all-app release coverage until both response paths are revalidated.",
-          "evidence": "fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/m5-mbp; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/windows-laptop",
-          "recordedAt": "2026-07-24T05:25:20Z",
-          "productSha": "faaf5af99c89e38cc43f18239ea94747f62bf16b",
-          "harnessSha": "b838abf5a87b32c3f7ab8eaef43ea97133fb43d9",
-          "hostScope": ["m5-mbp", "windows-laptop"],
+          "label": "ODS Talk revalidation required",
+          "reason": "Fresh exact-commit release runs loaded Qwen3 4B 128K through Linux llama-server on tower2, Apple llama-server on m5-mbp, and Windows llama-server on windows-laptop. Tower2 loaded and routed the exact model in 3.9 seconds, but Talk replied that it generated the challenge phrase without actually returning it. M5 returned only a generated .MEDIA audio marker and omitted the challenge text, while Windows did not finish within the enforced 180-second inference limit. Keep this model out of Talk/all-app release coverage globally until challenge-bound response behavior is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/m5-mbp; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/windows-laptop; fleet-test/runs/2026-07-24T10-53-17Z-release-product-68d41e774eb1-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/tower2",
+          "recordedAt": "2026-07-24T12:06:17Z",
+          "productSha": "68d41e774eb13be334aa8cd3904ecbadaf69f4bf",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "globalScope": true,
           "expiresAt": "2026-08-24T00:00:00Z"
         }
       },

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -285,19 +285,22 @@ def test_smollm3_3b_runtime_context_is_64k_and_it_remains_a_revalidation_candida
     assert not _agent_viable_for_release(model)
 
 
-def test_qwen3_4b_128k_talk_block_is_m5_and_windows_scoped():
+def test_qwen3_4b_128k_talk_block_is_global_after_linux_revalidation():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["qwen3-4b-128k-q4"]
     compatibility = model["app_compatibility"]["hermes_talk"]
 
     assert compatibility["status"] == "unsupported_until_revalidated"
-    assert compatibility["hostScope"] == ["m5-mbp", "windows-laptop"]
+    assert compatibility["globalScope"] is True
+    assert "hostScope" not in compatibility
     assert "cycle-006/m5-mbp" in compatibility["evidence"]
     assert "cycle-005/windows-laptop" in compatibility["evidence"]
+    assert "cycle-006/tower2" in compatibility["evidence"]
     assert ".MEDIA" in compatibility["reason"]
     assert "180-second" in compatibility["reason"]
-    assert _agent_viable_for_release(model)
+    assert "3.9 seconds" in compatibility["reason"]
+    assert not _agent_viable_for_release(model)
     assert not _agent_viable_for_release(model, host="m5-mbp")
     assert not _agent_viable_for_release(model, host="windows-laptop")
 
@@ -460,7 +463,11 @@ def test_replacement_low_vram_long_context_models_are_cataloged_for_validation()
         assert model["context_length"] >= HERMES_CONTEXT_FLOOR
         assert model["gguf_sha256"] == sha256
         assert model["gguf_url"].startswith(url_prefix)
-        if model_id in {"granite3.1-2b-instruct-q4", "phi3-mini-128k-q4"}:
+        if model_id in {
+            "granite3.1-2b-instruct-q4",
+            "phi3-mini-128k-q4",
+            "qwen3-4b-128k-q4",
+        }:
             assert not _agent_viable_for_release(model)
         else:
             assert _agent_viable_for_release(model)
@@ -651,7 +658,10 @@ def test_qwen3_4b_long_context_replacements_are_release_candidates():
             assert model["size_bytes"] == expected_model["size_bytes"]
         if model_id != "qwen3.5-4b-q4":
             assert model.get("install_recommendation") is False
-        assert _agent_viable_for_release(model)
+        if model_id == "qwen3-4b-128k-q4":
+            assert not _agent_viable_for_release(model)
+        else:
+            assert _agent_viable_for_release(model)
 
 
 def test_qwen25_7b_is_not_agent_viable_on_low_vram_windows_until_revalidated():


### PR DESCRIPTION
## Summary
- expand the existing Qwen3 4B 128K Talk revalidation verdict from M5/Windows scope to global scope
- record the fresh exact-SHA Tower2 Linux failure where Talk acknowledged but omitted the challenge phrase
- keep release candidate selection from scheduling this model for all-app coverage until revalidated

## Evidence
- product: 68d41e774eb13be334aa8cd3904ecbadaf69f4bf
- harness: 954deb755b0730719512ac3675a748474180e01c
- run: 2026-07-24T10-53-17Z-release-product-68d41e774eb1-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/tower2
- exact model loaded in 3.9s; Talk returned an acknowledgement without the challenge phrase; recovery restored baseline and deleted the test model

## Validation
- python -m pytest ods/tests/test-model-library-coverage.py ods/tests/test-model-library-verdicts.py -q (38 passed)
- git diff --check