### PR TITLE
fix(models): gate Granite 4.1 OpenCode on Spark

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -480,13 +480,13 @@
         "opencode": {
           "status": "unsupported_until_revalidated",
           "label": "OpenCode revalidation required",
-          "reason": "A fresh release-grade fleet model-UI run loaded Granite 4.1 3B on tower2, strix-halo, spark, m5-mbp, and strixy. Tower2, Spark, M5, and Strixy passed OpenCode, while strix-halo routed correctly through Lemonade but OpenCode received only the first character of the requested verification phrase. Keep this model out of all-app release coverage on strix-halo until the Lemonade/OpenCode path is revalidated.",
-          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/tower2; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/strix-halo; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/spark; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/m5-mbp; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/strixy",
-          "recordedAt": "2026-07-23T23:10:16Z",
-          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
-          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
-          "hostScope": ["strix-halo"],
-          "expiresAt": "2026-08-23T00:00:00Z"
+          "reason": "Release-grade fleet evidence has shown intermittent one-character OpenCode answers for Granite 4.1 3B on strix-halo and spark. In the fresh exact-commit Spark failure, ODS Talk, LiteLLM, Open WebUI, and Perplexica passed and routed to the exact llama-server model, but OpenCode stopped after two output tokens and returned only \"O\" instead of its challenge-bound verification phrase. Keep this model out of all-app release coverage on those hosts until the OpenCode path is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/strix-halo; fleet-test/runs/2026-07-24T14-11-30Z-release-product-f35e9af8eeab-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/spark",
+          "recordedAt": "2026-07-24T16:36:20Z",
+          "productSha": "f35e9af8eeab7bb154081d1a3076ad9824f58616",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "hostScope": ["strix-halo", "spark"],
+          "expiresAt": "2026-08-24T00:00:00Z"
         },
         "hermes_talk": {
           "status": "unsupported_until_revalidated",

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -471,7 +471,7 @@ def test_real_catalog_smollm3_perplexica_block_is_global():
     assert llama_server["agentViability"]["status"] == "agent_viable"
 
 
-def test_real_catalog_granite41_opencode_block_is_strix_halo_scoped():
+def test_real_catalog_granite41_opencode_block_is_strix_halo_and_spark_scoped():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["granite4.1-3b-q4"]
 
@@ -489,7 +489,7 @@ def test_real_catalog_granite41_opencode_block_is_strix_halo_scoped():
     )
 
     assert strix_halo["opencode"]["status"] == "unsupported_until_revalidated"
-    assert spark["opencode"]["status"] == "unknown"
+    assert spark["opencode"]["status"] == "unsupported_until_revalidated"
     assert tower2["opencode"]["status"] == "unknown"
 
 


### PR DESCRIPTION
## What changed

- extend the existing Granite 4.1 3B OpenCode compatibility block to `spark`
- preserve Tower2 eligibility and keep the block host-scoped to Strix Halo and Spark
- update the dashboard API compatibility test to enforce the new scope

## Why

Fresh exact-commit fleet evidence on Spark loaded Granite 4.1 3B and passed ODS Talk, LiteLLM, Open WebUI, and Perplexica through the expected llama-server route. OpenCode stopped after two output tokens and returned only `O` instead of its challenge-bound verification phrase. The run recovered the 35B baseline, deleted the test model, and ended cleanly.

This matches the existing one-character OpenCode failure class recorded on Strix Halo, so the model should stay out of all-app release selection on those two hosts until revalidated. Tower2 remains eligible because its fresh cycle passed.

## Evidence

- product: `f35e9af8eeab7bb154081d1a3076ad9824f58616`
- harness: `954deb755b0730719512ac3675a748474180e01c`
- run: `2026-07-24T14-11-30Z-release-product-f35e9af8eeab-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/spark`

## Validation

- `python -m json.tool ods/config/model-library.json`
- `python -m pytest ods/extensions/services/dashboard-api/tests/test_performance_oracle.py ods/tests/test-model-library-coverage.py -q` — 74 passed
