### PR TITLE
fix(installer): make multi-GPU setup pipeline-safe

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Installer Contract Checks
         run: |
           bash tests/contracts/test-installer-contracts.sh
+          bash tests/test-phase03-multigpu-tty.sh
           bash tests/contracts/test-preflight-fixtures.sh
           bash tests/test-preflight-resolver-bug.sh
           python3 tests/contracts/test-network-exposure-contracts.py

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -28,6 +28,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
+	@bash tests/test-phase03-multigpu-tty.sh
 	@bash tests/contracts/test-preflight-fixtures.sh
 	@bash tests/test-preflight-resolver-bug.sh
 	@bash tests/test-linux-cloud-mode.sh

--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -360,7 +360,7 @@ run_custom() {
   for svc in whisper comfyui embeddings; do
     local valid=false
     while ! $valid; do
-      read -rp "  GPU for ${WHT}${svc}${NC} (0-$((GPU_COUNT-1))): " chosen
+      read -rp "  GPU for ${WHT}${svc}${NC} (0-$((GPU_COUNT-1))): " chosen < /dev/tty
       if [[ "$chosen" =~ ^[0-9]+$ ]] && [[ $chosen -ge 0 ]] && [[ $chosen -lt $GPU_COUNT ]]; then
         CUSTOM_ASSIGNMENT[$svc]=$chosen; valid=true
       else
@@ -378,8 +378,11 @@ run_custom() {
     $found || default_llama+="${idx},"
   done
   default_llama="${default_llama%,}"
+  if [[ -z "$default_llama" ]]; then
+    default_llama=$(IFS=,; echo "${GPU_INDICES[*]}")
+  fi
 
-  read -rp "  GPUs for ${WHT}llama_server${NC} [${default_llama}]: " llama_input
+  read -rp "  GPUs for ${WHT}llama_server${NC} [${default_llama}]: " llama_input < /dev/tty
   llama_input="${llama_input:-$default_llama}"
   IFS=',' read -ra LLAMA_GPUS_CUSTOM <<< "$llama_input"
   for g in "${LLAMA_GPUS_CUSTOM[@]}"; do
@@ -429,9 +432,13 @@ run_custom() {
   echo -e "  ${WHT}Llama parallelism:${NC}  mode=${BGRN}${mode}${NC}  TP=${tp}  PP=${pp}  mem_util=${mem_util}  ${DIM}(min_rank=${min_rank})${NC}"
   echo ""
 
-  read -rp "  Apply this configuration? [Y/n]: " confirm
+  read -rp "  Apply this configuration? [Y/n]: " confirm < /dev/tty
   confirm="${confirm:-Y}"
-  [[ ! $confirm =~ ^[Yy]$ ]] && warn "Cancelled." && return
+  if [[ ! $confirm =~ ^[Yy]$ ]]; then
+    warn "Custom assignment cancelled; using automatic assignment."
+    run_automatic
+    return
+  fi
 
   local llama_uuids_json
   llama_uuids_json=$(for g in "${LLAMA_GPUS_CUSTOM[@]}"; do echo "\"${GPU_UUIDS[$g]}\""; done | jq -sc '.')
@@ -541,7 +548,7 @@ else
     echo -e "      ${DIM}Assign GPUs to services manually${NC}"
     echo ""
 
-    read -rp "  Selection [1]: " choice
+    read -rp "  Selection [1]: " choice < /dev/tty
     choice="${choice:-1}"
     case "$choice" in
     1) run_automatic ;;

--- a/ods/tests/test-phase03-multigpu-tty.sh
+++ b/ods/tests/test-phase03-multigpu-tty.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FEATURES_PHASE="$ROOT_DIR/installers/phases/03-features.sh"
+ASSIGN_GPUS_SCRIPT="$ROOT_DIR/scripts/assign_gpus.py"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$FEATURES_PHASE" ]] || fail "missing phase 03: $FEATURES_PHASE"
+[[ -f "$ASSIGN_GPUS_SCRIPT" ]] || fail "missing GPU assignment helper: $ASSIGN_GPUS_SCRIPT"
+
+# The hosted bootstrap is commonly launched as `curl ... | bash`. In that
+# shape stdin belongs to the exhausted curl pipeline, so every interactive
+# multi-GPU prompt must read from the controlling terminal instead.
+prompt_read_count=0
+while IFS= read -r prompt_read; do
+    prompt_read_count=$((prompt_read_count + 1))
+    [[ "$prompt_read" == *"< /dev/tty"* ]] || fail "prompt does not read from /dev/tty: $prompt_read"
+done < <(grep -nE '^[[:space:]]*read -rp "  (GPU for|GPUs for|Apply this configuration|Selection \[1\])' "$FEATURES_PHASE")
+[[ $prompt_read_count -eq 4 ]] || fail "expected four interactive multi-GPU prompt reads"
+pass "all multi-GPU prompts use the controlling terminal"
+
+# util-linux `script` gives the child a real controlling terminal while the
+# explicit </dev/null reproduces the bootstrap's exhausted stdin. The static
+# contract above remains portable; this behavioral lane runs where util-linux
+# is available (including the Linux CI image).
+if ! command -v script >/dev/null 2>&1 || ! script --version 2>&1 | grep -qi 'util-linux'; then
+    echo "[SKIP] util-linux script is unavailable; PTY behavior not exercised"
+    exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/scripts"
+cp "$ASSIGN_GPUS_SCRIPT" "$tmp_dir/scripts/assign_gpus.py"
+
+cat >"$tmp_dir/harness.sh" <<'HARNESS'
+#!/usr/bin/env bash
+set -euo pipefail
+
+INTERACTIVE=true
+DRY_RUN=false
+INSTALL_CHOICE=1
+TIER=1
+ODS_MODE=local
+ENABLE_VOICE=false
+ENABLE_WORKFLOWS=false
+ENABLE_RAG=false
+ENABLE_RECOMMENDED=false
+ENABLE_HERMES=false
+ENABLE_OPENCLAW=false
+ENABLE_COMFYUI=false
+ENABLE_APE=false
+ENABLE_PERPLEXICA=false
+ENABLE_PRIVACY_SHIELD=false
+ENABLE_LANGFUSE=false
+ENABLE_BRAVE_SEARCH=false
+GPU_COUNT=3
+GPU_BACKEND=nvidia
+HOST_ARCH=amd64
+HOST_PAGE_SIZE=4096
+INSTALL_DIR="$HARNESS_TMP/install"
+SCRIPT_DIR="$HARNESS_TMP"
+LLM_MODEL_SIZE_MB=6000
+MAX_CONTEXT=8192
+VERBOSE=false
+DEBUG=false
+AMB=
+BGRN=
+DIM=
+GRN=
+NC=
+RED=
+WHT=
+GPU_TOPOLOGY_JSON='{
+  "vendor": "nvidia",
+  "gpu_count": 3,
+  "gpus": [
+    {"index": 0, "uuid": "GPU-0000", "name": "GTX 1080 Ti", "memory_gb": 11, "memory_free_gb": 11},
+    {"index": 1, "uuid": "GPU-1111", "name": "GTX 1080 Ti", "memory_gb": 11, "memory_free_gb": 11},
+    {"index": 2, "uuid": "GPU-2222", "name": "GTX 1080", "memory_gb": 8, "memory_free_gb": 8}
+  ],
+  "links": [
+    {"gpu_a": 0, "gpu_b": 1, "rank": 20, "link_type": "PHB", "link_label": "PHB"},
+    {"gpu_a": 0, "gpu_b": 2, "rank": 10, "link_type": "SYS", "link_label": "SYS"},
+    {"gpu_a": 1, "gpu_b": 2, "rank": 10, "link_type": "SYS", "link_label": "SYS"}
+  ]
+}'
+
+ods_progress() { :; }
+show_phase() { :; }
+show_install_menu() { :; }
+ai_warn() { :; }
+log() { :; }
+warn() { printf 'WARN: %s\n' "$*"; }
+success() { printf 'SUCCESS: %s\n' "$*"; }
+chapter() { :; }
+bootline() { :; }
+signal() { :; }
+get_rank() { printf '10\n'; }
+error() {
+    printf 'ERROR: %s\n' "$*" >&2
+    return 1
+}
+
+# shellcheck source=/dev/null
+source "$FEATURES_PHASE"
+
+jq -e '.gpu_assignment.services.llama_server.gpus | length > 0' \
+    <<<"$GPU_ASSIGNMENT_JSON" >/dev/null
+printf 'LLAMA_GPUS=%s\n' \
+    "$(jq -r '.gpu_assignment.services.llama_server.gpus | join(",")' <<<"$GPU_ASSIGNMENT_JSON")"
+printf 'WHISPER_GPUS=%s\n' \
+    "$(jq -r '.gpu_assignment.services.whisper.gpus | join(",")' <<<"$GPU_ASSIGNMENT_JSON")"
+printf 'COMFYUI_GPUS=%s\n' \
+    "$(jq -r '.gpu_assignment.services.comfyui.gpus | join(",")' <<<"$GPU_ASSIGNMENT_JSON")"
+printf 'EMBEDDINGS_GPUS=%s\n' \
+    "$(jq -r '.gpu_assignment.services.embeddings.gpus | join(",")' <<<"$GPU_ASSIGNMENT_JSON")"
+printf 'PHASE03_COMPLETED\n'
+HARNESS
+chmod +x "$tmp_dir/harness.sh"
+
+run_with_closed_stdin() {
+    local name="$1" input="$2" output
+    local command
+    shift 2
+    output="$tmp_dir/$name.log"
+    printf -v command 'env FEATURES_PHASE=%q HARNESS_TMP=%q bash %q </dev/null' \
+        "$FEATURES_PHASE" "$tmp_dir" "$tmp_dir/harness.sh"
+
+    printf '%b' "$input" | timeout 20s script -qefc "$command" /dev/null >"$output" 2>&1 \
+        || {
+            cat "$output" >&2
+            fail "$name path failed with closed stdin"
+        }
+    grep -q 'PHASE03_COMPLETED' "$output" || {
+        cat "$output" >&2
+        fail "$name path did not complete phase 03"
+    }
+    for expected in "$@"; do
+        grep -Fq "$expected" "$output" || {
+            cat "$output" >&2
+            fail "$name path is missing expected output: $expected"
+        }
+    done
+}
+
+run_with_closed_stdin automatic '1\n' 'SUCCESS: Assignment complete'
+pass "automatic assignment completes with closed stdin"
+
+run_with_closed_stdin automatic-default '\n' 'SUCCESS: Assignment complete'
+pass "empty mode selection keeps the automatic default with closed stdin"
+
+run_with_closed_stdin custom '2\n0\n1\n2\n0,1,2\nY\n' \
+    'SUCCESS: Custom configuration applied.' \
+    'LLAMA_GPUS=GPU-0000,GPU-1111,GPU-2222' \
+    'WHISPER_GPUS=GPU-0000' \
+    'COMFYUI_GPUS=GPU-1111' \
+    'EMBEDDINGS_GPUS=GPU-2222'
+pass "custom assignment completes with closed stdin"
+
+run_with_closed_stdin custom-empty-llama-default '2\n0\n1\n2\n\nY\n' \
+    'SUCCESS: Custom configuration applied.' \
+    'LLAMA_GPUS=GPU-0000,GPU-1111,GPU-2222'
+pass "custom assignment keeps llama-server assigned when auxiliary services use every GPU"
+
+run_with_closed_stdin custom-cancel '2\n0\n1\n2\n0,1,2\nn\n' \
+    'WARN: Custom assignment cancelled; using automatic assignment.' \
+    'SUCCESS: Assignment complete'
+pass "cancelled custom assignment falls back to a valid automatic assignment"


### PR DESCRIPTION
## Summary

Makes the Linux multi-GPU setup safe when ODS is launched through the documented hosted bootstrap:

```bash
curl -fsSL https://install.osmantic.com/ods.sh | bash
```

- reads every interactive multi-GPU prompt from the controlling terminal
- guarantees a non-empty default llama-server assignment when auxiliary services consume every GPU
- converts custom-assignment cancellation into a valid automatic assignment instead of continuing with empty state
- adds behavioral regression coverage with inherited stdin forced to EOF

## Root cause

`get-ods.sh` is consumed through a pipe and eventually `exec`s the checked-out installer without restoring stdin. The initial install menu already reads from `/dev/tty`, but four later prompts in phase `03-features` inherited the exhausted curl pipeline:

1. automatic/custom mode selection
2. per-service GPU selection
3. llama-server GPU list
4. custom assignment confirmation

The first `read` returned non-zero and `set -e` aborted phase 03 before the user could respond. Detection, driver validation, and topology discovery had already succeeded.

## Confirmed edge cases fixed

The adversarial review reproduced two adjacent invalid-state paths in the same custom setup flow:

- assigning all GPUs to auxiliary services left the default llama-server list empty; pressing Enter produced a zero-GPU llama assignment
- declining the custom confirmation returned with an empty `GPU_ASSIGNMENT_JSON`, so downstream extraction failed instead of recovering

The first case now defaults llama-server to the detected GPU list. The second falls back to topology-aware automatic assignment.

## Invariants preserved

- interactive prompts use the controlling terminal; data transforms continue to use stdin/process substitution normally
- Enter on the mode prompt still selects automatic assignment
- every successful path produces at least one llama-server GPU
- cancellation cannot reach persistence with empty assignment state
- non-interactive assignment and valid persisted-assignment reuse are unchanged
- topology detection, tier selection, assignment policy, `.env` encoding, Compose overlays, and runtime consumers are unchanged

## Regression coverage

`tests/test-phase03-multigpu-tty.sh` uses util-linux `script` to provide a controlling PTY while launching the phase harness with `</dev/null>`, reproducing the hosted bootstrap contract. It covers a heterogeneous three-GPU topology and verifies:

- automatic selection with closed stdin
- empty mode selection retaining the automatic default
- complete custom assignment with closed stdin
- empty llama-server default when all auxiliary services have GPU selections
- custom cancellation recovering through automatic assignment

A portable static contract also requires all four interactive multi-GPU reads to use `/dev/tty`. The behavioral cases assert the selected path and exact service GPU UUIDs, use a bounded timeout to prevent a prompt regression from hanging CI, and avoid Bash features newer than the macOS system Bash.

## Validation

### GitHub CI

All reported checks pass, including:

- Linux integration smoke and installer contracts
- ShellCheck
- Ubuntu 22.04/24.04, Debian 12, Mint 21.3, Fedora 41, Rocky 9, Arch, Manjaro, CachyOS, and openSUSE matrix
- macOS smoke
- PowerShell lint on Ubuntu and Windows
- dashboard API/frontend
- env-schema tiers, Python lint, and secret scan

The Linux installer-contract log confirms all five PTY behavioral cases pass.

### Focused local validation

- Bash parser on Linux installer phases, macOS installer scripts, and the new test
- PowerShell parser across the Windows installer tree
- JSON/YAML parsers for env schema, workflow, and Compose files
- Python compile for `assign_gpus.py`
- `python -m pytest tests/test-assign-gpus.py extensions/services/dashboard-api/tests/test_gpu_detailed.py -q` -> `116 passed`
- Bash 3.2 guard contracts -> `10 passed`
- hosted bootstrap verifier -> passed
- real `docker compose config --quiet` renders for NVIDIA multi-GPU, AMD multi-GPU, macOS, and CPU overlays
- `git diff --check`

## Independent adversarial review

A separate clean-room review found no reproducible production defect after the fixes. It did reproduce two defects in the first test revision: custom cases could pass if the selector incorrectly called automatic assignment, and `mapfile` made the portable contract incompatible with Bash 3.2. Both were corrected. A deliberate selector mutation now fails on the missing custom-path receipt and exact GPU mapping.
## Compatibility and scope

| Area | Result |
|---|---|
| Linux clean hosted install | Fixed and behaviorally tested |
| Linux direct installer | Same prompts, now explicitly terminal-bound |
| Update / second interactive run | Uses the same fixed terminal path |
| Non-interactive rerun / persisted assignment | Unchanged; official contracts pass |
| Disabled optional services | Compose gating unchanged |
| Partial custom cancellation | Recovers to valid automatic assignment |
| Windows | Separate PowerShell installer untouched; parser/lint pass |
| macOS | Separate installer untouched; parser/smoke/Compose render pass |
| Dashboard API/frontend | Consumers unchanged; tests pass |
| Documentation | Documented bootstrap command now matches implementation; no text change required |

No persistent format, public API, Compose schema, secret handling, or runtime contract changes are introduced.