### PR TITLE
fix(hermes): honor literal response requests

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1067,22 +1067,22 @@
         "perplexica": {
           "status": "unsupported_until_revalidated",
           "label": "Perplexica revalidation required",
-          "reason": "Fresh exact-commit release coverage on strix-halo loaded Qwen 2.5 Coder 1.5B 128K through Lemonade and passed challenge-bound ODS Talk, LiteLLM, and Open WebUI. Perplexica routed to the exact model but answered with unrelated Eiffel Tower prose and omitted its requested verification phrase. Keep this model out of Perplexica release coverage on strix-halo until revalidated.",
-          "evidence": "fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo",
-          "recordedAt": "2026-07-24T13:57:35Z",
-          "productSha": "9ad366f47050b81121c832de353cd799ad9dbfdf",
-          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
-          "hostScope": ["strix-halo"],
+          "reason": "Fresh exact-route browser coverage on strix-halo and windows-laptop loaded Qwen 2.5 Coder 1.5B 128K and passed challenge-bound ODS Talk, LiteLLM, and Open WebUI. Perplexica returned unrelated prose and omitted its requested verification phrase on both hosts. Keep this model out of Perplexica release coverage on those hosts until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-24T18-04-guardrail-diagnostic-windows-qwen25-coder-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T18:08:00Z",
+          "productSha": "f35e9af8eeab7bb154081d1a3076ad9824f58616",
+          "harnessSha": "7c6cd3af853b9151fdb46170b59105401def3036",
+          "hostScope": ["strix-halo", "windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         },
         "agent_viability": {
           "status": "not_agent_viable",
-          "reason": "The model failed agent-required browser verification on tower2 in ODS Talk and on strix-halo in OpenCode and Perplexica after exact-model routing. Keep it out of agent-required release coverage on those hosts until the affected app paths are revalidated.",
-          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2; fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo",
-          "recordedAt": "2026-07-24T13:57:35Z",
-          "productSha": "9ad366f47050b81121c832de353cd799ad9dbfdf",
-          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
-          "hostScope": ["tower2", "strix-halo"],
+          "reason": "The model failed agent-required browser verification on tower2 in ODS Talk, on strix-halo in OpenCode and Perplexica, and on windows-laptop in Perplexica after exact-model routing. Keep it out of agent-required release coverage on those hosts until the affected app paths are revalidated.",
+          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2; fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-24T18-04-guardrail-diagnostic-windows-qwen25-coder-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T18:08:00Z",
+          "productSha": "f35e9af8eeab7bb154081d1a3076ad9824f58616",
+          "harnessSha": "7c6cd3af853b9151fdb46170b59105401def3036",
+          "hostScope": ["tower2", "strix-halo", "windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         }
       },
@@ -1107,14 +1107,20 @@
       "llama_server_image": null,
       "app_compatibility": {
         "agent_viability": {
-          "status": "not_agent_viable",
-          "reason": "Fleet model-UI run 2026-07-16T11-44Z on windows-laptop loaded this model successfully, but ODS Talk never returned the requested verification phrase; keep it out of agent-required release coverage until revalidated.",
-          "evidence": "fleet-test/runs/2026-07-16T11-44-05Z-release-affected-product-d11ef611-harness-a7745b8-windows-pair/model-ui/cycle-004/windows-laptop"
+          "status": "verified",
+          "label": "Agent workflow verified on Windows",
+          "reason": "Targeted windows-laptop browser revalidation with the literal-response persona guardrail loaded the exact Qwen 2.5 Coder 3B 128K route and passed challenge-bound ODS Talk plus every deployed LLM consumer, baseline restore, deletion, inventory, and environment cleanup.",
+          "evidence": "fleet-test/runs/2026-07-24T18-23-guardrail-fullapp-windows-qwen25-coder-3b-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T18:30:00Z",
+          "hostScope": ["windows-laptop"]
         },
         "hermes_talk": {
-          "status": "unsupported_until_revalidated",
-          "reason": "Fleet model-UI run 2026-07-16T11-44Z on windows-laptop loaded this model successfully, but ODS Talk never returned the requested verification phrase; keep it out of ODS Talk release coverage until revalidated.",
-          "evidence": "fleet-test/runs/2026-07-16T11-44-05Z-release-affected-product-d11ef611-harness-a7745b8-windows-pair/model-ui/cycle-004/windows-laptop"
+          "status": "verified",
+          "label": "ODS Talk verified on Windows",
+          "reason": "Targeted windows-laptop browser revalidation with the literal-response persona guardrail loaded the exact Qwen 2.5 Coder 3B 128K route and ODS Talk returned the exact challenge phrase. Every other deployed LLM consumer and all restore/cleanup gates passed in the same cycle.",
+          "evidence": "fleet-test/runs/2026-07-24T18-23-guardrail-fullapp-windows-qwen25-coder-3b-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T18:30:00Z",
+          "hostScope": ["windows-laptop"]
         }
       },
       "install_recommendation": false

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -712,7 +712,7 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
 
     assert len(candidates) >= 6
     assert {
-        "qwen2.5-coder-1.5b-128k-q4",
+        "qwen2.5-coder-3b-128k-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
         "granite4.0-h-1b-q4",
@@ -726,7 +726,13 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     )
     assert all_by_id["smollm3-3b-q4"]["contextLength"] == 65536
     assert all_by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
-    assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
+    assert by_id["qwen2.5-coder-3b-128k-q4"]["contextLength"] == 128000
+    assert by_id["qwen2.5-coder-3b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
+        "verified"
+    )
+    assert by_id["qwen2.5-coder-3b-128k-q4"]["appCompatibility"]["agentViability"]["status"] == (
+        "verified"
+    )
     assert "qwen3-4b-instruct-2507-q4" in candidate_ids
     assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] >= 64000
     assert by_id["qwen3-4b-instruct-2507-q4"]["appCompatibility"]["agentViability"]["status"] == (
@@ -749,7 +755,11 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert all_by_id["falcon-h1-3b-instruct-q4"]["appCompatibility"]["agentViability"]["status"] == (
         "not_agent_viable"
     )
-    assert all_by_id["qwen2.5-coder-1.5b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert (
+        all_by_id["qwen2.5-coder-1.5b-128k-q4"]["appCompatibility"]["perplexica"]["status"]
+        == "unsupported_until_revalidated"
+    )
+    assert "qwen2.5-coder-1.5b-128k-q4" not in candidate_ids
     assert all_by_id["phi3-mini-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
     assert all_by_id["phi3-mini-128k-q4"]["appCompatibility"]["perplexica"]["status"] == (
         "unsupported_until_revalidated"

--- a/ods/extensions/services/hermes/SOUL.md.template
+++ b/ods/extensions/services/hermes/SOUL.md.template
@@ -17,6 +17,7 @@ A few specific things this means:
 
 ## How to talk (this is the most important section)
 
+- **Honor literal-output requests exactly.** If the user asks you to return, repeat, echo, or say a specific phrase and nothing else, output those literal characters only. Do not call a tool, paraphrase, substitute a canned capability example, add commentary, or claim you produced the phrase without actually including it.
 - **Default length is one or two short sentences.** Most questions don't need paragraphs. If the user asks "what's the weather," say "Seventy-two and sunny in San Francisco right now." Don't follow up with a forecast unless they ask.
 - **Speak in sentences, not lists.** "It's running on AMD, Lemonade is serving the model, and ComfyUI is available for image generation" is what someone *says*. The same content as bullets would sound jarring read aloud.
 - **This applies to "options" questions too.** If the user asks for ideas (gift, restaurant, activity, anniversary plan, weekend trip), give them as comma-separated sentences with quick context — not a numbered list. **Bad:** *"1. **Romantic dinner** — nice restaurant\n2. **Day trip** — get out of the city\n3. **Experience-based** — cooking class"*. **Good:** *"A few angles: a quiet romantic dinner somewhere new, a day trip to get out of the city, or something experiential like a cooking class together. What's the vibe you're going for?"* The good version sounds like a friend brainstorming; the bad one sounds like a checklist read aloud.

--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -350,6 +350,10 @@ def build_compact_soul(env_path: Path) -> str:
         "You are ODS, the resident assistant on this ODS install. "
         "Keep answers brief, natural, and accurate. Use tools when the task needs them.",
         "",
+        "If the user asks for a specific phrase and nothing else, output those "
+        "literal characters only. Do not call a tool, paraphrase, substitute a "
+        "canned example, or add commentary.",
+        "",
         "## Install facts",
         f"- Host: `{device}`",
         f"- GPU/backend: {gpu}",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -550,15 +550,20 @@ def test_qwen3_17b_is_below_release_context_floor_without_yarn_policy():
     assert not _agent_viable_for_release(model)
 
 
-def test_qwen25_coder_3b_is_not_agent_viable_until_revalidated():
+def test_qwen25_coder_3b_is_verified_for_windows_after_full_app_revalidation():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
-    compatibility = by_id["qwen2.5-coder-3b-128k-q4"]["app_compatibility"]
+    model = by_id["qwen2.5-coder-3b-128k-q4"]
+    compatibility = model["app_compatibility"]
 
-    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
-    assert compatibility["agent_viability"]["evidence"]
-    assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
-    assert not _agent_viable_for_release(by_id["qwen2.5-coder-3b-128k-q4"])
+    assert compatibility["agent_viability"]["status"] == "verified"
+    assert compatibility["agent_viability"]["hostScope"] == ["windows-laptop"]
+    assert "18-23-guardrail-fullapp" in compatibility["agent_viability"]["evidence"]
+    assert compatibility["hermes_talk"]["status"] == "verified"
+    assert compatibility["hermes_talk"]["hostScope"] == ["windows-laptop"]
+    assert "18-23-guardrail-fullapp" in compatibility["hermes_talk"]["evidence"]
+    assert _agent_viable_for_release(model)
+    assert _agent_viable_for_release(model, host="windows-laptop")
 
 
 def test_falcon_h1_15b_is_not_talk_or_opencode_agent_viable_until_revalidated():
@@ -611,13 +616,18 @@ def test_qwen25_coder_15b_128k_has_scoped_app_blocks_until_revalidated():
     assert "webfetch tool payload" in compatibility["opencode"]["reason"]
     assert compatibility["opencode"]["hostScope"] == ["strix-halo"]
     assert compatibility["perplexica"]["status"] == "unsupported_until_revalidated"
-    assert "Eiffel Tower" in compatibility["perplexica"]["reason"]
-    assert compatibility["perplexica"]["hostScope"] == ["strix-halo"]
+    assert "unrelated prose" in compatibility["perplexica"]["reason"]
+    assert compatibility["perplexica"]["hostScope"] == ["strix-halo", "windows-laptop"]
     assert compatibility["agent_viability"]["status"] == "not_agent_viable"
-    assert compatibility["agent_viability"]["hostScope"] == ["tower2", "strix-halo"]
+    assert compatibility["agent_viability"]["hostScope"] == [
+        "tower2",
+        "strix-halo",
+        "windows-laptop",
+    ]
     assert _agent_viable_for_release(model)
     assert not _agent_viable_for_release(model, host="tower2")
     assert not _agent_viable_for_release(model, host="strix-halo")
+    assert not _agent_viable_for_release(model, host="windows-laptop")
 
 
 def test_mistral_nemo_talk_block_is_scoped_to_apple_llama_server():

--- a/ods/tests/test-windows-hermes-soul.sh
+++ b/ods/tests/test-windows-hermes-soul.sh
@@ -15,6 +15,8 @@ LINUX_PHASE_06="$ROOT_DIR/installers/phases/06-directories.sh"
 LINUX_PHASE_11="$ROOT_DIR/installers/phases/11-services.sh"
 LINUX_CLI="$ROOT_DIR/ods-cli"
 HERMES_COMPOSE="$ROOT_DIR/extensions/services/hermes/compose.yaml"
+HERMES_SOUL="$ROOT_DIR/extensions/services/hermes/SOUL.md.template"
+SOUL_BUILDER="$ROOT_DIR/scripts/build-installation-context.py"
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -78,6 +80,8 @@ check 'If a previous failed' "$LINUX_CLI" "Linux CLI documents pre-compose SOUL 
 
 check './data/persona/SOUL.md:/opt/hermes/docker/SOUL.md:ro' "$HERMES_COMPOSE" "Hermes compose mounts generated persona file"
 reject ':/opt/data/SOUL.md' "$HERMES_COMPOSE" "Hermes compose avoids nested /opt/data/SOUL.md bind mount"
+check 'Honor literal-output requests exactly.' "$HERMES_SOUL" "Full Hermes persona prioritizes exact literal replies"
+check 'literal characters only' "$SOUL_BUILDER" "Compact Hermes persona prioritizes exact literal replies"
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- prioritize exact literal-output requests in both full and compact Hermes SOUL profiles
- record the real Windows Qwen 2.5 Coder 3B all-app revalidation and make it the sixth Windows 8GB release candidate
- scope the Qwen 2.5 Coder 1.5B Perplexica/agent block to Windows after its exact-route semantic failure

## Live evidence
A controlled windows-laptop browser cycle loaded `qwen2.5-coder-3b-128k-q4` and passed:
- exact challenge-bound ODS Talk on the exact model/route
- LiteLLM, Open WebUI, and Perplexica probes
- baseline restore and restored-app probes
- candidate deletion, final inventory, artifact integrity, and environment cleanup

Evidence: `fleet-test/runs/2026-07-24T18-23-guardrail-fullapp-windows-qwen25-coder-3b-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop`

The 1.5B candidate separately passed Talk after the guardrail but returned unrelated content through Perplexica, so it remains excluded on Windows rather than weakening the validator.

## Tests
- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/tests/test-model-library-verdicts.py ods/extensions/services/dashboard-api/tests/test_performance_oracle.py` (76 passed)
- `bash ods/tests/test-windows-hermes-soul.sh` (29 passed)
- `python -m py_compile ods/scripts/build-installation-context.py`
- `git diff --check`