### PR TITLE
fix: refresh Windows Hermes context after services settle

### DIFF
--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -2394,6 +2394,16 @@ $installReadiness = Write-ODSInstallReadinessSummary -Checks $readinessChecks `
     -LogPath (Join-Path $installDir "logs\install.log") `
     -DashboardUrl "http://localhost:$dashboardPort" `
     -PassThru
+
+# The first post-compose persona render happens as soon as the required core
+# containers exist. Optional extension containers can still be entering the
+# running set at that point, which previously left Windows Hermes claiming
+# that no extensions were active. Refresh again after readiness has observed
+# the final stack and sync the authoritative service inventory into Hermes.
+if ($enableHermes -and (Get-Command Invoke-HermesSoulRefresh -ErrorAction SilentlyContinue)) {
+    Invoke-HermesSoulRefresh -InstallRoot $installDir -SyncContainer
+}
+
 if ($installReadiness -and $installReadiness.AllReady -and $llmModelReady -and $sttModelReady) {
     $allHealthy = $true
 }

--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -389,7 +389,11 @@ def build_soul(
     context = build_context_block(env_path)
 
     if _INSERT_MARKER in template:
-        assembled = template.replace(_INSERT_MARKER, context)
+        # Replace only the dedicated insertion line. The template also names
+        # the literal marker in its operator-facing regeneration instructions;
+        # replacing every occurrence duplicated the full install context at
+        # the end of SOUL.md and could double an already-large system prompt.
+        assembled = template.replace(_INSERT_MARKER, context, 1)
     else:
         # Template doesn't have the marker yet — append the block so
         # operators upgrading from an older template still get the

--- a/ods/tests/test-windows-hermes-soul.sh
+++ b/ods/tests/test-windows-hermes-soul.sh
@@ -64,6 +64,11 @@ check 'SOUL.md.template' "$PHASE_06" "Windows phase 06 has template fallback"
 check 'INSTALLATION_CONTEXT' "$PHASE_06" "fallback removes dynamic marker"
 check 'Invoke-HermesSoulRefresh -InstallRoot $installDir' "$PHASE_06" "Windows phase 06 renders SOUL before compose"
 check 'Invoke-HermesSoulRefresh -InstallRoot $installDir -SyncContainer' "$INSTALLER" "Windows installer syncs SOUL after compose"
+if [[ "$(grep -Fc 'Invoke-HermesSoulRefresh -InstallRoot $installDir -SyncContainer' "$INSTALLER")" -ge 2 ]]; then
+    pass "Windows installer refreshes SOUL again after readiness settles"
+else
+    fail "Windows installer must refresh SOUL after optional services settle"
+fi
 check '-LemonadeCompact:($gpuInfo.Backend -eq "amd")' "$PHASE_06" "Windows AMD applies compact Hermes toolset profile"
 check 'http://litellm:4000/v1' "$PHASE_06" "Windows AMD Hermes routes through LiteLLM"
 
@@ -82,6 +87,27 @@ check './data/persona/SOUL.md:/opt/hermes/docker/SOUL.md:ro' "$HERMES_COMPOSE" "
 reject ':/opt/data/SOUL.md' "$HERMES_COMPOSE" "Hermes compose avoids nested /opt/data/SOUL.md bind mount"
 check 'Honor literal-output requests exactly.' "$HERMES_SOUL" "Full Hermes persona prioritizes exact literal replies"
 check 'literal characters only' "$SOUL_BUILDER" "Compact Hermes persona prioritizes exact literal replies"
+
+python_cmd="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+if [[ -n "$python_cmd" ]]; then
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+    printf '%s\n' '<!-- INSTALLATION_CONTEXT -->' \
+        'The literal `<!-- INSTALLATION_CONTEXT -->` marker is documented here.' \
+        > "$tmp_dir/template.md"
+    printf '%s\n' 'ODS_DEVICE_NAME=test-host' > "$tmp_dir/.env"
+    "$python_cmd" "$SOUL_BUILDER" \
+        --template "$tmp_dir/template.md" \
+        --env "$tmp_dir/.env" \
+        --output "$tmp_dir/SOUL.md" >/dev/null
+    if [[ "$(grep -c '^## About this ODS install' "$tmp_dir/SOUL.md")" -eq 1 ]]; then
+        pass "SOUL builder inserts dynamic context exactly once"
+    else
+        fail "SOUL builder duplicated dynamic context through marker documentation"
+    fi
+else
+    fail "python is required for SOUL builder contract test"
+fi
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- refresh the Windows Hermes installation context after readiness observes the settled stack
- replace only the dedicated SOUL template insertion marker so operator documentation cannot duplicate the full context
- add regression coverage for both behaviors

## Fleet evidence
The six-host release run installed cleanly everywhere, but Windows capability grounding failed because SOUL.md reported no extension services and duplicated its dynamic context. Rebuilding the context after services settled produced the correct active service inventory.

## Validation
- Python compile and PowerShell AST parse
- test-windows-hermes-soul.sh: 31 passed
- test-windows-readiness-summary.sh: 15 passed
- test-windows-installer-flags.sh: 30 passed
- test-installer-context-parity.sh: 61 passed
- test-windows-service-plan.sh: 20 passed