### PR TITLE
fix(oracle): tolerate an explicit null aliases in a catalog entry

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -168,7 +168,7 @@ def _model_aliases(model: dict[str, Any]) -> set[str]:
         str(model.get("gguf_file") or ""),
         str(model.get("llm_model_name") or ""),
     }
-    aliases.update(str(alias or "") for alias in model.get("aliases", []))
+    aliases.update(str(alias or "") for alias in model.get("aliases", []) or [])
     for part in model.get("gguf_parts", []) or []:
         if isinstance(part, dict):
             aliases.add(str(part.get("file") or ""))

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -11,6 +11,7 @@ from performance_oracle import (
     model_compatibility_runtime_context,
     model_app_compatibility,
     model_publisher,
+    normalize_catalog_entry,
     rank_pre_download_models,
 )
 
@@ -91,6 +92,32 @@ def test_current_model_matches_complete_phi_aliases_and_runtime_prefixes():
     assert current_model_matches(mini, None, mini["gguf_file"])
     assert not current_model_matches(full, None, mini["gguf_file"])
     assert not current_model_matches(full, "custom.phi-4")
+
+
+def test_normalize_catalog_entry_tolerates_explicit_null_aliases():
+    """A catalog entry may carry an explicit ``"aliases": null`` (JSON null).
+
+    ``.get("aliases", [])`` only substitutes the default when the key is
+    absent, so a null value used to raise TypeError and take down every
+    caller of load_model_catalog. Aliases are still derived from the other
+    identity fields.
+    """
+    entry = normalize_catalog_entry(
+        {"id": "m", "gguf": "model-Q4_K_M.gguf", "aliases": None}
+    )
+
+    assert entry is not None
+    assert "m" in entry["aliases"]
+    assert "model-Q4_K_M.gguf" in entry["aliases"]
+
+
+def test_normalize_catalog_entry_keeps_listed_aliases():
+    entry = normalize_catalog_entry(
+        {"id": "m", "gguf": "model-Q4_K_M.gguf", "aliases": ["custom-alias"]}
+    )
+
+    assert entry is not None
+    assert "custom-alias" in entry["aliases"]
 
 
 def test_real_catalog_phi_models_have_exactly_one_loaded_identity(data_dir, tmp_path):


### PR DESCRIPTION
## Problem

`_model_aliases` expands a catalog entry's aliases with:

```python
aliases.update(str(alias or "") for alias in model.get("aliases", []))   # line 171
for part in model.get("gguf_parts", []) or []:                           # line 172
```

`.get("aliases", [])` only substitutes the default when the key is **absent**. An entry carrying an explicit JSON null (`"aliases": null`) yields `None`, so iterating raises:

```
TypeError: 'NoneType' object is not iterable
```

That propagates out of `normalize_catalog_entry` → `load_model_catalog`, which backs `routers/models.py` and `routers/talk.py`.

The **very next line** already guards the same shape with `or []`, so the two lines are simply inconsistent.

## Fix

One word, matching the adjacent line:

```diff
-    aliases.update(str(alias or "") for alias in model.get("aliases", []))
+    aliases.update(str(alias or "") for alias in model.get("aliases", []) or [])
```

Aliases are still derived from `id`/`name`/`gguf` when the field is null, and listed aliases keep working.

## Honest note on reachability

This is a robustness/consistency fix, not a report of a break in a shipped path. I checked before opening it:

- The shipped `config/model-library.json` (52 entries) does not use the `aliases` field at all.
- The HuggingFace import path (`routers/models.py`) does not write `aliases` either.

So reaching it today requires a hand-edited or fork-customized catalog that writes `"aliases": null` — which `docs/VALIDATION_REPRODUCIBILITY.md` explicitly contemplates ("changed model catalogs" for forks). Feel free to close if you'd rather not carry the guard.

## Verification

Ran `normalize_catalog_entry` directly against the current file and against the pre-fix line:

```
[fixed]  null_aliases=PASS          listed_aliases=PASS
[buggy]  null_aliases=FAIL(TypeError)  listed_aliases=PASS
```

Added two tests to `test_performance_oracle.py`:
- `test_normalize_catalog_entry_tolerates_explicit_null_aliases` — fails before this change, passes after.
- `test_normalize_catalog_entry_keeps_listed_aliases` — guards against the fix silently dropping real aliases.