### PR TITLE
fix(models): scope Qwen 1.5B Perplexica block to M5

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1067,22 +1067,22 @@
         "perplexica": {
           "status": "unsupported_until_revalidated",
           "label": "Perplexica revalidation required",
-          "reason": "Fresh exact-route browser coverage on strix-halo and windows-laptop loaded Qwen 2.5 Coder 1.5B 128K and passed challenge-bound ODS Talk, LiteLLM, and Open WebUI. Perplexica returned unrelated prose and omitted its requested verification phrase on both hosts. Keep this model out of Perplexica release coverage on those hosts until revalidated.",
-          "evidence": "fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-24T18-04-guardrail-diagnostic-windows-qwen25-coder-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
-          "recordedAt": "2026-07-24T18:08:00Z",
-          "productSha": "f35e9af8eeab7bb154081d1a3076ad9824f58616",
-          "harnessSha": "7c6cd3af853b9151fdb46170b59105401def3036",
-          "hostScope": ["strix-halo", "windows-laptop"],
+          "reason": "Fresh exact-route browser coverage on strix-halo, m5-mbp, and windows-laptop loaded Qwen 2.5 Coder 1.5B 128K and passed challenge-bound ODS Talk, LiteLLM, and Open WebUI. Perplexica returned unrelated research output and omitted its requested verification phrase on all three hosts. Keep this model out of Perplexica release coverage on those hosts until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-24T20-41-29Z-release-product-8318f6cf37d8-harness-7b83ca3a780f-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/m5-mbp; fleet-test/runs/2026-07-24T18-04-guardrail-diagnostic-windows-qwen25-coder-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T22:22:05Z",
+          "productSha": "8318f6cf37d878ea5d31dab0f557678f1e8ca3ef",
+          "harnessSha": "7b83ca3a780f502f6f12c90596256fe1cb8235af",
+          "hostScope": ["strix-halo", "m5-mbp", "windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         },
         "agent_viability": {
           "status": "not_agent_viable",
-          "reason": "The model failed agent-required browser verification on tower2 in ODS Talk, on strix-halo in OpenCode and Perplexica, on spark in OpenCode, and on windows-laptop in Perplexica after exact-model routing. Keep it out of agent-required release coverage on those hosts until the affected app paths are revalidated.",
-          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2; fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-24T20-41-29Z-release-product-8318f6cf37d8-harness-7b83ca3a780f-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/spark; fleet-test/runs/2026-07-24T18-04-guardrail-diagnostic-windows-qwen25-coder-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
-          "recordedAt": "2026-07-24T22:11:24Z",
+          "reason": "The model failed agent-required browser verification on tower2 in ODS Talk, on strix-halo in OpenCode and Perplexica, on spark in OpenCode, and on m5-mbp and windows-laptop in Perplexica after exact-model routing. Keep it out of agent-required release coverage on those hosts until the affected app paths are revalidated.",
+          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2; fleet-test/runs/2026-07-24T12-22-22Z-release-product-9ad366f47050-harness-954deb755b07-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-24T20-41-29Z-release-product-8318f6cf37d8-harness-7b83ca3a780f-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/spark; fleet-test/runs/2026-07-24T20-41-29Z-release-product-8318f6cf37d8-harness-7b83ca3a780f-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/m5-mbp; fleet-test/runs/2026-07-24T18-04-guardrail-diagnostic-windows-qwen25-coder-product-f35e9af8eeab-harness-7c6cd3af853b/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T22:22:05Z",
           "productSha": "8318f6cf37d878ea5d31dab0f557678f1e8ca3ef",
           "harnessSha": "7b83ca3a780f502f6f12c90596256fe1cb8235af",
-          "hostScope": ["tower2", "strix-halo", "spark", "windows-laptop"],
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         }
       },

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -493,7 +493,7 @@ def test_real_catalog_granite41_opencode_block_is_strix_halo_and_spark_scoped():
     assert tower2["opencode"]["status"] == "unknown"
 
 
-def test_real_catalog_qwen25_coder_15b_opencode_block_includes_spark():
+def test_real_catalog_qwen25_coder_15b_blocks_include_spark_and_m5():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["qwen2.5-coder-1.5b-128k-q4"]
 
@@ -509,7 +509,8 @@ def test_real_catalog_qwen25_coder_15b_opencode_block_includes_spark():
     assert spark["opencode"]["status"] == "unsupported_until_revalidated"
     assert spark["agentViability"]["status"] == "not_agent_viable"
     assert m5_mbp["opencode"]["status"] == "unknown"
-    assert m5_mbp["agentViability"]["status"] == "unknown"
+    assert m5_mbp["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert m5_mbp["agentViability"]["status"] == "not_agent_viable"
 
 
 def test_real_catalog_qwen3_4b_instruct_windows_revalidation_is_verified():

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -616,19 +616,21 @@ def test_qwen25_coder_15b_128k_has_scoped_app_blocks_until_revalidated():
     assert "webfetch tool payload" in compatibility["opencode"]["reason"]
     assert compatibility["opencode"]["hostScope"] == ["strix-halo", "spark"]
     assert compatibility["perplexica"]["status"] == "unsupported_until_revalidated"
-    assert "unrelated prose" in compatibility["perplexica"]["reason"]
-    assert compatibility["perplexica"]["hostScope"] == ["strix-halo", "windows-laptop"]
+    assert "unrelated research output" in compatibility["perplexica"]["reason"]
+    assert compatibility["perplexica"]["hostScope"] == ["strix-halo", "m5-mbp", "windows-laptop"]
     assert compatibility["agent_viability"]["status"] == "not_agent_viable"
     assert compatibility["agent_viability"]["hostScope"] == [
         "tower2",
         "strix-halo",
         "spark",
+        "m5-mbp",
         "windows-laptop",
     ]
     assert _agent_viable_for_release(model)
     assert not _agent_viable_for_release(model, host="tower2")
     assert not _agent_viable_for_release(model, host="strix-halo")
     assert not _agent_viable_for_release(model, host="spark")
+    assert not _agent_viable_for_release(model, host="m5-mbp")
     assert not _agent_viable_for_release(model, host="windows-laptop")
 
 


### PR DESCRIPTION
## Summary
- record the fresh M5 exact-route Perplexica failure for Qwen 2.5 Coder 1.5B
- exclude that model from M5 Perplexica and agent-required release coverage until revalidated
- preserve the host-scoped behavior for unaffected hosts

## Evidence
The fresh six-cycle fleet diagnostic loaded the exact model on m5-mbp. ODS Talk, LiteLLM, and Open WebUI passed signed challenge checks; Perplexica returned unrelated research output without its requested challenge. Recovery restored the baseline successfully.

## Tests
- python -m pytest ods/tests/test-model-library-coverage.py ods/extensions/services/dashboard-api/tests/test_performance_oracle.py -q (75 passed)
- git diff --check