### PR TITLE
fix(models): scope Qwen2.5 OpenCode failure to Strix Halo

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1124,6 +1124,17 @@
           "harnessSha": "3930eeed3597593c50a897533902ff6ce740bb32",
           "hostScope": ["tower2"],
           "expiresAt": "2026-08-25T00:00:00Z"
+        },
+        "opencode": {
+          "status": "unsupported_until_revalidated",
+          "label": "OpenCode revalidation required on Strix Halo",
+          "reason": "Fresh exact-commit release coverage on strix-halo loaded Qwen 2.5 Coder 3B 128K through the browser switchboard and passed challenge-bound ODS Talk, LiteLLM, Open WebUI, and Perplexica, but OpenCode returned only the verification prefix instead of the full unpredictable phrase. Keep this model out of Strix Halo all-app release coverage until its literal-response behavior is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-25T02-56-13Z-release-product-89c6e46fde88-harness-78aeb37d418e-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo",
+          "recordedAt": "2026-07-25T04:23:22Z",
+          "productSha": "89c6e46fde886ed4edac2bd4c1c2f7cb6beba6d6",
+          "harnessSha": "78aeb37d418efae52efd04e4bc7e64eac128fbb7",
+          "hostScope": ["strix-halo"],
+          "expiresAt": "2026-08-25T00:00:00Z"
         }
       },
       "install_recommendation": false

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -817,16 +817,22 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "qwen3-1.7b-q4" not in candidate_ids
 
 
-def test_real_catalog_blocks_qwen25_coder_3b_talk_only_on_tower():
+def test_real_catalog_scopes_qwen25_coder_3b_host_failures():
     catalog = _official_model_catalog()
     model = next(model for model in catalog if model["id"] == "qwen2.5-coder-3b-128k-q4")
 
     tower = model_app_compatibility(model, runtime_context={"hosts": ["tower2"]})
+    halo = model_app_compatibility(model, runtime_context={"hosts": ["strix-halo"]})
     windows = model_app_compatibility(model, runtime_context={"hosts": ["windows-laptop"]})
 
     assert tower["hermesTalk"]["status"] == "unsupported_until_revalidated"
     assert tower["agentViability"]["status"] == "unknown"
+    assert tower["opencode"]["status"] == "unknown"
+    assert halo["hermesTalk"]["status"] == "unknown"
+    assert halo["opencode"]["status"] == "unsupported_until_revalidated"
+    assert halo["agentViability"]["status"] == "unknown"
     assert windows["hermesTalk"]["status"] == "unknown"
+    assert windows["opencode"]["status"] == "unknown"
     assert windows["agentViability"]["status"] == "verified"
 
 

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -550,7 +550,7 @@ def test_qwen3_17b_is_below_release_context_floor_without_yarn_policy():
     assert not _agent_viable_for_release(model)
 
 
-def test_qwen25_coder_3b_is_verified_on_windows_and_talk_blocked_on_tower():
+def test_qwen25_coder_3b_is_verified_on_windows_and_host_failures_are_scoped():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["qwen2.5-coder-3b-128k-q4"]
@@ -563,9 +563,14 @@ def test_qwen25_coder_3b_is_verified_on_windows_and_talk_blocked_on_tower():
     assert compatibility["hermes_talk"]["hostScope"] == ["tower2"]
     assert "23-54-27Z-release" in compatibility["hermes_talk"]["evidence"]
     assert "acknowledged" in compatibility["hermes_talk"]["reason"]
+    assert compatibility["opencode"]["status"] == "unsupported_until_revalidated"
+    assert compatibility["opencode"]["hostScope"] == ["strix-halo"]
+    assert "02-56-13Z-release" in compatibility["opencode"]["evidence"]
+    assert "verification prefix" in compatibility["opencode"]["reason"]
     assert _agent_viable_for_release(model)
     assert _agent_viable_for_release(model, host="windows-laptop")
     assert not _agent_viable_for_release(model, host="tower2")
+    assert not _agent_viable_for_release(model, host="strix-halo")
 
 
 def test_falcon_h1_15b_is_not_talk_or_opencode_agent_viable_until_revalidated():


### PR DESCRIPTION
## What changed

- records the fresh Strix Halo OpenCode incompatibility for Qwen 2.5 Coder 3B 128K
- keeps the verdict scoped to the `opencode` consumer on `strix-halo`
- preserves the existing verified Windows support and Tower2 Talk-only restriction
- adds catalog and dashboard compatibility contract coverage

## Why

In the fresh exact-main six-cycle fleet run, Strix Halo loaded the exact Qwen2.5 model and passed ODS Talk, LiteLLM, Open WebUI, and Perplexica. OpenCode returned only the `ODS verify` prefix instead of the full unpredictable verification phrase. The harness recovered the baseline and cleaned the downloaded model successfully.

Scoping the compatibility verdict lets release planning select the next eligible distinct model on Strix Halo without incorrectly excluding Qwen2.5 from Windows.

## Validation

- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/extensions/services/dashboard-api/tests/test_performance_oracle.py` — 76 passed
- `git diff --check`

Evidence: `fleet-test/runs/2026-07-25T02-56-13Z-release-product-89c6e46fde88-harness-78aeb37d418e-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo`
