### PR TITLE
fix(models): replan AMD GPUs for larger swaps

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -971,7 +971,7 @@ def _gpu_capacity_by_uuid(topology: dict) -> dict[str, int]:
     return capacities
 
 
-def _run_nvidia_gpu_planner(topology: dict, required_mb: int) -> dict:
+def _run_gpu_planner(topology: dict, required_mb: int) -> dict:
     planner = INSTALL_DIR / "scripts" / "assign_gpus.py"
     if not planner.is_file():
         raise RuntimeError(f"GPU assignment planner is missing: {planner}")
@@ -1024,6 +1024,111 @@ def _run_nvidia_gpu_planner(topology: dict, required_mb: int) -> dict:
     if not isinstance(parallelism, dict):
         raise RuntimeError("GPU assignment planner omitted llama parallelism")
     return planned
+
+
+def _build_model_gpu_assignment_plan(
+    current_assignment: dict,
+    topology: dict,
+    model: dict,
+    target: Path,
+    *,
+    context_length: int | None = None,
+    runtime_profile: dict | None = None,
+) -> dict | None:
+    """Return a validated llama GPU expansion while preserving other services."""
+    capacities = _gpu_capacity_by_uuid(topology)
+    if len(capacities) < 2:
+        raise RuntimeError("Multi-GPU topology does not contain usable GPU capacities")
+
+    current_llama = current_assignment["gpu_assignment"]["services"]["llama_server"]
+    current_gpus = current_llama["gpus"]
+    missing = [uuid for uuid in current_gpus if uuid not in capacities]
+    if missing:
+        raise RuntimeError(
+            "Persisted llama GPU assignment references missing devices; "
+            "run 'ods gpu reassign --auto'"
+        )
+
+    required_mb = _target_model_vram_budget_mb(
+        model,
+        target,
+        context_length=context_length,
+        runtime_profile=runtime_profile,
+    )
+    current_capacity_mb = sum(capacities[uuid] for uuid in current_gpus)
+    if current_capacity_mb >= required_mb:
+        return None
+    if str(current_assignment["gpu_assignment"].get("strategy") or "").lower() == "manual":
+        raise RuntimeError(
+            "The manual llama GPU assignment is too small for this model; "
+            "run 'ods gpu reassign --manual' to choose a larger set"
+        )
+
+    planned = _run_gpu_planner(topology, required_mb)
+    planned_llama = planned["gpu_assignment"]["services"]["llama_server"]
+    planned_gpus = planned_llama["gpus"]
+    unknown = [uuid for uuid in planned_gpus if uuid not in capacities]
+    if unknown:
+        raise RuntimeError("GPU assignment planner selected devices outside the live topology")
+    planned_capacity_mb = sum(capacities[uuid] for uuid in planned_gpus)
+    if planned_capacity_mb < required_mb:
+        raise RuntimeError(
+            f"Target model needs about {required_mb} MiB of GPU capacity, but "
+            f"the planner assigned only {planned_capacity_mb} MiB"
+        )
+
+    merged = json.loads(json.dumps(current_assignment))
+    merged_root = merged["gpu_assignment"]
+    merged_root["services"]["llama_server"] = planned_llama
+    auxiliary_gpus = {
+        uuid
+        for name, service in merged_root["services"].items()
+        if name != "llama_server" and isinstance(service, dict)
+        for uuid in service.get("gpus") or []
+    }
+    merged_root["strategy"] = (
+        "colocated" if auxiliary_gpus.intersection(planned_gpus) else "dedicated"
+    )
+
+    mode = str((planned_llama.get("parallelism") or {}).get("mode") or "none")
+    split_mode = {
+        "tensor": "row",
+        "hybrid": "row",
+        "pipeline": "layer",
+    }.get(mode, "none")
+    tensor_split = (planned_llama.get("parallelism") or {}).get("tensor_split")
+    if not isinstance(tensor_split, list) or len(tensor_split) != len(planned_gpus):
+        # In layer/pipeline mode an empty split lets llama.cpp fit layers to
+        # each device's live free memory. Reusing the old split can leave a
+        # newly added device idle and over-allocate another one.
+        tensor_split = []
+    gpu_indices = planned_llama.get("gpu_indices") or []
+    if (
+        len(gpu_indices) != len(planned_gpus)
+        or len(set(gpu_indices)) != len(gpu_indices)
+        or not all(isinstance(index, int) and index >= 0 for index in gpu_indices)
+    ):
+        raise RuntimeError("GPU assignment planner returned invalid device indices")
+
+    encoded = base64.b64encode(
+        json.dumps(merged, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    return {
+        "env_updates": {
+            "GPU_ASSIGNMENT_JSON_B64": encoded,
+            "LLAMA_SERVER_GPU_UUIDS": ",".join(planned_gpus),
+            "LLAMA_SERVER_GPU_INDICES": ",".join(str(index) for index in gpu_indices),
+            "LLAMA_ARG_SPLIT_MODE": split_mode,
+            "LLAMA_ARG_TENSOR_SPLIT": ",".join(str(value) for value in tensor_split),
+        },
+        "env_removals": [],
+        "previous_gpus": list(current_gpus),
+        "planned_gpus": list(planned_gpus),
+        "required_mb": required_mb,
+        "planned_capacity_mb": planned_capacity_mb,
+        "split_mode": split_mode,
+        "tensor_split": tensor_split,
+    }
 
 
 def _plan_nvidia_model_gpu_assignment(
@@ -1083,7 +1188,6 @@ def _plan_nvidia_model_gpu_assignment(
     capacities = _gpu_capacity_by_uuid(topology)
     if len(capacities) < 2:
         raise RuntimeError("Multi-GPU topology does not contain usable NVIDIA capacities")
-
     if current_assignment is None:
         current_assignment = _legacy_nvidia_gpu_assignment(env, topology)
         if current_assignment is None:  # Defensive: restriction checked above.
@@ -1172,6 +1276,219 @@ def _plan_nvidia_model_gpu_assignment(
         "split_mode": split_mode,
         "tensor_split": tensor_split,
     }
+
+
+def _legacy_amd_gpu_assignment(env: dict, topology: dict) -> dict | None:
+    """Recover the pre-contract ROCm index restriction as canonical UUIDs."""
+    raw_indices = str(
+        env.get("LLAMA_SERVER_GPU_INDICES")
+        or env.get("ROCR_VISIBLE_DEVICES")
+        or ""
+    ).strip()
+    raw_uuids = str(env.get("LLAMA_SERVER_GPU_UUIDS") or "").strip()
+    if not raw_indices and not raw_uuids:
+        return None
+
+    gpus = [
+        gpu
+        for gpu in topology.get("gpus") or []
+        if isinstance(gpu, dict)
+        and isinstance(gpu.get("index"), int)
+        and str(gpu.get("uuid") or "").strip()
+    ]
+    index_to_uuid = {str(gpu["index"]): str(gpu["uuid"]).strip() for gpu in gpus}
+    uuid_to_index = {uuid: int(index) for index, uuid in index_to_uuid.items()}
+
+    if raw_indices:
+        requested_indices = [token.strip() for token in raw_indices.split(",") if token.strip()]
+        if (
+            not requested_indices
+            or len(requested_indices) != len(set(requested_indices))
+            or any(token not in index_to_uuid for token in requested_indices)
+        ):
+            raise RuntimeError(
+                "Legacy ROCm GPU assignment is invalid; run 'ods gpu reassign --auto'"
+            )
+        llama_gpus = [index_to_uuid[token] for token in requested_indices]
+    else:
+        llama_gpus = [token.strip() for token in raw_uuids.split(",") if token.strip()]
+        if (
+            not llama_gpus
+            or len(llama_gpus) != len(set(llama_gpus))
+            or any(uuid not in uuid_to_index for uuid in llama_gpus)
+        ):
+            raise RuntimeError(
+                "Legacy ROCm GPU assignment is invalid; run 'ods gpu reassign --auto'"
+            )
+
+    split_mode = str(env.get("LLAMA_ARG_SPLIT_MODE") or "none").strip().lower()
+    parallelism_mode = {"row": "tensor", "layer": "pipeline"}.get(split_mode, "none")
+    llama_service = {
+        "gpus": llama_gpus,
+        "gpu_indices": [uuid_to_index[uuid] for uuid in llama_gpus],
+        "parallelism": {
+            "mode": parallelism_mode,
+            "tensor_parallel_size": len(llama_gpus) if parallelism_mode == "tensor" else 1,
+            "pipeline_parallel_size": (
+                len(llama_gpus) if parallelism_mode == "pipeline" else 1
+            ),
+            "gpu_memory_utilization": 0.95,
+        },
+    }
+    tensor_split = [
+        token.strip()
+        for token in str(env.get("LLAMA_ARG_TENSOR_SPLIT") or "").split(",")
+        if token.strip()
+    ]
+    if len(tensor_split) == len(llama_gpus):
+        try:
+            parsed_split = [float(token) for token in tensor_split]
+        except ValueError:
+            parsed_split = []
+        if parsed_split and all(math.isfinite(value) and value > 0 for value in parsed_split):
+            llama_service["parallelism"]["tensor_split"] = parsed_split
+
+    services = {"llama_server": llama_service}
+    for service, index_key, uuid_key in (
+        ("whisper", "WHISPER_GPU_INDEX", "WHISPER_GPU_UUID"),
+        ("comfyui", "COMFYUI_GPU_INDEX", "COMFYUI_GPU_UUID"),
+        ("embeddings", "EMBEDDINGS_GPU_INDEX", "EMBEDDINGS_GPU_UUID"),
+    ):
+        index_token = str(env.get(index_key) or "").strip()
+        uuid = index_to_uuid.get(index_token) or str(env.get(uuid_key) or "").strip()
+        if uuid in uuid_to_index:
+            services[service] = {
+                "gpus": [uuid],
+                "gpu_indices": [uuid_to_index[uuid]],
+            }
+    return {
+        "gpu_assignment": {
+            "version": "1.0",
+            "strategy": "colocated",
+            "services": services,
+        }
+    }
+
+
+def _amd_architecture_plan(
+    env: dict,
+    topology: dict,
+    planned_gpus: list[str],
+) -> tuple[dict[str, str], list[str]]:
+    """Keep ODS-managed ROCm architecture overrides valid for the new subset."""
+    gpu_by_uuid = {
+        str(gpu.get("uuid") or "").strip(): gpu
+        for gpu in topology.get("gpus") or []
+        if isinstance(gpu, dict) and str(gpu.get("uuid") or "").strip()
+    }
+    gfx_versions = []
+    for uuid in planned_gpus:
+        gfx = str((gpu_by_uuid.get(uuid) or {}).get("gfx_version") or "").strip().lower()
+        if not gfx or gfx in {"unknown", "null"}:
+            raise RuntimeError(
+                "ROCm topology is missing a gfx architecture for a planned GPU; "
+                "run 'ods gpu reassign --manual' or refresh hardware detection"
+            )
+        gfx_versions.append(gfx)
+
+    unique_gfx = set(gfx_versions)
+    if "gfx1151" in unique_gfx and len(unique_gfx) > 1:
+        raise RuntimeError(
+            "ODS cannot safely combine gfx1151 with a different AMD architecture "
+            "in one llama-server process; choose a compatible set with "
+            "'ods gpu reassign --manual'"
+        )
+
+    updates: dict[str, str] = {}
+    removals: list[str] = []
+    if unique_gfx == {"gfx1151"}:
+        updates["HSA_OVERRIDE_GFX_VERSION"] = "11.5.1"
+        updates["LEMONADE_LLAMACPP_ROCM_BIN"] = "/opt/llama-custom/llama-server"
+    else:
+        ods_managed_values = {
+            "HSA_OVERRIDE_GFX_VERSION": "11.5.1",
+            "LEMONADE_LLAMACPP_ROCM_BIN": "/opt/llama-custom/llama-server",
+        }
+        for key, ods_value in ods_managed_values.items():
+            if str(env.get(key) or "").strip() == ods_value:
+                removals.append(key)
+    return updates, removals
+
+
+def _plan_amd_model_gpu_assignment(
+    env: dict,
+    model: dict,
+    target: Path,
+    *,
+    context_length: int | None = None,
+    runtime_profile: dict | None = None,
+) -> dict | None:
+    """Expand a managed Linux ROCm assignment as part of model activation."""
+    if str(env.get("GPU_BACKEND") or "").lower() != "amd":
+        return None
+    if str(env.get("AMD_INFERENCE_LOCATION") or "container").lower() != "container":
+        return None
+    if str(env.get("AMD_INFERENCE_MANAGED") or "true").lower() in {"0", "false", "no"}:
+        return None
+    try:
+        gpu_count = int(env.get("GPU_COUNT") or 1)
+    except (TypeError, ValueError):
+        return None
+    if gpu_count <= 1:
+        return None
+
+    encoded_assignment = str(env.get("GPU_ASSIGNMENT_JSON_B64") or "").strip()
+    current_assignment = _decode_gpu_assignment(encoded_assignment)
+    if current_assignment is None and encoded_assignment:
+        raise RuntimeError(
+            "Persisted GPU assignment is malformed; run 'ods gpu reassign --auto'"
+        )
+
+    legacy_indices = str(
+        env.get("LLAMA_SERVER_GPU_INDICES")
+        or env.get("ROCR_VISIBLE_DEVICES")
+        or ""
+    ).strip()
+    legacy_uuids = str(env.get("LLAMA_SERVER_GPU_UUIDS") or "").strip()
+    if current_assignment is None and not legacy_indices and not legacy_uuids:
+        # Empty ROCr visibility exposes all devices, so no subset expansion is
+        # needed and an operator may intentionally be managing it externally.
+        return None
+
+    topology_path = INSTALL_DIR / "config" / "gpu-topology.json"
+    try:
+        topology = json.loads(topology_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Multi-GPU topology is unavailable: {exc}") from exc
+    if str(topology.get("vendor") or "").lower() != "amd":
+        raise RuntimeError("Multi-GPU topology does not describe AMD devices")
+
+    if current_assignment is None:
+        current_assignment = _legacy_amd_gpu_assignment(env, topology)
+        if current_assignment is None:  # Defensive: restriction checked above.
+            raise RuntimeError("Legacy ROCm GPU assignment could not be recovered")
+
+    plan = _build_model_gpu_assignment_plan(
+        current_assignment,
+        topology,
+        model,
+        target,
+        context_length=context_length,
+        runtime_profile=runtime_profile,
+    )
+    if plan is None:
+        return None
+
+    planned_indices = plan["env_updates"]["LLAMA_SERVER_GPU_INDICES"]
+    plan["env_updates"]["ROCR_VISIBLE_DEVICES"] = planned_indices
+    arch_updates, arch_removals = _amd_architecture_plan(
+        env,
+        topology,
+        plan["planned_gpus"],
+    )
+    plan["env_updates"].update(arch_updates)
+    plan["env_removals"].extend(arch_removals)
+    return plan
 
 
 def _safe_model_artifact_path(models_dir: Path, filename: object) -> Path | None:
@@ -6714,6 +7031,18 @@ class AgentHandler(BaseHTTPRequestHandler):
                     context_length=context_length,
                     runtime_profile=runtime_profile,
                 )
+            elif (
+                platform.system() == "Linux"
+                and str(gpu_backend).lower() == "amd"
+                and not windows_native_llama
+            ):
+                gpu_assignment_plan = _plan_amd_model_gpu_assignment(
+                    env_pre,
+                    model,
+                    target,
+                    context_length=context_length,
+                    runtime_profile=runtime_profile,
+                )
 
             # Capture every mutable file and service state before the first write.
             env_snapshot = _snapshot_text_file(env_path)
@@ -6842,6 +7171,8 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "LLAMA_ARG_SPEC_TYPE",
                     "LLAMA_ARG_SPEC_DRAFT_N_MAX",
                 }
+                if gpu_assignment_plan:
+                    remove_keys.update(gpu_assignment_plan.get("env_removals") or [])
                 remove_keys.difference_update(updates)
                 # Only update LLAMA_SERVER_IMAGE on Docker backends.
                 # macOS runs llama-server natively (no Docker image to pull).
@@ -10597,8 +10928,10 @@ def _compose_restart_llama_server(env: dict):
             _run(["docker", "compose"] + compose_flags + ["stop", "llama-server"], 120)
             _run(["docker", "compose"] + compose_flags + ["up", "-d", "llama-server"], 300)
         else:
-            _run(["docker", "stop", "ods-llama-server"], 120)
-            _run(["docker", "start", "ods-llama-server"], 300)
+            # A plain start reuses the old container environment and would
+            # silently ignore a newly planned ROCR_VISIBLE_DEVICES subset.
+            logger.warning("No compose flags — using AMD container recreation fallback")
+            _recreate_llama_server(env)
     else:
         # llama.cpp: recreate to pick up new GGUF_FILE from .env
         if compose_flags:
@@ -10777,6 +11110,8 @@ def _llama_recreate_argv(
     replacement_keys = {
         "LLAMA_PARALLEL", "LLAMA_REASONING", "GGUF_FILE", "LLM_MODEL",
         "CTX_SIZE", "MAX_CONTEXT", "LLAMA_SERVER_IMAGE",
+        "ROCR_VISIBLE_DEVICES", "LLAMA_SERVER_GPU_INDICES",
+        "HSA_OVERRIDE_GFX_VERSION", "LEMONADE_LLAMACPP_ROCM_BIN",
     }
     replacement_env = {
         key: str(value)
@@ -10787,6 +11122,15 @@ def _llama_recreate_argv(
         visible_devices = str(env.get("LLAMA_SERVER_GPU_UUIDS") or "").strip()
         if visible_devices:
             replacement_env["NVIDIA_VISIBLE_DEVICES"] = visible_devices
+    elif str(env.get("GPU_BACKEND") or "").lower() == "amd":
+        for key in (
+            "ROCR_VISIBLE_DEVICES",
+            "LLAMA_SERVER_GPU_INDICES",
+            "HSA_OVERRIDE_GFX_VERSION",
+            "LEMONADE_LLAMACPP_ROCM_BIN",
+        ):
+            if key in env:
+                replacement_env[key] = str(env.get(key) or "")
     seen_env_keys = set()
     for entry in container_config.get("Env") or []:
         key = str(entry).split("=", 1)[0]

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -1026,6 +1026,11 @@ def _run_gpu_planner(topology: dict, required_mb: int) -> dict:
     return planned
 
 
+def _run_nvidia_gpu_planner(topology: dict, required_mb: int) -> dict:
+    """Preserve the NVIDIA safety-test hook over the shared planner."""
+    return _run_gpu_planner(topology, required_mb)
+
+
 def _build_model_gpu_assignment_plan(
     current_assignment: dict,
     topology: dict,

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -10955,6 +10955,52 @@ def _as_argv(value: object) -> list[str]:
     return []
 
 
+def _refresh_llamacpp_passthrough(value: str, env: dict) -> str:
+    """Refresh model-swap flags embedded in Lemonade's --llamacpp-args."""
+    replacements = {}
+    if "LLAMA_ARG_SPLIT_MODE" in env:
+        replacements["--split-mode"] = str(env.get("LLAMA_ARG_SPLIT_MODE") or "none")
+    if "LLAMA_ARG_TENSOR_SPLIT" in env:
+        replacements["--tensor-split"] = str(env.get("LLAMA_ARG_TENSOR_SPLIT") or "").strip()
+    if not replacements:
+        return value
+
+    try:
+        arguments = shlex.split(value)
+    except ValueError:
+        return value
+
+    refreshed = []
+    seen = set()
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        matched = False
+        for flag, replacement in replacements.items():
+            if argument == flag:
+                seen.add(flag)
+                if replacement:
+                    refreshed.extend([flag, replacement])
+                index += 2 if index + 1 < len(arguments) else 1
+                matched = True
+                break
+            if argument.startswith(f"{flag}="):
+                seen.add(flag)
+                if replacement:
+                    refreshed.extend([flag, replacement])
+                index += 1
+                matched = True
+                break
+        if not matched:
+            refreshed.append(argument)
+            index += 1
+
+    for flag, replacement in replacements.items():
+        if flag not in seen and replacement:
+            refreshed.extend([flag, replacement])
+    return shlex.join(refreshed)
+
+
 def _refresh_llama_cmd(command: list[str], env: dict) -> list[str]:
     replacements = {
         "--model": f"/models/{env.get('GGUF_FILE', '')}",
@@ -10965,6 +11011,22 @@ def _refresh_llama_cmd(command: list[str], env: dict) -> list[str]:
     index = 0
     while index < len(command):
         argument = command[index]
+        if argument == "--llamacpp-args" and index + 1 < len(command):
+            refreshed.extend(
+                [
+                    argument,
+                    _refresh_llamacpp_passthrough(str(command[index + 1]), env),
+                ]
+            )
+            index += 2
+            continue
+        if argument.startswith("--llamacpp-args="):
+            value = argument.split("=", 1)[1]
+            refreshed.append(
+                f"--llamacpp-args={_refresh_llamacpp_passthrough(value, env)}"
+            )
+            index += 1
+            continue
         matched = False
         for flag, replacement in replacements.items():
             if argument == flag and index + 1 < len(command):

--- a/ods/docs/MODEL-MANAGEMENT.md
+++ b/ods/docs/MODEL-MANAGEMENT.md
@@ -90,19 +90,29 @@ downstream routes before reporting success. A late failure restores the prior
 files, runtime, and persisted app routes and then proves the previous model is
 serving again.
 
-On Linux NVIDIA installations with more than one GPU, the same transaction
-also checks the target model's declared or size-derived VRAM envelope against
-the persisted llama-server assignment. If the existing subset is too small,
-ODS reruns the topology planner, expands llama-server to a sufficient GPU
-subset, and updates
+On Linux NVIDIA and managed Linux AMD/ROCm installations with more than one
+GPU, the same transaction also checks the target model's declared or
+size-derived VRAM envelope against the persisted llama-server assignment. If
+the existing subset is too small, ODS reruns the topology planner, expands
+llama-server to a sufficient GPU subset, and updates
 `GPU_ASSIGNMENT_JSON_B64`, `LLAMA_SERVER_GPU_UUIDS`,
 `LLAMA_SERVER_GPU_INDICES`, `LLAMA_ARG_SPLIT_MODE`, and
 `LLAMA_ARG_TENSOR_SPLIT` atomically with the model route. Pipeline assignments
 clear a stale explicit tensor split so llama.cpp can fit layers to the live
 free memory of heterogeneous cards. If activation fails, the previous model
 and GPU assignment are both restored and health-proven before rollback is
-reported as successful. Single-GPU, AMD, Apple, Windows-native, and
-unpersisted all-GPU fallback configurations keep their existing behavior.
+reported as successful.
+
+For AMD, ODS also updates `ROCR_VISIBLE_DEVICES`. The runtime accepts the
+expanded assignment only when every selected GPU has a detected `gfx`
+architecture. A homogeneous `gfx1151` set receives the ODS-managed HSA override
+and custom llama.cpp binary; ODS refuses to combine `gfx1151` with another
+architecture in one llama-server process because that override is not
+device-scoped. Custom operator-provided HSA or llama.cpp override values are
+preserved; only the exact values managed by ODS are removed when they no longer
+match the selected GPU architecture.
+Single-GPU, Apple, Windows-native AMD/Lemonade, externally managed inference,
+and unpersisted all-GPU fallback configurations keep their existing behavior.
 
 To inspect or intentionally override a multi-GPU plan, use the supported CLI
 instead of editing the encoded assignment in `.env`:

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -1500,6 +1500,80 @@ class TestRecreateLlamaServerFromInspect:
             "-lc", "exec lemonade-server serve --port 8080",
         ]
 
+    def test_amd_recreate_refreshes_lemonade_split_contract(
+        self, monkeypatch,
+    ):
+        inspect_config = {
+            "Config": {
+                "Image": "host.example/lemonade:amd",
+                "Entrypoint": ["/bin/sh", "/opt/lemonade-entrypoint.sh"],
+                "Cmd": [
+                    "serve",
+                    "--port",
+                    "8080",
+                    "--llamacpp-args",
+                    "--metrics --host 0.0.0.0 --split-mode=row "
+                    "--tensor-split 3,1",
+                ],
+                "Env": [
+                    "GPU_BACKEND=amd",
+                    "LLAMA_ARG_SPLIT_MODE=row",
+                    "LLAMA_ARG_TENSOR_SPLIT=3,1",
+                    "ROCR_VISIBLE_DEVICES=0,1",
+                ],
+            },
+            "HostConfig": {},
+            "NetworkSettings": {"Networks": {}},
+            "Mounts": [],
+        }
+        env = {
+            "GPU_BACKEND": "amd",
+            "LLAMA_ARG_SPLIT_MODE": "layer",
+            "LLAMA_ARG_TENSOR_SPLIT": "",
+            "ROCR_VISIBLE_DEVICES": "0,1,2",
+            "LLAMA_SERVER_GPU_INDICES": "0,1,2",
+        }
+
+        argv, _calls = self._capture_recreate(monkeypatch, inspect_config, env)
+
+        passthrough_index = argv.index("--llamacpp-args")
+        assert argv[passthrough_index + 1] == (
+            "--metrics --host 0.0.0.0 --split-mode layer"
+        )
+        assert "LLAMA_ARG_SPLIT_MODE=layer" in argv
+        assert "LLAMA_ARG_TENSOR_SPLIT=" in argv
+        assert "ROCR_VISIBLE_DEVICES=0,1,2" in argv
+
+    @pytest.mark.parametrize(
+        ("original", "expected"),
+        [
+            (
+                "--metrics --split-mode row --tensor-split=2,1",
+                "--metrics --split-mode layer",
+            ),
+            (
+                "--metrics --split-mode=row",
+                "--metrics --split-mode layer",
+            ),
+            (
+                "--metrics",
+                "--metrics --split-mode layer",
+            ),
+        ],
+    )
+    def test_refresh_lemonade_passthrough_handles_supported_flag_forms(
+        self,
+        original,
+        expected,
+    ):
+        assert _mod._refresh_llamacpp_passthrough(
+            original,
+            {
+                "LLAMA_ARG_SPLIT_MODE": "layer",
+                "LLAMA_ARG_TENSOR_SPLIT": "",
+            },
+        ) == expected
+
     def test_nvidia_recreate_preserves_device_request_full_command_and_networks(
         self, monkeypatch,
     ):

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -2471,6 +2471,29 @@ def test_amd_model_gpu_plan_preserves_sufficient_assignment(tmp_path, monkeypatc
     ) is None
 
 
+def test_amd_selected_context_can_expand_persisted_gpu_subset(tmp_path, monkeypatch):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    model = {
+        "id": "amd-context-test",
+        "vram_required_gb": 28,
+        "size_mb": 24000,
+    }
+
+    assert _mod._plan_amd_model_gpu_assignment(env, model, target) is None
+
+    plan = _mod._plan_amd_model_gpu_assignment(
+        env,
+        model,
+        target,
+        context_length=131072,
+    )
+
+    assert plan is not None
+    assert plan["required_mb"] == 38339
+    assert plan["previous_gpus"] == ["AMD-card-0", "AMD-card-1"]
+    assert plan["planned_gpus"] == ["AMD-card-0", "AMD-card-1", "AMD-card-2"]
+
+
 def test_amd_model_gpu_plan_is_idempotent_after_expansion(tmp_path, monkeypatch):
     _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
     first_plan = _mod._plan_amd_model_gpu_assignment(

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -1332,6 +1332,34 @@ class TestComposeRestartLlamaServer:
             ],
         ]
 
+    def test_amd_without_compose_flags_recreates_to_apply_rocm_visibility(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        recreated = []
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(_mod, "resolve_compose_flags", lambda: [])
+        monkeypatch.setattr(
+            _mod,
+            "_recreate_llama_server",
+            lambda env: recreated.append(dict(env)),
+        )
+
+        _compose_restart_llama_server(
+            {
+                "GPU_BACKEND": "amd",
+                "ROCR_VISIBLE_DEVICES": "0,1,2",
+            }
+        )
+
+        assert recreated == [
+            {
+                "GPU_BACKEND": "amd",
+                "ROCR_VISIBLE_DEVICES": "0,1,2",
+            }
+        ]
+
 
 class TestRecreateLlamaServerFromInspect:
 
@@ -1368,6 +1396,10 @@ class TestRecreateLlamaServerFromInspect:
                     "CTX_SIZE=4096",
                     "MAX_CONTEXT=4096",
                     "LLAMA_SERVER_IMAGE=host.example/lemonade:amd",
+                    "ROCR_VISIBLE_DEVICES=0,1",
+                    "LLAMA_SERVER_GPU_INDICES=0,1",
+                    "HSA_OVERRIDE_GFX_VERSION=11.5.1",
+                    "LEMONADE_LLAMACPP_ROCM_BIN=/opt/llama-custom/llama-server",
                 ],
                 "Labels": {"com.docker.compose.service": "llama-server"},
                 "Hostname": "llama-amd",
@@ -1424,6 +1456,9 @@ class TestRecreateLlamaServerFromInspect:
             "MAX_CONTEXT": "65536",
             "LLM_MODEL": "new-amd",
             "LLAMA_SERVER_IMAGE": "host.example/lemonade:amd",
+            "GPU_BACKEND": "amd",
+            "ROCR_VISIBLE_DEVICES": "0,1,2",
+            "LLAMA_SERVER_GPU_INDICES": "0,1,2",
         }
 
         argv, calls = self._capture_recreate(monkeypatch, inspect_config, env)
@@ -1453,6 +1488,10 @@ class TestRecreateLlamaServerFromInspect:
         assert "CTX_SIZE=65536" in argv
         assert "MAX_CONTEXT=65536" in argv
         assert "LLAMA_SERVER_IMAGE=host.example/lemonade:amd" in argv
+        assert "ROCR_VISIBLE_DEVICES=0,1,2" in argv
+        assert "LLAMA_SERVER_GPU_INDICES=0,1,2" in argv
+        assert not any(arg.startswith("HSA_OVERRIDE_GFX_VERSION=") for arg in argv)
+        assert not any(arg.startswith("LEMONADE_LLAMACPP_ROCM_BIN=") for arg in argv)
         image_index = argv.index("host.example/lemonade:amd")
         assert argv[argv.index("--entrypoint"):argv.index("--entrypoint") + 2] == [
             "--entrypoint", "/bin/sh",
@@ -2227,6 +2266,353 @@ def _write_nvidia_gpu_plan_fixture(tmp_path, monkeypatch):
     return install_dir, target, env
 
 
+def _amd_gpu_contract():
+    topology = {
+        "vendor": "amd",
+        "gpu_count": 3,
+        "gpus": [
+            {
+                "index": 0,
+                "uuid": "AMD-card-0",
+                "name": "Radeon PRO W7900",
+                "memory_gb": 16,
+                "gfx_version": "gfx1100",
+                "memory_type": "discrete",
+            },
+            {
+                "index": 1,
+                "uuid": "AMD-card-1",
+                "name": "Radeon PRO W7900",
+                "memory_gb": 16,
+                "gfx_version": "gfx1100",
+                "memory_type": "discrete",
+            },
+            {
+                "index": 2,
+                "uuid": "AMD-card-2",
+                "name": "Radeon PRO W7900",
+                "memory_gb": 16,
+                "gfx_version": "gfx1100",
+                "memory_type": "discrete",
+            },
+        ],
+        "links": [
+            {"gpu_a": 0, "gpu_b": 1, "link_type": "PCIE", "link_label": "PHB", "rank": 30},
+            {"gpu_a": 0, "gpu_b": 2, "link_type": "PCIE", "link_label": "PHB", "rank": 30},
+            {"gpu_a": 1, "gpu_b": 2, "link_type": "PCIE", "link_label": "PHB", "rank": 30},
+        ],
+    }
+    assignment = {
+        "gpu_assignment": {
+            "version": "1.0",
+            "strategy": "colocated",
+            "services": {
+                "llama_server": {
+                    "gpus": ["AMD-card-0", "AMD-card-1"],
+                    "gpu_indices": [0, 1],
+                    "parallelism": {
+                        "mode": "pipeline",
+                        "tensor_parallel_size": 1,
+                        "pipeline_parallel_size": 2,
+                        "gpu_memory_utilization": 0.95,
+                    },
+                },
+                "whisper": {"gpus": ["AMD-card-2"], "gpu_indices": [2]},
+            },
+        }
+    }
+    return topology, assignment
+
+
+def _install_amd_gpu_contract(install_dir, env_path):
+    config_dir = install_dir / "config"
+    scripts_dir = install_dir / "scripts"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    planner_source = _agent_path.parents[1] / "scripts" / "assign_gpus.py"
+    (scripts_dir / "assign_gpus.py").write_text(
+        planner_source.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    topology, assignment = _amd_gpu_contract()
+    (config_dir / "gpu-topology.json").write_text(
+        json.dumps(topology),
+        encoding="utf-8",
+    )
+    encoded = base64.b64encode(
+        json.dumps(assignment, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    with env_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            "GPU_COUNT=3\n"
+            "AMD_INFERENCE_LOCATION=container\n"
+            "AMD_INFERENCE_MANAGED=true\n"
+            f"GPU_ASSIGNMENT_JSON_B64={encoded}\n"
+            "LLAMA_SERVER_GPU_UUIDS=AMD-card-0,AMD-card-1\n"
+            "LLAMA_SERVER_GPU_INDICES=0,1\n"
+            "ROCR_VISIBLE_DEVICES=0,1\n"
+            "LLAMA_ARG_SPLIT_MODE=layer\n"
+            "LLAMA_ARG_TENSOR_SPLIT=\n"
+        )
+    return encoded
+
+
+def _write_amd_gpu_plan_fixture(tmp_path, monkeypatch):
+    install_dir = tmp_path / "install"
+    models_dir = install_dir / "data" / "models"
+    models_dir.mkdir(parents=True)
+    env_path = install_dir / ".env"
+    env_path.write_text("GPU_BACKEND=amd\n", encoding="utf-8")
+    _install_amd_gpu_contract(install_dir, env_path)
+    target = models_dir / "target.gguf"
+    target.write_bytes(b"model")
+    env = _mod.load_env(env_path)
+    monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+    return install_dir, target, env
+
+
+def test_amd_model_gpu_plan_expands_persisted_rocm_subset(tmp_path, monkeypatch):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+
+    plan = _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    )
+
+    assert plan is not None
+    assert plan["previous_gpus"] == ["AMD-card-0", "AMD-card-1"]
+    assert plan["planned_gpus"] == ["AMD-card-0", "AMD-card-1", "AMD-card-2"]
+    assert plan["env_updates"]["LLAMA_SERVER_GPU_INDICES"] == "0,1,2"
+    assert plan["env_updates"]["ROCR_VISIBLE_DEVICES"] == "0,1,2"
+
+
+def test_amd_model_gpu_plan_preserves_sufficient_assignment(tmp_path, monkeypatch):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+
+    assert _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 28, "size_mb": 24000},
+        target,
+    ) is None
+
+
+def test_amd_model_gpu_plan_is_idempotent_after_expansion(tmp_path, monkeypatch):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    first_plan = _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    )
+    env.update(first_plan["env_updates"])
+
+    assert _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    ) is None
+
+
+def test_amd_model_gpu_plan_migrates_legacy_rocm_indices(tmp_path, monkeypatch):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    env.pop("GPU_ASSIGNMENT_JSON_B64")
+    env.pop("LLAMA_SERVER_GPU_UUIDS")
+
+    plan = _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    )
+
+    assert plan["previous_gpus"] == ["AMD-card-0", "AMD-card-1"]
+    migrated = _mod._decode_gpu_assignment(
+        plan["env_updates"]["GPU_ASSIGNMENT_JSON_B64"]
+    )
+    assert migrated["gpu_assignment"]["services"]["llama_server"]["gpu_indices"] == [
+        0,
+        1,
+        2,
+    ]
+
+
+def test_amd_model_gpu_plan_rejects_invalid_legacy_rocm_indices(
+    tmp_path,
+    monkeypatch,
+):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    env.pop("GPU_ASSIGNMENT_JSON_B64")
+    env.pop("LLAMA_SERVER_GPU_UUIDS")
+    env["LLAMA_SERVER_GPU_INDICES"] = "0,9"
+    env["ROCR_VISIBLE_DEVICES"] = "0,9"
+
+    with pytest.raises(RuntimeError, match="Legacy ROCm GPU assignment is invalid"):
+        _mod._plan_amd_model_gpu_assignment(
+            env,
+            {"vram_required_gb": 40, "size_mb": 35000},
+            target,
+        )
+
+
+def test_amd_model_gpu_plan_preserves_unrestricted_all_gpu_runtime(
+    tmp_path,
+    monkeypatch,
+):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    for key in (
+        "GPU_ASSIGNMENT_JSON_B64",
+        "LLAMA_SERVER_GPU_UUIDS",
+        "LLAMA_SERVER_GPU_INDICES",
+        "ROCR_VISIBLE_DEVICES",
+    ):
+        env.pop(key, None)
+
+    assert _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    ) is None
+
+
+def test_amd_model_gpu_plan_rejects_small_manual_assignment(tmp_path, monkeypatch):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    assignment = _mod._decode_gpu_assignment(env["GPU_ASSIGNMENT_JSON_B64"])
+    assignment["gpu_assignment"]["strategy"] = "manual"
+    env["GPU_ASSIGNMENT_JSON_B64"] = base64.b64encode(
+        json.dumps(assignment, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+
+    with pytest.raises(RuntimeError, match="ods gpu reassign --manual"):
+        _mod._plan_amd_model_gpu_assignment(
+            env,
+            {"vram_required_gb": 40, "size_mb": 35000},
+            target,
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"AMD_INFERENCE_LOCATION": "host"},
+        {"AMD_INFERENCE_LOCATION": "external"},
+        {"AMD_INFERENCE_MANAGED": "false"},
+        {"GPU_COUNT": "1"},
+    ],
+)
+def test_amd_model_gpu_plan_leaves_unmanaged_or_single_gpu_runtime_unchanged(
+    tmp_path,
+    monkeypatch,
+    overrides,
+):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    env.update(overrides)
+
+    assert _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    ) is None
+
+
+def test_amd_model_gpu_plan_rejects_non_amd_topology(tmp_path, monkeypatch):
+    install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    topology_path = install_dir / "config" / "gpu-topology.json"
+    topology = json.loads(topology_path.read_text(encoding="utf-8"))
+    topology["vendor"] = "nvidia"
+    topology_path.write_text(json.dumps(topology), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="does not describe AMD"):
+        _mod._plan_amd_model_gpu_assignment(
+            env,
+            {"vram_required_gb": 40, "size_mb": 35000},
+            target,
+        )
+
+
+def test_amd_model_gpu_plan_rejects_unknown_planned_gfx(tmp_path, monkeypatch):
+    install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    topology_path = install_dir / "config" / "gpu-topology.json"
+    topology = json.loads(topology_path.read_text(encoding="utf-8"))
+    topology["gpus"][2]["gfx_version"] = "unknown"
+    topology_path.write_text(json.dumps(topology), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="missing a gfx architecture"):
+        _mod._plan_amd_model_gpu_assignment(
+            env,
+            {"vram_required_gb": 40, "size_mb": 35000},
+            target,
+        )
+
+
+def test_amd_model_gpu_plan_rejects_mixed_gfx1151_runtime(tmp_path, monkeypatch):
+    install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    topology_path = install_dir / "config" / "gpu-topology.json"
+    topology = json.loads(topology_path.read_text(encoding="utf-8"))
+    topology["gpus"][2]["gfx_version"] = "gfx1151"
+    topology_path.write_text(json.dumps(topology), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="cannot safely combine gfx1151"):
+        _mod._plan_amd_model_gpu_assignment(
+            env,
+            {"vram_required_gb": 40, "size_mb": 35000},
+            target,
+        )
+
+
+def test_amd_model_gpu_plan_sets_strix_halo_runtime_contract(tmp_path, monkeypatch):
+    install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    topology_path = install_dir / "config" / "gpu-topology.json"
+    topology = json.loads(topology_path.read_text(encoding="utf-8"))
+    for gpu in topology["gpus"]:
+        gpu["gfx_version"] = "gfx1151"
+    topology_path.write_text(json.dumps(topology), encoding="utf-8")
+
+    plan = _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    )
+
+    assert plan["env_updates"]["HSA_OVERRIDE_GFX_VERSION"] == "11.5.1"
+    assert (
+        plan["env_updates"]["LEMONADE_LLAMACPP_ROCM_BIN"]
+        == "/opt/llama-custom/llama-server"
+    )
+    assert plan["env_removals"] == []
+
+
+def test_amd_model_gpu_plan_removes_only_ods_managed_strix_overrides(
+    tmp_path,
+    monkeypatch,
+):
+    _install_dir, target, env = _write_amd_gpu_plan_fixture(tmp_path, monkeypatch)
+    env.update(
+        {
+            "HSA_OVERRIDE_GFX_VERSION": "11.5.1",
+            "LEMONADE_LLAMACPP_ROCM_BIN": "/opt/llama-custom/llama-server",
+        }
+    )
+
+    plan = _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    )
+
+    assert set(plan["env_removals"]) == {
+        "HSA_OVERRIDE_GFX_VERSION",
+        "LEMONADE_LLAMACPP_ROCM_BIN",
+    }
+
+    env["HSA_OVERRIDE_GFX_VERSION"] = "10.3.0"
+    env["LEMONADE_LLAMACPP_ROCM_BIN"] = "/opt/operator/llama-server"
+    custom_plan = _mod._plan_amd_model_gpu_assignment(
+        env,
+        {"vram_required_gb": 40, "size_mb": 35000},
+        target,
+    )
+    assert custom_plan["env_removals"] == []
+
+
 def test_model_gpu_plan_expands_davep_two_gpu_assignment(tmp_path, monkeypatch):
     _install_dir, target, env = _write_nvidia_gpu_plan_fixture(tmp_path, monkeypatch)
 
@@ -2907,6 +3293,116 @@ class TestModelActivateRollback:
             "GPU-ti-0,GPU-1080,GPU-ti-2"
         )
         assert restart_envs[1]["LLAMA_SERVER_GPU_UUIDS"] == "GPU-ti-0,GPU-1080"
+        assert env_path.read_text(encoding="utf-8") == original_env
+        assert _mod.load_env(env_path)["GPU_ASSIGNMENT_JSON_B64"] == original_assignment
+
+    def test_larger_model_replans_and_commits_amd_rocm_assignment(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        install_dir, env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path, gpu_backend="amd", lemonade=True)
+        )
+        catalog_path = install_dir / "config" / "model-library.json"
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        catalog["models"][0].update({
+            "size_mb": 35000,
+            "vram_required_gb": 40,
+        })
+        catalog_path.write_text(json.dumps(catalog), encoding="utf-8")
+        _install_amd_gpu_contract(install_dir, env_path)
+        restart_envs = []
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(
+            _mod,
+            "_resolve_lemonade_model_id",
+            lambda *_args, **_kwargs: "extra.new-model.gguf",
+        )
+        monkeypatch.setattr(
+            _mod,
+            "_compose_restart_llama_server",
+            lambda env: restart_envs.append(dict(env)),
+        )
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "target-model")
+
+        assert handler.response_code == 200
+        assert handler.parse_response()["gpu_assignment_changed"] is True
+        assert restart_envs[0]["ROCR_VISIBLE_DEVICES"] == "0,1,2"
+        assert restart_envs[0]["LLAMA_SERVER_GPU_INDICES"] == "0,1,2"
+        persisted = _mod.load_env(env_path)
+        assert persisted["ROCR_VISIBLE_DEVICES"] == "0,1,2"
+        assignment = _mod._decode_gpu_assignment(
+            persisted["GPU_ASSIGNMENT_JSON_B64"]
+        )
+        assert assignment["gpu_assignment"]["services"]["llama_server"]["gpus"] == [
+            "AMD-card-0",
+            "AMD-card-1",
+            "AMD-card-2",
+        ]
+        receipt = json.loads(
+            (install_dir / "data" / "model-activation-receipt.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert receipt["gpuAssignment"]["activeGpus"] == [
+            "AMD-card-0",
+            "AMD-card-1",
+            "AMD-card-2",
+        ]
+
+    def test_failed_activation_rolls_back_amd_rocm_assignment(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        install_dir, env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path, gpu_backend="amd", lemonade=True)
+        )
+        catalog_path = install_dir / "config" / "model-library.json"
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        catalog["models"][0].update({
+            "size_mb": 35000,
+            "vram_required_gb": 40,
+        })
+        catalog_path.write_text(json.dumps(catalog), encoding="utf-8")
+        original_assignment = _install_amd_gpu_contract(install_dir, env_path)
+        original_env = env_path.read_text(encoding="utf-8")
+        restart_envs = []
+
+        def readiness(env, *_args, **kwargs):
+            if env.get("GGUF_FILE") == "new-model.gguf":
+                return None if (kwargs.get("return_identity") or kwargs.get("return_proof")) else False
+            return _mock_verified_readiness(*_args, **kwargs)
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(
+            _mod,
+            "_resolve_lemonade_model_id",
+            lambda env, gguf_file, **_kwargs: f"extra.{gguf_file}",
+        )
+        monkeypatch.setattr(
+            _mod,
+            "_compose_restart_llama_server",
+            lambda env: restart_envs.append(dict(env)),
+        )
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", readiness)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "target-model")
+
+        assert handler.response_code == 500
+        assert handler.parse_response()["rolled_back"] is True
+        assert restart_envs[0]["ROCR_VISIBLE_DEVICES"] == "0,1,2"
+        assert restart_envs[1]["ROCR_VISIBLE_DEVICES"] == "0,1"
         assert env_path.read_text(encoding="utf-8") == original_env
         assert _mod.load_env(env_path)["GPU_ASSIGNMENT_JSON_B64"] == original_assignment
 


### PR DESCRIPTION
## Summary

Linux AMD/ROCm installs can persist a llama-server GPU subset sized for the install-time model. A later activation of a larger GGUF updates the model route, but previously retained the old ROCm visibility and split contract. The new model could therefore leave available GPUs unused or fail after mutation.

This PR extends the rollback-safe model activation transaction from #2065 to managed Linux AMD/ROCm runtimes.

## Root cause

- `GPU_ASSIGNMENT_JSON_B64`, `LLAMA_SERVER_GPU_INDICES`, and `ROCR_VISIBLE_DEVICES` remained tied to the previous model envelope.
- The no-compose fallback stopped and started the old container, which cannot apply changed environment variables.
- Its inspect-and-recreate replacement refreshed ROCm environment variables but initially retained the stale `--split-mode` embedded in Lemonade's `--llamacpp-args`.
- AMD architecture overrides are process-wide, so expanding a subset without validating every selected `gfx` target can create an invalid mixed runtime.

## Behavior and invariants

| Invariant | Implementation |
|---|---|
| Do not alter unaffected platforms | Gated to Linux + AMD + managed container inference + multi-GPU |
| Keep sufficient assignments stable | No planner or runtime mutation when current capacity covers the target |
| Respect operator intent | Undersized `manual` assignments fail with the supported reassign command; externally managed and unrestricted all-GPU configurations remain unchanged |
| Preserve auxiliary placement | Only `llama_server` is merged from the new plan; Whisper, ComfyUI, and embeddings retain their assignments |
| Apply ROCm visibility coherently | Canonical assignment, UUID/index projections, split mode, tensor split, and `ROCR_VISIBLE_DEVICES` are written together |
| Keep architecture overrides safe | Every selected GPU requires a known `gfx`; mixed `gfx1151` processes are rejected; exact ODS-managed overrides are removed when no longer applicable, while operator values are preserved |
| Commit model and GPU state atomically | GPU env updates/removals are inside the existing activation snapshot and rollback transaction |
| Apply env changes without Compose flags | Inspect-and-recreate replaces stop/start, preserves the runtime contract, and refreshes ROCm visibility plus Lemonade split/tensor flags while retaining image, mounts, devices, groups, networks, ports, healthcheck, labels, limits, and rollback container |
| Restore on late failure | The exact previous `.env`, assignment, model route, and runtime are restored and health-proven |

## Compatibility

### Included

- Clean managed Linux AMD/ROCm multi-GPU installs
- Existing canonical assignment contracts
- Legacy ROCm index/UUID restrictions
- Repeated activation and idempotent reruns
- Homogeneous discrete AMD sets
- Homogeneous `gfx1151` sets using the managed Strix Halo runtime contract

### Intentionally unchanged

- Windows AMD native Lemonade/Vulkan
- macOS/Metal
- NVIDIA behavior beyond the shared helper from #2065
- Single-GPU systems
- External or unmanaged AMD inference
- Empty/unrestricted ROCr visibility

## Validation

| Evidence | Result |
|---|---|
| Focused planner/activation/recreate/rollback tests | Passed, including selected-context expansion |
| Full `test_model_activate.py` | 230 passed |
| Model activation + GPU planner/API suites | 348 passed |
| Full Dashboard API suite | 1,900 passed, 2 skipped |
| Ruff (`E,F,W`) and Python compile | Passed |
| PowerShell AST parser | 31 files passed |
| Shell syntax (`make lint`) | Passed |
| Linux AMD, NVIDIA, WSL, and macOS dispatch smoke | Passed |
| Installer simulation harness | Passed |
| Real AMD Compose render with GPUs `0,1,2` | Passed; ROCr visibility and layer split rendered correctly |
| Rebase onto exact #2065 head `01197436` | Conflict-free; focused suites passed |
| Independent edge probes for Lemonade passthrough flags | 4 passed |
| `git diff --check` | Passed |

<details>
<summary>Baseline-only validation findings</summary>

- `tests/contracts/test-amd-lemonade-contracts.sh` reports the existing Linux Lemonade Hermes timeout contract failure. The same `63 passed, 1 failed` result reproduces on current `main` at `ac90d567`; this PR does not touch that path.
- BATS failures reproduced on current `main` in the same root/container harness. The PR-specific focused and smoke suites pass.
- The Windows checkout required LF normalization in a disposable Linux copy for shell simulation; no repository files were rewritten for that workaround.

</details>

## Test coverage added

- Two-GPU AMD subset expands to three GPUs for a larger model or a selected context that crosses the capacity boundary
- Sufficient assignment remains byte-for-byte stable
- Second activation is idempotent
- Legacy ROCm indices migrate to canonical assignment state
- Invalid legacy indices and wrong-vendor topology fail before mutation
- Manual, external, unmanaged, single-GPU, and unrestricted configurations remain unchanged
- Unknown `gfx` and unsafe mixed `gfx1151` plans are rejected
- Homogeneous `gfx1151` receives the managed runtime contract
- Only exact ODS-managed architecture overrides are removed
- No-compose recreation applies fresh ROCm env, refreshes embedded Lemonade split flags, clears stale tensor splits, and drops stale architecture overrides
- Successful activation persists a receipt and the expanded assignment
- Late activation failure restores the exact prior AMD env and runtime

## Independent review

A second review started from the final diff without assuming the implementation was correct. It replayed the PR on current `main`, exercised missing and existing passthrough flags, both supported `--flag value` and `--flag=value` forms, empty tensor split removal, preservation of unrelated flags, and rollback/platform gates. No additional reproducible defect was found, so no speculative changes were added.

## Release note

A real Linux AMD/ROCm multi-GPU validation receipt is still required before release because this development host does not expose AMD hardware. The automated suite proves planning, persistence, Compose rendering, recreation, and rollback contracts, but does not substitute for a physical ROCm model-load test.

## Dependency

This is intentionally stacked on #2065 and is now rebased onto its current head (`01197436`). After #2065 merges, this branch must be rebased onto `main` and the checks rerun before merge.

