### PR TITLE
fix(hermes): read slash-worker pids from a known ps layout

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -134,6 +134,11 @@ jobs:
       - name: CPU-Only Path Tests
         run: bash tests/test-cpu-only-path.sh
 
+      - name: Hermes Slash Worker Prune Tests
+        run: |
+          bash tests/test-hermes-slash-worker-prune.sh
+          python3 tests/contracts/test-hermes-worker-guardrails.py
+
       - name: Installer Contract Checks
         run: |
           bash tests/contracts/test-installer-contracts.sh

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -26,6 +26,10 @@ test: ## Run unit and contract tests
 	@bash tests/test-installer-context-parity.sh
 	@bash tests/test-hermes-context-floor.sh
 	@echo ""
+	@echo "=== Hermes slash worker prune ==="
+	@bash tests/test-hermes-slash-worker-prune.sh
+	@python3 tests/contracts/test-hermes-worker-guardrails.py
+	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
 	@bash tests/test-phase03-multigpu-tty.sh

--- a/ods/scripts/prune-hermes-slash-workers.sh
+++ b/ods/scripts/prune-hermes-slash-workers.sh
@@ -67,9 +67,37 @@ if [[ -z "$CONTAINER" ]]; then
     exit 1
 fi
 
+# Turn one process-table layout into the normalized row this script works on:
+#
+#     pid <TAB> age_seconds <TAB> original ps line
+#
+# `has_age=1` means the caller asked ps for an elapsed-time column, so field 2
+# holds seconds. `has_age=0` means the layout only has `pid` then the command,
+# and age is recorded as -1 ("unknown") rather than being read out of whichever
+# column happens to sit in position 2.
+normalize_workers() {
+    local has_age="$1"
+    awk -v has_age="$has_age" '
+        $0 !~ /tui_gateway[.]slash_worker/ {
+            next
+        }
+        {
+            pid = $1
+            if (pid !~ /^[0-9]+$/) {
+                next
+            }
+            age = -1
+            if (has_age == "1" && $2 ~ /^[0-9]+$/) {
+                age = $2
+            }
+            print pid "\t" age "\t" $0
+        }
+    '
+}
+
 collect_workers() {
     if [[ -n "${ODS_HERMES_SLASH_WORKER_PS_FIXTURE:-}" ]]; then
-        cat "$ODS_HERMES_SLASH_WORKER_PS_FIXTURE"
+        normalize_workers 1 < "$ODS_HERMES_SLASH_WORKER_PS_FIXTURE"
         return 0
     fi
 
@@ -78,13 +106,35 @@ collect_workers() {
         return 1
     fi
     if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
-        echo "[INFO] $CONTAINER is not running; nothing to prune"
+        # stderr, not stdout: stdout is the normalized worker stream.
+        echo "[INFO] $CONTAINER is not running; nothing to prune" >&2
         return 0
     fi
 
-    docker exec "$CONTAINER" sh -c \
-        "ps -eo pid=,etimes=,args= 2>/dev/null || ps -ef 2>/dev/null" \
-        | grep '[t]ui_gateway[.]slash_worker' || true
+    # Each ps layout is requested in its own `docker exec` so the caller knows
+    # which columns came back. Asking the container to pick via `A || B` hid
+    # that from us: the shapes differ (`ps -ef` leads with UID, not PID), so a
+    # fallback line was read as pid=<uid>, age=<pid> — which silently pruned
+    # nothing on images that print a UID name, and targeted an unrelated pid on
+    # images that print a numeric UID.
+    local raw
+
+    # procps: pid, elapsed seconds, full command line.
+    if raw="$(docker exec "$CONTAINER" sh -c 'ps -eo pid=,etimes=,args=' 2>/dev/null)" \
+        && [[ -n "$raw" ]]; then
+        printf '%s\n' "$raw" | normalize_workers 1
+        return 0
+    fi
+
+    # POSIX/busybox: same leading pid column, no elapsed-time column available.
+    if raw="$(docker exec "$CONTAINER" sh -c 'ps -eo pid=,args=' 2>/dev/null)" \
+        && [[ -n "$raw" ]]; then
+        printf '%s\n' "$raw" | normalize_workers 0
+        return 0
+    fi
+
+    echo "[WARN] could not read the process table inside $CONTAINER" >&2
+    return 0
 }
 
 WORKERS_FILE="$(mktemp)"
@@ -92,19 +142,7 @@ CANDIDATES_FILE="$(mktemp)"
 OVERAGE_FILE="$(mktemp)"
 trap 'rm -f "$WORKERS_FILE" "$CANDIDATES_FILE" "$OVERAGE_FILE"' EXIT
 
-collect_workers | awk '
-    $0 ~ /tui_gateway[.]slash_worker/ {
-        pid = $1
-        age = $2
-        if (pid !~ /^[0-9]+$/) {
-            next
-        }
-        if (age !~ /^[0-9]+$/) {
-            age = -1
-        }
-        print pid "\t" age "\t" $0
-    }
-' > "$WORKERS_FILE"
+collect_workers > "$WORKERS_FILE"
 
 WORKER_COUNT="$(wc -l < "$WORKERS_FILE" | tr -d ' ')"
 if [[ "$WORKER_COUNT" -eq 0 ]]; then
@@ -117,7 +155,10 @@ awk -F '\t' -v max_age="$MAX_AGE_SECONDS" '$2 >= max_age {print}' \
 
 if [[ "$WORKER_COUNT" -gt "$MAX_COUNT" ]]; then
     OVERAGE=$(( WORKER_COUNT - MAX_COUNT ))
-    sort -t "$(printf '\t')" -k2,2nr "$WORKERS_FILE" \
+    # Oldest first. When the container could not report elapsed time every age
+    # is -1, so break the tie on the lowest pid — the longest-lived worker —
+    # instead of leaving the pick to sort order.
+    sort -t "$(printf '\t')" -k2,2nr -k1,1n "$WORKERS_FILE" \
         | head -n "$OVERAGE" > "$OVERAGE_FILE"
     cat "$OVERAGE_FILE" >> "$CANDIDATES_FILE"
 fi

--- a/ods/scripts/prune-hermes-slash-workers.sh
+++ b/ods/scripts/prune-hermes-slash-workers.sh
@@ -134,7 +134,7 @@ collect_workers() {
     fi
 
     echo "[WARN] could not read the process table inside $CONTAINER" >&2
-    return 0
+    return 1
 }
 
 WORKERS_FILE="$(mktemp)"

--- a/ods/tests/test-hermes-slash-worker-prune.sh
+++ b/ods/tests/test-hermes-slash-worker-prune.sh
@@ -87,6 +87,10 @@ case "${1:-}" in
         [[ "${1:-}" == "-c" ]] && shift
         cmd="${1:-}"
 
+        if [[ "${ODS_TEST_PS_MODE:-procps}" == "broken" ]]; then
+            exit 1
+        fi
+
         if [[ "$cmd" == *"while read"* ]]; then
             cat >> "$ODS_TEST_KILL_LOG"
             exit 0
@@ -206,6 +210,21 @@ if grep -q "is not running" "$OUT"; then
     pass "stopped container: reports that the container is not running"
 else
     fail "stopped container: reports that the container is not running" "$(cat "$OUT")"
+fi
+
+OUT="$WORKDIR/out7.txt"
+KILL_LOG="$WORKDIR/kill7.txt"; : > "$KILL_LOG"
+rc="$(run_prune broken "$OUT")"
+check_eq "unreadable process table: exits nonzero" "1" "$rc"
+if grep -q "could not read the process table" "$OUT"; then
+    pass "unreadable process table: reports the inspection failure"
+else
+    fail "unreadable process table: reports the inspection failure" "$(cat "$OUT")"
+fi
+if grep -q "no Hermes slash workers found" "$OUT"; then
+    fail "unreadable process table: never claims that no workers exist" "$(cat "$OUT")"
+else
+    pass "unreadable process table: never claims that no workers exist"
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────

--- a/ods/tests/test-hermes-slash-worker-prune.sh
+++ b/ods/tests/test-hermes-slash-worker-prune.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Behavioural tests for scripts/prune-hermes-slash-workers.sh.
+#
+# The existing contract test only asserts that guardrail strings appear in the
+# script. Nothing exercised the part that decides which pids get killed, which
+# is where the interesting failure modes live: the script reads a process table
+# out of the Hermes container, and different images ship different `ps`
+# implementations.
+#
+# Run: bash tests/test-hermes-slash-worker-prune.sh
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PRUNE="$ROOT_DIR/scripts/prune-hermes-slash-workers.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; echo "       $2"; FAIL=$((FAIL + 1)); }
+
+check_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$label"
+    else
+        fail "$label" "expected [$expected] got [$actual]"
+    fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# ── Process-table fixtures ────────────────────────────────────────────────
+# pid 101/103 are old, 102 is young. pid 1 and 200 are not slash workers.
+
+cat > "$WORKDIR/procps.txt" <<'EOF'
+    1     9999 /sbin/init
+  101     7200 python -m hermes.tui_gateway.slash_worker --id a
+  102       60 python -m hermes.tui_gateway.slash_worker --id b
+  103     5400 python -m hermes.tui_gateway.slash_worker --id c
+  200      120 /bin/sh
+EOF
+
+# `ps -eo pid=,args=` — POSIX subset, no elapsed-time column.
+cat > "$WORKDIR/posix.txt" <<'EOF'
+    1 /sbin/init
+  101 python -m hermes.tui_gateway.slash_worker --id a
+  102 python -m hermes.tui_gateway.slash_worker --id b
+  103 python -m hermes.tui_gateway.slash_worker --id c
+  200 /bin/sh
+EOF
+
+# `ps -ef` — leads with UID, so the pid sits in column 2. A numeric UID is what
+# containers print when the running uid has no passwd entry.
+cat > "$WORKDIR/ef.txt" <<'EOF'
+UID          PID    PPID  C STIME TTY          TIME CMD
+1000           1       0  0 10:00 ?        00:00:00 /sbin/init
+1000         101       1  0 08:00 ?        00:00:01 python -m hermes.tui_gateway.slash_worker --id a
+1000         102       1  0 11:00 ?        00:00:01 python -m hermes.tui_gateway.slash_worker --id b
+1000         103       1  0 09:00 ?        00:00:01 python -m hermes.tui_gateway.slash_worker --id c
+EOF
+
+# ── docker shim ───────────────────────────────────────────────────────────
+# Models a container image by deciding which `ps` invocations succeed:
+#   ODS_TEST_PS_MODE=procps  → `ps -eo pid=,etimes=,args=` works
+#   ODS_TEST_PS_MODE=posix   → it fails; only `ps -ef` / `ps -eo pid=,args=` work
+# Killed pids are appended to $ODS_TEST_KILL_LOG.
+
+mkdir -p "$WORKDIR/bin"
+cat > "$WORKDIR/bin/docker" <<'SHIM'
+#!/usr/bin/env bash
+set -uo pipefail
+
+case "${1:-}" in
+    ps)
+        [[ "${ODS_TEST_CONTAINER_MISSING:-0}" == "1" ]] && exit 0
+        echo "ods-hermes"
+        exit 0
+        ;;
+    exec)
+        shift
+        while [[ "${1:-}" == -* ]]; do shift; done   # drop -i and friends
+        shift                                        # container name
+        shift 2>/dev/null                            # sh
+        [[ "${1:-}" == "-c" ]] && shift
+        cmd="${1:-}"
+
+        if [[ "$cmd" == *"while read"* ]]; then
+            cat >> "$ODS_TEST_KILL_LOG"
+            exit 0
+        fi
+
+        if [[ "$cmd" == *"etimes"* ]]; then
+            if [[ "${ODS_TEST_PS_MODE:-procps}" == "procps" ]]; then
+                cat "$ODS_TEST_PROCPS_FIXTURE"
+                exit 0
+            fi
+            # etimes is unsupported here. Honour an inline `|| ps -ef` fallback
+            # exactly the way a container shell would.
+            if [[ "$cmd" == *"ps -ef"* ]]; then
+                cat "$ODS_TEST_EF_FIXTURE"
+                exit 0
+            fi
+            exit 1
+        fi
+
+        if [[ "$cmd" == *"pid=,args="* ]]; then
+            cat "$ODS_TEST_POSIX_FIXTURE"
+            exit 0
+        fi
+
+        exit 1
+        ;;
+esac
+exit 0
+SHIM
+chmod +x "$WORKDIR/bin/docker"
+
+export ODS_TEST_PROCPS_FIXTURE="$WORKDIR/procps.txt"
+export ODS_TEST_POSIX_FIXTURE="$WORKDIR/posix.txt"
+export ODS_TEST_EF_FIXTURE="$WORKDIR/ef.txt"
+
+run_prune() {
+    # Usage: run_prune <ps-mode> <output-var-file> [extra args...]
+    local mode="$1"; shift
+    local outfile="$1"; shift
+    ODS_TEST_PS_MODE="$mode" \
+    ODS_TEST_KILL_LOG="$KILL_LOG" \
+    PATH="$WORKDIR/bin:$PATH" \
+        bash "$PRUNE" "$@" > "$outfile" 2>&1
+    echo $?
+}
+
+selected_pids() {
+    # pids the script reported as selected for pruning, comma separated
+    grep -oE '^  pid=[0-9]+' "$1" | grep -oE '[0-9]+' | paste -sd, -
+}
+
+killed_pids() {
+    if [[ -s "$KILL_LOG" ]]; then
+        tr -d ' ' < "$KILL_LOG" | grep -E '^[0-9]+$' | paste -sd, -
+    else
+        echo ""
+    fi
+}
+
+# ── 1. Fixture path: age policy ───────────────────────────────────────────
+
+OUT="$WORKDIR/out1.txt"
+KILL_LOG="$WORKDIR/kill1.txt"; : > "$KILL_LOG"
+ODS_HERMES_SLASH_WORKER_PS_FIXTURE="$WORKDIR/procps.txt" \
+    bash "$PRUNE" --max-age-seconds 3600 --max-count 99 > "$OUT" 2>&1
+check_eq "fixture: only workers older than max-age are selected" "101,103" "$(selected_pids "$OUT")"
+
+# ── 2. Fixture path: count policy prunes the oldest overage ───────────────
+
+OUT="$WORKDIR/out2.txt"
+ODS_HERMES_SLASH_WORKER_PS_FIXTURE="$WORKDIR/procps.txt" \
+    bash "$PRUNE" --max-age-seconds 99999 --max-count 2 > "$OUT" 2>&1
+check_eq "fixture: count overage prunes the single oldest worker" "101" "$(selected_pids "$OUT")"
+
+# ── 3. Container path, procps layout ──────────────────────────────────────
+
+OUT="$WORKDIR/out3.txt"
+KILL_LOG="$WORKDIR/kill3.txt"; : > "$KILL_LOG"
+rc="$(run_prune procps "$OUT" --max-age-seconds 3600 --max-count 99 --force)"
+check_eq "procps container: exits 0" "0" "$rc"
+check_eq "procps container: selects the aged workers" "101,103" "$(selected_pids "$OUT")"
+check_eq "procps container: kills exactly those pids" "101,103" "$(killed_pids)"
+
+# ── 4. Container path, image without an elapsed-time column ───────────────
+#
+# This is the regression. The script used to ask the container shell for
+# `ps -eo pid=,etimes=,args= || ps -ef`; on the fallback branch column 1 is the
+# UID, so pid 1000 (the uid) was pruned and the real workers were left running.
+
+OUT="$WORKDIR/out4.txt"
+KILL_LOG="$WORKDIR/kill4.txt"; : > "$KILL_LOG"
+rc="$(run_prune posix "$OUT" --max-age-seconds 99999 --max-count 1 --force)"
+check_eq "posix container: exits 0" "0" "$rc"
+check_eq "posix container: selects real worker pids, never the uid column" "101,102" "$(selected_pids "$OUT")"
+check_eq "posix container: kills real worker pids" "101,102" "$(killed_pids)"
+
+if grep -q 'pid=1000' "$OUT"; then
+    fail "posix container: uid column must not be read as a pid" "output selected pid=1000"
+else
+    pass "posix container: uid column must not be read as a pid"
+fi
+
+# ── 5. Unknown ages never trip the age policy on their own ────────────────
+
+OUT="$WORKDIR/out5.txt"
+KILL_LOG="$WORKDIR/kill5.txt"; : > "$KILL_LOG"
+rc="$(run_prune posix "$OUT" --max-age-seconds 0 --max-count 99)"
+check_eq "posix container: unknown age is not treated as older than max-age" "" "$(selected_pids "$OUT")"
+
+# ── 6. Stopped container does not leak its notice into the worker stream ──
+
+OUT="$WORKDIR/out6.txt"
+KILL_LOG="$WORKDIR/kill6.txt"; : > "$KILL_LOG"
+rc="$(ODS_TEST_CONTAINER_MISSING=1 run_prune procps "$OUT")"
+check_eq "stopped container: exits 0" "0" "$rc"
+if grep -q "is not running" "$OUT"; then
+    pass "stopped container: reports that the container is not running"
+else
+    fail "stopped container: reports that the container is not running" "$(cat "$OUT")"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "[PASS] Hermes slash worker prune behaviour"


### PR DESCRIPTION
## Problem

`scripts/prune-hermes-slash-workers.sh` asks the container shell to choose its own process-table command:

```sh
ps -eo pid=,etimes=,args= 2>/dev/null || ps -ef 2>/dev/null
```

and then parses whatever comes back as `pid=$1, age=$2`. The two layouts do not line up — `ps -ef` leads with **UID**, so on the fallback branch column 1 is the UID and column 2 is the pid.

Two failure modes, depending on what the Hermes image's `ps` prints:

| image prints | result |
|---|---|
| UID **name** (`root`) | column 1 fails the numeric-pid check, every worker row is dropped → `[PASS] no Hermes slash workers found` while the leak this tool exists to clear keeps growing |
| UID **number** (uid with no passwd entry) | the uid is read as the pid and the real pid is read as an age → `--force` signals an unrelated process and the workers stay up |

Both are silent: `ods repair hermes-workers` reports success either way.

A second, smaller defect: the "container is not running" notice was written to **stdout**, which is the worker stream. It was fed straight into the parser and discarded, so a stopped container also printed `no Hermes slash workers found`.

## Fix

- Request each layout in its own `docker exec` so the caller knows which columns came back, and normalise to `pid / age / command` in one place.
- The POSIX fallback is now `ps -eo pid=,args=` — pid stays in column 1, and the age is recorded as unknown (`-1`) instead of being invented from whatever sits in column 2.
- Unknown ages never satisfy the max-age policy on their own. When a count overage still has to pick victims and no ages are available, the tie breaks on the lowest pid (longest-lived worker) rather than on sort order.
- The stopped-container notice goes to stderr.

Behaviour on procps images — the common case — is unchanged; tests 3 below pin that.

## Tests

`tests/test-hermes-slash-worker-prune.sh` (new) drives the real script through a `docker` shim that models both image families and records which pids get killed. 12 assertions.

Verified red on the pre-fix script:

```
[FAIL] posix container: selects real worker pids, never the uid column
       expected [101,102] got [1000]
[FAIL] posix container: kills real worker pids
       expected [101,102] got [1000]
[FAIL] posix container: uid column must not be read as a pid
       output selected pid=1000
[FAIL] posix container: unknown age is not treated as older than max-age
       expected [] got [1000]
[FAIL] stopped container: reports that the container is not running
       [PASS] no Hermes slash workers found

Passed: 7  Failed: 5
```

Green after the fix (12/12), on both Git Bash and Linux.

`tests/contracts/test-hermes-worker-guardrails.py` already existed but was an orphan — no Makefile target, no CI job, not in `release-gate.sh` — so nothing guarded this script at all. Both tests are now wired into `make test` and the Linux CI job.

`shellcheck -S warning` clean on both scripts.