### PR TITLE
fix(mode-switch): stop --status aborting before it prints anything

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Safe Env Loading Tests
         run: bash tests/test-safe-env.sh
 
+      - name: Mode Switch Tests
+        run: bash tests/test-mode-switch-status.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -56,6 +56,9 @@ test: ## Run unit and contract tests
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
 	@echo ""
+	@echo "=== mode switch status and switching ==="
+	@bash tests/test-mode-switch-status.sh
+	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh

--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -39,8 +39,15 @@ env_set() {
 }
 
 show_status() {
-    local current
-    current=$(grep "^ODS_MODE=" "$ENV_FILE" 2>/dev/null | cut -d= -f2)
+    local current=""
+    if [[ -f "$ENV_FILE" ]]; then
+        # `grep` exits 1 when the key is absent and the script runs under
+        # `set -euo pipefail`, so a bare pipeline here aborted the whole script
+        # before the default below could apply — status printed nothing at all.
+        current=$(grep -m1 "^ODS_MODE=" "$ENV_FILE" | cut -d= -f2- | tr -d '"\047\r' || true)
+    else
+        warn ".env not found at $ENV_FILE — showing defaults"
+    fi
     echo "Current mode: ${current:-local}"
     echo ""
     echo "Available modes:"

--- a/ods/tests/test-mode-switch-status.sh
+++ b/ods/tests/test-mode-switch-status.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Behavioural coverage for scripts/mode-switch.sh.
+#
+# scripts/README.md and docs/MODE-SWITCH.md both point operators at this
+# script, but nothing exercised it. `--status` in particular is the read-only
+# entry point people reach for first, and it has to survive a .env that is
+# missing or does not pin ODS_MODE.
+#
+# Run: bash tests/test-mode-switch-status.sh
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE_SWITCH="$ROOT_DIR/scripts/mode-switch.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; echo "       $2"; FAIL=$((FAIL + 1)); }
+
+check_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$label"
+    else
+        fail "$label" "expected [$expected] got [$actual]"
+    fi
+}
+
+check_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$label"
+    else
+        fail "$label" "missing [$needle] in: $haystack"
+    fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# mode-switch.sh resolves .env as <script dir>/../.env, so give it a fixture
+# install root to operate on.
+new_root() {
+    local root
+    root="$(mktemp -d "$WORKDIR/root.XXXXXX")"
+    mkdir -p "$root/scripts"
+    cp "$MODE_SWITCH" "$root/scripts/"
+    printf '%s' "$root"
+}
+
+run_mode() {
+    local root="$1"; shift
+    ( cd "$root/scripts" && bash ./mode-switch.sh "$@" ) 2>&1
+}
+
+run_rc() {
+    local root="$1"; shift
+    ( cd "$root/scripts" && bash ./mode-switch.sh "$@" ) >/dev/null 2>&1
+    echo $?
+}
+
+current_mode_line() {
+    grep -m1 "^Current mode:" <<< "$1" || true
+}
+
+# ── 1. No .env at all ─────────────────────────────────────────────────────
+#
+# The regression: `current=$(grep ... | cut ...)` under `set -euo pipefail`
+# aborted the script when grep matched nothing, so --status printed nothing
+# and exited non-zero. The `${current:-local}` default was unreachable.
+
+ROOT="$(new_root)"
+OUT="$(run_mode "$ROOT" --status)"
+check_eq "no .env: exits 0" "0" "$(run_rc "$ROOT" --status)"
+check_eq "no .env: falls back to the default mode" "Current mode: local" "$(current_mode_line "$OUT")"
+check_contains "no .env: still lists the available modes" "Available modes:" "$OUT"
+check_contains "no .env: says why the value is a default" ".env not found" "$OUT"
+
+# ── 2. .env present but ODS_MODE not pinned ───────────────────────────────
+
+ROOT="$(new_root)"
+printf 'LLM_API_URL=http://llama-server:8080\n' > "$ROOT/.env"
+OUT="$(run_mode "$ROOT" --status)"
+check_eq "no ODS_MODE key: exits 0" "0" "$(run_rc "$ROOT" --status)"
+check_eq "no ODS_MODE key: falls back to the default mode" "Current mode: local" "$(current_mode_line "$OUT")"
+
+# ── 3. ODS_MODE pinned ────────────────────────────────────────────────────
+
+ROOT="$(new_root)"
+printf 'ODS_MODE=cloud\n' > "$ROOT/.env"
+check_eq "pinned mode is reported" "Current mode: cloud" "$(current_mode_line "$(run_mode "$ROOT" --status)")"
+
+ROOT="$(new_root)"
+printf 'ODS_MODE="hybrid"\n' > "$ROOT/.env"
+check_eq "quoted mode is reported unquoted" "Current mode: hybrid" "$(current_mode_line "$(run_mode "$ROOT" --status)")"
+
+ROOT="$(new_root)"
+printf 'ODS_MODE=cloud\r\n' > "$ROOT/.env"
+check_eq "CRLF .env does not leak a carriage return" "Current mode: cloud" "$(current_mode_line "$(run_mode "$ROOT" --status)")"
+
+# ── 4. Bare invocation defaults to status ─────────────────────────────────
+
+ROOT="$(new_root)"
+printf 'ODS_MODE=cloud\n' > "$ROOT/.env"
+check_eq "no argument defaults to status" "Current mode: cloud" "$(current_mode_line "$(run_mode "$ROOT")")"
+
+# ── 5. Switching still works ──────────────────────────────────────────────
+
+ROOT="$(new_root)"
+printf 'ODS_MODE=local\nLLM_API_URL=http://llama-server:8080\n' > "$ROOT/.env"
+run_mode "$ROOT" cloud > /dev/null
+check_eq "switch updates ODS_MODE" "ODS_MODE=cloud" "$(grep -m1 '^ODS_MODE=' "$ROOT/.env")"
+check_eq "switch repoints LLM_API_URL" "LLM_API_URL=http://litellm:4000" "$(grep -m1 '^LLM_API_URL=' "$ROOT/.env")"
+check_eq "switched mode is reported back" "Current mode: cloud" "$(current_mode_line "$(run_mode "$ROOT" --status)")"
+
+ROOT="$(new_root)"
+printf 'ODS_MODE=cloud\n' > "$ROOT/.env"
+run_mode "$ROOT" local > /dev/null
+check_eq "switching back to local repoints LLM_API_URL" "LLM_API_URL=http://llama-server:8080" "$(grep -m1 '^LLM_API_URL=' "$ROOT/.env")"
+
+# ── 6. Bad input is rejected ──────────────────────────────────────────────
+
+ROOT="$(new_root)"
+printf 'ODS_MODE=local\n' > "$ROOT/.env"
+check_eq "unknown mode exits 1" "1" "$(run_rc "$ROOT" banana)"
+check_contains "unknown mode explains itself" "Unknown mode" "$(run_mode "$ROOT" banana)"
+
+ROOT="$(new_root)"
+check_eq "switching without .env exits 1" "1" "$(run_rc "$ROOT" cloud)"
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "[PASS] mode-switch status and switching"


### PR DESCRIPTION
## Problem

`show_status` read the current mode with a bare pipeline:

```sh
current=$(grep "^ODS_MODE=" "$ENV_FILE" 2>/dev/null | cut -d= -f2)
echo "Current mode: ${current:-local}"
```

The script runs under `set -euo pipefail`. When `ODS_MODE` is absent — or `.env` does not exist at all — `grep` exits 1, `pipefail` propagates it, and `set -e` kills the script **on that assignment**. Nothing is printed: no current mode, no list of available modes, no error. The command just exits 2.

The `${current:-local}` fallback on the very next line shows the absent key was meant to be handled. It was simply unreachable.

Reproduced from a clean checkout, where `.env` has not been generated yet:

```
$ bash scripts/mode-switch.sh --status
$ echo $?
2
```

`scripts/README.md` lists this script for operators and `docs/MODE-SWITCH.md` documents it as the mode-switching backend, so `--status` — the read-only entry point people reach for first — is exactly the invocation that fails.

## Fix

- Guard the read with a `.env` existence check and tolerate a missing key, so the documented default is actually reached.
- Say when the reported value is a default rather than something configured, instead of silently implying `local` is set.
- Read with `cut -d= -f2-` and strip quotes/CR the way the rest of the repo does, so `ODS_MODE="hybrid"` or a CRLF `.env` reports the mode rather than a mangled string.

Switching behaviour is untouched.

## Tests

`tests/test-mode-switch-status.sh` (new, 17 assertions) covers status with and without `.env`, a `.env` that omits `ODS_MODE`, quoted and CRLF values, the bare no-argument invocation, switching in both directions, and rejection of bad input. Nothing tested this script before.

Red on the pre-fix script:

```
[FAIL] no .env: exits 0
[FAIL] no .env: falls back to the default mode
[FAIL] no .env: still lists the available modes
[FAIL] no .env: says why the value is a default
[FAIL] no ODS_MODE key: exits 0
[FAIL] no ODS_MODE key: falls back to the default mode
[FAIL] quoted mode is reported unquoted

Passed: 10  Failed: 7
```

Green after the fix: 17/17 on Git Bash and Linux. `shellcheck -S warning` clean.

Wired into `make test` and the Linux CI job.