### PR TITLE
fix(models): scope Qwen Coder failure and repair macOS cleanup

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1127,13 +1127,13 @@
         },
         "opencode": {
           "status": "unsupported_until_revalidated",
-          "label": "OpenCode revalidation required on Strix Halo",
-          "reason": "Fresh exact-commit release coverage on strix-halo loaded Qwen 2.5 Coder 3B 128K through the browser switchboard and passed challenge-bound ODS Talk, LiteLLM, Open WebUI, and Perplexica, but OpenCode returned only the verification prefix instead of the full unpredictable phrase. Keep this model out of Strix Halo all-app release coverage until its literal-response behavior is revalidated.",
-          "evidence": "fleet-test/runs/2026-07-25T02-56-13Z-release-product-89c6e46fde88-harness-78aeb37d418e-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo",
-          "recordedAt": "2026-07-25T04:23:22Z",
-          "productSha": "89c6e46fde886ed4edac2bd4c1c2f7cb6beba6d6",
-          "harnessSha": "78aeb37d418efae52efd04e4bc7e64eac128fbb7",
-          "hostScope": ["strix-halo"],
+          "label": "OpenCode revalidation required on Strix Halo and Spark",
+          "reason": "Fresh exact-commit release coverage on strix-halo and spark loaded Qwen 2.5 Coder 3B 128K through the browser switchboard and passed challenge-bound ODS Talk, LiteLLM, Open WebUI, and Perplexica, but OpenCode did not return the exact unpredictable phrase. Strix Halo returned only the verification prefix; Spark changed the required 'ODS verify' prefix to 'ODES verify'. Keep this model out of Strix Halo and Spark all-app release coverage until its literal-response behavior is revalidated. Prior Strix Halo evidence: fleet-test/runs/2026-07-25T02-56-13Z-release-product-89c6e46fde88-harness-78aeb37d418e-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo.",
+          "evidence": "fleet-test/runs/2026-07-25T07-36-57Z-release-product-ac90d567a6ea-harness-bfe040f32941-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/spark",
+          "recordedAt": "2026-07-25T09:13:26Z",
+          "productSha": "ac90d567a6ea721cedc2817f98edca16dd60dd0a",
+          "harnessSha": "bfe040f32941fa3cf82f709a02ab65dcf2e28c7a",
+          "hostScope": ["strix-halo", "spark"],
           "expiresAt": "2026-08-25T00:00:00Z"
         }
       },

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -823,6 +823,7 @@ def test_real_catalog_scopes_qwen25_coder_3b_host_failures():
 
     tower = model_app_compatibility(model, runtime_context={"hosts": ["tower2"]})
     halo = model_app_compatibility(model, runtime_context={"hosts": ["strix-halo"]})
+    spark = model_app_compatibility(model, runtime_context={"hosts": ["spark"]})
     windows = model_app_compatibility(model, runtime_context={"hosts": ["windows-laptop"]})
 
     assert tower["hermesTalk"]["status"] == "unsupported_until_revalidated"
@@ -831,6 +832,9 @@ def test_real_catalog_scopes_qwen25_coder_3b_host_failures():
     assert halo["hermesTalk"]["status"] == "unknown"
     assert halo["opencode"]["status"] == "unsupported_until_revalidated"
     assert halo["agentViability"]["status"] == "unknown"
+    assert spark["hermesTalk"]["status"] == "unknown"
+    assert spark["opencode"]["status"] == "unsupported_until_revalidated"
+    assert spark["agentViability"]["status"] == "unknown"
     assert windows["hermesTalk"]["status"] == "unknown"
     assert windows["opencode"]["status"] == "unknown"
     assert windows["agentViability"]["status"] == "verified"

--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -171,21 +171,6 @@ else
 fi
 
 # 2. Stop and remove host service definitions
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    log_info "Removing macOS LaunchAgents..."
-    for _label in \
-        com.ods.llm-bridge \
-        com.ods.host-agent-bridge \
-        com.ods.host-agent \
-        com.ods.opencode-web \
-        com.ods.llama-server \
-        com.ods.full-model-download; do
-        launchctl bootout "gui/$(id -u)/${_label}" >/dev/null 2>&1 || true
-        rm -f "$HOME/Library/LaunchAgents/${_label}.plist" 2>/dev/null || true
-    done
-    unset _label
-fi
-
 log_info "Removing systemd user services..."
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
 for unit in opencode-web.service openclaw-session-cleanup.timer \
@@ -210,7 +195,8 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     log_info "Removing macOS LaunchAgents..."
     _ods_uid="$(id -u)"
     _ods_agents_cleaned=true
-    for _ods_agent_label in com.ods.host-agent com.ods.opencode-web \
+    for _ods_agent_label in com.ods.llm-bridge com.ods.host-agent-bridge \
+                            com.ods.host-agent com.ods.opencode-web \
                             com.ods.llama-server com.ods.full-model-download; do
         _ods_agent_plist="$HOME/Library/LaunchAgents/${_ods_agent_label}.plist"
         if launchctl print "gui/${_ods_uid}/${_ods_agent_label}" >/dev/null 2>&1; then

--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -97,8 +97,8 @@ fi
 echo "[contract] Linux Lemonade Hermes timeout is lifted from the ODS default"
 if grep -q '_hermes_request_timeout=900' installers/phases/11-services.sh \
    && grep -q -- '--request-timeout-seconds "$_hermes_request_timeout"' installers/phases/11-services.sh \
-   && grep -q 'is_windows_bash || \[\[ "$runtime" == "lemonade" || "$llm_backend" == "lemonade" \]\]' scripts/bootstrap-upgrade.sh \
-   && grep -q 'is_windows_bash || \[\[ "$_gpu_backend_for_hermes" == "amd" || "$_hermes_llm_backend_for_timeout" == "lemonade" \]\]' scripts/bootstrap-upgrade.sh; then
+   && grep -Fq 'elif [[ "${ODS_MODE:-local}" != "cloud" ]] && { [[ "${GPU_BACKEND:-}" == "amd" ]] || _phase11_external_lemonade; }; then' installers/phases/11-services.sh \
+   && grep -Fq 'if is_windows_bash || [[ "$switchboard_mode" == "enabled" || "$runtime" == "lemonade" || "$llm_backend" == "lemonade" ]]; then' scripts/bootstrap-upgrade.sh; then
     pass "Linux Lemonade Hermes provider timeout is upgraded to 900s"
 else
     fail "Linux Lemonade Hermes config must pass --request-timeout-seconds 900 at install and after bootstrap swap"

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -564,13 +564,16 @@ def test_qwen25_coder_3b_is_verified_on_windows_and_host_failures_are_scoped():
     assert "23-54-27Z-release" in compatibility["hermes_talk"]["evidence"]
     assert "acknowledged" in compatibility["hermes_talk"]["reason"]
     assert compatibility["opencode"]["status"] == "unsupported_until_revalidated"
-    assert compatibility["opencode"]["hostScope"] == ["strix-halo"]
-    assert "02-56-13Z-release" in compatibility["opencode"]["evidence"]
-    assert "verification prefix" in compatibility["opencode"]["reason"]
+    assert compatibility["opencode"]["hostScope"] == ["strix-halo", "spark"]
+    assert "07-36-57Z-release" in compatibility["opencode"]["evidence"]
+    assert "/cycle-006/spark" in compatibility["opencode"]["evidence"]
+    assert "02-56-13Z-release" in compatibility["opencode"]["reason"]
+    assert "ODES verify" in compatibility["opencode"]["reason"]
     assert _agent_viable_for_release(model)
     assert _agent_viable_for_release(model, host="windows-laptop")
     assert not _agent_viable_for_release(model, host="tower2")
     assert not _agent_viable_for_release(model, host="strix-halo")
+    assert not _agent_viable_for_release(model, host="spark")
 
 
 def test_falcon_h1_15b_is_not_talk_or_opencode_agent_viable_until_revalidated():


### PR DESCRIPTION
## Summary
- record the fresh Spark OpenCode literal-response failure for Qwen 2.5 Coder 3B
- extend the existing host-scoped OpenCode exclusion from Strix Halo to Spark
- preserve the verified Windows result and add catalog/oracle regression coverage
- consolidate duplicate macOS LaunchAgent uninstall cleanup so only loaded agents are booted out while every current/legacy plist remains covered

## Evidence
Final11 loaded the exact Qwen 2.5 Coder 3B model on Spark and passed ODS Talk, LiteLLM, Open WebUI, and Perplexica. OpenCode routed to the correct model but changed the challenge prefix from **ODS verify** to **ODES verify**. Failure recovery restored Qwen3.6 and deleted the test model.

The native release gate also exposed a duplicate unconditional LaunchAgent cleanup block. The consolidated load-aware path now covers `com.ods.llm-bridge`, `com.ods.host-agent-bridge`, current agents, and legacy agents without spurious `bootout` calls.

## Tests
- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/extensions/services/dashboard-api/tests/test_performance_oracle.py` (76 passed)
- `bash ods/tests/test-macos-uninstall-launchagents.sh` on Tower2 (5 scenarios passed)
- full native Linux `make gate` on Tower2 (release gate passed)
- GitHub Actions matrix (all checks green)