### PR TITLE
fix(gguf): reject boolean values in integer metadata fields

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -165,7 +165,7 @@ def _read_array(reader: _Reader, depth: int = 0) -> Any:
 
 def _first_int(metadata: dict[str, Any], suffixes: tuple[str, ...]) -> int | None:
     for key, value in metadata.items():
-        if key.endswith(suffixes) and isinstance(value, int):
+        if key.endswith(suffixes) and isinstance(value, int) and not isinstance(value, bool):
             return value
     return None
 

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -315,3 +315,15 @@ def test_accepts_str_path_as_well_as_path_object(tmp_path):
 
     assert result["readable"] is True
     assert result["path"] == str(path)
+
+
+def test_boolean_metadata_value_is_ignored_for_integer_fields(tmp_path):
+    path = _write(tmp_path, "boolmeta.gguf", build_gguf([
+        ("general.architecture", STR, "llama"),
+        ("is_enabled.context_length", BOOL, True),
+    ]))
+
+    result = inspect_gguf(path)
+
+    assert result["readable"] is True
+    assert result["context_length"] is None


### PR DESCRIPTION
## Summary

Preserve the original #2004 fix while moving it to a maintainer-owned branch that can receive the repository's required CI.

Python `bool` values are subclasses of `int`. GGUF metadata parsing therefore accepted booleans as integer fields and could treat `true` as `1` for context or embedding dimensions. This change excludes booleans from integer metadata candidates.

## Credit

The code commit retains the original author and implementation from @ary230 in #2004. This PR replaces that fork-based PR only because GitHub reported no checks for its head even after it was refreshed onto current `main`.

## Validation

- `python -m pytest -q tests/test_gguf_inspector.py`
- 27 passed
- `git diff --check origin/main...HEAD`
