### PR TITLE
fix(comfyui): run RDNA4 natively and persist bounded MIOpen cache

### DIFF
--- a/ods/docs/EXTENSIONS.md
+++ b/ods/docs/EXTENSIONS.md
@@ -315,15 +315,25 @@ services:
   comfyui:
     image: ignatberesnev/comfyui-gfx1151:v0.2
     container_name: ods-comfyui
+    restart: unless-stopped
     devices:
       - /dev/dri:/dev/dri
       - /dev/kfd:/dev/kfd
     group_add:
       - "${VIDEO_GID:-44}"
       - "${RENDER_GID:-992}"
+    security_opt:
+      - no-new-privileges:true
+    shm_size: 8g
     environment:
-      - HSA_OVERRIDE_GFX_VERSION=11.5.1
-    # ... ports, volumes, healthcheck, deploy, etc.
+      # Deliberately no HSA_OVERRIDE_GFX_VERSION and no PYTORCH_TUNABLEOP_ENABLED —
+      # see the comments in compose.amd.yaml for the full rationale.
+      - MIOPEN_FIND_MODE=FAST
+      - TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
+    volumes:
+      - ./data/comfyui/ComfyUI:/opt/ComfyUI:z
+      - ./data/comfyui/miopen:/root/.config/miopen:z
+    # ... ports, command, healthcheck, deploy, etc.
 ```
 
 ### GPU Overlay Quick Reference
@@ -341,7 +351,7 @@ services:
 AMD ROCm requires additional container configuration compared to NVIDIA:
 - **Device passthrough:** `/dev/dri` (rendering) and `/dev/kfd` (compute)
 - **Group membership:** Container user must be in the host's `video` and `render` groups
-- **GFX version override:** Set `HSA_OVERRIDE_GFX_VERSION` to match your GPU (check with `rocminfo | grep gfx`)
+- **GFX version override:** Leave `HSA_OVERRIDE_GFX_VERSION` unset. Never set it to an arch that is not your card's own: ROCm will hand the GPU wrong-arch kernels, which do not just run slowly — they fault the card (`HW Exception ... GPU Hang`). Never define it as an empty string either: ROCm checks whether the variable is *defined*, not whether it is non-empty, and then enumerates zero GPUs. Modern images ship kernels for the native arch (check yours with `rocminfo | grep gfx`), so the spoof is unnecessary.
 - **Security relaxation:** `cap_add: SYS_PTRACE` and `seccomp:unconfined` may be needed for ROCm profiling
 
 ## Compatibility Checklist

--- a/ods/docs/EXTENSIONS.md
+++ b/ods/docs/EXTENSIONS.md
@@ -359,7 +359,11 @@ services:
       - "${VIDEO_GID:-44}"
       - "${RENDER_GID:-992}"
     environment:
-      - HSA_OVERRIDE_GFX_VERSION=11.5.1
+      - MIOPEN_FIND_MODE=FAST
+      - TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
+    volumes:
+      - ./data/comfyui/ComfyUI:/opt/ComfyUI:z
+      - ./data/comfyui/miopen:/root/.config/miopen:z
     # ... ports, volumes, healthcheck, deploy, etc.
 ```
 
@@ -378,7 +382,7 @@ services:
 AMD ROCm requires additional container configuration compared to NVIDIA:
 - **Device passthrough:** `/dev/dri` (rendering) and `/dev/kfd` (compute)
 - **Group membership:** Container user must be in the host's `video` and `render` groups
-- **GFX version override:** Set `HSA_OVERRIDE_GFX_VERSION` to match your GPU (check with `rocminfo | grep gfx`)
+- **GFX version override:** Avoid setting `HSA_OVERRIDE_GFX_VERSION` unless a specific image requires emulation. A wrong value can dispatch incompatible kernels; an empty value is also invalid. Prefer an image that contains kernels for the native `rocminfo` architecture.
 - **Security relaxation:** `cap_add: SYS_PTRACE` and `seccomp:unconfined` may be needed for ROCm profiling
 
 ## Compatibility Checklist

--- a/ods/extensions/services/comfyui/README.md
+++ b/ods/extensions/services/comfyui/README.md
@@ -23,7 +23,7 @@ ComfyUI is GPU-only. The service definition is split by GPU vendor:
 | Backend | Compose file | Notes |
 |---------|-------------|-------|
 | NVIDIA (CUDA) | `compose.nvidia.yaml` | Requires NVIDIA Container Toolkit |
-| AMD (ROCm) | `compose.amd.yaml` | Targets gfx1151 (RX 9000 series); uses ROCm with flash attention |
+| AMD (ROCm) | `compose.amd.yaml` | Runs on the GPU's native arch — the bundled image ships a ROCm 7.2 PyTorch whose arch list includes gfx1151 (Strix Halo) and gfx1201 (RDNA4), among others; uses flash attention |
 
 > **Apple Silicon:** ComfyUI is not currently configured for Apple Silicon (macOS ARM). Use the native ComfyUI application instead.
 
@@ -51,8 +51,9 @@ Environment variables (set in `.env`):
 | Host Path | Container Path | Purpose |
 |-----------|---------------|---------|
 | `./data/comfyui/ComfyUI` | `/opt/ComfyUI` | Full ComfyUI installation (models, outputs, custom nodes) |
+| `./data/comfyui/miopen` | `/root/.config/miopen` | Persists MIOpen find-db so first-generation tuning survives container recreates |
 
-> **Note:** The AMD image uses a single volume containing the entire ComfyUI directory. Models go inside `./data/comfyui/ComfyUI/models/` rather than a separate `./data/comfyui/models/` mount.
+> **Note:** The AMD image keeps the entire ComfyUI directory in a single mount. Models go inside `./data/comfyui/ComfyUI/models/` rather than a separate `./data/comfyui/models/` mount.
 
 ### Model Subdirectories (NVIDIA)
 
@@ -98,7 +99,7 @@ Place model files in the appropriate subdirectory under `./data/comfyui/models/`
 - `manifest.yaml` — Service metadata (port, health endpoint, GPU backends, features)
 - `compose.yaml` — Base stub (actual definition is in GPU overlays)
 - `compose.nvidia.yaml` — NVIDIA CUDA service definition
-- `compose.amd.yaml` — AMD ROCm service definition (gfx1151)
+- `compose.amd.yaml` — AMD ROCm service definition (runs the GPU's native arch)
 - `startup.sh` — Entrypoint script: sets up model symlinks and launches ComfyUI server
 - `Dockerfile` — Container build definition (used by NVIDIA overlay)
 

--- a/ods/extensions/services/comfyui/README.md
+++ b/ods/extensions/services/comfyui/README.md
@@ -23,7 +23,7 @@ ComfyUI is GPU-only. The service definition is split by GPU vendor:
 | Backend | Compose file | Notes |
 |---------|-------------|-------|
 | NVIDIA (CUDA) | `compose.nvidia.yaml` | Requires NVIDIA Container Toolkit |
-| AMD (ROCm) | `compose.amd.yaml` | Targets gfx1151 (RX 9000 series); uses ROCm with flash attention |
+| AMD (ROCm) | `compose.amd.yaml` | Runs the detected GPU's native architecture; the bundled ROCm 7.2 torch wheel includes gfx1151 and gfx1201; uses flash attention |
 
 > **Apple Silicon:** ComfyUI is not currently configured for Apple Silicon (macOS ARM). Use the native ComfyUI application instead.
 
@@ -51,8 +51,9 @@ Environment variables (set in `.env`):
 | Host Path | Container Path | Purpose |
 |-----------|---------------|---------|
 | `./data/comfyui/ComfyUI` | `/opt/ComfyUI` | Full ComfyUI installation (models, outputs, custom nodes) |
+| `./data/comfyui/miopen` | `/root/.config/miopen` | Persists the MIOpen find database across container recreations |
 
-> **Note:** The AMD image uses a single volume containing the entire ComfyUI directory. Models go inside `./data/comfyui/ComfyUI/models/` rather than a separate `./data/comfyui/models/` mount.
+> **Note:** The AMD image keeps the entire ComfyUI directory in a single mount. Models go inside `./data/comfyui/ComfyUI/models/` rather than a separate `./data/comfyui/models/` mount. ODS leaves `HSA_OVERRIDE_GFX_VERSION` absent in this container so gfx1151 and gfx1201 both run their native kernels.
 
 ### Model Subdirectories (NVIDIA)
 
@@ -98,7 +99,7 @@ Place model files in the appropriate subdirectory under `./data/comfyui/models/`
 - `manifest.yaml` — Service metadata (port, health endpoint, GPU backends, features)
 - `compose.yaml` — Base stub (actual definition is in GPU overlays)
 - `compose.nvidia.yaml` — NVIDIA CUDA service definition
-- `compose.amd.yaml` — AMD ROCm service definition (gfx1151)
+- `compose.amd.yaml` — AMD ROCm service definition (native GPU architecture)
 - `startup.sh` — Entrypoint script: sets up model symlinks and launches ComfyUI server
 - `Dockerfile` — Container build definition (used by NVIDIA overlay)
 

--- a/ods/extensions/services/comfyui/compose.amd.yaml
+++ b/ods/extensions/services/comfyui/compose.amd.yaml
@@ -21,10 +21,23 @@ services:
       # Do not "fix" this by setting the var to an empty string — ROCm checks whether
       # it is *defined*, not whether it is non-empty, then fails parsing "".
       # Leave it absent so each GPU is used as its native arch.
-      - PYTORCH_TUNABLEOP_ENABLED=1
+      #
+      # No PYTORCH_TUNABLEOP_ENABLED either. On arches without a shipped tuning DB
+      # (e.g. gfx1201) it exhaustively benchmarks every GEMM shape on first use —
+      # ~8 min at full board power before the first sampling step — and the results
+      # CSV lands in the process cwd inside the container layer, so it is re-paid
+      # on every recreate. hipBLASLt's built-in heuristics are close enough; if you
+      # re-enable it, set PYTORCH_TUNABLEOP_FILENAME to a bind-mounted path.
+      #
+      # MIOPEN_FIND_MODE=FAST picks conv kernels heuristically instead of
+      # compile-and-race-every-candidate, which took 20+ min for a single SDXL VAE
+      # decode on a cold cache. What little JIT remains is persisted via the
+      # miopen volume below.
+      - MIOPEN_FIND_MODE=FAST
       - TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
     volumes:
       - ./data/comfyui/ComfyUI:/opt/ComfyUI:z
+      - ./data/comfyui/miopen:/root/.config/miopen:z
     ports:
       - "${BIND_ADDRESS:-127.0.0.1}:${COMFYUI_PORT:-8188}:8188"
     command: >-

--- a/ods/extensions/services/comfyui/compose.amd.yaml
+++ b/ods/extensions/services/comfyui/compose.amd.yaml
@@ -13,7 +13,14 @@ services:
       - no-new-privileges:true
     shm_size: 8g
     environment:
-      - HSA_OVERRIDE_GFX_VERSION=11.5.1
+      # No HSA_OVERRIDE_GFX_VERSION. The image name says gfx1151, but the torch it
+      # ships is a stock ROCm 7.2 wheel whose arch list already includes gfx1201
+      # (RDNA4) — so RDNA4 cards need no spoofing. Forcing 11.5.1 here made ROCm
+      # hand gfx1151 (RDNA3.5) kernels to a gfx1201 card, which does not merely run
+      # slowly: it faults the card ("HW Exception by GPU node-N ... reason: GPU Hang").
+      # Do not "fix" this by setting the var to an empty string — ROCm checks whether
+      # it is *defined*, not whether it is non-empty, then fails parsing "".
+      # Leave it absent so each GPU is used as its native arch.
       - PYTORCH_TUNABLEOP_ENABLED=1
       - TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
     volumes:

--- a/ods/extensions/services/comfyui/compose.amd.yaml
+++ b/ods/extensions/services/comfyui/compose.amd.yaml
@@ -13,11 +13,20 @@ services:
       - no-new-privileges:true
     shm_size: 8g
     environment:
-      - HSA_OVERRIDE_GFX_VERSION=11.5.1
-      - PYTORCH_TUNABLEOP_ENABLED=1
+      # Run the host's native ISA. The ROCm 7.2 torch wheel in this image
+      # includes both gfx1151 and gfx1201; spoofing gfx1201 as 11.5.1 dispatches
+      # incompatible kernels and can hang the GPU. Do not add an empty
+      # HSA_OVERRIDE_GFX_VERSION either: ROCm treats an empty override as invalid.
+      #
+      # TunableOp is intentionally disabled. On a cold architecture it benchmarks
+      # every GEMM before the first image and stores its result in the ephemeral
+      # container layer. MIOpen FAST avoids the analogous exhaustive convolution
+      # search, while the bind mount below preserves the remaining find database.
+      - MIOPEN_FIND_MODE=FAST
       - TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
     volumes:
       - ./data/comfyui/ComfyUI:/opt/ComfyUI:z
+      - ./data/comfyui/miopen:/root/.config/miopen:z
     ports:
       - "${BIND_ADDRESS:-127.0.0.1}:${COMFYUI_PORT:-8188}:8188"
     command: >-

--- a/ods/extensions/services/comfyui/compose.yaml
+++ b/ods/extensions/services/comfyui/compose.yaml
@@ -1,6 +1,6 @@
 # ComfyUI — Image Generation
 # This base stub is merged with a GPU-specific overlay:
-#   compose.amd.yaml   (AMD ROCm, gfx1151)
+#   compose.amd.yaml   (AMD ROCm, native GPU arch)
 #   compose.nvidia.yaml (NVIDIA CUDA)
 # The GPU overlay provides the full service definition.
 # This file exists so the registry can detect comfyui as enabled.

--- a/ods/extensions/services/comfyui/compose.yaml
+++ b/ods/extensions/services/comfyui/compose.yaml
@@ -4,7 +4,7 @@
 # The actual container definition lives in GPU-specific overlay files that are
 # merged with this stub at runtime by the installer/compose resolver:
 #
-#   compose.amd.yaml             — AMD ROCm (single GPU, gfx1151)
+#   compose.amd.yaml             — AMD ROCm (single GPU, native gfx architecture)
 #   compose.nvidia.yaml          — NVIDIA CUDA (single GPU, builds local Dockerfile)
 #   compose.multigpu-amd.yaml    — AMD ROCm multi-GPU
 #   compose.multigpu-nvidia.yaml — NVIDIA multi-GPU

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -746,12 +746,26 @@ else
         ai "Cloud mode — skipping image model download"
     elif [[ "$GPU_BACKEND" == "amd" ]]; then
         COMFYUI_BASE="$INSTALL_DIR/data/comfyui/ComfyUI/models"
+        COMFYUI_MIOPEN_CACHE="$INSTALL_DIR/data/comfyui/miopen"
     elif [[ "$GPU_BACKEND" == "nvidia" ]]; then
         COMFYUI_BASE="$INSTALL_DIR/data/comfyui/models"
     fi
     if [[ "$ENABLE_COMFYUI" == "true" && "${ODS_MODE:-local}" != "cloud" && ( "$GPU_BACKEND" == "amd" || "$GPU_BACKEND" == "nvidia" ) ]]; then
         SDXL_CHECKPOINT_DIR="$COMFYUI_BASE/checkpoints"
         mkdir -p "$SDXL_CHECKPOINT_DIR"
+        if [[ "$GPU_BACKEND" == "amd" ]]; then
+            # Pre-create the cache as the install owner. This avoids Docker
+            # creating a root-owned bind source and keeps it traversable for
+            # both rootful and rootless container runtimes.
+            mkdir -p "$COMFYUI_MIOPEN_CACHE"
+            if ! chmod u+rwx,go+rx "$COMFYUI_MIOPEN_CACHE" 2>>"$LOG_FILE"; then
+                ai_warn "Could not normalize MIOpen cache permissions; continuing because the install owner may still have access"
+            fi
+            if [[ ! -w "$COMFYUI_MIOPEN_CACHE" || ! -x "$COMFYUI_MIOPEN_CACHE" ]]; then
+                ai_bad "MIOpen cache is not writable: $COMFYUI_MIOPEN_CACHE"
+                exit 1
+            fi
+        fi
         # NVIDIA ComfyUI also needs output/input/workflows bind-mount dirs
         if [[ "$GPU_BACKEND" == "nvidia" ]]; then
             mkdir -p "$INSTALL_DIR/data/comfyui"/{output,input,workflows}

--- a/ods/tests/contracts/test-amd-comfyui-architecture.sh
+++ b/ods/tests/contracts/test-amd-comfyui-architecture.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+AMD_COMPOSE="extensions/services/comfyui/compose.amd.yaml"
+BASE_COMPOSE="extensions/services/comfyui/compose.yaml"
+NVIDIA_COMPOSE="extensions/services/comfyui/compose.nvidia.yaml"
+INSTALL_PHASE="installers/phases/11-services.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+for file in "$AMD_COMPOSE" "$BASE_COMPOSE" "$NVIDIA_COMPOSE" "$INSTALL_PHASE"; do
+    [[ -f "$file" ]] || fail "missing contract input: $file"
+done
+
+# Both supported AMD architectures must run their native ISA. In particular,
+# a global installer HSA override for the llama/Lemonade path must not leak into
+# ComfyUI through Compose interpolation.
+if grep -Eq '^[[:space:]]*-[[:space:]]*HSA_OVERRIDE_GFX_VERSION(=|:|\$)' \
+    "$AMD_COMPOSE"; then
+    fail "AMD ComfyUI must not define or interpolate HSA_OVERRIDE_GFX_VERSION"
+fi
+if grep -q 'PYTORCH_TUNABLEOP' "$AMD_COMPOSE"; then
+    fail "AMD ComfyUI must not enable exhaustive TunableOp startup tuning"
+fi
+grep -qF -- '- MIOPEN_FIND_MODE=FAST' "$AMD_COMPOSE" \
+    || fail "AMD ComfyUI must use bounded MIOpen kernel selection"
+grep -qF -- './data/comfyui/miopen:/root/.config/miopen:z' "$AMD_COMPOSE" \
+    || fail "AMD ComfyUI must persist its MIOpen cache across recreations"
+grep -qF 'restart: unless-stopped' "$AMD_COMPOSE" \
+    || fail "AMD ComfyUI must retain its restart policy"
+grep -qF "COMFYUI_MIOPEN_CACHE=\"\$INSTALL_DIR/data/comfyui/miopen\"" "$INSTALL_PHASE" \
+    || fail "the installer must select the persistent AMD MIOpen cache"
+grep -qF "mkdir -p \"\$COMFYUI_MIOPEN_CACHE\"" "$INSTALL_PHASE" \
+    || fail "the installer must pre-create the AMD MIOpen cache"
+grep -qF "chmod u+rwx,go+rx \"\$COMFYUI_MIOPEN_CACHE\"" "$INSTALL_PHASE" \
+    || fail "the installer must keep the AMD MIOpen cache writable and traversable"
+pass "cold-start and recreation safeguards are present"
+
+# Preserve the current registry/switchboard overlay contract and keep unrelated
+# backends free of AMD-only runtime controls.
+grep -qF 'compose.multigpu-amd.yaml' "$BASE_COMPOSE" \
+    || fail "the ComfyUI stub lost its AMD multi-GPU overlay documentation"
+grep -qF 'compose.multigpu-nvidia.yaml' "$BASE_COMPOSE" \
+    || fail "the ComfyUI stub lost its NVIDIA multi-GPU overlay documentation"
+if grep -Eq 'HSA_OVERRIDE_GFX_VERSION|MIOPEN_FIND_MODE|PYTORCH_TUNABLEOP' \
+    "$BASE_COMPOSE" "$NVIDIA_COMPOSE"; then
+    fail "AMD-only runtime controls leaked into base or NVIDIA ComfyUI"
+fi
+pass "base, NVIDIA, CPU, and Apple paths remain AMD-control no-ops"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Exercise the install-time permission behavior with a restrictive ambient
+# umask. A marker simulates a compiled MIOpen entry and must survive recreation.
+cache_dir="$tmp_dir/ODS install/data/comfyui/miopen"
+(
+    umask 077
+    mkdir -p "$cache_dir"
+    chmod u+rwx,go+rx "$cache_dir"
+)
+[[ -w "$cache_dir" && -x "$cache_dir" ]] \
+    || fail "install owner cannot write/traverse the MIOpen cache"
+cache_mode="$(stat -c '%a' "$cache_dir" 2>/dev/null || stat -f '%Lp' "$cache_dir")"
+(( 8#$cache_mode & 0111 )) \
+    || fail "MIOpen cache is not traversable: mode $cache_mode"
+printf 'cached-kernel\n' > "$cache_dir/find-db.marker"
+mkdir -p "$cache_dir"
+chmod u+rwx,go+rx "$cache_dir"
+[[ "$(cat "$cache_dir/find-db.marker")" == "cached-kernel" ]] \
+    || fail "container recreation preparation discarded the MIOpen cache"
+pass "MIOpen cache permissions and recreation persistence are executable"
+
+if command -v docker >/dev/null 2>&1 \
+    && docker compose version >/dev/null 2>&1 \
+    && command -v jq >/dev/null 2>&1; then
+    base_rendered="$(docker compose -f "$BASE_COMPOSE" config --format json)"
+    jq -e '(.services // {}) | length == 0' >/dev/null <<<"$base_rendered" \
+        || fail "base ComfyUI stub unexpectedly defines a runtime service"
+
+    nvidia_rendered="$(docker compose -f "$BASE_COMPOSE" -f "$NVIDIA_COMPOSE" \
+        config --format json)"
+    jq -e '.services.comfyui.environment
+        | has("HSA_OVERRIDE_GFX_VERSION") | not' >/dev/null <<<"$nvidia_rendered" \
+        || fail "NVIDIA ComfyUI inherited the AMD HSA override"
+    jq -e '[.services.comfyui.volumes[]?.target]
+        | index("/root/.config/miopen") | not' >/dev/null <<<"$nvidia_rendered" \
+        || fail "NVIDIA ComfyUI inherited the AMD MIOpen cache"
+    pass "rendered base/CPU/Apple and NVIDIA paths remain AMD-control no-ops"
+
+    for gfx in gfx1151 gfx1201; do
+        env_file="$tmp_dir/$gfx.env"
+        {
+            printf 'AMDGPU_TARGET=%s\n' "$gfx"
+            printf 'COMFYUI_PORT=18188\n'
+            printf 'VIDEO_GID=44\n'
+            printf 'RENDER_GID=992\n'
+            if [[ "$gfx" == "gfx1151" ]]; then
+                # This remains valid for llama/Lemonade, but must not be
+                # inherited by ComfyUI.
+                printf 'HSA_OVERRIDE_GFX_VERSION=11.5.1\n'
+            fi
+        } > "$env_file"
+
+        docker_env_file="$env_file"
+        if command -v cygpath >/dev/null 2>&1; then
+            docker_env_file="$(cygpath -w "$env_file")"
+        fi
+
+        rendered="$(docker compose --env-file "$docker_env_file" \
+            -f "$BASE_COMPOSE" -f "$AMD_COMPOSE" config --format json)"
+        jq -e '.services.comfyui.environment.MIOPEN_FIND_MODE == "FAST"' \
+            >/dev/null <<<"$rendered" \
+            || fail "$gfx render lost MIOPEN_FIND_MODE=FAST"
+        jq -e '.services.comfyui.environment
+            | has("HSA_OVERRIDE_GFX_VERSION") | not' >/dev/null <<<"$rendered" \
+            || fail "$gfx render leaked HSA_OVERRIDE_GFX_VERSION into ComfyUI"
+        jq -e '.services.comfyui.environment
+            | has("PYTORCH_TUNABLEOP_ENABLED") | not' >/dev/null <<<"$rendered" \
+            || fail "$gfx render re-enabled TunableOp"
+        jq -e '.services.comfyui.volumes[]
+            | select(.target == "/root/.config/miopen" and .type == "bind")' \
+            >/dev/null <<<"$rendered" \
+            || fail "$gfx render lost the persistent MIOpen bind mount"
+        pass "$gfx Compose render uses native architecture controls"
+    done
+else
+    echo "[SKIP] docker compose and jq are required for rendered gfx1151/gfx1201 checks"
+fi
+
+echo "AMD ComfyUI architecture contracts passed"

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -320,6 +320,9 @@ if grep -q '_env_set "HSA_OVERRIDE_GFX_VERSION" "\$gfx_ver"' ods-cli; then
   exit 1
 fi
 
+echo "[contract] AMD ComfyUI uses native gfx architecture"
+bash tests/contracts/test-amd-comfyui-architecture.sh
+
 echo "[contract] dashboard diagnostics route through docker network URLs"
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   tmp_env="$(mktemp)"


### PR DESCRIPTION
Supersedes #1785 with the original author commits preserved in history, current main integrated, and executable architecture/recreation contracts added. Removes the wrong gfx spoof and exhaustive TunableOp startup tuning, uses MIOPEN_FIND_MODE=FAST, persists the MIOpen cache, and proves gfx1151/gfx1201 renders plus NVIDIA/base isolation. The original author reports successful dual-R9700 SDXL generation; this maintainer branch exists so the full protected CI can run before merge.