### PR TITLE
fix(hermes): bound local model response length

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -8561,6 +8561,7 @@ def _patch_hermes_config_text(
     model_name: str,
     base_url: str | None = None,
     context_length: int | None = None,
+    max_tokens: int = 1024,
 ) -> tuple[str, bool]:
     """Return Hermes YAML with its routing fields updated line-for-line."""
     lines = text.splitlines()
@@ -8581,6 +8582,9 @@ def _patch_hermes_config_text(
             changed = True
         if context_length and "context_length" not in model_fields:
             new_lines.append(f"{model_indent}context_length: {int(context_length)}")
+            changed = True
+        if max_tokens and "max_tokens" not in model_fields:
+            new_lines.append(f"{model_indent}max_tokens: {int(max_tokens)}")
             changed = True
 
     for line in lines:
@@ -8617,6 +8621,13 @@ def _patch_hermes_config_text(
             new_lines.append(new_line)
             changed = changed or new_line != line
             continue
+        if in_model_block and re.match(r"^\s+max_tokens:\s*", line):
+            # Preserve an operator's explicit output cap. ODS only supplies
+            # its bounded default when the field is absent.
+            model_fields.add("max_tokens")
+            model_indent = line[:len(line) - len(line.lstrip())]
+            new_lines.append(line)
+            continue
         if context_length and re.match(r"^\s+context_length:\s*", line):
             indent = line[:len(line) - len(line.lstrip())]
             new_line = f"{indent}context_length: {int(context_length)}"
@@ -8638,6 +8649,8 @@ def _patch_hermes_config_text(
             new_lines.append(f'{model_indent}base_url: "{base_url}"')
         if context_length:
             new_lines.append(f"{model_indent}context_length: {int(context_length)}")
+        if max_tokens:
+            new_lines.append(f"{model_indent}max_tokens: {int(max_tokens)}")
         changed = True
 
     return "\n".join(new_lines) + "\n", changed

--- a/ods/config/generated-config-contracts.json
+++ b/ods/config/generated-config-contracts.json
@@ -239,6 +239,12 @@
           "needle": "context_length: 131072"
         },
         {
+          "id": "template-output-cap",
+          "type": "yaml_text_contains",
+          "path": "extensions/services/hermes/cli-config.yaml.template",
+          "needle": "max_tokens: 1024"
+        },
+        {
           "id": "patcher-updates-model-name",
           "type": "file_contains",
           "path": "scripts/patch-hermes-config.py",

--- a/ods/extensions/services/hermes/cli-config.yaml.template
+++ b/ods/extensions/services/hermes/cli-config.yaml.template
@@ -48,6 +48,14 @@ model:
   # exceeded / max compression attempts reached" loops.
   context_length: 131072
 
+  # Bound each model turn even when a local model ignores the concise-response
+  # persona or falls into a repetition loop. Without an explicit cap Hermes
+  # leaves max_tokens unset; a runaway response can then occupy the only local
+  # inference slot indefinitely and leave ODS Talk stuck on "Responding".
+  # Hermes may take multiple capped turns for tool workflows, so this limits
+  # pathological output without limiting the overall agent task.
+  max_tokens: 1024
+
 # =============================================================================
 # Provider overrides — local inference needs a generous first-token budget
 # =============================================================================

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -344,6 +344,7 @@ function Update-HermesConfigFile {
         [string]$BaseUrl,
         [int]$ContextLength,
         [int]$RequestTimeoutSeconds = 180,
+        [int]$MaxTokens = 1024,
         [switch]$LemonadeCompact
     )
 
@@ -355,6 +356,10 @@ function Update-HermesConfigFile {
     $content = $content -replace '(?m)^  base_url: ".*"\r?$', "  base_url: `"$BaseUrl`""
     $content = $content -replace '(?m)^  context_length: .+\r?$', "  context_length: $ContextLength"
     $content = $content -replace '(?m)^    context_length: .+\r?$', "    context_length: $ContextLength"
+    if ($MaxTokens -lt 1) { $MaxTokens = 1024 }
+    if ($content -notmatch '(?m)^  max_tokens:\s*\d+\s*$') {
+        $content = $content -replace '(?m)^model:\s*$', "model:`n  max_tokens: $MaxTokens"
+    }
     if ($RequestTimeoutSeconds -lt 1) { $RequestTimeoutSeconds = 180 }
 
     $timeoutMatch = [regex]::Match($content, '(?m)^    request_timeout_seconds:\s*(\d+)\s*$')

--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -75,7 +75,14 @@ def _key_value(lines: list[str], block: tuple[int, int], key: str, indent: int) 
     return None
 
 
-def _ensure_model(lines: list[str], model: str | None, base_url: str | None, context_length: int | None, api_key: str | None = None) -> None:
+def _ensure_model(
+    lines: list[str],
+    model: str | None,
+    base_url: str | None,
+    context_length: int | None,
+    api_key: str | None = None,
+    max_tokens: int = 1024,
+) -> None:
     block = _top_level_block(lines, "model")
     if block is None:
         insert = ["model:"]
@@ -88,6 +95,8 @@ def _ensure_model(lines: list[str], model: str | None, base_url: str | None, con
             insert.append(f'  api_key: "{api_key}"')
         if context_length:
             insert.append(f"  context_length: {context_length}")
+        if max_tokens:
+            insert.append(f"  max_tokens: {max_tokens}")
         lines[:0] = insert + [""]
         return
 
@@ -98,7 +107,12 @@ def _ensure_model(lines: list[str], model: str | None, base_url: str | None, con
     if api_key:
         block = _set_key(lines, block, "api_key", f'"{api_key}"', 2)
     if context_length:
-        _set_key(lines, block, "context_length", str(context_length), 2)
+        block = _set_key(lines, block, "context_length", str(context_length), 2)
+    # Existing operator values win, but migrate configs that predate ODS's
+    # bounded-output default. An unset Hermes cap lets a repetitive local
+    # model monopolize the only inference slot until an outer timeout fires.
+    if max_tokens and not _has_key(lines, block, "max_tokens", 2):
+        _set_key(lines, block, "max_tokens", str(max_tokens), 2)
 
 
 def _ensure_provider_timeout(lines: list[str], provider: str = "custom", timeout_seconds: int = 180) -> None:
@@ -259,12 +273,13 @@ def patch_config(
     context_length: int | None,
     api_key: str | None = None,
     request_timeout_seconds: int = 180,
+    max_tokens: int = 1024,
 ) -> bool:
     original = path.read_text(encoding="utf-8")
     trailing_newline = original.endswith("\n")
     lines = original.splitlines()
 
-    _ensure_model(lines, model, base_url, context_length, api_key)
+    _ensure_model(lines, model, base_url, context_length, api_key, max_tokens)
     _ensure_provider_timeout(lines, timeout_seconds=request_timeout_seconds)
     _ensure_auxiliary(lines, context_length)
     _ensure_whatsapp_bridge(lines)
@@ -287,6 +302,7 @@ def main() -> int:
     parser.add_argument("--api-key", help="Bearer token Hermes uses to call the LLM (needed when routing through litellm)")
     parser.add_argument("--context-length", type=int)
     parser.add_argument("--request-timeout-seconds", type=int, default=180)
+    parser.add_argument("--max-tokens", type=int, default=1024)
     args = parser.parse_args()
 
     if not args.path.exists():
@@ -298,6 +314,7 @@ def main() -> int:
         args.context_length,
         args.api_key,
         args.request_timeout_seconds,
+        args.max_tokens,
     )
     print("changed" if changed else "unchanged")
     return 0

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -21,6 +21,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MODEL = "qwen3.5-9b"
 DEFAULT_GGUF = "Qwen3.5-9B-Q4_K_M.gguf"
 DEFAULT_CONTEXT = 131072
+DEFAULT_HERMES_MAX_TOKENS = 1024
 DEFAULT_LITELLM_KEY = "sk-lemonade"
 NO_KEY = "no-key"
 
@@ -115,6 +116,7 @@ def render_hermes(inputs: RenderInputs) -> RenderedFile:
   provider: "custom"
   base_url: "{base_url}"
   context_length: {inputs.context_length}
+  max_tokens: {DEFAULT_HERMES_MAX_TOKENS}
 
 auxiliary:
   compression:

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -101,6 +101,14 @@ assert_grep "installers/windows/install-windows.ps1" 'CTX_SIZE=\$\(\$tierConfig\
 
 echo ""
 echo "Hermes config patch paths:"
+assert_grep "extensions/services/hermes/cli-config.yaml.template" '^  max_tokens: 1024$' \
+    "Hermes template bounds each model turn"
+assert_grep "scripts/render-runtime-configs.py" '^DEFAULT_HERMES_MAX_TOKENS = 1024$' \
+    "runtime renderer uses the bounded Hermes output default"
+assert_grep "bin/ods-host-agent.py" 'max_tokens: int = 1024' \
+    "runtime model switch patcher migrates an uncapped Hermes config"
+assert_grep "installers/windows/phases/06-directories.ps1" '\[int\]\$MaxTokens = 1024' \
+    "Windows installer migrates an uncapped Hermes config"
 assert_grep "installers/phases/11-services.sh" '_hermes_context="\$\{MAX_CONTEXT:-65536\}"' \
     "Linux Hermes patcher uses selected context with 64K fallback"
 assert_grep "installers/phases/11-services.sh" '--context-length "\$_hermes_context"' \
@@ -198,6 +206,9 @@ pass "Hermes patcher updates base_url"
 grep -q '^  context_length: 65536$' "$tmp_hermes" \
     || fail "Hermes patcher updates model.context_length"
 pass "Hermes patcher updates model.context_length"
+grep -q '^  max_tokens: 1024$' "$tmp_hermes" \
+    || fail "Hermes patcher adds the bounded model output default"
+pass "Hermes patcher adds the bounded model output default"
 grep -q '^    request_timeout_seconds: 180$' "$tmp_hermes" \
     || fail "Hermes patcher writes local provider request timeout"
 pass "Hermes patcher writes local provider request timeout"
@@ -236,6 +247,7 @@ pass "Hermes patcher writes WhatsApp bridge port away from Open WebUI"
 cat > "$tmp_hermes_custom" <<'HERMES_CUSTOM_EOF'
 model:
   default: "old-model"
+  max_tokens: 2048
 platforms:
   whatsapp:
     enabled: true
@@ -260,6 +272,9 @@ pass "Hermes patcher preserves custom WhatsApp bridge port"
 grep -q '^    request_timeout_seconds: 360$' "$tmp_hermes_custom" \
     || fail "Hermes patcher preserves custom provider request timeout"
 pass "Hermes patcher preserves custom provider request timeout"
+grep -q '^  max_tokens: 2048$' "$tmp_hermes_custom" \
+    || fail "Hermes patcher preserves a custom model output cap"
+pass "Hermes patcher preserves a custom model output cap"
 
 echo ""
 echo "Results: $PASS passed"

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -252,6 +252,7 @@ def test_hermes_uses_lemonade_model_id_for_amd() -> None:
     assert 'default: "extra.Amd.gguf"' in content
     assert 'base_url: "http://litellm:4000/v1"' in content
     assert "context_length: 65536" in content
+    assert "max_tokens: 1024" in content
 
 
 def test_perplexica_default_model_matches_route() -> None:


### PR DESCRIPTION
## Summary
- cap each Hermes model turn at 1,024 tokens so pathological local-model repetition cannot monopolize ODS Talk indefinitely
- migrate uncapped configs through installer, renderer, Windows, and runtime model-switch paths while preserving operator overrides
- lock the cap into generated-config and installer parity contracts

## Root cause
A real six-cycle M5 fleet run restored Qwen 3.6 successfully, then Hermes generated a massively repetitive response without an end-of-message until the 180-second UI test timeout. Hermes supports model.max_tokens, but ODS did not set it.

## Validation
- python -m pytest -q ods/tests/test-render-runtime-configs.py (14 passed)
- ods/tests/test-installer-context-parity.sh (67 passed)
- python ods/scripts/validate-generated-configs.py (pass)
- ods/tests/test-generated-config-contracts.sh (pass)
- Windows PowerShell parser: 06-directories.ps1 syntax pass
- full release gate and live M5 reproduction in progress