### PR TITLE
fix(token-spy): price on the longest matching model prefix

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -620,13 +620,16 @@ def estimate_cost(model: str, input_tokens: int, output_tokens: int,
     if provider:
         return provider.calculate_cost(usage, model)
 
-    # Fallback to hardcoded rates for backwards compatibility
+    # Fallback to hardcoded rates for backwards compatibility.
+    # Longest match wins, as the provider plugins already do: a shorter family
+    # prefix must not shadow a more specific one just because it is declared
+    # first (gpt-4o would otherwise price every gpt-4o-mini call).
     rates = None
+    matched = ""
     model_lower = (model or "").lower()
     for prefix, r in COST_PER_MILLION.items():
-        if prefix in model_lower:
-            rates = r
-            break
+        if prefix in model_lower and len(prefix) > len(matched):
+            matched, rates = prefix, r
     if not rates:
         return 0.0
 

--- a/ods/extensions/services/token-spy/tests/test_cost_estimation.py
+++ b/ods/extensions/services/token-spy/tests/test_cost_estimation.py
@@ -1,0 +1,60 @@
+"""Fallback pricing lookup contracts for estimate_cost."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+pytest.importorskip("fastapi")
+
+
+@pytest.fixture(scope="module")
+def token_spy_main(tmp_path_factory):
+    data_dir = tmp_path_factory.mktemp("token-spy-data")
+    # main.py mints and writes an API key at import when none is configured.
+    import os
+
+    os.environ.setdefault("TOKEN_SPY_API_KEY", "test-key")
+    os.environ.setdefault("DB_PATH", str(data_dir / "usage.db"))
+    sys.path.insert(0, str(TOKEN_SPY_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"token_spy_main_{uuid4().hex}", TOKEN_SPY_DIR / "main.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(TOKEN_SPY_DIR))
+
+
+def _input_rate(module, model):
+    """USD for one million input tokens on the hardcoded fallback table."""
+    return module.estimate_cost(model, 1_000_000, 0, 0, 0, "no-such-provider")
+
+
+def test_fallback_prefers_the_longest_matching_prefix(token_spy_main):
+    # gpt-4o is a substring of gpt-4o-mini and is declared first; matching on
+    # declaration order would bill mini traffic at the full gpt-4o rate.
+    assert _input_rate(token_spy_main, "gpt-4o-mini") == pytest.approx(0.15)
+    assert _input_rate(token_spy_main, "gpt-4o") == pytest.approx(2.50)
+
+
+def test_fallback_table_has_no_shadowed_entries(token_spy_main):
+    """Every prefix must be reachable, whatever order the table is written in."""
+    table = token_spy_main.COST_PER_MILLION
+    for prefix in table:
+        cost = _input_rate(token_spy_main, prefix)
+        assert cost == pytest.approx(table[prefix]["input"]), prefix
+
+
+def test_unknown_model_is_free(token_spy_main):
+    assert _input_rate(token_spy_main, "some-unlisted-model") == 0.0
+    assert _input_rate(token_spy_main, "") == 0.0


### PR DESCRIPTION
## Problem

`COST_PER_MILLION` is documented as *"Cost per million tokens by model prefix (longer prefixes matched first)"*, but the fallback lookup in `estimate_cost` walks the dict in declaration order and breaks on the first substring hit:

```python
for prefix, r in COST_PER_MILLION.items():
    if prefix in model_lower:
        rates = r
        break
```

The table declares `gpt-4o` before `gpt-4o-mini`, and `gpt-4o` is a substring of `gpt-4o-mini`, so mini traffic never reaches its own row:

| model | correct input rate | charged before |
|---|---|---|
| `gpt-4o-mini` | $0.15 / 1M | ❌ $2.50 / 1M |
| `gpt-4o` | $2.50 / 1M | $2.50 / 1M |

Output tokens were off by the same factor ($0.60 → $10.00). That is a ~16x overstatement of spend on the one shadowed pair in the table; the Anthropic and Kimi blocks happen to be written longest-first and were unaffected.

The provider plugins already get this right — `OpenAIProvider.get_model_pricing` iterates `sorted(self.COST_TABLE.keys(), key=len, reverse=True)`. Only this backwards-compatibility fallback disagreed, so the bug surfaced whenever `ProviderRegistry.get_or_none()` returned nothing for the request's provider.

## Fix

Keep the longest match rather than the first, matching the plugins and making the table order-independent for future entries:

```python
for prefix, r in COST_PER_MILLION.items():
    if prefix in model_lower and len(prefix) > len(matched):
        matched, rates = prefix, r
```

No table rows are reordered or re-priced — only the selection rule changes.

## Tests

New `tests/test_cost_estimation.py`:
- the `gpt-4o` / `gpt-4o-mini` pair resolves to its own rate,
- **every** prefix in the table is reachable at its declared input rate, so a future entry that shadows an existing one fails here rather than silently mispricing,
- unknown and empty model names stay free.

The first two fail on the previous lookup. The module is guarded with `pytest.importorskip("fastapi")` so it skips where the service deps are absent.

```
$ python -m pytest extensions/services/token-spy/tests/test_cost_estimation.py -q
3 passed
```