### PR TITLE
fix(windows): make Bash validation portable under Git Bash

### DIFF
--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -80,6 +80,12 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 3
 fi
 
+jq_raw() {
+  # Native Windows jq emits CRLF under Git Bash. Normalize raw scalar/list
+  # output before Bash compares schema keys and values.
+  jq -r "$@" | tr -d '\r'
+}
+
 # -----------------------------
 # .env parsing (robust)
 # -----------------------------
@@ -186,9 +192,9 @@ length_errors=()
 contract_errors=()
 duplicate_errors=()
 
-mapfile -t required_keys < <(jq -r '.required[]?' "$SCHEMA_FILE")
+mapfile -t required_keys < <(jq_raw '.required[]?' "$SCHEMA_FILE")
 
-mapfile -t schema_keys < <(jq -r '.properties | keys[]' "$SCHEMA_FILE")
+mapfile -t schema_keys < <(jq_raw '.properties | keys[]' "$SCHEMA_FILE")
 declare -A SCHEMA_KEY_SET
 for key in "${schema_keys[@]}"; do
     SCHEMA_KEY_SET["$key"]=1
@@ -223,7 +229,7 @@ for key in "${schema_keys[@]}"; do
     val="${ENV_MAP[$key]-}"
     [[ -z "$val" ]] && continue
 
-    expected_type="$(jq -r --arg k "$key" '.properties[$k].type // "string"' "$SCHEMA_FILE")"
+    expected_type="$(jq_raw --arg k "$key" '.properties[$k].type // "string"' "$SCHEMA_FILE")"
 
     # Type validation
     case "$expected_type" in
@@ -253,7 +259,7 @@ for key in "${schema_keys[@]}"; do
         : # enums in our schema are for strings; ignore otherwise
       else
         if ! jq -e --arg k "$key" --arg v "$val" '.properties[$k].enum | index($v) != null' "$SCHEMA_FILE" >/dev/null 2>&1; then
-          allowed="$(jq -r --arg k "$key" '.properties[$k].enum | join(", ")' "$SCHEMA_FILE")"
+          allowed="$(jq_raw --arg k "$key" '.properties[$k].enum | join(", ")' "$SCHEMA_FILE")"
           enum_errors+=("$key: invalid value '$val' (allowed: $allowed) (line ${ENV_LINE[$key]:-?})")
         fi
       fi
@@ -262,13 +268,13 @@ for key in "${schema_keys[@]}"; do
     # Range validation (minimum/maximum) for numbers/integers
     if [[ "$expected_type" == "integer" || "$expected_type" == "number" ]]; then
       if jq -e --arg k "$key" '.properties[$k].minimum? != null' "$SCHEMA_FILE" >/dev/null 2>&1; then
-        minv="$(jq -r --arg k "$key" '.properties[$k].minimum' "$SCHEMA_FILE")"
+        minv="$(jq_raw --arg k "$key" '.properties[$k].minimum' "$SCHEMA_FILE")"
         if awk "BEGIN{exit !($val < $minv)}" 2>/dev/null; then
           range_errors+=("$key: value $val is < minimum $minv (line ${ENV_LINE[$key]:-?})")
         fi
       fi
       if jq -e --arg k "$key" '.properties[$k].maximum? != null' "$SCHEMA_FILE" >/dev/null 2>&1; then
-        maxv="$(jq -r --arg k "$key" '.properties[$k].maximum' "$SCHEMA_FILE")"
+        maxv="$(jq_raw --arg k "$key" '.properties[$k].maximum' "$SCHEMA_FILE")"
         if awk "BEGIN{exit !($val > $maxv)}" 2>/dev/null; then
           range_errors+=("$key: value $val is > maximum $maxv (line ${ENV_LINE[$key]:-?})")
         fi
@@ -279,7 +285,7 @@ for key in "${schema_keys[@]}"; do
     # CHANGEME so secrets must be replaced with real values before the stack runs.
     if [[ "$expected_type" == "string" ]]; then
       if jq -e --arg k "$key" '.properties[$k].minLength? != null' "$SCHEMA_FILE" >/dev/null 2>&1; then
-        minlen="$(jq -r --arg k "$key" '.properties[$k].minLength' "$SCHEMA_FILE")"
+        minlen="$(jq_raw --arg k "$key" '.properties[$k].minLength' "$SCHEMA_FILE")"
         if (( ${#val} < minlen )); then
           length_errors+=("$key: value length ${#val} is < minLength $minlen (line ${ENV_LINE[$key]:-?})")
         fi
@@ -442,7 +448,7 @@ log_info "Keys in schema: ${#schema_keys[@]}"
 log_info "Required keys: ${#required_keys[@]}"
 
 # Optional: print helpful summary of secrets (without values)
-secret_count=$(jq -r '.properties | to_entries[] | select(.value.secret==true) | .key' "$SCHEMA_FILE" | wc -l | tr -d ' ')
+secret_count=$(jq_raw '.properties | to_entries[] | select(.value.secret==true) | .key' "$SCHEMA_FILE" | wc -l | tr -d ' ')
 if [[ "$secret_count" =~ ^[0-9]+$ ]] && (( secret_count > 0 )); then
   log_info "Schema marks ${secret_count} key(s) as secrets (values not printed)."
 fi

--- a/ods/tests/test-linux-install-preflight.sh
+++ b/ods/tests/test-linux-install-preflight.sh
@@ -54,9 +54,9 @@ if "$LP" --json >"$JSON_OUT" 2>/dev/null || true; then
     :
 fi
 if command -v python3 >/dev/null 2>&1; then
-    if python3 - <<PY
+    if python3 - "$JSON_OUT" <<'PY'
 import json, sys
-path = "$JSON_OUT"
+path = sys.argv[1]
 with open(path, encoding="utf-8") as f:
     r = json.load(f)
 assert r.get("kind") == "linux-install-preflight"
@@ -100,9 +100,9 @@ EOF
     if PATH="$PODMAN_TMP:$PATH" "$LP" --json >"$PODMAN_JSON" 2>/dev/null || true; then
         :
     fi
-    if python3 - <<PY
-import json
-path = "$PODMAN_JSON"
+    if python3 - "$PODMAN_JSON" <<'PY'
+import json, sys
+path = sys.argv[1]
 with open(path, encoding="utf-8") as f:
     report = json.load(f)
 checks = {c["id"]: c for c in report["checks"]}

--- a/ods/tests/test-validate-env.sh
+++ b/ods/tests/test-validate-env.sh
@@ -109,6 +109,31 @@ else
 fi
 
 # 5. .env missing one required key → exit 2
+REAL_JQ="$(command -v jq)"
+CRLF_JQ_DIR="$TMP_DIR/crlf-jq"
+mkdir -p "$CRLF_JQ_DIR"
+cat > "$CRLF_JQ_DIR/jq" <<'EOF'
+#!/usr/bin/env bash
+set -o pipefail
+if [[ " $* " == *" -r "* ]]; then
+    "$ODS_TEST_REAL_JQ" "$@" | sed $'s/$/\r/'
+    exit "${PIPESTATUS[0]}"
+fi
+exec "$ODS_TEST_REAL_JQ" "$@"
+EOF
+chmod +x "$CRLF_JQ_DIR/jq"
+set +e
+PATH="$CRLF_JQ_DIR:$PATH" ODS_TEST_REAL_JQ="$REAL_JQ" \
+    "$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" \
+    "$TMP_DIR/valid.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
+r=$?
+set -e
+if [[ $r -eq 0 ]]; then
+    pass "CRLF jq raw output is normalized"
+else
+    fail "CRLF jq raw output should yield exit 0, got $r"
+fi
+
 cat > "$TMP_DIR/missing.env" <<'EOF'
 WEBUI_SECRET=test-secret
 SEARXNG_SECRET=searxsecret


### PR DESCRIPTION
## Summary
- normalize native Windows jq CRLF raw output before Bash comparisons
- pass Git Bash temp paths to Python as argv so MSYS path conversion works
- add deterministic regression coverage for CRLF-producing jq

## Why
Current main fails 7 validate-env cases and 2 Linux preflight cases when the Bash test suites run on Windows Git Bash. These are independent portability fixes extracted from the stale remote-GPU PR #1638.

## Verification
- Windows Git Bash: test-validate-env.sh: 31 passed, 0 failed
- Windows Git Bash: test-linux-install-preflight.sh: 15 passed, 0 failed
- bash -n on all three changed scripts
- git diff --check

Supersedes only the two portability hunks from #1638; no remote-provider behavior is included.

Co-authored-by: Lightheartdevs <Lightheartdevs@users.noreply.github.com>