### PR TITLE
fix(gpu): stop hybrid splits stranding a GPU on odd counts

### DIFF
--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -418,13 +418,18 @@ run_custom() {
 
   # NOTE: keep in sync with assign_gpus.py select_parallelism()
   local mode tp pp mem_util
+  # An odd GPU count has no even tensor grouping: tp*pp would come out one
+  # short and the leftover GPU would be listed but never placed. Pipeline
+  # covers every GPU, so fall back instead of splitting.
   if   [[ $n -eq 1 ]];         then mode="none";     tp=1;  pp=1;        mem_util=0.95
   elif [[ $min_rank -ge 80 ]]; then
-    if   [[ $n -le 3 ]];       then mode="tensor";   tp=$n; pp=1;        mem_util=0.92
-    else                            mode="hybrid";   tp=2;  pp=$((n/2)); mem_util=0.93; fi
+    if   [[ $n -le 3 ]];        then mode="tensor";   tp=$n; pp=1;        mem_util=0.92
+    elif (( n % 2 != 0 ));      then mode="pipeline"; tp=1;  pp=$n;       mem_util=0.95
+    else                             mode="hybrid";   tp=2;  pp=$((n/2)); mem_util=0.93; fi
   elif [[ $min_rank -le 10 ]]; then mode="pipeline"; tp=1;  pp=$n;       mem_util=0.95
   elif [[ $n -le 3 ]];         then mode="pipeline"; tp=1;  pp=$n;       mem_util=0.95
-  elif [[ $min_rank -ge 40 ]]; then mode="hybrid";   tp=2;  pp=$((n/2)); mem_util=0.93
+  elif [[ $min_rank -ge 40 && $((n % 2)) -eq 0 ]]; then
+                                    mode="hybrid";   tp=2;  pp=$((n/2)); mem_util=0.93
   else                              mode="pipeline"; tp=1;  pp=$n;       mem_util=0.95
   fi
 

--- a/ods/scripts/assign_gpus.py
+++ b/ods/scripts/assign_gpus.py
@@ -299,7 +299,10 @@ def largest_pow2_divisor(n: int) -> int:
     Find the largest power of 2 p such that:
       - p divides n evenly
       - p <= sqrt(n)  (keeps tensor_size <= pipeline_size for balance)
-    Minimum return value is 2 (hybrid requires at least 2 tensor groups).
+    Returns 1 when no such factor exists — an odd GPU count has no even
+    tensor grouping. Hybrid needs tensor_size * pipeline_size == GPU count,
+    so callers fall back to pipeline rather than clamping to 2 and leaving
+    the odd GPU out of the plan.
     """
     p = 1
     while True:
@@ -309,7 +312,7 @@ def largest_pow2_divisor(n: int) -> int:
         if candidate > math.sqrt(n):
             break
         p = candidate
-    return max(2, p)
+    return p
 
 
 def is_heterogeneous(gpus: list) -> bool:
@@ -321,6 +324,29 @@ def compute_tensor_split(gpus: list) -> list:
     """Proportional VRAM weights, rounded to 4 decimal places."""
     total = sum(g.memory_mb for g in gpus)
     return [round(g.memory_mb / total, 4) for g in gpus]
+
+
+def _pipeline_only(n: int) -> LlamaParallelism:
+    return LlamaParallelism(
+        mode="pipeline",
+        tensor_parallel_size=1,
+        pipeline_parallel_size=n,
+        gpu_memory_utilization=0.95,
+    )
+
+
+def _hybrid_or_pipeline(n: int, split: Optional[list]) -> LlamaParallelism:
+    """Hybrid split, or pipeline when the GPU count has no even grouping."""
+    tp = largest_pow2_divisor(n)
+    if tp < 2:
+        return _pipeline_only(n)
+    return LlamaParallelism(
+        mode="hybrid",
+        tensor_parallel_size=tp,
+        pipeline_parallel_size=n // tp,
+        gpu_memory_utilization=0.93,
+        tensor_split=split,
+    )
 
 
 def select_parallelism(subset: Subset) -> LlamaParallelism:
@@ -357,51 +383,20 @@ def select_parallelism(subset: Subset) -> LlamaParallelism:
                 tensor_split=split,
             )
         else:
-            tp = largest_pow2_divisor(n)
-            pp = n // tp
-            return LlamaParallelism(
-                mode="hybrid",
-                tensor_parallel_size=tp,
-                pipeline_parallel_size=pp,
-                gpu_memory_utilization=0.93,
-                tensor_split=split,
-            )
+            return _hybrid_or_pipeline(n, split)
 
     # Cross-NUMA PCIe
     if rank <= 10:
-        return LlamaParallelism(
-            mode="pipeline",
-            tensor_parallel_size=1,
-            pipeline_parallel_size=n,
-            gpu_memory_utilization=0.95,
-        )
+        return _pipeline_only(n)
 
     # Same-NUMA PCIe (rank 11-79)
     if n <= 3:
-        return LlamaParallelism(
-            mode="pipeline",
-            tensor_parallel_size=1,
-            pipeline_parallel_size=n,
-            gpu_memory_utilization=0.95,
-        )
+        return _pipeline_only(n)
     else:
         if rank >= 40:
-            tp = largest_pow2_divisor(n)
-            pp = n // tp
-            return LlamaParallelism(
-                mode="hybrid",
-                tensor_parallel_size=tp,
-                pipeline_parallel_size=pp,
-                gpu_memory_utilization=0.93,
-                tensor_split=split,
-            )
+            return _hybrid_or_pipeline(n, split)
         else:
-            return LlamaParallelism(
-                mode="pipeline",
-                tensor_parallel_size=1,
-                pipeline_parallel_size=n,
-                gpu_memory_utilization=0.95,
-            )
+            return _pipeline_only(n)
 
 
 #  Phase 4: Build Output JSON

--- a/ods/tests/test-assign-gpus.py
+++ b/ods/tests/test-assign-gpus.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 import subprocess
@@ -5,6 +6,32 @@ import sys
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "../scripts/assign_gpus.py")
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures/topology_json")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("assign_gpus_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+assign_gpus = _load_module()
+
+
+def select(n, rank, vram_mb=24000):
+    """Run select_parallelism against a synthetic n-GPU subset at `rank`."""
+    gpus = [
+        assign_gpus.GPU(index=i, uuid=f"GPU-{i}", name="test",
+                        memory_mb=vram_mb, memory_total_mb=vram_mb)
+        for i in range(n)
+    ]
+    subset = assign_gpus.Subset(
+        gpus=gpus,
+        min_link_rank=rank,
+        total_vram_mb=vram_mb * n,
+        all_pairs_highbw=rank >= assign_gpus.HIGH_BW_THRESHOLD,
+    )
+    return assign_gpus.select_parallelism(subset)
 
 def fixture_path(name):
     return os.path.join(FIXTURES_DIR, name)
@@ -466,11 +493,13 @@ class TestEightGpuNv12FullMesh:
         assert len(set(uuids)) == 3
 
     def test_model_fits_one_gpu_extras_back_to_llama_nvlink(self):
-        # NVLink pair wins, remaining=6: 3 to services, 3 extras → llama=5 GPUs, hybrid
+        # NVLink pair wins, remaining=6: 3 to services, 3 extras → llama=5 GPUs.
+        # No power of two divides 5, so a hybrid split would place only 4 of
+        # them and strand the fifth; pipeline spans all five.
         _, out, _ = run(self.TOPO, 70000)
         p = parallelism(out)
-        assert p["mode"] == "hybrid"
-        assert p["gpu_memory_utilization"] == 0.93
+        assert p["mode"] == "pipeline"
+        assert p["gpu_memory_utilization"] == 0.95
 
     def test_model_fits_one_gpu_llama_5gpus(self):
         _, out, _ = run(self.TOPO, 70000)
@@ -480,13 +509,13 @@ class TestEightGpuNv12FullMesh:
         _, out, _ = run(self.TOPO, 100000)
         assert len(llama(out)["gpus"]) == 5
 
-    def test_model_needs_two_gpus_hybrid_nvlink(self):
+    def test_model_needs_two_gpus_pipeline_nvlink(self):
         _, out, _ = run(self.TOPO, 100000)
         p = parallelism(out)
-        assert p["mode"] == "hybrid"
-        assert p["tensor_parallel_size"] == 2
-        assert p["pipeline_parallel_size"] == 2
-        assert p["gpu_memory_utilization"] == 0.93
+        assert p["mode"] == "pipeline"
+        assert p["tensor_parallel_size"] == 1
+        assert p["pipeline_parallel_size"] == 5
+        assert p["gpu_memory_utilization"] == 0.95
 
     def test_model_needs_five_gpus_no_extras(self):
         # 350GB needs 5 GPUs. remaining=3 exactly → no extras → llama has 5 GPUs
@@ -494,12 +523,12 @@ class TestEightGpuNv12FullMesh:
         assert len(llama(out)["gpus"]) == 5
         assert out["strategy"] == "dedicated"
 
-    def test_model_needs_five_gpus_hybrid(self):
+    def test_model_needs_five_gpus_pipeline(self):
         _, out, _ = run(self.TOPO, 350000)
         p = parallelism(out)
-        assert p["mode"] == "hybrid"
-        assert p["tensor_parallel_size"] == 2
-        assert p["pipeline_parallel_size"] == 2
+        assert p["mode"] == "pipeline"
+        assert p["tensor_parallel_size"] == 1
+        assert p["pipeline_parallel_size"] == 5
 
     def test_model_needs_five_gpus_services_dedicated(self):
         _, out, _ = run(self.TOPO, 350000)
@@ -609,10 +638,14 @@ class TestParallelismModeSelection:
         assert p["mode"] == "pipeline"
         assert p["pipeline_parallel_size"] == 3
 
-    def test_nvlink_full_mesh_five_gpus_hybrid(self):
-        # NV12 full mesh, extras push back → 5 GPUs → hybrid
+    def test_nvlink_full_mesh_five_gpus_pipeline(self):
+        # NV12 full mesh, extras push back → 5 GPUs. Five has no even tensor
+        # grouping, so hybrid would place only 4 of them; pipeline covers all.
         _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json"), 100000)
-        assert parallelism(out)["mode"] == "hybrid"
+        p = parallelism(out)
+        assert len(llama(out)["gpu_indices"]) == 5
+        assert p["mode"] == "pipeline"
+        assert p["pipeline_parallel_size"] == 5
 
     def test_mem_util_none_is_095(self):
         _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_1gpu_pcie.json"), 20000)
@@ -623,9 +656,44 @@ class TestParallelismModeSelection:
         assert parallelism(out)["gpu_memory_utilization"] == 0.92
 
     def test_mem_util_hybrid_is_093(self):
-        _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json"), 100000)
-        assert parallelism(out)["gpu_memory_utilization"] == 0.93
+        assert select(4, rank=90).gpu_memory_utilization == 0.93
 
     def test_mem_util_pipeline_is_095(self):
         _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_4gpus_soc.json"), 100000)
         assert parallelism(out)["gpu_memory_utilization"] == 0.95
+
+
+# ── Parallelism covers every assigned GPU ─────────────────────────────────────
+
+class TestParallelismCoversAllGpus:
+    """tensor_parallel_size * pipeline_parallel_size must equal the GPU count.
+
+    A plan that multiplies out to fewer placements than GPUs hands llama.cpp a
+    GPU it never uses, so the card is reserved and idle.
+    """
+
+    RANKS = [0, 5, 30, 50, 90]
+
+    def test_product_equals_gpu_count(self):
+        for n in range(1, 17):
+            for rank in self.RANKS:
+                p = select(n, rank)
+                product = p.tensor_parallel_size * p.pipeline_parallel_size
+                assert product == n, (
+                    f"n={n} rank={rank} mode={p.mode} "
+                    f"tp={p.tensor_parallel_size} pp={p.pipeline_parallel_size}"
+                )
+
+    def test_odd_nvlink_counts_fall_back_to_pipeline(self):
+        for n in (5, 7, 9, 11):
+            p = select(n, rank=90)
+            assert p.mode == "pipeline"
+            assert p.pipeline_parallel_size == n
+
+    def test_even_nvlink_counts_still_hybrid(self):
+        for n in (4, 6, 8, 16):
+            assert select(n, rank=90).mode == "hybrid"
+
+    def test_largest_pow2_divisor_always_divides(self):
+        for n in range(1, 65):
+            assert n % assign_gpus.largest_pow2_divisor(n) == 0


### PR DESCRIPTION
## Problem

`largest_pow2_divisor` documents two properties — *"p divides n evenly"* and *"Minimum return value is 2"* — that cannot both hold, because no power of two divides an odd number. The floor wins:

```python
return max(2, p)
```

So for every odd GPU count, `tensor_parallel_size * pipeline_parallel_size` comes out one short and a GPU that was assigned to llama-server is never placed:

| llama GPUs | tp | pp | placed |
|---|---|---|---|
| 4 | 2 | 2 | 4 ✅ |
| **5** | **2** | **2** | **4** ❌ |
| 6 | 2 | 3 | 6 ✅ |
| **7** | **2** | **3** | **6** ❌ |

Five GPUs is not a corner case — it is what the shipped 8-GPU NV12 fixture produces, because `assign_services` pushes `remaining[3:]` back to llama specifically so "no GPU sits idle":

```
$ python scripts/assign_gpus.py --topology tests/fixtures/topology_json/nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json --model-size 100000
llama gpus 5 [0, 1, 5, 6, 7]
parallelism {'mode': 'hybrid', 'tensor_parallel_size': 2, 'pipeline_parallel_size': 2, ...}
```

An A100 is reserved by llama-server and left out of the topology — the exact outcome the push-back logic exists to prevent.

`installers/phases/03-features.sh` carries a hand-maintained mirror of this rule (marked `NOTE: keep in sync with assign_gpus.py select_parallelism()`) that hardcodes `tp=2; pp=$((n/2))`, so the manual multi-GPU selection path stranded a GPU the same way.

## Fix

- `largest_pow2_divisor` returns the honest divisor, `1` when none exists, and its docstring now says so.
- `_hybrid_or_pipeline` falls back to pipeline when no even tensor grouping exists; pipeline spans every GPU. The two hybrid call sites and the four duplicated pipeline literals collapse into it.
- The shell mirror gets the same odd-count guard.

Even counts are unaffected — 4, 6, 8, 16 still get their hybrid split at the same `gpu_memory_utilization`.

Not touched: the shell mirror still hardcodes `tp=2` for even counts where Python picks the largest divisor ≤ √n (they diverge at n=16: `tp=2 pp=8` vs `tp=4 pp=4`). That is a pre-existing difference in a separate code path and changing it would alter working 16-GPU configurations, so it is out of scope here.

## Tests

Three existing cases pinned `tp=2 pp=2` for a five-GPU assignment — they were asserting the stranded plan, and are updated to the pipeline outcome with the reason inline. Those five-GPU fixtures were also the *only* hybrid output the suite exercised, and the assertions never multiplied `tp * pp` out, which is how this survived.

New `TestParallelismCoversAllGpus` checks the missing invariant directly against `select_parallelism`: `tp * pp == GPU count` for counts 1–16 across every rank band, odd NVLink counts fall back to pipeline, even ones stay hybrid, and `largest_pow2_divisor` divides its input for 1–64.

```
$ python -m pytest tests/test-assign-gpus.py -q
89 passed
```

Against the previous algorithm, 7 fail. `bash -n` passes on the installer phase and `tests/test-phase03-multigpu-tty.sh` still passes.