### PR TITLE
fix(litellm): keep cloud routing authoritative

### DIFF
--- a/ods/config/litellm/cloud.yaml
+++ b/ods/config/litellm/cloud.yaml
@@ -1,4 +1,10 @@
 model_list:
+  # Stable public alias used by Switchboard-aware ODS consumers.
+  - model_name: ods/current
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+
   - model_name: default
     litellm_params:
       model: anthropic/claude-sonnet-4-5-20250514

--- a/ods/extensions/services/litellm/README.md
+++ b/ods/extensions/services/litellm/README.md
@@ -25,6 +25,10 @@ ODS does not expose LiteLLM as a normal dashboard quicklink. The upstream LiteLL
 
 The active mode is controlled by `ODS_MODE` in `.env`. The corresponding config file is loaded automatically from `config/litellm/`.
 
+`ODS_MODEL_SWITCHBOARD=enabled` selects the local Switchboard route only when
+the active mode has a local runtime. `ODS_MODE=cloud` always keeps
+`config/litellm/cloud.yaml` authoritative.
+
 ### local (default)
 
 Routes all requests to llama-server. No cloud API keys required.

--- a/ods/extensions/services/litellm/compose.yaml
+++ b/ods/extensions/services/litellm/compose.yaml
@@ -12,12 +12,14 @@ services:
       - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
       - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       - LANGFUSE_ENABLED=${LANGFUSE_ENABLED:-false}
+      - ODS_MODE=${ODS_MODE:-local}
       - ODS_MODEL_SWITCHBOARD=${ODS_MODEL_SWITCHBOARD:-observe}
       - TOKEN_SPY_URL=${TOKEN_SPY_URL:-http://token-spy:8080}
       - TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}
     volumes:
       - ./config/litellm/${ODS_MODE:-local}.yaml:/app/config.yaml:ro,z
       - ./config/litellm/switchboard.yaml:/app/switchboard.yaml:ro,z
+      - ./extensions/services/litellm/select-config.sh:/app/ods-select-config.sh:ro,z
       # LiteLLM resolves custom callback modules relative to the generated
       # /tmp/config.yaml, so the callback must be mounted alongside it.
       - ./extensions/services/litellm/ods_token_spy_callback.py:/tmp/ods_token_spy_callback.py:ro,z
@@ -26,10 +28,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        CONFIG_PATH=/app/config.yaml
-        if [ "$$ODS_MODEL_SWITCHBOARD" = "enabled" ]; then
-          CONFIG_PATH=/app/switchboard.yaml
-        fi
+        CONFIG_PATH=$$(sh /app/ods-select-config.sh)
         export CONFIG_PATH
         python3 -c "
         import os

--- a/ods/extensions/services/litellm/select-config.sh
+++ b/ods/extensions/services/litellm/select-config.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+mode="${ODS_MODE:-local}"
+switchboard="${ODS_MODEL_SWITCHBOARD:-observe}"
+mode_config="${1:-/app/config.yaml}"
+switchboard_config="${2:-/app/switchboard.yaml}"
+
+# Cloud routing is authoritative in cloud mode. The switchboard config targets
+# ODS's local model-router and is valid only for modes with a local runtime.
+if [ "$mode" != "cloud" ] && [ "$switchboard" = "enabled" ]; then
+    printf '%s\n' "$switchboard_config"
+else
+    printf '%s\n' "$mode_config"
+fi

--- a/ods/tests/contracts/test-windows-amd-local-compose.sh
+++ b/ods/tests/contracts/test-windows-amd-local-compose.sh
@@ -168,10 +168,10 @@ switchboard_litellm_rendered="$(
     config litellm
 )"
 
-grep -q 'CONFIG_PATH=/app/config.yaml' <<<"$switchboard_litellm_rendered" \
-  || { echo "[FAIL] AMD LiteLLM render must keep the base CONFIG_PATH command"; exit 1; }
-grep -q 'CONFIG_PATH=/app/switchboard.yaml' <<<"$switchboard_litellm_rendered" \
-  || { echo "[FAIL] AMD LiteLLM render must keep switchboard.yaml selection"; exit 1; }
+grep -q 'ODS_MODE: local' <<<"$switchboard_litellm_rendered" \
+  || { echo "[FAIL] AMD LiteLLM render must receive the active ODS mode"; exit 1; }
+grep -q 'ods-select-config.sh' <<<"$switchboard_litellm_rendered" \
+  || { echo "[FAIL] AMD LiteLLM render must keep the mode-aware config selector"; exit 1; }
 
 # Match the Windows installer's precedence: platform overlays are loaded before
 # extension base/GPU overlays. Rendering the complete stack catches a later

--- a/ods/tests/test-litellm-amd-auth-enforced.sh
+++ b/ods/tests/test-litellm-amd-auth-enforced.sh
@@ -24,11 +24,14 @@ echo "[guard] LiteLLM AMD overlay must preserve switchboard command"
 if grep -q 'exec litellm --config /app/config.yaml' \
         extensions/services/litellm/compose.amd.yaml; then
     fail "compose.amd.yaml: hard-coded config.yaml bypasses switchboard.yaml"
-elif grep -q 'CONFIG_PATH=/app/switchboard.yaml' \
-        extensions/services/litellm/compose.yaml; then
-    pass "compose.amd.yaml: does not override the base switchboard-aware command"
+elif grep -q 'ods-select-config.sh' extensions/services/litellm/compose.yaml \
+        && grep -Fq '[ "$mode" != "cloud" ]' \
+            extensions/services/litellm/select-config.sh \
+        && grep -Fq '[ "$switchboard" = "enabled" ]' \
+            extensions/services/litellm/select-config.sh; then
+    pass "compose.amd.yaml: preserves the mode-aware switchboard selector"
 else
-    fail "compose.yaml: missing base switchboard-aware LiteLLM command"
+    fail "compose.yaml: missing mode-aware LiteLLM config selector"
 fi
 
 echo "[guard] open-webui must not hardcode OPENAI_API_KEY=no-key on AMD"

--- a/ods/tests/test-litellm-config-selection.sh
+++ b/ods/tests/test-litellm-config-selection.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELECTOR="$ROOT_DIR/extensions/services/litellm/select-config.sh"
+COMPOSE="$ROOT_DIR/extensions/services/litellm/compose.yaml"
+CLOUD_CONFIG="$ROOT_DIR/config/litellm/cloud.yaml"
+passed=0
+failed=0
+
+check_selection() {
+    local mode="$1"
+    local switchboard="$2"
+    local expected="$3"
+    local actual
+
+    actual="$(
+        ODS_MODE="$mode" ODS_MODEL_SWITCHBOARD="$switchboard" \
+            sh "$SELECTOR" /mode.yaml /switchboard.yaml
+    )"
+    if [[ "$actual" == "$expected" ]]; then
+        printf '[PASS] %s + %s -> %s\n' "$mode" "$switchboard" "$expected"
+        passed=$((passed + 1))
+    else
+        printf '[FAIL] %s + %s: expected %s, got %s\n' \
+            "$mode" "$switchboard" "$expected" "$actual"
+        failed=$((failed + 1))
+    fi
+}
+
+[[ -f "$SELECTOR" ]] || {
+    printf '[FAIL] LiteLLM config selector is missing\n'
+    exit 1
+}
+
+check_selection local observe /mode.yaml
+check_selection local enabled /switchboard.yaml
+check_selection hybrid enabled /switchboard.yaml
+check_selection lemonade enabled /switchboard.yaml
+check_selection cloud observe /mode.yaml
+check_selection cloud enabled /mode.yaml
+
+if grep -Fq 'ODS_MODE=${ODS_MODE:-local}' "$COMPOSE" \
+    && grep -Fq 'sh /app/ods-select-config.sh' "$COMPOSE"; then
+    printf '[PASS] Compose passes mode and delegates config selection\n'
+    passed=$((passed + 1))
+else
+    printf '[FAIL] Compose does not use the tested config selector\n'
+    failed=$((failed + 1))
+fi
+
+if grep -Fq 'model_name: ods/current' "$CLOUD_CONFIG"; then
+    printf '[PASS] Cloud config exposes the stable ods/current alias\n'
+    passed=$((passed + 1))
+else
+    printf '[FAIL] Cloud config does not expose the stable ods/current alias\n'
+    failed=$((failed + 1))
+fi
+
+printf '\nResult: %d passed, %d failed\n' "$passed" "$failed"
+(( failed == 0 ))


### PR DESCRIPTION
## Summary
- keep cloud.yaml authoritative when ODS_MODE=cloud, even if Switchboard is enabled
- expose the stable ods/current alias from cloud routing
- extract config selection into a portable, behavior-tested shell helper
- update AMD compose guards to follow the tested selector

## Why
Current main selects switchboard.yaml whenever ODS_MODEL_SWITCHBOARD=enabled. In cloud mode that silently replaces cloud providers with the local model-router route. Simply retaining cloud.yaml is not enough because Switchboard-aware consumers request ods/current, so this PR closes both sides of the contract.

## Verification
- config-selection truth table: 8 passed, 0 failed
- Windows AMD compose contract: pass
- LiteLLM AMD auth/selector guards: 5 passed, 0 failed
- runtime renderer suite: pass
- switchboard bypass inventory: pass
- generated-config contracts: pass
- bash syntax and git diff checks: pass

This is the first behavior slice of the remote-provider routing convergence plan in #2088.

Co-authored-by: Lightheartdevs <Lightheartdevs@users.noreply.github.com>