### PR TITLE
fix(settings): apply SearXNG config to the SearXNG container

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -369,13 +369,17 @@ def _empty_value_unsets_env_key(key: str, field: dict[str, Any]) -> bool:
 def _match_apply_service(key: str) -> Optional[str]:
     if key in _LLAMA_APPLY_KEYS or key.startswith(("LLAMA_", "GGUF_")):
         return "llama-server"
+    # SEARXNG_URL points Hermes at a search backend; the rest of the SEARXNG_*
+    # keys (port, secret) are read by the searxng container itself. Open WebUI
+    # reaches searxng over the fixed internal port and consumes neither.
     if key == "SEARXNG_URL":
         return "hermes"
+    if key.startswith("SEARXNG_"):
+        return "searxng"
     if (
         key in _OPEN_WEBUI_APPLY_KEYS
         or key.startswith("WEBUI_")
         or key.startswith("OPENAI_API_")
-        or key.startswith("SEARXNG_")
     ):
         return "open-webui"
     if key in _TOKEN_SPY_APPLY_KEYS or key.startswith("TOKEN_SPY_"):

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1264,3 +1264,29 @@ def test_env_example_keys_are_present_in_schema():
     schema_keys = set(schema.get("properties", {}))
 
     assert documented_keys - schema_keys == set()
+
+
+def test_settings_apply_plan_routes_searxng_keys_to_searxng():
+    from settings import _compute_env_apply_plan
+
+    # SEARXNG_PORT and SEARXNG_SECRET are only read by the searxng container
+    # (extensions/services/searxng/compose.yaml). Recreating open-webui would
+    # take chat down without ever applying the new value.
+    plan = _compute_env_apply_plan(
+        {"SEARXNG_PORT": "8888", "SEARXNG_SECRET": "old"},
+        {"SEARXNG_PORT": "8899", "SEARXNG_SECRET": "new"},
+    )
+
+    assert plan["services"] == ["searxng"]
+    assert plan["manualKeys"] == []
+
+
+def test_settings_apply_plan_keeps_searxng_url_on_hermes():
+    from settings import _compute_env_apply_plan
+
+    plan = _compute_env_apply_plan(
+        {"SEARXNG_URL": "http://searxng:8080"},
+        {"SEARXNG_URL": "http://search:8080"},
+    )
+
+    assert plan["services"] == ["hermes"]


### PR DESCRIPTION
## Problem

`_match_apply_service` sends every `SEARXNG_*` key except `SEARXNG_URL` to **open-webui**:

```python
if key == "SEARXNG_URL":
    return "hermes"
if (
    key in _OPEN_WEBUI_APPLY_KEYS
    or key.startswith("WEBUI_")
    or key.startswith("OPENAI_API_")
    or key.startswith("SEARXNG_")     # <- everything else
):
    return "open-webui"
```

The schema defines three such keys — `SEARXNG_URL`, `SEARXNG_PORT`, `SEARXNG_SECRET` — and only the first belongs to another service (it points Hermes at a search backend, per `extensions/services/hermes/compose.yaml`). The other two are read solely by the searxng container:

```yaml
# extensions/services/searxng/compose.yaml
- SEARXNG_BASE_URL=http://localhost:${SEARXNG_PORT:-8888}/
- SEARXNG_SECRET=${SEARXNG_SECRET:?...}
- "${BIND_ADDRESS:-127.0.0.1}:${SEARXNG_PORT:-8888}:8080"
```

Open WebUI consumes neither — it reaches searxng over the fixed internal port via a literal in `docker-compose.base.yml` (`SEARXNG_QUERY_URL: "http://searxng:8080/search?..."`), not from `.env`.

So editing `SEARXNG_SECRET` or `SEARXNG_PORT` in the dashboard and clicking Apply:

- recreated **open-webui**, taking chat down for a restart that could not apply the value;
- left **searxng** running with the stale secret and the old published port;
- reported success.

`"searxng"` is already listed in `_SETTINGS_APPLY_ALLOWED_SERVICES`, so the plan was always permitted to target it — no key ever mapped to it.

## Fix

```python
if key == "SEARXNG_URL":
    return "hermes"
if key.startswith("SEARXNG_"):
    return "searxng"
```

`SEARXNG_URL` keeps its existing Hermes routing.

## Tests

Two cases in `tests/test_settings_env.py`: `SEARXNG_PORT`/`SEARXNG_SECRET` plan to `["searxng"]` (fails on the previous mapping, which planned `["open-webui"]`), and `SEARXNG_URL` still plans to `["hermes"]`.

```
$ python -m pytest extensions/services/dashboard-api/tests/test_settings_env.py -q
76 passed
$ python -m pytest extensions/services/dashboard-api/tests/ -q -k "settings or apply"
103 passed
```