### PR TITLE
fix(settings): recreate litellm for the keys only litellm reads

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -55,6 +55,13 @@ _TOKEN_SPY_APPLY_KEYS = {
 _PRIVACY_SHIELD_APPLY_KEYS = {
     "TARGET_API_URL", "PII_CACHE_ENABLED", "SHIELD_PORT",
 }
+# Keys whose prefix suggests another service but which only litellm reads.
+# Open WebUI's OPENAI_API_KEY comes from OPEN_WEBUI_LLM_API_KEY, and the
+# langfuse container never sees the tracing toggle — litellm registers the
+# callback from it.
+_LITELLM_APPLY_KEYS = {
+    "OPENAI_API_KEY", "LANGFUSE_ENABLED",
+}
 _MANUAL_RESTART_KEYS = {
     "BIND_ADDRESS",
     "DASHBOARD_API_KEY", "ODS_AGENT_KEY", "DASHBOARD_PORT",
@@ -369,6 +376,8 @@ def _empty_value_unsets_env_key(key: str, field: dict[str, Any]) -> bool:
 def _match_apply_service(key: str) -> Optional[str]:
     if key in _LLAMA_APPLY_KEYS or key.startswith(("LLAMA_", "GGUF_")):
         return "llama-server"
+    if key in _LITELLM_APPLY_KEYS:
+        return "litellm"
     if key == "SEARXNG_URL":
         return "hermes"
     if (

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1264,3 +1264,30 @@ def test_env_example_keys_are_present_in_schema():
     schema_keys = set(schema.get("properties", {}))
 
     assert documented_keys - schema_keys == set()
+
+
+def test_settings_apply_plan_routes_litellm_only_keys_to_litellm():
+    from settings import _compute_env_apply_plan
+
+    # extensions/services/litellm/compose.yaml is the only place that reads
+    # ${OPENAI_API_KEY} and ${LANGFUSE_ENABLED}. Open WebUI's OPENAI_API_KEY
+    # comes from OPEN_WEBUI_LLM_API_KEY and the langfuse container never sees
+    # the toggle, so recreating either could not apply the change.
+    plan = _compute_env_apply_plan(
+        {"OPENAI_API_KEY": "sk-old", "LANGFUSE_ENABLED": "false"},
+        {"OPENAI_API_KEY": "sk-new", "LANGFUSE_ENABLED": "true"},
+    )
+
+    assert plan["services"] == ["litellm"]
+    assert plan["manualKeys"] == []
+
+
+def test_settings_apply_plan_keeps_other_langfuse_keys_on_langfuse():
+    from settings import _compute_env_apply_plan
+
+    plan = _compute_env_apply_plan(
+        {"LANGFUSE_PORT": "3100"},
+        {"LANGFUSE_PORT": "3101"},
+    )
+
+    assert plan["services"] == ["langfuse"]


### PR DESCRIPTION
## Problem

Two keys in `_match_apply_service` are captured by a prefix rule that names the wrong service:

- `OPENAI_API_KEY` hits `key.startswith("OPENAI_API_")` → **open-webui**
- `LANGFUSE_ENABLED` hits `key.startswith("LANGFUSE_")` → **langfuse**

Neither container reads either value. The only place in the tree that interpolates them is litellm:

```yaml
# extensions/services/litellm/compose.yaml
- OPENAI_API_KEY=${OPENAI_API_KEY:-}
- LANGFUSE_ENABLED=${LANGFUSE_ENABLED:-false}
...
if os.environ.get('LANGFUSE_ENABLED') == 'true':   # registers the callback
```

Open WebUI does set a container variable named `OPENAI_API_KEY`, but it is sourced from a different `.env` key:

```yaml
# docker-compose.base.yml
OPENAI_API_KEY: "${OPEN_WEBUI_LLM_API_KEY:-}"
```

and the langfuse service has no tracing toggle at all — it is the collector, not the emitter.

So rotating a cloud provider key, or switching Langfuse tracing on, from the dashboard:

- recreated an unrelated service (chat downtime for the `OPENAI_API_KEY` case),
- left litellm running with the old key / no callback,
- and reported the apply as `ready`.

`OPENAI_API_KEY` is the only schema key starting with `OPENAI_API_`, so that prefix branch existed solely to catch this one key.

## Fix

A small explicit set checked before the prefix rules:

```python
_LITELLM_APPLY_KEYS = {"OPENAI_API_KEY", "LANGFUSE_ENABLED"}
```

Every other `LANGFUSE_*` key (port, secrets, init values) still routes to langfuse, which does read those.

Out of scope: `ANTHROPIC_API_KEY`, `TOGETHER_API_KEY` and `MINIMAX_API_KEY` are also litellm-only but currently fall through to `manualKeys`, which tells the user to restart the stack. That is disruptive rather than wrong, so it is left alone here.

## Tests

`tests/test_settings_env.py` gains a case pinning both keys to `["litellm"]` (fails on the previous mapping, which planned `["langfuse", "open-webui"]`) and one confirming `LANGFUSE_PORT` still plans `["langfuse"]`.

```
$ python -m pytest extensions/services/dashboard-api/tests/ -q -k "settings or apply"
103 passed
```