### PR TITLE
feat(routing): canonicalize LiteLLM mode rendering

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -8442,7 +8442,10 @@ def _render_model_router_runtime_configs(
         "context_length": int(context_length),
         "switchboard_mode": switchboard_mode,
     }
-    for surface in ("model-router-endpoints", "litellm-switchboard"):
+    surfaces = ["model-router-endpoints"]
+    if str(common["ods_mode"]).strip().lower() != "cloud":
+        surfaces.append("litellm-switchboard")
+    for surface in surfaces:
         if _render_runtime_config(install_dir, surface, **common):
             continue
         message = f"Failed to render required {surface} config"

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -8522,6 +8522,7 @@ def _write_lemonade_config(
 
 def _write_windows_native_litellm_config(install_dir: Path, gguf_file: str, env: dict):
     """Regenerate LiteLLM local.yaml for native Windows llama-server."""
+    # ODS-CONTRACT-WRITER: litellm-local-native
     config_path = install_dir / "config" / "litellm" / "local.yaml"
     port = env.get("AMD_INFERENCE_PORT") or env.get("OLLAMA_PORT") or "8080"
     api_base = f"http://host.docker.internal:{port}/v1"

--- a/ods/config/generated-config-contracts.json
+++ b/ods/config/generated-config-contracts.json
@@ -133,6 +133,7 @@
       "target_paths": [
         "config/litellm/local.yaml"
       ],
+      "writer_marker": "ODS-CONTRACT-WRITER: litellm-local-native",
       "writers": [
         {
           "platform": "canonical-renderer",
@@ -140,6 +141,10 @@
         },
         {
           "platform": "windows-installer",
+          "path": "installers/windows/install-windows.ps1"
+        },
+        {
+          "platform": "windows-env-generator",
           "path": "installers/windows/lib/env-generator.ps1"
         },
         {

--- a/ods/config/generated-config-contracts.json
+++ b/ods/config/generated-config-contracts.json
@@ -110,8 +110,12 @@
       ],
       "writers": [
         {
-          "platform": "canonical",
+          "platform": "canonical-renderer",
           "path": "scripts/render-runtime-configs.py"
+        },
+        {
+          "platform": "checked-in-template",
+          "path": "config/litellm/local.yaml"
         }
       ],
       "invariants": [
@@ -124,6 +128,39 @@
       ]
     },
     {
+      "id": "litellm-local-native",
+      "label": "LiteLLM host-native local model routing",
+      "target_paths": [
+        "config/litellm/local.yaml"
+      ],
+      "writers": [
+        {
+          "platform": "canonical-renderer",
+          "path": "scripts/render-runtime-configs.py"
+        },
+        {
+          "platform": "windows-installer",
+          "path": "installers/windows/lib/env-generator.ps1"
+        },
+        {
+          "platform": "windows-upgrade",
+          "path": "scripts/bootstrap-upgrade.sh"
+        },
+        {
+          "platform": "windows-runtime",
+          "path": "bin/ods-host-agent.py"
+        }
+      ],
+      "invariants": [
+        {
+          "id": "native-local-projection-exists",
+          "type": "file_contains",
+          "path": "scripts/render-runtime-configs.py",
+          "needle": "def render_litellm_local_native"
+        }
+      ]
+    },
+    {
       "id": "litellm-cloud",
       "label": "LiteLLM cloud model routing",
       "target_paths": [
@@ -131,8 +168,12 @@
       ],
       "writers": [
         {
-          "platform": "canonical",
+          "platform": "canonical-preview",
           "path": "scripts/render-runtime-configs.py"
+        },
+        {
+          "platform": "checked-in-template",
+          "path": "config/litellm/cloud.yaml"
         }
       ],
       "invariants": [
@@ -152,8 +193,12 @@
       ],
       "writers": [
         {
-          "platform": "canonical",
+          "platform": "canonical-preview",
           "path": "scripts/render-runtime-configs.py"
+        },
+        {
+          "platform": "checked-in-template",
+          "path": "config/litellm/hybrid.yaml"
         }
       ],
       "invariants": [
@@ -172,6 +217,10 @@
         "config/litellm/lemonade.yaml"
       ],
       "writers": [
+        {
+          "platform": "canonical-renderer",
+          "path": "scripts/render-runtime-configs.py"
+        },
         {
           "platform": "linux",
           "path": "installers/phases/06-directories.sh"
@@ -214,8 +263,12 @@
       ],
       "writers": [
         {
-          "platform": "canonical",
+          "platform": "canonical-renderer",
           "path": "scripts/render-runtime-configs.py"
+        },
+        {
+          "platform": "checked-in-template",
+          "path": "config/litellm/switchboard.yaml"
         }
       ],
       "invariants": [
@@ -241,8 +294,12 @@
       ],
       "writers": [
         {
-          "platform": "canonical",
+          "platform": "canonical-renderer",
           "path": "scripts/render-runtime-configs.py"
+        },
+        {
+          "platform": "windows-installer",
+          "path": "installers/windows/lib/env-generator.ps1"
         }
       ],
       "invariants": [

--- a/ods/config/generated-config-contracts.json
+++ b/ods/config/generated-config-contracts.json
@@ -103,6 +103,69 @@
       ]
     },
     {
+      "id": "litellm-local",
+      "label": "LiteLLM local model routing",
+      "target_paths": [
+        "config/litellm/local.yaml"
+      ],
+      "writers": [
+        {
+          "platform": "canonical",
+          "path": "scripts/render-runtime-configs.py"
+        }
+      ],
+      "invariants": [
+        {
+          "id": "local-routes-to-llama-server",
+          "type": "yaml_text_contains",
+          "path": "config/litellm/local.yaml",
+          "needle": "api_base: http://llama-server:8080/v1"
+        }
+      ]
+    },
+    {
+      "id": "litellm-cloud",
+      "label": "LiteLLM cloud model routing",
+      "target_paths": [
+        "config/litellm/cloud.yaml"
+      ],
+      "writers": [
+        {
+          "platform": "canonical",
+          "path": "scripts/render-runtime-configs.py"
+        }
+      ],
+      "invariants": [
+        {
+          "id": "cloud-exposes-stable-alias",
+          "type": "yaml_text_contains",
+          "path": "config/litellm/cloud.yaml",
+          "needle": "model_name: ods/current"
+        }
+      ]
+    },
+    {
+      "id": "litellm-hybrid",
+      "label": "LiteLLM hybrid model routing",
+      "target_paths": [
+        "config/litellm/hybrid.yaml"
+      ],
+      "writers": [
+        {
+          "platform": "canonical",
+          "path": "scripts/render-runtime-configs.py"
+        }
+      ],
+      "invariants": [
+        {
+          "id": "hybrid-preserves-cloud-fallback",
+          "type": "yaml_text_contains",
+          "path": "config/litellm/hybrid.yaml",
+          "needle": "fallbacks:"
+        }
+      ]
+    },
+    {
       "id": "litellm-lemonade",
       "label": "LiteLLM Lemonade model routing",
       "target_paths": [
@@ -140,6 +203,54 @@
           "type": "file_contains",
           "path": "scripts/bootstrap-upgrade.sh",
           "needle": "extra."
+        }
+      ]
+    },
+    {
+      "id": "litellm-switchboard",
+      "label": "LiteLLM stable-alias Switchboard routing",
+      "target_paths": [
+        "config/litellm/switchboard.yaml"
+      ],
+      "writers": [
+        {
+          "platform": "canonical",
+          "path": "scripts/render-runtime-configs.py"
+        }
+      ],
+      "invariants": [
+        {
+          "id": "switchboard-exposes-stable-alias",
+          "type": "yaml_text_contains",
+          "path": "config/litellm/switchboard.yaml",
+          "needle": "model_name: ods/current"
+        },
+        {
+          "id": "switchboard-routes-to-model-router",
+          "type": "yaml_text_contains",
+          "path": "config/litellm/switchboard.yaml",
+          "needle": "api_base: http://model-router:9099/v1"
+        }
+      ]
+    },
+    {
+      "id": "model-router-endpoints",
+      "label": "Model Router endpoint allowlist",
+      "target_paths": [
+        "config/model-router/endpoints.json"
+      ],
+      "writers": [
+        {
+          "platform": "canonical",
+          "path": "scripts/render-runtime-configs.py"
+        }
+      ],
+      "invariants": [
+        {
+          "id": "router-endpoint-document",
+          "type": "file_contains",
+          "path": "config/model-router/endpoints.json",
+          "needle": "\"endpoints\""
         }
       ]
     },

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1782,6 +1782,7 @@ else
         fi
     done
     if [[ "$_macos_switchboard_mode" == "enabled" ]] \
+       && [[ "$(read_env_value "${INSTALL_DIR}/.env" "ODS_MODE")" != "cloud" ]] \
        && ! "$_macos_runtime_renderer" "${INSTALL_DIR}/scripts/render-runtime-configs.py" \
             --surface litellm-switchboard "${_macos_router_args[@]}" >> "$ODS_LOG_FILE" 2>&1; then
         ai_err "Failed to render required litellm-switchboard config"

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -1064,9 +1064,10 @@ LITELLM_EOF
         error "Model router config renderer is unavailable"
         return 1
     fi
+    _router_ods_mode="${ODS_MODE_VALUE:-${ODS_MODE:-local}}"
     _router_common_args=(
         --switchboard-mode "${ODS_MODEL_SWITCHBOARD_VALUE:-observe}"
-        --ods-mode "${ODS_MODE:-local}"
+        --ods-mode "$_router_ods_mode"
         --gpu-backend "${GPU_BACKEND:-nvidia}"
         --gguf-file "${GGUF_FILE:-}"
         --lemonade-model-id "${LEMONADE_MODEL_VALUE:-}"
@@ -1076,7 +1077,11 @@ LITELLM_EOF
         --output-root "$INSTALL_DIR"
         --write
     )
-    for _router_surface in model-router-endpoints litellm-switchboard; do
+    _router_surfaces=(model-router-endpoints)
+    if [[ "$_router_ods_mode" != "cloud" ]]; then
+        _router_surfaces+=(litellm-switchboard)
+    fi
+    for _router_surface in "${_router_surfaces[@]}"; do
         if ! "$_router_renderer_py" "$SCRIPT_DIR/scripts/render-runtime-configs.py" \
             --surface "$_router_surface" "${_router_common_args[@]}" \
             >> "$LOG_FILE" 2>&1; then
@@ -1085,6 +1090,7 @@ LITELLM_EOF
         fi
     done
     unset _router_renderer_py _router_surface _router_common_args
+    unset _router_ods_mode _router_surfaces
 
     # Validate generated .env against schema (fails fast on missing/unknown keys).
     _phase06_step "validate-env"

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -850,6 +850,7 @@ litellm_settings:
   request_timeout: 900
   stream_timeout: 900
 "@
+                    # ODS-CONTRACT-WRITER: litellm-local-native
                     [System.IO.File]::WriteAllText((Join-Path $litellmDir "local.yaml"), $litellmLocal, (New-Object System.Text.UTF8Encoding($false)))
                     Write-AISuccess "Patched LiteLLM local config for native llama-server"
                 }

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -834,6 +834,7 @@ litellm_settings:
   request_timeout: 900
   stream_timeout: 900
 "@
+        # ODS-CONTRACT-WRITER: litellm-local-native
         Write-Utf8NoBom -Path (Join-Path $litellmDir "local.yaml") -Content $localConfig
     }
 

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -1719,6 +1719,7 @@ activate_windows_lemonade_full_model() {
 }
 
 refresh_windows_native_litellm_local_config_after_swap() {
+    # ODS-CONTRACT-WRITER: litellm-local-native
     is_windows_bash || return 0
 
     local runtime runtime_mode location managed

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -73,6 +73,130 @@ def opencode_key(inputs: RenderInputs) -> str:
     return inputs.litellm_key if inputs.ods_mode == "lemonade" else NO_KEY
 
 
+def render_litellm_local(inputs: RenderInputs) -> RenderedFile:
+    content = """model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/default
+      api_base: http://llama-server:8080/v1
+      api_key: not-needed
+
+  - model_name: "*"
+    litellm_params:
+      model: openai/*
+      api_base: http://llama-server:8080/v1
+      api_key: not-needed
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 120
+  stream_timeout: 60
+"""
+    return RenderedFile("litellm-local", "config/litellm/local.yaml", content)
+
+
+def render_litellm_cloud(inputs: RenderInputs) -> RenderedFile:
+    content = """model_list:
+  # Stable public alias used by Switchboard-aware ODS consumers.
+  - model_name: ods/current
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: default
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: gpt4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: fast
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: minimax
+    litellm_params:
+      model: openai/MiniMax-M2.7
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: minimax-fast
+    litellm_params:
+      model: openai/MiniMax-M2.7-highspeed
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+router_settings:
+  routing_strategy: simple-shuffle
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+"""
+    return RenderedFile("litellm-cloud", "config/litellm/cloud.yaml", content)
+
+
+def render_litellm_hybrid(inputs: RenderInputs) -> RenderedFile:
+    content = """model_list:
+  - model_name: local
+    litellm_params:
+      model: openai/default
+      api_base: http://llama-server:8080/v1
+      api_key: not-needed
+
+  - model_name: cloud
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: minimax
+    litellm_params:
+      model: openai/MiniMax-M2.7
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: minimax-fast
+    litellm_params:
+      model: openai/MiniMax-M2.7-highspeed
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: default
+    litellm_params:
+      model: openai/default
+      api_base: http://llama-server:8080/v1
+      api_key: not-needed
+
+router_settings:
+  routing_strategy: simple-shuffle
+  num_retries: 2
+  fallbacks:
+    - local:
+        - cloud
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 120
+  stream_timeout: 60
+"""
+    return RenderedFile("litellm-hybrid", "config/litellm/hybrid.yaml", content)
+
+
 def render_litellm_lemonade(inputs: RenderInputs) -> RenderedFile:
     model = lemonade_model_id(inputs)
     api_base = inputs.lemonade_api_base.rstrip("/") or "http://llama-server:8080/api/v1"
@@ -304,6 +428,9 @@ def render_model_router_endpoints(inputs: RenderInputs) -> RenderedFile:
 RENDERERS: dict[str, Callable[[RenderInputs], RenderedFile]] = {
     "env": render_env,
     "opencode": render_opencode,
+    "litellm-local": render_litellm_local,
+    "litellm-cloud": render_litellm_cloud,
+    "litellm-hybrid": render_litellm_hybrid,
     "litellm-lemonade": render_litellm_lemonade,
     "perplexica": render_perplexica,
     "hermes": render_hermes,
@@ -336,11 +463,27 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def select_surfaces(surface: str, switchboard_mode: str = "observe") -> list[str]:
+def select_surfaces(
+    surface: str,
+    ods_mode: str = "local",
+    switchboard_mode: str = "observe",
+) -> list[str]:
     if surface == "all":
-        surfaces = ["env", "opencode", "litellm-lemonade", "perplexica", "hermes",
-                    "model-router-endpoints"]
-        if switchboard_mode == "enabled":
+        mode_surface = {
+            "local": "litellm-local",
+            "cloud": "litellm-cloud",
+            "hybrid": "litellm-hybrid",
+            "lemonade": "litellm-lemonade",
+        }[ods_mode]
+        surfaces = [
+            "env",
+            "opencode",
+            mode_surface,
+            "perplexica",
+            "hermes",
+            "model-router-endpoints",
+        ]
+        if switchboard_mode == "enabled" and ods_mode != "cloud":
             surfaces.append("litellm-switchboard")
         return surfaces
     return [surface]
@@ -360,7 +503,14 @@ def render(args: argparse.Namespace) -> dict[str, object]:
         opencode_port=args.opencode_port,
         context_length=args.context_length,
     )
-    files = [RENDERERS[name](inputs) for name in select_surfaces(args.surface, inputs.switchboard_mode)]
+    files = [
+        RENDERERS[name](inputs)
+        for name in select_surfaces(
+            args.surface,
+            inputs.ods_mode,
+            inputs.switchboard_mode,
+        )
+    ]
     written: list[str] = []
     if args.write:
         output_root = Path(args.output_root)

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -99,6 +99,44 @@ litellm_settings:
     return RenderedFile("litellm-local", "config/litellm/local.yaml", content)
 
 
+def render_litellm_local_native(inputs: RenderInputs) -> RenderedFile:
+    model = inputs.gguf_file or inputs.model
+    api_base = inputs.llm_base_url.rstrip("/") or "http://host.docker.internal:8080/v1"
+    content = f"""model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/{model}
+      api_base: {api_base}
+      api_key: not-needed
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+  - model_name: "*"
+    litellm_params:
+      model: openai/*
+      api_base: {api_base}
+      api_key: not-needed
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 900
+  stream_timeout: 900
+"""
+    return RenderedFile(
+        "litellm-local-native",
+        "config/litellm/local.yaml",
+        content,
+    )
+
+
 def render_litellm_cloud(inputs: RenderInputs) -> RenderedFile:
     content = """model_list:
   # Stable public alias used by Switchboard-aware ODS consumers.
@@ -429,6 +467,7 @@ RENDERERS: dict[str, Callable[[RenderInputs], RenderedFile]] = {
     "env": render_env,
     "opencode": render_opencode,
     "litellm-local": render_litellm_local,
+    "litellm-local-native": render_litellm_local_native,
     "litellm-cloud": render_litellm_cloud,
     "litellm-hybrid": render_litellm_hybrid,
     "litellm-lemonade": render_litellm_lemonade,
@@ -503,6 +542,11 @@ def render(args: argparse.Namespace) -> dict[str, object]:
         opencode_port=args.opencode_port,
         context_length=args.context_length,
     )
+    if args.surface == "litellm-switchboard" and inputs.ods_mode == "cloud":
+        raise ValueError(
+            "litellm-switchboard is local-runtime-only and cannot be rendered "
+            "for ODS_MODE=cloud"
+        )
     files = [
         RENDERERS[name](inputs)
         for name in select_surfaces(
@@ -530,7 +574,11 @@ def render(args: argparse.Namespace) -> dict[str, object]:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    payload = render(args)
+    try:
+        payload = render(args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
     if args.format == "paths":
         for item in payload["files"]:
             print(item["path"])

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -100,6 +100,7 @@ litellm_settings:
 
 
 def render_litellm_local_native(inputs: RenderInputs) -> RenderedFile:
+    # ODS-CONTRACT-WRITER: litellm-local-native
     model = inputs.gguf_file or inputs.model
     api_base = inputs.llm_base_url.rstrip("/") or "http://host.docker.internal:8080/v1"
     content = f"""model_list:

--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -180,6 +180,7 @@ def main(argv: list[str]) -> int:
             "env",
             "opencode",
             "litellm-local",
+            "litellm-local-native",
             "litellm-cloud",
             "litellm-hybrid",
             "litellm-lemonade",

--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -176,7 +176,18 @@ def main(argv: list[str]) -> int:
             surface_id = validate_surface(issues, surface, f"$.surfaces[{index}]")
             if surface_id:
                 surface_ids.append(surface_id)
-        required = {"env", "opencode", "litellm-lemonade", "perplexica", "hermes"}
+        required = {
+            "env",
+            "opencode",
+            "litellm-local",
+            "litellm-cloud",
+            "litellm-hybrid",
+            "litellm-lemonade",
+            "litellm-switchboard",
+            "model-router-endpoints",
+            "perplexica",
+            "hermes",
+        }
         issues.require(set(surface_ids) == required, "$.surfaces", f"must define exactly {sorted(required)}")
 
     issues.exit_if_any()

--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -12,6 +12,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PATH = ROOT / "config" / "generated-config-contracts.json"
 VALID_INVARIANTS = {"file_contains", "yaml_text_contains", "json_path_enum_contains"}
+WRITER_SOURCE_SUFFIXES = {".py", ".ps1", ".sh"}
 
 
 class Issues:
@@ -66,11 +67,25 @@ def validate_string_list(issues: Issues, value: Any, path: str) -> list[str]:
     return result
 
 
-def validate_writers(issues: Issues, value: Any, path: str) -> None:
+def discover_marked_writers(marker: str) -> set[str]:
+    writers: set[str] = set()
+    for source in ROOT.rglob("*"):
+        if not source.is_file() or source.suffix.lower() not in WRITER_SOURCE_SUFFIXES:
+            continue
+        relative = source.relative_to(ROOT)
+        if relative.parts and relative.parts[0] == "tests":
+            continue
+        if marker in source.read_text(encoding="utf-8", errors="replace"):
+            writers.add(relative.as_posix())
+    return writers
+
+
+def validate_writers(issues: Issues, value: Any, path: str) -> set[str]:
     if not isinstance(value, list) or not value:
         issues.add(path, "must be a non-empty array")
-        return
+        return set()
     platforms: list[str] = []
+    targets: set[str] = set()
     for index, writer in enumerate(value):
         writer_path = f"{path}[{index}]"
         if not isinstance(writer, dict):
@@ -83,7 +98,9 @@ def validate_writers(issues: Issues, value: Any, path: str) -> None:
         if nonempty_string(platform):
             platforms.append(platform)
         if nonempty_string(target):
+            targets.add(str(target))
             issues.require((ROOT / target).exists(), f"{writer_path}.path", f"file does not exist: {target}")
+    return targets
 
 
 def validate_invariant(issues: Issues, invariant: Any, path: str) -> None:
@@ -134,7 +151,22 @@ def validate_surface(issues: Issues, surface: Any, path: str) -> str | None:
     issues.require(nonempty_string(surface_id), f"{path}.id", "must be a non-empty string")
     issues.require(nonempty_string(surface.get("label")), f"{path}.label", "must be a non-empty string")
     validate_string_list(issues, surface.get("target_paths"), f"{path}.target_paths")
-    validate_writers(issues, surface.get("writers"), f"{path}.writers")
+    writer_paths = validate_writers(issues, surface.get("writers"), f"{path}.writers")
+    writer_marker = surface.get("writer_marker")
+    if writer_marker is not None:
+        issues.require(
+            nonempty_string(writer_marker),
+            f"{path}.writer_marker",
+            "must be a non-empty string",
+        )
+        if nonempty_string(writer_marker):
+            marked_paths = discover_marked_writers(str(writer_marker))
+            issues.require(
+                marked_paths == writer_paths,
+                f"{path}.writers",
+                "must exactly match marked writers "
+                f"(declared={sorted(writer_paths)}, marked={sorted(marked_paths)})",
+            )
 
     invariants = surface.get("invariants")
     if not isinstance(invariants, list) or not invariants:

--- a/ods/tests/test-generated-config-contracts.sh
+++ b/ods/tests/test-generated-config-contracts.sh
@@ -5,6 +5,30 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 python3 -m py_compile "$ROOT_DIR/scripts/validate-generated-configs.py"
 python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$ROOT_DIR/config/generated-config-contracts.json"
+
+missing_writer_contract="$(mktemp)"
+trap 'rm -f "$missing_writer_contract"' EXIT
+python3 - "$ROOT_DIR/config/generated-config-contracts.json" "$missing_writer_contract" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+contract = json.loads(source.read_text(encoding="utf-8"))
+surface = next(item for item in contract["surfaces"] if item["id"] == "litellm-local-native")
+surface["writers"] = [
+    writer
+    for writer in surface["writers"]
+    if writer["path"] != "installers/windows/install-windows.ps1"
+]
+target.write_text(json.dumps(contract), encoding="utf-8")
+PY
+if python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$missing_writer_contract" >/dev/null 2>&1; then
+    echo "[FAIL] writer marker validation accepted an incomplete ownership inventory" >&2
+    exit 1
+fi
+
 python3 "$ROOT_DIR/tests/test-fedora-strix-compat.py"
 python3 "$ROOT_DIR/tests/test-embedding-model-contract.py"
 

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -44,7 +44,7 @@ def test_all_surfaces_render() -> None:
     payload = run_renderer("--surface", "all")
     surfaces = {item["surface"] for item in payload["files"]}
     assert surfaces == {
-        "env", "opencode", "litellm-lemonade", "perplexica", "hermes",
+        "env", "opencode", "litellm-local", "perplexica", "hermes",
         "model-router-endpoints",
     }
     assert payload["mode"] == "dry-run"
@@ -63,6 +63,47 @@ def test_switchboard_surface_gated_on_enabled_mode() -> None:
     assert 'model_name: "*"' in switchboard["content"]
     assert "api_base: http://model-router:9099/v1" in switchboard["content"]
     assert switchboard["content"].count("http://model-router:9099/v1") == 4
+
+
+def test_all_selects_one_mode_config() -> None:
+    expected = {
+        "local": "litellm-local",
+        "cloud": "litellm-cloud",
+        "hybrid": "litellm-hybrid",
+        "lemonade": "litellm-lemonade",
+    }
+    all_mode_surfaces = set(expected.values())
+    for mode, expected_surface in expected.items():
+        payload = run_renderer("--surface", "all", "--ods-mode", mode)
+        surfaces = {item["surface"] for item in payload["files"]}
+        assert surfaces & all_mode_surfaces == {expected_surface}
+
+
+def test_cloud_enabled_never_renders_local_switchboard() -> None:
+    payload = run_renderer(
+        "--surface",
+        "all",
+        "--ods-mode",
+        "cloud",
+        "--switchboard-mode",
+        "enabled",
+    )
+    surfaces = {item["surface"] for item in payload["files"]}
+    assert "litellm-cloud" in surfaces
+    assert "litellm-switchboard" not in surfaces
+    cloud = file_by_surface(payload, "litellm-cloud")["content"]
+    assert "model_name: ods/current" in cloud
+    assert "model-router" not in cloud
+
+
+def test_checked_in_mode_configs_match_renderer() -> None:
+    for mode in ("local", "cloud", "hybrid"):
+        payload = run_renderer("--surface", f"litellm-{mode}", "--ods-mode", mode)
+        rendered = file_by_surface(payload, f"litellm-{mode}")["content"]
+        checked_in = (ROOT / "config" / "litellm" / f"{mode}.yaml").read_text(
+            encoding="utf-8"
+        )
+        assert rendered == checked_in
 
 
 def test_enabled_env_exports_switchboard_webui_gateway() -> None:
@@ -307,6 +348,9 @@ def main() -> int:
     tests = [
         test_all_surfaces_render,
         test_switchboard_surface_gated_on_enabled_mode,
+        test_all_selects_one_mode_config,
+        test_cloud_enabled_never_renders_local_switchboard,
+        test_checked_in_mode_configs_match_renderer,
         test_enabled_env_exports_switchboard_webui_gateway,
         test_enabled_perplexica_uses_stable_alias,
         test_enabled_hermes_uses_stable_switchboard_alias,

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -96,6 +96,44 @@ def test_cloud_enabled_never_renders_local_switchboard() -> None:
     assert "model-router" not in cloud
 
 
+def test_explicit_cloud_switchboard_render_fails_closed() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--surface",
+            "litellm-switchboard",
+            "--ods-mode",
+            "cloud",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.returncode == 2
+    assert "local-runtime-only" in proc.stderr
+
+
+def test_native_local_projection_uses_host_route_and_concrete_model() -> None:
+    payload = run_renderer(
+        "--surface",
+        "litellm-local-native",
+        "--ods-mode",
+        "local",
+        "--gguf-file",
+        "Native-Model.gguf",
+        "--llm-base-url",
+        "http://host.docker.internal:13306/v1",
+    )
+    content = file_by_surface(payload, "litellm-local-native")["content"]
+    assert "model: openai/Native-Model.gguf" in content
+    assert "api_base: http://host.docker.internal:13306/v1" in content
+    assert "enable_thinking: false" in content
+    assert "request_timeout: 900" in content
+    assert "stream_timeout: 900" in content
+
+
 def test_checked_in_mode_configs_match_renderer() -> None:
     for mode in ("local", "cloud", "hybrid"):
         payload = run_renderer("--surface", f"litellm-{mode}", "--ods-mode", mode)
@@ -350,6 +388,8 @@ def main() -> int:
         test_switchboard_surface_gated_on_enabled_mode,
         test_all_selects_one_mode_config,
         test_cloud_enabled_never_renders_local_switchboard,
+        test_explicit_cloud_switchboard_render_fails_closed,
+        test_native_local_projection_uses_host_route_and_concrete_model,
         test_checked_in_mode_configs_match_renderer,
         test_enabled_env_exports_switchboard_webui_gateway,
         test_enabled_perplexica_uses_stable_alias,

--- a/ods/tests/test-runtime-config-wiring.py
+++ b/ods/tests/test-runtime-config-wiring.py
@@ -55,6 +55,15 @@ def test_openclaw_receives_persisted_lemonade_model_id() -> None:
     assert "`extra.${GGUF_FILE}`" in injector
 
 
+def test_cloud_callers_do_not_render_local_switchboard() -> None:
+    linux = read("installers/phases/06-directories.sh")
+    macos = read("installers/macos/install-macos.sh")
+    host_agent = read("bin/ods-host-agent.py")
+    assert 'if [[ "$_router_ods_mode" != "cloud" ]]' in linux
+    assert '"ODS_MODE")" != "cloud"' in macos
+    assert 'str(common["ods_mode"]).strip().lower() != "cloud"' in host_agent
+
+
 def main() -> int:
     for test in (
         test_linux_installer_uses_renderer_with_fallback,
@@ -62,6 +71,7 @@ def main() -> int:
         test_bootstrap_upgrade_promotes_lemonade_model_id,
         test_host_agent_uses_renderer_with_fallback,
         test_openclaw_receives_persisted_lemonade_model_id,
+        test_cloud_callers_do_not_render_local_switchboard,
     ):
         test()
         print(f"[PASS] {test.__name__}")


### PR DESCRIPTION
## Summary
- add canonical renderer surfaces for local, cloud, and hybrid LiteLLM modes
- make all-surface rendering select exactly one mode configuration
- prevent cloud+Switchboard state from rendering the local switchboard file
- enforce checked-in golden parity and expand generated-config ownership contracts

## Why
Remote-provider work needs one routing serializer. Current rendering covers Lemonade and Switchboard but omits local, cloud, and hybrid, leaving those modes outside the canonical state model. This slice proves the serializer before platform writers are moved onto it.

## Verification
- runtime renderer suite: 16 passed
- all ODS mode selections table-tested
- cloud+enabled excludes model-router and retains ods/current
- local/cloud/hybrid checked-in configs match rendered output byte-for-byte
- generated config contract suite: pass
- runtime wiring suite: pass
- Ruff, py_compile, and git diff checks: pass

Depends conceptually on the cloud-selection fix merged in #2091. This PR does not yet remove platform fallback writers; that is the next reviewed slice.

Co-authored-by: Lightheartdevs <Lightheartdevs@users.noreply.github.com>