### PR TITLE
fix(updates): order pre-releases below the release they precede

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -142,6 +142,27 @@ def _normalize_version(value: Optional[str]) -> str:
     return (value or "").strip().lstrip("v")
 
 
+def _release_parts(value: str) -> list[int]:
+    """Numeric release identifiers, stopping at the pre-release suffix.
+
+    A pre-release's identifiers are not part of the release number, so parsing
+    must stop at the first non-numeric component rather than skipping it.
+    Skipping promotes the digit in "2.6.0-rc.2" into the patch slot, making the
+    installed build read as 2.6.2 — newer than every release it precedes.
+    """
+    release = re.split(r"[-+]", value, maxsplit=1)[0]
+    parts: list[int] = []
+    for component in release.split("."):
+        if not component.isdigit():
+            break
+        parts.append(int(component))
+    return (parts + [0, 0, 0])[:3]
+
+
+def _is_prerelease(value: str) -> bool:
+    return "-" in value
+
+
 def _build_version_result(current: str, payload: Optional[dict]) -> dict:
     current = _normalize_version(current)
     result = {
@@ -162,11 +183,15 @@ def _build_version_result(current: str, payload: Optional[dict]) -> dict:
     result["changelog_url"] = payload.get("changelog_url")
     result["checked_at"] = payload.get("checked_at") or result["checked_at"]
 
-    current_parts = [int(x) for x in current.split(".") if x.isdigit()][:3]
-    latest_parts = [int(x) for x in latest.split(".") if x.isdigit()][:3]
-    current_parts += [0] * (3 - len(current_parts))
-    latest_parts += [0] * (3 - len(latest_parts))
-    result["update_available"] = latest_parts > current_parts
+    current_parts = _release_parts(current)
+    latest_parts = _release_parts(latest)
+    # A pre-release sorts below the release it precedes, so the same release
+    # number is still an upgrade for someone running 2.6.0-rc.2.
+    result["update_available"] = latest_parts > current_parts or (
+        latest_parts == current_parts
+        and _is_prerelease(current)
+        and not _is_prerelease(latest)
+    )
     return result
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import httpx
+import pytest
 
 from host_agent_client import AgentHTTPError, AgentUnavailable
 
@@ -598,3 +599,38 @@ def test_trigger_update_action_backup(test_client, monkeypatch):
     assert calls[0][0:2] == ("POST", "/v1/update/backup")
     assert calls[0][2]["backup_id"].startswith("dashboard-")
     assert calls[0][3] == 65
+
+
+@pytest.mark.parametrize(
+    ("current", "latest", "expected"),
+    [
+        # A pre-release identifier is not part of the release number. Skipping
+        # non-numeric components instead of stopping at them read "2.6.0-rc.2"
+        # as 2.6.2, so an rc build was never offered its own release.
+        ("2.6.0-rc.2", "2.6.0", True),
+        ("2.6.0-rc.2", "2.6.1", True),
+        ("2.0.0-beta.1", "2.0.0", True),
+        ("2.0.0-beta.1", "2.0.1", True),
+        ("2.0.0-strix-halo", "2.0.0", True),
+        # Stable comparisons are unchanged.
+        ("2.5.3", "2.6.0", True),
+        ("2.9.0", "2.10.0", True),
+        ("2.10.0", "2.9.0", False),
+        ("2.6.0", "2.6.0", False),
+        ("2.6.0", "2.5.3", False),
+    ],
+)
+def test_build_version_result_orders_prereleases_below_their_release(current, latest, expected):
+    from routers.updates import _build_version_result
+
+    result = _build_version_result(current, {"latest": latest})
+    assert result["update_available"] is expected
+
+
+def test_release_parts_stops_at_prerelease_suffix():
+    from routers.updates import _release_parts
+
+    assert _release_parts("2.6.0-rc.2") == [2, 6, 0]
+    assert _release_parts("2.6.0+build.7") == [2, 6, 0]
+    assert _release_parts("2.6") == [2, 6, 0]
+    assert _release_parts("") == [0, 0, 0]


### PR DESCRIPTION
## Problem

`_build_version_result` compared versions by keeping only the fully-numeric dot components:

```python
current_parts = [int(x) for x in current.split(".") if x.isdigit()][:3]
```

The filter **drops** non-numeric components instead of stopping at them, so a digit that belongs to a pre-release identifier gets promoted into the release triple:

```
"2.6.0-rc.2".split(".")  ->  ["2", "6", "0-rc", "2"]
        isdigit filter   ->  ["2", "6",          "2"]  ->  [2, 6, 2]
```

An rc or beta build therefore reported itself as **newer** than every release it precedes:

```
current=2.0.0-beta.1  latest=2.0.0  update_available=False
current=2.0.0-beta.1  latest=2.0.1  update_available=False
current=2.6.0-rc.2    latest=2.6.0  update_available=False
current=2.6.0-rc.2    latest=2.7.0  update_available=False   # 2.7.0 vs parsed 2.6.2 -> only this one recovers
```

A machine left on a pre-release never saw the upgrade off it. `/releases/latest` excludes pre-releases on GitHub's side, so this only ever affected `current` — but the changelog shows ODS has shipped non-plain versions (`2.0.0-strix-halo`, `0.3.0-dev`), and any `-rc.N` / `-beta.N` build hits the promotion.

## Fix

- `_release_parts` parses the release triple up to the first non-numeric component and pads to three, so `2.6.0-rc.2` and `2.6.0+build.7` both give `[2, 6, 0]`.
- A pre-release sorts below the same release number, so the stable build of that version registers as an update.

Stable-to-stable comparison is unchanged, including the `2.9.0 -> 2.10.0` ordering that a string compare would get wrong.

## Tests

`tests/test_updates.py` gains a parametrised case over five pre-release and five stable pairs, plus a direct `_release_parts` check. Six fail on the previous parser.

```
$ python -m pytest extensions/services/dashboard-api/tests/test_updates.py -q
38 passed
```