### PR TITLE
fix(token-spy): stop the skills block inflating the file above it

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -481,6 +481,10 @@ async def on_shutdown():
 # ── Analysis ─────────────────────────────────────────────────────────────────
 
 # Map of known workspace filenames to their DB column names
+# Heading that opens the skill-injection block. Shared so the block is both
+# measured on its own and treated as a boundary for the workspace files above it.
+SKILLS_SECTION_HEADING = "Skills (mandatory)"
+
 WORKSPACE_FILE_MAP = {
     "AGENTS.md": "workspace_agents_chars",
     "SOUL.md": "workspace_soul_chars",
@@ -517,9 +521,12 @@ def analyze_system_prompt(system_blocks: list) -> dict:
     if ctx_match:
         after_ctx = text[ctx_match.start():]
         # Build list of all known file markers: ## AGENTS.md, ## SOUL.md, etc.
-        # Also include ## Silent Replies, ## Heartbeats, ## Runtime as end markers
+        # Also include the sections that follow the workspace files as end
+        # markers. "Skills (mandatory)" belongs here as well: it is measured
+        # separately below, so leaving it out lets the last workspace file's
+        # span run through it and count those characters twice.
         all_file_names = list(WORKSPACE_FILE_MAP.keys())
-        end_markers = ["Silent Replies", "Heartbeats", "Runtime"]
+        end_markers = ["Silent Replies", "Heartbeats", "Runtime", SKILLS_SECTION_HEADING]
 
         # Find positions of all ## FILENAME.md markers within the context
         file_positions = []
@@ -530,9 +537,11 @@ def analyze_system_prompt(system_blocks: list) -> dict:
                 content_start = m.end() + 1  # skip the newline after header
                 file_positions.append((m.start(), content_start, fname))
 
-        # Also find end-of-context markers (sections that follow workspace files)
+        # Also find end-of-context markers (sections that follow workspace
+        # files). The lookahead stands in for \b, which never matches after a
+        # heading that ends in punctuation such as "Skills (mandatory)".
         for marker in end_markers:
-            pattern = re.compile(r"^## " + re.escape(marker) + r"\b", re.MULTILINE)
+            pattern = re.compile(r"^## " + re.escape(marker) + r"(?=\W|$)", re.MULTILINE)
             m = pattern.search(after_ctx)
             if m:
                 file_positions.append((m.start(), m.start(), None))  # None = end marker
@@ -559,7 +568,8 @@ def analyze_system_prompt(system_blocks: list) -> dict:
 
     # Extract skills section (## Skills (mandatory) ... until next ## at same level)
     skills_match = re.search(
-        r"^## Skills \(mandatory\)\n(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL
+        r"^## " + re.escape(SKILLS_SECTION_HEADING) + r"\n(.*?)(?=^## |\Z)",
+        text, re.MULTILINE | re.DOTALL
     )
     if skills_match:
         result["skill_injection_chars"] = len(skills_match.group(0))

--- a/ods/extensions/services/token-spy/tests/test_system_prompt_analysis.py
+++ b/ods/extensions/services/token-spy/tests/test_system_prompt_analysis.py
@@ -1,0 +1,105 @@
+"""System-prompt breakdown contracts for analyze_system_prompt."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+pytest.importorskip("fastapi")
+
+
+@pytest.fixture(scope="module")
+def token_spy_main(tmp_path_factory):
+    data_dir = tmp_path_factory.mktemp("token-spy-data")
+    # main.py mints and writes an API key at import when none is configured.
+    os.environ.setdefault("TOKEN_SPY_API_KEY", "test-key")
+    os.environ.setdefault("DB_PATH", str(data_dir / "usage.db"))
+    sys.path.insert(0, str(TOKEN_SPY_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"token_spy_main_prompt_{uuid4().hex}", TOKEN_SPY_DIR / "main.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(TOKEN_SPY_DIR))
+
+
+SOUL_BODY = "Soul body B."
+SKILLS_BODY = "- skill one\n- skill two"
+
+PROMPT = f"""You are an agent.
+
+# Project Context
+
+## AGENTS.md
+
+Agent rules body A.
+
+## SOUL.md
+
+{SOUL_BODY}
+
+## Skills (mandatory)
+
+{SKILLS_BODY}
+
+## Heartbeats
+
+heartbeat config
+"""
+
+
+def test_skills_block_is_not_folded_into_the_preceding_file(token_spy_main):
+    # The skills block is measured on its own, so the workspace file above it
+    # must stop at its heading. Running through it counted those characters in
+    # both buckets and subtracted them twice from the base prompt.
+    result = token_spy_main.analyze_system_prompt([{"text": PROMPT}])
+
+    assert result["workspace_soul_chars"] < len(SOUL_BODY) + 5
+    assert result["skill_injection_chars"] > len(SKILLS_BODY)
+    assert result["workspace_soul_chars"] < result["skill_injection_chars"]
+
+
+def test_breakdown_reconciles_with_the_total(token_spy_main):
+    result = token_spy_main.analyze_system_prompt([{"text": PROMPT}])
+
+    accounted = sum(
+        value for key, value in result.items()
+        if key.startswith("workspace_") or key == "skill_injection_chars"
+    )
+    assert accounted + result["base_prompt_chars"] == result["system_prompt_total_chars"]
+    # A file's size must not depend on whether a skills block follows it.
+    # It did while the file's span ran through the block.
+    without_skills = token_spy_main.analyze_system_prompt([{
+        "text": PROMPT.replace(f"## Skills (mandatory)\n\n{SKILLS_BODY}\n\n", ""),
+    }])
+    assert without_skills["workspace_soul_chars"] == result["workspace_soul_chars"]
+
+
+def test_prompt_without_skills_section_is_unchanged(token_spy_main):
+    prompt = PROMPT.replace(f"## Skills (mandatory)\n\n{SKILLS_BODY}\n\n", "")
+    result = token_spy_main.analyze_system_prompt([{"text": prompt}])
+
+    assert result["skill_injection_chars"] == 0
+    accounted = sum(
+        value for key, value in result.items()
+        if key.startswith("workspace_") or key == "skill_injection_chars"
+    )
+    assert accounted + result["base_prompt_chars"] == result["system_prompt_total_chars"]
+
+
+def test_empty_system_prompt(token_spy_main):
+    assert token_spy_main.analyze_system_prompt([]) == {
+        "system_prompt_total_chars": 0,
+        "base_prompt_chars": 0,
+    }


### PR DESCRIPTION
## Problem

`analyze_system_prompt` measures each workspace file from its `## FILE.md` heading up to the next known marker. The marker list is the workspace filenames plus three trailing sections:

```python
end_markers = ["Silent Replies", "Heartbeats", "Runtime"]
```

The skill-injection heading is missing from it, even though the same function measures that block separately a few lines below. When the skills block sits between the workspace files and `## Heartbeats` — where the agent emits it — the last workspace file's span runs straight through it, and those characters land in **two** buckets.

`base_prompt_chars` is computed as the total minus everything accounted, so the double count is subtracted twice. On a small sample prompt:

| field | before | after |
|---|---|---|
| `workspace_soul_chars` | 62 | 14 |
| `skill_injection_chars` | 48 | 48 |
| `base_prompt_chars` | 65 | 113 |

SOUL.md's actual body is 12 characters. The dashboard panel exists to show *where* the context window is going, and it was attributing the entire skill injection to whichever workspace file happened to precede it while under-reporting the base prompt by exactly that amount.

## Fix

- Hoist the heading to `SKILLS_SECTION_HEADING` and use it both as an end marker and in the block's own matcher, so the two can't drift apart again.
- The end-marker pattern used `\b`, which never matches after a heading ending in `)`. Replaced with a `(?=\W|$)` lookahead — same behaviour for the existing word-ending markers, and it works for `Skills (mandatory)`.

Prompts with no skills section are unaffected.

## Tests

New `tests/test_system_prompt_analysis.py`:
- the skills block is not folded into the preceding file,
- a file's measured size does not change when a skills block is added after it,
- the breakdown reconciles with the total, with and without a skills section,
- the empty-input contract.

Two fail on the previous marker list.

```
$ python -m pytest extensions/services/token-spy/tests/ -q
24 passed
```

Guarded with `pytest.importorskip("fastapi")` so it skips where the service deps are absent.