### PR TITLE
fix(model-router): hold non-streamed evidence to the streaming bar

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -1078,10 +1078,22 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
     except (ValueError, UnicodeDecodeError):
         pass
 
-    if probe_id:
+    # Same bar as the streaming path: evidence exists only when the routed
+    # model actually answered. A reader treats its presence as the proof, so
+    # an upstream error or a foreign identity must leave no record. A response
+    # that names no model is attributed to the routed model, as when a stream
+    # carries no identity.
+    served_identities = (
+        [response_model] if isinstance(response_model, str) and response_model else []
+    )
+    if (
+        probe_id
+        and 200 <= upstream.status_code < 300
+        and all(model == route["runtimeModelId"] for model in served_identities)
+    ):
         _record_evidence({**evidence_base,
                           "status": upstream.status_code,
-                          "responseModel": str(response_model or ""),
+                          "responseModel": route["runtimeModelId"],
                           "lemonadeRoute": lemonade_route})
 
     if 200 <= upstream.status_code < 300:

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -1002,3 +1002,66 @@ class TestRoutedTelemetry:
             "authorization": "Bearer shared-secret",
             "body": {"model": "Concrete.gguf"},
         }]
+
+
+def _set_json_upstream(mod, payload, *, status=200):
+    """Point the router at a fixed non-streaming upstream response."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json=payload)
+    mod.app.state.http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+class TestNonStreamingEvidenceGuards:
+    """Evidence must mean the same thing on both response paths.
+
+    The streaming path already refuses to record when the upstream failed or
+    answered as a different model; a probe that reads back evidence treats its
+    presence as proof the route served the request.
+    """
+
+    def _evidence(self, client, probe_id):
+        return client.get(
+            f"/internal/route-evidence/{probe_id}",
+            headers={"Authorization": "Bearer internal-secret"},
+        )
+
+    def _probe(self, client, probe_id):
+        return client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": _signed_marker(probe_id)}],
+        })
+
+    def test_upstream_error_records_no_evidence(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        probe_id = str(uuid.uuid4())
+        _set_json_upstream(mod, {"error": {"message": "model not loaded"}}, status=500)
+
+        assert self._probe(client, probe_id).status_code == 500
+        assert self._evidence(client, probe_id).status_code == 404
+
+    def test_wrong_concrete_identity_records_no_evidence(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        probe_id = str(uuid.uuid4())
+        _set_json_upstream(mod, {
+            "id": "c1", "model": "Wrong.gguf",
+            "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+        })
+
+        assert self._probe(client, probe_id).status_code == 200
+        assert self._evidence(client, probe_id).status_code == 404
+
+    def test_response_without_identity_records_routed_evidence(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        probe_id = str(uuid.uuid4())
+        _set_json_upstream(mod, {
+            "id": "c1",
+            "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+        })
+
+        assert self._probe(client, probe_id).status_code == 200
+        record = self._evidence(client, probe_id)
+        assert record.status_code == 200
+        assert record.json()["responseModel"] == "Concrete.gguf"


### PR DESCRIPTION
## Problem

Route evidence is the proof that the routed model answered a probe — `/internal/route-evidence/{probe_id}` returns a record, and a reader treats its presence as the proof. The streaming path guards it carefully:

```python
if (completed and rewriter.completed and probe_id
        and 200 <= upstream.status_code < 300
        and all(model == route["runtimeModelId"] for model in rewriter.models)):
    _record_evidence(...)
```

The non-streaming path, a few lines below, records unconditionally:

```python
if probe_id:
    _record_evidence({**evidence_base,
                      "status": upstream.status_code,
                      "responseModel": str(response_model or ""),
                      "lemonadeRoute": lemonade_route})
```

Three ways the two disagree on the same probe:

| upstream response | streaming | non-streaming (before) |
|---|---|---|
| HTTP 500 | no record | ✅ record written |
| `{"model": "Wrong.gguf"}` | no record | ✅ record written, `responseModel: "Wrong.gguf"` |
| no `model` field | record, `responseModel` = routed model | record, `responseModel: ""` |

The first two mean a probe against a runtime that failed to load, or that answered as a different model, produced evidence a reader takes as proof the route served the request. The existing suite covers both refusals on the streaming side (`test_stream_with_wrong_concrete_identity_records_no_evidence`, `test_failed_stream_records_no_evidence_and_releases_admission`) and neither on the non-streaming side.

## Fix

Apply the same status and identity conditions, and report the routed model when the response names none — `all()` over an empty identity list is `True`, exactly as the streaming path handles a stream that carries no identity.

The `status` field stays in the record, so a consumer that does look at it sees no change for the cases that still qualify.

## Tests

New `TestNonStreamingEvidenceGuards` mirrors the three streaming cases against a non-streaming upstream. All three fail on the previous code.

```
$ python -m pytest tests/test_router.py -q
51 passed
```