### PR TITLE
fix(dashboard): show days in the Settings uptime

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -25,6 +25,7 @@ import {
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { serviceUrl } from '../lib/serviceUrls'
+import { formatUptime } from '../utils/formatUptime'
 
 // Compute overall health from services (excludes not_deployed from counts)
 function computeHealth(services) {
@@ -149,17 +150,6 @@ function formatTokenCount(n) {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
   return `${n}`
-}
-
-// Format uptime: 90061 → "1d 1h 1m"
-function formatUptime(seconds) {
-  if (!seconds) return '—'
-  const d = Math.floor(seconds / 86400)
-  const h = Math.floor((seconds % 86400) / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  if (d > 0) return `${d}d ${h}h ${m}m`
-  if (h > 0) return `${h}h ${m}m`
-  return `${m}m`
 }
 
 function clamp(value, min, max) {

--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -25,6 +25,7 @@ import { Link } from 'react-router-dom'
 import EnvEditor from '../components/settings/EnvEditor'
 import { useTheme } from '../contexts/ThemeContext'
 import { dashboardHost, serviceUrl } from '../lib/serviceUrls'
+import { formatUptime } from '../utils/formatUptime'
 import {
   clearSettingsFollowUp,
   loadSettingsFollowUp,
@@ -57,12 +58,6 @@ const fetchPayload = async (url, ms = 8000, options = {}) => {
   const response = await fetchJson(url, ms, options)
   if (!response.ok) throw await buildErrorFromResponse(response)
   return response.json()
-}
-
-const formatUptime = (secs = 0) => {
-  const hours = Math.floor(secs / 3600)
-  const mins = Math.floor((secs % 3600) / 60)
-  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`
 }
 
 const formatInstallDate = (value) => {

--- a/ods/extensions/services/dashboard/src/utils/__tests__/formatUptime.test.js
+++ b/ods/extensions/services/dashboard/src/utils/__tests__/formatUptime.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { formatUptime } from '../formatUptime'
+
+describe('formatUptime', () => {
+  it('renders days once the uptime passes 24h', () => {
+    // Dropping the day unit turned three days into "83h 20m" on Settings.
+    expect(formatUptime(3 * 86400 + 11 * 3600 + 20 * 60)).toBe('3d 11h 20m')
+    expect(formatUptime(90061)).toBe('1d 1h 1m')
+  })
+
+  it('omits the day unit below 24h', () => {
+    expect(formatUptime(3600 + 5 * 60)).toBe('1h 5m')
+  })
+
+  it('omits the hour unit below 1h', () => {
+    expect(formatUptime(7 * 60)).toBe('7m')
+    expect(formatUptime(59)).toBe('0m')
+  })
+
+  it('renders absent values as an em dash', () => {
+    expect(formatUptime(0)).toBe('—')
+    expect(formatUptime(undefined)).toBe('—')
+    expect(formatUptime(null)).toBe('—')
+  })
+})

--- a/ods/extensions/services/dashboard/src/utils/formatUptime.js
+++ b/ods/extensions/services/dashboard/src/utils/formatUptime.js
@@ -1,0 +1,24 @@
+/**
+ * formatUptime — render a duration in seconds as "1d 1h 1m".
+ *
+ * Shared by the Dashboard and Settings pages, which both display the same
+ * `uptime` value from /api/settings/summary. Keeping one implementation stops
+ * the two from disagreeing about long uptimes, where dropping the day unit
+ * turns three days into "83h 20m".
+ *
+ * Falsy input (0, null, undefined — a service that is not running, or a field
+ * the API did not return) renders as an em dash rather than "0m", because the
+ * value is absent rather than zero.
+ *
+ * @param {number} seconds
+ * @returns {string}
+ */
+export function formatUptime(seconds) {
+  if (!seconds) return '—'
+  const days = Math.floor(seconds / 86400)
+  const hours = Math.floor((seconds % 86400) / 3600)
+  const mins = Math.floor((seconds % 3600) / 60)
+  if (days > 0) return `${days}d ${hours}h ${mins}m`
+  if (hours > 0) return `${hours}h ${mins}m`
+  return `${mins}m`
+}


### PR DESCRIPTION
## Problem

Two pages render the same `uptime` value from the same `/api/settings/summary` field, with two different formatters.

`Dashboard.jsx` carries a day unit:

```js
if (d > 0) return `${d}d ${h}h ${m}m`
```

`Settings.jsx` stops at hours:

```js
const formatUptime = (secs = 0) => {
  const hours = Math.floor(secs / 3600)
  const mins = Math.floor((secs % 3600) / 60)
  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`
}
```

So a server up for three days reads **"3d 11h 20m"** on the Dashboard and **"83h 20m"** on Settings. For an always-on local box — which is what ODS is — the Settings figure keeps climbing into the hundreds of hours and stops being readable.

## Fix

Move the day-aware implementation into `src/utils/formatUptime.js` and import it from both pages, so the two cannot drift again. No change to the Dashboard's output.

One behaviour change on Settings: an absent uptime (`0`, `null`, a field the API did not return) now renders as an em dash instead of `"0m"`, matching what Dashboard already did for services that report none. The Settings tile falls back to `'Unknown'` only on a null-ish value, and an em dash is truthy, so it displays the dash — the value is missing rather than zero.

## Tests

New `src/utils/__tests__/formatUptime.test.js` covers the day, hour, minute, and absent branches, including the three-day case that motivated the fix.

```
$ npx vitest run --no-cache src/utils src/pages/Settings.test.jsx src/pages/Dashboard.test.jsx
Test Files  5 passed (5)
     Tests  43 passed (43)
$ npm run lint    # clean
$ npm run build   # ✓ built
```