### PR TITLE
fix(token-spy): store the MEMORY.md prompt bucket on SQLite

### DIFF
--- a/ods/extensions/services/token-spy/db.py
+++ b/ods/extensions/services/token-spy/db.py
@@ -119,7 +119,7 @@ def log_usage(entry: dict):
         "system_prompt_total_chars",
         "workspace_agents_chars", "workspace_soul_chars", "workspace_tools_chars",
         "workspace_identity_chars", "workspace_user_chars", "workspace_heartbeat_chars",
-        "workspace_bootstrap_chars",
+        "workspace_bootstrap_chars", "workspace_memory_chars",
         "skill_injection_chars", "base_prompt_chars",
         "conversation_history_chars",
         "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",

--- a/ods/extensions/services/token-spy/tests/test_usage_report.py
+++ b/ods/extensions/services/token-spy/tests/test_usage_report.py
@@ -216,3 +216,52 @@ class TestShortSpanAtDateMax:
         db = load_sqlite_db(tmp_path, monkeypatch)
         with pytest.raises(ValueError, match="out of range"):
             db._parse_report_dates("9999-12-01", "9999-12-31")
+
+
+class TestWorkspacePromptColumns:
+    def test_memory_chars_survive_a_round_trip(self, tmp_path, monkeypatch):
+        """MEMORY.md chars must persist like every other workspace bucket.
+
+        The Anthropic provider breaks the system prompt down per workspace
+        file, MEMORY.md included, and the Postgres backend stores that
+        bucket. When the SQLite insert omits the column the metric reads
+        back as 0 forever, so the dashboard shows the same prompt as
+        smaller on the default backend than on Postgres.
+        """
+        db = load_sqlite_db(tmp_path, monkeypatch)
+
+        insert_usage(
+            db,
+            "2026-05-01T10:00:00Z",
+            workspace_memory_chars=4096,
+            workspace_agents_chars=512,
+        )
+
+        conn = db._get_conn()
+        conn.row_factory = __import__("sqlite3").Row
+        row = dict(conn.execute("SELECT * FROM usage").fetchone())
+        assert row["workspace_memory_chars"] == 4096
+        assert row["workspace_agents_chars"] == 512
+
+    def test_every_declared_workspace_column_is_written(self, tmp_path, monkeypatch):
+        """The insert column list must cover the whole workspace breakdown.
+
+        Adding a column to the schema without adding it to log_usage fails
+        silently — no error, just a metric pinned at its default.
+        """
+        db = load_sqlite_db(tmp_path, monkeypatch)
+        conn = db._get_conn()
+        declared = {
+            row[1] for row in conn.execute("PRAGMA table_info(usage)")
+            if row[1].startswith("workspace_")
+        }
+
+        entry = {"agent": "Hermes", "model": "claude-opus-4-5"}
+        entry.update({column: index + 1 for index, column in enumerate(sorted(declared))})
+        db.log_usage(entry)
+
+        conn.row_factory = __import__("sqlite3").Row
+        row = dict(conn.execute("SELECT * FROM usage").fetchone())
+        assert {column: row[column] for column in declared} == {
+            column: entry[column] for column in declared
+        }


### PR DESCRIPTION
## Problem

`usage.workspace_memory_chars` is declared in the SQLite schema (`db.py:58`) and the Postgres backend both writes and reads it (`db_postgres.py:167,196,251`), but the SQLite `log_usage` insert column list skips it (`db.py:122`).

`AnthropicProvider.WORKSPACE_FILE_MAP` emits `workspace_memory_chars` for every request whose system prompt carries a `MEMORY.md` section (`providers/anthropic.py:41`). On the default SQLite backend that value is dropped without an error and reads back as 0 forever, so the same agent shows a smaller system-prompt breakdown on SQLite than on Postgres.

## Fix

Add `workspace_memory_chars` to the insert column list.

## Tests

Two regression tests in `tests/test_usage_report.py`:
- a MEMORY.md round trip through `log_usage` → `SELECT`;
- a schema-driven check that every `workspace_*` column declared on the table is actually written, so the next schema addition cannot go missing the same silent way.

Both fail on `main` (`workspace_memory_chars` reads 0), pass with the fix. Full token-spy suite: 22 passed.