### PR TITLE
fix(installer): read the LAN IP by its route label, not field position

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -56,6 +56,9 @@ test: ## Run unit and contract tests
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
 	@echo ""
+	@echo "=== LAN IP detection for the success card / QR ==="
+	@bash tests/test-lan-ip-detection.sh
+	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh

--- a/ods/lib/qrcode.sh
+++ b/ods/lib/qrcode.sh
@@ -10,12 +10,23 @@
 _ods_lan_ip() {
     local lan_ip=""
     if command -v ip >/dev/null 2>&1; then
-        lan_ip=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
+        # Key off the `src` label rather than a fixed field number. Only a
+        # route through a gateway prints `... via GW dev IF src ADDR`; a
+        # directly-connected route omits `via GW`, which shifts every later
+        # field two positions left and turns a positional read into whatever
+        # follows (the `uid` value). Matches the detection in
+        # installers/phases/06-directories.sh.
+        lan_ip=$(ip -4 route get 1.1.1.1 2>/dev/null \
+            | awk '{for (i = 1; i <= NF; i++) if ($i == "src") print $(i + 1); exit}')
     fi
 
     if [[ -z "$lan_ip" ]] && command -v ifconfig >/dev/null 2>&1; then
         lan_ip=$(ifconfig 2>/dev/null | awk '/inet / && $2 != "127.0.0.1" {print $2; exit}')
     fi
+
+    # Anything that is not a dotted quad would render as a broken URL in the
+    # success card and the QR code, so drop it rather than print it.
+    [[ "$lan_ip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || lan_ip=""
 
     printf '%s' "$lan_ip"
 }

--- a/ods/tests/test-lan-ip-detection.sh
+++ b/ods/tests/test-lan-ip-detection.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Test lib/qrcode.sh: _ods_lan_ip must read the source address by label.
+#
+# `ip route get` only prints `via <gateway>` when the destination is reached
+# through a router. A directly-connected destination omits those two fields,
+# so every later field shifts left and a fixed-position read lands on the
+# wrong token. The success card and the install QR code are built from this
+# value, so a wrong read ships the user a URL they cannot open.
+#
+# Run from repo root:  bash ods/tests/test-lan-ip-detection.sh
+# Or from ods:         bash tests/test-lan-ip-detection.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$ROOT_DIR/lib/qrcode.sh" ]] || fail "lib/qrcode.sh not found"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Stub `ip` and hide `ifconfig` so only the `ip route get` branch is exercised.
+mkdir -p "$tmpdir/bin"
+cat > "$tmpdir/bin/ip" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$ODS_TEST_IP_ROUTE_OUTPUT"
+EOF
+chmod +x "$tmpdir/bin/ip"
+# Silence the ifconfig fallback so a real host address can never leak into
+# the cases that assert an empty result.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$tmpdir/bin/ifconfig"
+chmod +x "$tmpdir/bin/ifconfig"
+
+run_lan_ip() {
+    ODS_TEST_IP_ROUTE_OUTPUT="$1" PATH="$tmpdir/bin:$PATH" bash -c '
+        . "'"$ROOT_DIR"'/lib/qrcode.sh"
+        _ods_lan_ip
+    '
+}
+
+echo "Test 1: route through a gateway reports the source address"
+got="$(run_lan_ip '1.1.1.1 via 192.168.1.1 dev eth0 src 192.168.1.42 uid 1000')"
+[[ "$got" == "192.168.1.42" ]] || fail "gateway route: expected 192.168.1.42, got '$got'"
+pass "gateway route resolves the source address"
+
+echo "Test 2: directly-connected route reports the source address"
+# No `via <gateway>`: the fields after `dev` sit two positions earlier, which
+# is where a fixed-position read picks up the uid value instead of the address.
+got="$(run_lan_ip '1.1.1.1 dev eth0 src 10.0.0.5 uid 1000')"
+[[ "$got" == "10.0.0.5" ]] || fail "on-link route: expected 10.0.0.5, got '$got'"
+pass "on-link route resolves the source address"
+
+echo "Test 3: a route with no source address yields nothing"
+got="$(run_lan_ip '1.1.1.1 via 192.168.1.1 dev eth0')"
+[[ -z "$got" ]] || fail "expected empty result, got '$got'"
+pass "missing source address yields empty"
+
+echo "Test 4: non-address output never reaches the URL"
+got="$(run_lan_ip 'RTNETLINK answers: Network is unreachable')"
+[[ -z "$got" ]] || fail "expected empty result, got '$got'"
+pass "unparseable output yields empty"
+
+echo "Test 5: an empty LAN IP falls back to localhost in the QR URL"
+url="$(ODS_TEST_IP_ROUTE_OUTPUT='' PATH="$tmpdir/bin:$PATH" bash -c '
+    . "'"$ROOT_DIR"'/lib/qrcode.sh"
+    print_dashboard_qr
+' | grep -o 'http://[^ ]*' | head -n 1)"
+[[ "$url" == "http://localhost:3001" ]] || fail "expected localhost fallback, got '$url'"
+pass "empty detection falls back to localhost"
+
+echo ""
+echo "All LAN IP detection tests passed."


### PR DESCRIPTION
## Problem

`_ods_lan_ip` (`ods/lib/qrcode.sh:13`) reads the host LAN address positionally:

```bash
lan_ip=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
```

Field 7 is the source address **only when the destination is reached through a gateway**:

```
1.1.1.1 via 192.168.1.1 dev eth0 src 192.168.1.42 uid 1000
                                      ^-- $7
```

A directly-connected destination prints no `via <gateway>`, which shifts every later field two positions left:

```
1.1.1.1 dev eth0 src 10.0.0.5 uid 1000
                                  ^-- $7
```

`_ods_lan_ip` then returns `1000`. That value feeds `print_success_card` and `print_dashboard_qr`, so the end of a successful install advertises `http://1000:3001` and encodes it into the QR code the user scans with their phone.

The repo already has the correct idiom — `installers/phases/06-directories.sh:583` keys off the `src` label when detecting `HOST_LAN_IP`. This brings `qrcode.sh` in line.

## Fix

- Parse by the `src` label instead of a fixed field number, and pin the lookup to `ip -4`.
- Reject anything that is not a dotted quad, so unparseable output (`RTNETLINK answers: Network is unreachable`) falls back to `localhost` rather than reaching the URL.

## Tests

New `ods/tests/test-lan-ip-detection.sh` (wired into `make test`) stubs `ip`/`ifconfig` and covers the gateway route, the on-link route, a route with no `src`, unparseable output, and the localhost fallback in the QR URL.

On `main` the on-link case fails with `expected 10.0.0.5, got '1000'`; all five pass with the fix.