### PR TITLE
fix(installer): normalize the install dir on hosts without GNU realpath

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -66,6 +66,9 @@ test: ## Run unit and contract tests
 	@echo "=== mode switch status and switching ==="
 	@bash tests/test-mode-switch-status.sh
 	@echo ""
+	@echo "=== install-dir path normalization ==="
+	@bash tests/test-path-normalization.sh
+	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh

--- a/ods/installers/lib/path-utils.sh
+++ b/ods/installers/lib/path-utils.sh
@@ -12,36 +12,78 @@
 #   Add platform-specific path handling here.
 # ============================================================================
 
+# Collapse ".", "..", duplicate and trailing slashes without touching the
+# filesystem. Purely textual, so an install dir that does not exist yet
+# normalizes exactly like one that does.
+_normalize_path_lexically() {
+    local path="$1" segment
+    local -a segments=() kept=()
+    local saved_ifs="$IFS"
+    IFS='/' read -r -a segments <<< "$path"
+    IFS="$saved_ifs"
+
+    for segment in ${segments[@]+"${segments[@]}"}; do
+        case "$segment" in
+            "" | ".")
+                ;;
+            "..")
+                # A leading ".." has nothing to pop; drop it, since the caller
+                # already made the path absolute and /.. is /.
+                if [[ ${#kept[@]} -gt 0 ]]; then
+                    kept=(${kept[@]+"${kept[@]:0:${#kept[@]} - 1}"})
+                fi
+                ;;
+            *)
+                kept+=("$segment")
+                ;;
+        esac
+    done
+
+    local joined=""
+    for segment in ${kept[@]+"${kept[@]}"}; do
+        joined="$joined/$segment"
+    done
+    echo "${joined:-/}"
+}
+
 # Normalize a path (resolve symlinks, remove trailing slashes, make absolute)
 normalize_path() {
     local path="$1"
-    
+
     # Handle empty path
     if [[ -z "$path" ]]; then
         echo ""
         return 1
     fi
-    
+
     # Expand tilde to HOME
     path="${path/#\~/$HOME}"
-    
+
     # Make absolute if relative
     if [[ "$path" != /* ]]; then
         path="$(pwd)/$path"
     fi
-    
-    # Resolve symlinks and normalize (remove .., ., //)
-    if command -v realpath &>/dev/null; then
-        # GNU realpath (Linux)
-        realpath -m "$path" 2>/dev/null || echo "$path"
-    elif command -v grealpath &>/dev/null; then
-        # GNU realpath via Homebrew (macOS)
-        grealpath -m "$path" 2>/dev/null || echo "$path"
-    else
-        # Fallback: basic normalization without external dependencies
-        # This handles most cases but doesn't resolve all edge cases
-        echo "$path"
-    fi
+
+    # Resolve symlinks and normalize (remove .., ., //).
+    #
+    # Only GNU realpath is usable here: -m is what lets an install dir be
+    # normalized before it is created. macOS 12.3+ ships a BSD realpath that
+    # has neither -m nor tolerance for missing components, and it sits on PATH
+    # as plain `realpath` — so probing for the flag, rather than for the name,
+    # is what keeps Homebrew's coreutils grealpath from being shadowed by it.
+    local candidate resolved
+    for candidate in grealpath realpath; do
+        command -v "$candidate" &>/dev/null || continue
+        if resolved="$("$candidate" -m "$path" 2>/dev/null)" && [[ -n "$resolved" ]]; then
+            echo "$resolved"
+            return 0
+        fi
+    done
+
+    # No GNU realpath available: normalize textually rather than handing back
+    # the raw string. Symlinks stay unresolved, which is the one thing this
+    # cannot do without the filesystem.
+    _normalize_path_lexically "$path"
 }
 
 # Resolve installation directory with precedence:

--- a/ods/tests/test-path-normalization.sh
+++ b/ods/tests/test-path-normalization.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Test installers/lib/path-utils.sh: normalize_path must normalize on every
+# platform, not only where GNU realpath happens to be the `realpath` on PATH.
+#
+# macOS 12.3+ ships a BSD realpath. It has no -m and refuses paths whose
+# components do not exist yet, and it occupies the plain `realpath` name — so
+# a name-only probe picks it, its call fails, and the install dir is handed
+# back unnormalized. installers/macos/lib/constants.sh derives
+# ODS_INSTALL_DIR from this function.
+#
+# Run from repo root:  bash ods/tests/test-path-normalization.sh
+# Or from ods:         bash tests/test-path-normalization.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$ROOT_DIR/installers/lib/path-utils.sh" ]] || fail "installers/lib/path-utils.sh not found"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# A stand-in for BSD realpath: rejects -m and refuses missing components.
+mkdir -p "$tmpdir/bsd"
+# An absolute shebang: PATH is emptied out below, so `env` could not find a
+# shell to hand off to.
+cat > "$tmpdir/bsd/realpath" << 'EOF'
+#!/bin/sh
+if [ "$1" = "-m" ]; then
+    echo "realpath: illegal option -- m" >&2
+    exit 1
+fi
+[ -e "$1" ] || { echo "realpath: $1: No such file or directory" >&2; exit 1; }
+EOF
+chmod +x "$tmpdir/bsd/realpath"
+
+# A stand-in for a platform with no realpath of any kind.
+mkdir -p "$tmpdir/bare"
+
+normalize_with() {
+    local stub_dir="$1" input="$2"
+    # PATH is replaced outright so the host's real realpath cannot leak in;
+    # coreutils used by the function are bash builtins.
+    PATH="$stub_dir" "$BASH" -c '
+        . "'"$ROOT_DIR"'/installers/lib/path-utils.sh"
+        normalize_path "$1"
+    ' _ "$input"
+}
+
+for platform in bsd bare; do
+    echo "Test: normalize_path on a host with the '$platform' realpath"
+
+    got="$(normalize_with "$tmpdir/$platform" "/Users/example/ods/")"
+    [[ "$got" == "/Users/example/ods" ]] || fail "$platform: trailing slash not stripped (got '$got')"
+
+    got="$(normalize_with "$tmpdir/$platform" "/Users/example//ods")"
+    [[ "$got" == "/Users/example/ods" ]] || fail "$platform: duplicate slash not collapsed (got '$got')"
+
+    got="$(normalize_with "$tmpdir/$platform" "/Users/example/./ods")"
+    [[ "$got" == "/Users/example/ods" ]] || fail "$platform: '.' segment kept (got '$got')"
+
+    # The install dir does not exist yet during a first install, which is what
+    # -m exists for and what BSD realpath refuses outright.
+    got="$(normalize_with "$tmpdir/$platform" "/Users/example/tmp/../ods")"
+    [[ "$got" == "/Users/example/ods" ]] || fail "$platform: '..' segment kept (got '$got')"
+
+    got="$(normalize_with "$tmpdir/$platform" "/")"
+    [[ "$got" == "/" ]] || fail "$platform: root did not survive (got '$got')"
+
+    got="$(normalize_with "$tmpdir/$platform" "/..")"
+    [[ "$got" == "/" ]] || fail "$platform: /.. is not / (got '$got')"
+
+    pass "$platform host normalizes the install dir"
+done
+
+echo "Test: GNU realpath is still preferred when it is available"
+mkdir -p "$tmpdir/gnu"
+cat > "$tmpdir/gnu/grealpath" << 'EOF'
+#!/bin/sh
+echo "GREALPATH-WAS-USED"
+EOF
+chmod +x "$tmpdir/gnu/grealpath"
+cp "$tmpdir/bsd/realpath" "$tmpdir/gnu/realpath"
+got="$(normalize_with "$tmpdir/gnu" "/Users/example/ods/")"
+[[ "$got" == "GREALPATH-WAS-USED" ]] || fail "grealpath was shadowed by the BSD realpath (got '$got')"
+pass "grealpath wins over a realpath that cannot do the job"
+
+echo "Test: empty input still reports failure"
+if normalize_with "$tmpdir/bare" "" >/dev/null 2>&1; then
+    fail "empty path should return non-zero"
+fi
+pass "empty path returns non-zero"
+
+echo ""
+echo "All path normalization tests passed."


### PR DESCRIPTION
## Problem

`normalize_path` (`ods/installers/lib/path-utils.sh`) probes for the *name* `realpath`, and only falls back to `grealpath` when no `realpath` exists at all:

```bash
if command -v realpath &>/dev/null; then
    realpath -m "$path" 2>/dev/null || echo "$path"
elif command -v grealpath &>/dev/null; then     # <- "GNU realpath via Homebrew (macOS)"
    grealpath -m "$path" 2>/dev/null || echo "$path"
```

macOS 12.3+ ships a **BSD** realpath under exactly that name. So on every currently-supported macOS:

1. the first branch always wins and the branch written for macOS is unreachable;
2. BSD realpath has no `-m` (`realpath: illegal option -- m`), so the call fails;
3. the `|| echo "$path"` fallback returns the raw string — no normalization at all.

`-m` is not incidental. The install dir does not exist yet during a first install, and BSD realpath refuses paths whose components are missing, so even a hypothetical `realpath` without the flag could not do this job.

`installers/macos/lib/constants.sh:33` derives `ODS_INSTALL_DIR` from this function, so whatever the operator typed — trailing slash, `.`, `..` — propagates verbatim into every derived path, the generated `.env`, and the launchd plists.

## Fix

- Probe for the working **flag**, not the name: try `grealpath -m`, then `realpath -m`, and accept the first that actually succeeds. Linux is unchanged (its `realpath` is GNU and answers `-m`).
- When no GNU realpath exists at all, normalize lexically (collapse `.`, `..`, duplicate and trailing slashes) instead of returning the string unchanged. Symlinks stay unresolved — the one thing that genuinely needs the filesystem.

Kept Bash 3.2-safe (macOS system bash); `make test`'s `test-bash32-guards.sh` still passes.

## Tests

New `ods/tests/test-path-normalization.sh` (wired into `make test`) stubs a BSD-style realpath and a host with no realpath, and asserts normalization in both, that `grealpath` is not shadowed, and that empty input still returns non-zero.

On `main` the first assertion fails: `bsd: trailing slash not stripped (got '/Users/example/ods/')`.