### PR TITLE
fix(installer): stop the readiness summary flagging healthy containers

### DIFF
--- a/ods/installers/lib/readiness-summary.sh
+++ b/ods/installers/lib/readiness-summary.sh
@@ -74,7 +74,14 @@ ods_readiness_summary() {
         if _ods_readiness_is_ready_code "$http_code"; then
             state="ready"
             detail="HTTP $http_code"
-        elif [[ "$container_state" == "running" || "$container_state" == "starting" || "$container_state" == "host" ]]; then
+        # `healthy` belongs here with `running`: docker inspect reports the
+        # health status when the container declares a healthcheck and the plain
+        # status otherwise, so leaving it out made the container Docker vouches
+        # for rank below one Docker only knows is up. The probe URL and the
+        # healthcheck are not always the same endpoint — a service answering
+        # 404 on / while its own check passes is starting up, not broken.
+        elif [[ "$container_state" == "running" || "$container_state" == "healthy" \
+             || "$container_state" == "starting" || "$container_state" == "host" ]]; then
             state="starting"
             detail="HTTP $http_code"
         elif [[ "$container_state" == "missing" || "$container_state" == "docker-unavailable" ]]; then

--- a/ods/installers/windows/lib/readiness-summary.ps1
+++ b/ods/installers/windows/lib/readiness-summary.ps1
@@ -74,7 +74,12 @@ function Write-ODSInstallReadinessSummary {
         else {
             $state = "starting"
             $detail = "HTTP $($http.Code)"
-            if ($containerState -and $containerState -notin @("running", "starting", "host")) {
+            # "healthy" belongs with "running": Get-ODSReadinessContainerState
+            # reports the health status when the container declares a
+            # healthcheck and the plain status otherwise, so omitting it ranked
+            # the container Docker vouches for below one Docker only knows is
+            # up. Mirrors installers/lib/readiness-summary.sh.
+            if ($containerState -and $containerState -notin @("running", "healthy", "starting", "host")) {
                 $state = "needs attention"
                 $detail = "container $containerState, HTTP $($http.Code)"
             }

--- a/ods/tests/test-install-readiness-summary.sh
+++ b/ods/tests/test-install-readiness-summary.sh
@@ -54,6 +54,7 @@ case "$url" in
   *3001*) printf "200" ;;
   *3000*) printf "000"; exit 7 ;;
   *6333*) printf "000"; exit 7 ;;
+  *4000*) printf "404" ;;
   *) printf "404" ;;
 esac
 EOF
@@ -66,6 +67,8 @@ if [[ "$1" == "inspect" ]]; then
   case "$container" in
     ods-dashboard) echo "healthy"; exit 0 ;;
     ods-webui) echo "running"; exit 0 ;;
+    ods-litellm) echo "healthy"; exit 0 ;;
+    ods-comfyui) echo "unhealthy"; exit 0 ;;
     ods-qdrant) exit 1 ;;
     *) echo "missing"; exit 1 ;;
   esac
@@ -94,6 +97,8 @@ OUTPUT="$TMP_DIR/readiness.txt"
     printf 'Dashboard|http://127.0.0.1:3001|ods-dashboard|http://localhost:3001\n'
     printf 'Chat UI (Open WebUI)|http://127.0.0.1:3000|ods-webui|http://localhost:3000\n'
     printf 'Qdrant|http://127.0.0.1:6333|ods-qdrant|http://localhost:6333\n'
+    printf 'LiteLLM|http://127.0.0.1:4000|ods-litellm|http://localhost:4000\n'
+    printf 'ComfyUI|http://127.0.0.1:4000|ods-comfyui|http://localhost:4000\n'
 } | ods_readiness_summary "ods status" "/tmp/ods-install.log" "http://localhost:3001" > "$OUTPUT"
 
 echo ""
@@ -101,7 +106,7 @@ echo "=== Install readiness summary tests ==="
 echo ""
 
 assert_contains "$OUTPUT" "INSTALL READINESS" "summary has heading"
-assert_contains "$OUTPUT" "Ready now: 1/3" "summary counts ready services"
+assert_contains "$OUTPUT" "Ready now: 1/5" "summary counts ready services"
 assert_contains "$OUTPUT" "[OK] Dashboard" "summary lists ready service"
 [[ -s "$SUDO_MARKER" ]] && pass "summary honors DOCKER_CMD wrapper for docker inspect" || fail "summary ignored DOCKER_CMD wrapper"
 assert_contains "$OUTPUT" "[!!] Chat UI (Open WebUI)" "summary lists starting service"
@@ -110,6 +115,14 @@ assert_not_contains "$OUTPUT" "000000" "failed curl probe is normalized to a sin
 assert_contains "$OUTPUT" "[!!] Qdrant" "summary lists missing service"
 assert_contains "$OUTPUT" "not detected - missing" "summary explains missing container"
 assert_contains "$OUTPUT" "HTTP 000" "summary includes failed HTTP code"
+# A container whose own healthcheck passes must not rank below one Docker
+# only knows is running. The probe URL and the healthcheck are not always the
+# same endpoint, so a 404 here means "not up yet", not "go debug this".
+assert_contains "$OUTPUT" "[!!] LiteLLM" "summary lists healthy-but-unprobed service"
+assert_contains "$OUTPUT" "LiteLLM                      starting - HTTP 404" "healthy container reads as starting"
+assert_not_contains "$OUTPUT" "container healthy" "healthy container is never reported as needing attention"
+# unhealthy is the state that genuinely needs an operator.
+assert_contains "$OUTPUT" "ComfyUI                      needs attention - container unhealthy, HTTP 404" "unhealthy container still needs attention"
 assert_contains "$OUTPUT" "Open dashboard: http://localhost:3001" "summary shows dashboard next step"
 assert_contains "$OUTPUT" "Check status: ods status" "summary shows status command"
 assert_contains "$OUTPUT" "Logs: /tmp/ods-install.log" "summary shows log path"

--- a/ods/tests/test-windows-readiness-summary.sh
+++ b/ods/tests/test-windows-readiness-summary.sh
@@ -60,21 +60,29 @@ if command -v pwsh >/dev/null 2>&1; then
             param([string]$Container)
             if ($Container -eq "ods-webui") { return "running" }
             if ($Container -eq "ods-qdrant") { return "missing" }
+            if ($Container -eq "ods-comfyui") { return "unhealthy" }
             return "healthy"
         }
         $checks = @(
             @{ Name = "Dashboard"; Url = "http://localhost:3001"; Container = "ods-dashboard"; OpenUrl = "http://localhost:3001" },
             @{ Name = "Chat UI"; Url = "http://localhost:3000"; Container = "ods-webui"; OpenUrl = "http://localhost:3000" },
-            @{ Name = "Qdrant"; Url = "http://localhost:6333"; Container = "ods-qdrant"; OpenUrl = "http://localhost:6333" }
+            @{ Name = "Qdrant"; Url = "http://localhost:6333"; Container = "ods-qdrant"; OpenUrl = "http://localhost:6333" },
+            @{ Name = "LiteLLM"; Url = "http://localhost:4000"; Container = "ods-litellm"; OpenUrl = "http://localhost:4000" },
+            @{ Name = "ComfyUI"; Url = "http://localhost:8188"; Container = "ods-comfyui"; OpenUrl = "http://localhost:8188" }
         )
         Write-ODSInstallReadinessSummary -Checks $checks -StatusCommand ".\ods.ps1 status" -LogPath "C:\ods\logs\install.log" -DashboardUrl "http://localhost:3001"
     ')"
 
     [[ "$OUTPUT" == *"INSTALL READINESS"* ]] && pass "runtime summary has heading" || fail "runtime summary missing heading"
-    [[ "$OUTPUT" == *"Ready now: 1/3"* ]] && pass "runtime summary counts ready services" || fail "runtime summary count mismatch"
+    [[ "$OUTPUT" == *"Ready now: 1/5"* ]] && pass "runtime summary counts ready services" || fail "runtime summary count mismatch"
     [[ "$OUTPUT" == *"[OK] Dashboard"* ]] && pass "runtime summary lists ready service" || fail "runtime summary missing ready service"
     [[ "$OUTPUT" == *"[!!] Chat UI"* ]] && pass "runtime summary lists starting service" || fail "runtime summary missing starting service"
     [[ "$OUTPUT" == *"[!!] Qdrant"* ]] && pass "runtime summary lists missing service" || fail "runtime summary missing missing service"
+    # A container whose own healthcheck passes must not outrank one Docker
+    # only knows is running. Same contract as the Bash summary.
+    [[ "$OUTPUT" == *"LiteLLM"*"starting"* ]] && pass "healthy container reads as starting" || fail "healthy container was demoted below running"
+    [[ "$OUTPUT" != *"container healthy"* ]] && pass "healthy container is never reported as needing attention" || fail "healthy container reported as needing attention"
+    [[ "$OUTPUT" == *"container unhealthy"* ]] && pass "unhealthy container still needs attention" || fail "unhealthy container lost its attention state"
 else
     pass "PowerShell runtime behavior skipped (pwsh unavailable)"
 fi


### PR DESCRIPTION
## Problem

`_ods_readiness_container_state` returns whatever this reports:

```
{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}
```

So a container **with** a healthcheck yields `starting` / `healthy` / `unhealthy`, and one **without** yields `running`. The classifier only accepted `running`, `starting` and `host`:

```bash
elif [[ "$container_state" == "running" || "$container_state" == "starting" || "$container_state" == "host" ]]; then
    state="starting"
```

`healthy` falls through to the `else`, so **the container Docker actively vouches for ranks below one Docker only knows is up**, and the summary prints the self-contradicting line:

```
[!!] LiteLLM                      needs attention - container healthy, HTTP 404
```

The HTTP probe and the container's own healthcheck are not always the same endpoint — a service answering 404 on `/` while its own check passes is still coming up. The net effect is a false alarm at the end of an otherwise clean install, pointing the operator at a container that is fine. `installers/windows/lib/readiness-summary.ps1` carries the identical list and the identical bug.

## Fix

Group `healthy` with `running` on both platforms. `unhealthy` still needs an operator and is unchanged.

## Tests

- `tests/test-install-readiness-summary.sh`: adds a healthy container behind a 404 probe and an unhealthy one, asserting the first reads `starting` and the second keeps `needs attention`; also asserts the string `container healthy` never appears in the attention list.
- `tests/test-windows-readiness-summary.sh`: same two cases in the pwsh runtime block.

On `main` the Bash suite fails 2 assertions (`healthy container reads as starting`, `healthy container is never reported as needing attention`). Both suites are green with the fix; PowerShell output verified locally under Windows PowerShell 5.1.