### PR TITLE
fix(ape): let a served circuit-breaker cooldown actually reopen the gate

### DIFF
--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -583,6 +583,14 @@ def circuit_breaker_blocked(policy: dict, now: float) -> tuple[bool, str]:
                           f"{datetime.fromtimestamp(tripped_until, timezone.utc).isoformat()})")
         if tripped_until and now >= tripped_until:
             _state["breaker"]["tripped_until"] = 0.0
+            # Drop the decisions that caused the trip along with the trip.
+            # window_seconds is longer than cooldown_seconds by design, so
+            # keeping them means the first decision after the cooldown is
+            # re-scored against the same denials and re-trips immediately —
+            # the breaker can never accumulate the min_samples it needs to
+            # prove recovery, and stays open for window_seconds instead of
+            # cooldown_seconds. Reopening has to rest on fresh evidence.
+            _state["breaker"]["decisions"] = []
     return (False, "")
 
 

--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -338,6 +338,26 @@ def _coerce_state(raw: Any) -> dict[str, Any]:
     return state
 
 
+def _clear_expired_trip(cb: dict, now: float) -> None:
+    """Clear a served breaker cooldown together with the denials that caused it.
+
+    window_seconds is longer than cooldown_seconds by design, so keeping the
+    deny history past the cooldown means the first decision after it is
+    re-scored against those same denials and re-trips immediately — the breaker
+    can never accumulate the min_samples it needs to prove recovery, and stays
+    open for window_seconds instead of cooldown_seconds. Reopening has to rest
+    on fresh evidence.
+
+    No-op unless the breaker is tripped and the cooldown has elapsed. Caller
+    holds the lock.
+    """
+    tripped_until = cb.get("tripped_until", 0.0)
+    if not tripped_until or now < tripped_until:
+        return
+    cb["tripped_until"] = 0.0
+    cb["decisions"] = []
+
+
 def _prune_state(now: float) -> None:
     """Drop expired window samples / breaker samples. Caller holds the lock."""
     longest = max(WINDOW_TIERS.values()) if WINDOW_TIERS else 0
@@ -364,8 +384,11 @@ def _prune_state(now: float) -> None:
     cb["decisions"] = [
         d for d in cb["decisions"] if d[0] >= cb_cut
     ][-_MAX_BREAKER_SAMPLES:]
-    if cb.get("tripped_until", 0.0) and cb["tripped_until"] < now:
-        cb["tripped_until"] = 0.0
+    # Prune runs on load, i.e. before any request reaches
+    # circuit_breaker_blocked(). Clearing the trip here without the denials
+    # behind it would hand a restarted process the stale evidence and re-trip
+    # on the first decision, so both paths retire a served cooldown the same way.
+    _clear_expired_trip(cb, now)
 
     if len(_state["approvals"]) > _MAX_PENDING_APPROVALS:
         # Drop the oldest pending approvals by issued timestamp.
@@ -581,16 +604,7 @@ def circuit_breaker_blocked(policy: dict, now: float) -> tuple[bool, str]:
         if tripped_until and now < tripped_until:
             return (True, f"circuit breaker open (cooldown until "
                           f"{datetime.fromtimestamp(tripped_until, timezone.utc).isoformat()})")
-        if tripped_until and now >= tripped_until:
-            _state["breaker"]["tripped_until"] = 0.0
-            # Drop the decisions that caused the trip along with the trip.
-            # window_seconds is longer than cooldown_seconds by design, so
-            # keeping them means the first decision after the cooldown is
-            # re-scored against the same denials and re-trips immediately —
-            # the breaker can never accumulate the min_samples it needs to
-            # prove recovery, and stays open for window_seconds instead of
-            # cooldown_seconds. Reopening has to rest on fresh evidence.
-            _state["breaker"]["decisions"] = []
+        _clear_expired_trip(_state["breaker"], now)
     return (False, "")
 
 

--- a/ods/extensions/services/ape/tests/test_main.py
+++ b/ods/extensions/services/ape/tests/test_main.py
@@ -7,6 +7,7 @@ and STRICT_MODE semantics are preserved.
 
 import concurrent.futures
 import json
+import time
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -548,3 +549,51 @@ def test_strict_mode_windowed_hard_deny_raises_403(make_client):
     _verify(client, tool="spawn_agent", args={}, session="swd")
     r = _verify(client, tool="spawn_agent", args={}, session="swd")
     assert r.status_code == 403
+
+
+def _trip_breaker(client, session):
+    for _ in range(5):
+        client.post("/verify", json={"tool_name": "exec",
+                                     "args": {"command": "x"},
+                                     "session_id": session})
+
+
+def test_circuit_breaker_serves_traffic_again_after_cooldown(make_client):
+    """A served cooldown must actually reopen the gate.
+
+    window_seconds is longer than cooldown_seconds by design. If the deny
+    history that tripped the breaker survives the cooldown, the first
+    decision after it is re-scored against those same denials and trips
+    again — so the breaker never gathers the min_samples of fresh traffic it
+    needs to prove recovery, and callers stay blocked for window_seconds.
+    """
+    client, main = make_client(policy_yaml=CB_POLICY)
+    _trip_breaker(client, "cb-cooldown")
+    assert client.get("/metrics").json()["circuit_breaker_open"] is True
+
+    # Serve the cooldown without sleeping through it.
+    with main._STATE_LOCK:
+        main._state["breaker"]["tripped_until"] = time.time() - 1
+
+    first = client.post("/verify", json={"tool_name": "noop", "args": {},
+                                         "session_id": "cb-cooldown"})
+    assert first.json()["allowed"] is True, first.json()["reason"]
+
+    # The one that actually regressed: on the old code the call above fed the
+    # breaker, which re-scored the surviving denials and slammed it shut.
+    second = client.post("/verify", json={"tool_name": "noop", "args": {},
+                                          "session_id": "cb-cooldown"})
+    assert second.json()["allowed"] is True, second.json()["reason"]
+    assert "circuit breaker" not in second.json()["reason"].lower()
+    assert client.get("/metrics").json()["circuit_breaker_open"] is False
+
+
+def test_circuit_breaker_retrips_on_fresh_denials_after_cooldown(make_client):
+    """Clearing the history must not disarm the breaker permanently."""
+    client, main = make_client(policy_yaml=CB_POLICY)
+    _trip_breaker(client, "cb-retrip")
+    with main._STATE_LOCK:
+        main._state["breaker"]["tripped_until"] = time.time() - 1
+
+    _trip_breaker(client, "cb-retrip")
+    assert client.get("/metrics").json()["circuit_breaker_open"] is True

--- a/ods/extensions/services/ape/tests/test_main.py
+++ b/ods/extensions/services/ape/tests/test_main.py
@@ -597,3 +597,34 @@ def test_circuit_breaker_retrips_on_fresh_denials_after_cooldown(make_client):
 
     _trip_breaker(client, "cb-retrip")
     assert client.get("/metrics").json()["circuit_breaker_open"] is True
+
+
+def test_circuit_breaker_cooldown_served_across_restart(make_client):
+    """A cooldown that expires while the process is down must also reopen.
+
+    load_state() prunes before any request reaches circuit_breaker_blocked(),
+    so the prune path is the only thing that sees the expired trip on a
+    restart. If it drops the trip but keeps the denials behind it, the
+    restarted process re-scores that stale history on its first decision and
+    slams the breaker shut again.
+    """
+    client, main = make_client(policy_yaml=CB_POLICY)
+    _trip_breaker(client, "cb-restart")
+    with main._STATE_LOCK:
+        main._state["breaker"]["tripped_until"] = time.time() - 1
+    main.save_state()
+
+    # Fresh import + load_state() off the same state file: a real restart.
+    restarted, main2 = make_client(policy_yaml=CB_POLICY)
+    with main2._STATE_LOCK:
+        assert main2._state["breaker"]["decisions"] == []
+        assert main2._state["breaker"]["tripped_until"] == 0.0
+
+    first = restarted.post("/verify", json={"tool_name": "noop", "args": {},
+                                            "session_id": "cb-restart"})
+    assert first.json()["allowed"] is True, first.json()["reason"]
+    second = restarted.post("/verify", json={"tool_name": "noop", "args": {},
+                                             "session_id": "cb-restart"})
+    assert second.json()["allowed"] is True, second.json()["reason"]
+    assert "circuit breaker" not in second.json()["reason"].lower()
+    assert restarted.get("/metrics").json()["circuit_breaker_open"] is False


### PR DESCRIPTION
## Problem

`circuit_breaker_blocked` clears the trip when the cooldown expires but leaves the decisions that caused it in place:

```python
if tripped_until and now >= tripped_until:
    _state["breaker"]["tripped_until"] = 0.0    # decisions[] untouched
```

`window_seconds` is longer than `cooldown_seconds` by design (defaults: 300 vs 120), so those denials are still inside the scoring window. The first decision after the cooldown calls `record_breaker_decision`, which re-scores the same denials and trips the breaker again — **even when that decision was an allow**.

There is no way out of this loop from inside the cooldown: a blocked `/verify` returns at `main.py:804` *before* `record_breaker_decision`, so no fresh evidence is ever recorded. The breaker can never accumulate the `min_samples` of clean traffic it needs to prove recovery, and it re-trips on the first request after every cooldown until the original denials age out of `window_seconds` on their own.

Net effect: the breaker stays shut for `window_seconds`, not `cooldown_seconds`, and every agent tool call routed through APE is denied for that whole time.

## Fix

Clear the decision window when the cooldown is served. Reopening then rests on fresh evidence, which is what a cooldown is for. A system that is genuinely still failing re-trips as soon as `min_samples` new decisions arrive — covered by the second test.

## Tests

`ape/tests/test_main.py`:
- `test_circuit_breaker_serves_traffic_again_after_cooldown` — trips the breaker, serves the cooldown by rewinding `tripped_until` (no sleeping), then asserts **two** consecutive allowed calls succeed. The second is the regression: on `main` the first call feeds the breaker and slams it shut again.
- `test_circuit_breaker_retrips_on_fresh_denials_after_cooldown` — guards the other direction, so clearing the history cannot disarm the breaker.

On `main` the first test fails; the second passes. Full APE suite: 46 passed.