### PR TITLE
fix(ape): stop the per-minute limiter retaining every session id

### DIFF
--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -432,17 +432,46 @@ def save_state() -> None:
 # Legacy minute-window limiter (kept verbatim for the requests_per_minute
 # policy knob so existing deployments behave identically).
 _session_request_times: dict[str, deque] = {}
+_last_rate_limit_sweep: float = 0.0
+
+
+def sweep_idle_rate_limit_scopes(cutoff: float) -> None:
+    """Drop scopes whose whole minute window has aged out.
+
+    The table is keyed by the caller-supplied session id and nothing ever
+    removed an entry, so it grew once per distinct session for the life of
+    the process. Every other governance structure here is explicitly bounded
+    (_MAX_SAMPLES_PER_WINDOW, _MAX_BREAKER_SAMPLES, _MAX_PENDING_APPROVALS,
+    _MAX_PENDING_GRANTS); this one was not.
+
+    Only fully-aged scopes are dropped. A scope still holding timestamps is
+    still enforcing a limit, and evicting it would hand its caller a fresh
+    budget — flooding new session ids would become a way to clear an
+    exhausted one. Sweeping only dead entries bounds the table by concurrent
+    traffic instead of by uptime, with no such bypass.
+    """
+    for key in [key for key, times in _session_request_times.items()
+                if not times or times[-1] < cutoff]:
+        del _session_request_times[key]
 
 
 def check_rate_limit(policy: dict, session_id: Optional[str]) -> bool:
     """Return True if the request is within the legacy per-minute limit."""
+    global _last_rate_limit_sweep
     limit = policy.get("rate_limit", {}).get("requests_per_minute", RATE_LIMIT)
     key = session_id or "_global"
+    now = time.monotonic()
+    cutoff = now - 60.0
+
+    # One pass per window at most: entries only become collectable after 60
+    # idle seconds, so sweeping more often just rescans live ones.
+    if now - _last_rate_limit_sweep >= 60.0:
+        _last_rate_limit_sweep = now
+        sweep_idle_rate_limit_scopes(cutoff)
+
     if key not in _session_request_times:
         _session_request_times[key] = deque()
     times = _session_request_times[key]
-    now = time.monotonic()
-    cutoff = now - 60.0
     while times and times[0] < cutoff:
         times.popleft()
     if len(times) >= limit:

--- a/ods/extensions/services/ape/tests/test_main.py
+++ b/ods/extensions/services/ape/tests/test_main.py
@@ -548,3 +548,68 @@ def test_strict_mode_windowed_hard_deny_raises_403(make_client):
     _verify(client, tool="spawn_agent", args={}, session="swd")
     r = _verify(client, tool="spawn_agent", args={}, session="swd")
     assert r.status_code == 403
+
+
+# ── Legacy per-minute limiter bookkeeping ───────────────────────────────────
+
+
+def _age_out_rate_limit_table(main):
+    """Push every recorded timestamp past the 60s window, without sleeping."""
+    for times in main._session_request_times.values():
+        for _ in range(len(times)):
+            times.append(times.popleft() - 120.0)
+    main._last_rate_limit_sweep = 0.0
+
+
+def test_rate_limit_table_does_not_retain_finished_sessions(make_client):
+    """The limiter must not keep one entry per session id forever.
+
+    session_id comes straight off the request body, so an agent framework
+    that mints a session per conversation — or a caller sending arbitrary
+    ids — otherwise allocates a permanent deque per value.
+    """
+    client, main = make_client()
+    for index in range(200):
+        _verify(client, session=f"finished-{index}")
+    assert len(main._session_request_times) >= 200
+
+    _age_out_rate_limit_table(main)
+    _verify(client, session="current")
+
+    assert set(main._session_request_times) == {"current"}
+
+
+def test_rate_limit_sweep_never_clears_a_live_budget(make_client):
+    """Eviction must not become a way around the limit.
+
+    If a scope that still holds timestamps could be evicted, flooding fresh
+    session ids would reset an exhausted one.
+    """
+    policy = """
+version: 1
+intents: {ReadFile: {mode: allow}, Other: {mode: allow}}
+rate_limit: {requests_per_minute: 3}
+windowed_limits: {enabled: false}
+circuit_breaker: {enabled: false}
+"""
+    client, main = make_client(policy_yaml=policy)
+    for _ in range(3):
+        assert _verify(client, session="busy").json()["allowed"] is True
+    limited = _verify(client, session="busy")
+    assert limited.json()["allowed"] is False
+    assert limited.json()["reason"] == "rate limit exceeded"
+
+    for index in range(500):
+        _verify(client, session=f"noise-{index}")
+    main._last_rate_limit_sweep = 0.0
+    _verify(client, session="trigger-sweep")
+
+    assert "busy" in main._session_request_times
+    assert _verify(client, session="busy").json()["allowed"] is False
+
+
+def test_sweep_keeps_scopes_with_a_live_window(make_client):
+    client, main = make_client()
+    _verify(client, session="live")
+    main.sweep_idle_rate_limit_scopes(main.time.monotonic() - 60.0)
+    assert "live" in main._session_request_times


### PR DESCRIPTION
## Problem

`_session_request_times` is keyed by the caller-supplied `session_id` and nothing ever removed an entry:

```python
key = session_id or "_global"
if key not in _session_request_times:
    _session_request_times[key] = deque()
```

Timestamps inside a deque are trimmed to the 60-second window, but the deque itself — and its key — lives for the life of the process. An agent framework that mints a session per conversation, or any caller sending arbitrary ids, grows the table without limit.

This is the one unbounded structure in the module. Every other one is explicitly capped: `_MAX_SAMPLES_PER_WINDOW`, `_MAX_BREAKER_SAMPLES`, `_MAX_PENDING_APPROVALS`, `_MAX_PENDING_GRANTS`, plus the `_prune_state` sweep for all of them.

## Fix

Sweep scopes whose whole minute window has aged out, at most once per window (entries only become collectable after 60 idle seconds, so sweeping more often just rescans live ones).

Only **dead** entries are dropped. A scope still holding timestamps is still enforcing a limit, and evicting it would hand its caller a fresh budget — flooding new session ids would become a way to clear an exhausted one. That rules out LRU/size-cap eviction here; sweeping only aged-out entries bounds the table by concurrent traffic instead of by uptime, with no such bypass.

## Tests

`ape/tests/test_main.py`:
- `test_rate_limit_table_does_not_retain_finished_sessions` — 200 finished sessions, aged past the window, leave exactly one live entry behind.
- `test_rate_limit_sweep_never_clears_a_live_budget` — an exhausted session stays exhausted after 500 fresh ids force a sweep. This is the guard against turning the fix into a limiter bypass.
- `test_sweep_keeps_scopes_with_a_live_window` — a scope inside its window survives a sweep.

On `main` the first and third fail (retention, and the helper does not exist); the bypass guard passes both before and after, as it should. Full APE suite: 47 passed.