### PR TITLE
fix(ape): make path_guard deny a destination it cannot read

### DIFF
--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -685,7 +685,16 @@ def evaluate(intent: str, tool_name: str, args: dict, policy: dict) -> tuple[boo
     if mode == "path_guard":
         path = str(args.get("path", args.get("file", args.get("filename", ""))))
         if not path:
-            return True, "no path specified"
+            # Fail closed, like the empty-command case in allowlist above. A
+            # write whose destination this guard cannot see is precisely what
+            # it exists to stop: classify_intent routes any tool named for a
+            # write verb here, so args naming the destination something else
+            # (dest, target, output_path) would otherwise walk straight past
+            # allowed_paths.
+            return False, (
+                "no readable destination in args (expected path, file, or "
+                "filename); path_guard cannot verify the write"
+            )
         real = os.path.realpath(path)
         allowed_paths = intent_policy.get("allowed_paths", [])
         if any(real == p or real.startswith(p.rstrip("/") + "/") for p in allowed_paths):

--- a/ods/extensions/services/ape/tests/test_main.py
+++ b/ods/extensions/services/ape/tests/test_main.py
@@ -7,6 +7,9 @@ and STRICT_MODE semantics are preserved.
 
 import concurrent.futures
 import json
+import os
+
+import pytest
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -548,3 +551,91 @@ def test_strict_mode_windowed_hard_deny_raises_403(make_client):
     _verify(client, tool="spawn_agent", args={}, session="swd")
     r = _verify(client, tool="spawn_agent", args={}, session="swd")
     assert r.status_code == 403
+
+
+# ── path_guard mode ─────────────────────────────────────────────────────────
+
+
+def _path_guard_policy(allowed_root: str) -> str:
+    return f"""
+version: 1
+intents:
+  WriteFile:
+    mode: path_guard
+    allowed_paths:
+      - {allowed_root}
+  Other: {{mode: allow}}
+rate_limit: {{requests_per_minute: 100000}}
+windowed_limits: {{enabled: false}}
+circuit_breaker: {{enabled: false}}
+"""
+
+
+@pytest.fixture()
+def path_guard_client(make_client, tmp_path):
+    """A client whose write zone is a real directory on this platform.
+
+    evaluate() resolves the candidate with os.path.realpath, so a hard-coded
+    POSIX literal would not line up with allowed_paths off Linux.
+    """
+    root = os.path.realpath(str(tmp_path / "workspace"))
+    os.makedirs(root, exist_ok=True)
+    client, main = make_client(policy_yaml=_path_guard_policy(root))
+    return client, root
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="allowed_paths prefix matching is POSIX-separator only; APE ships "
+           "as a Linux container",
+)
+def test_path_guard_allows_a_write_inside_the_zone(path_guard_client):
+    client, root = path_guard_client
+    r = client.post("/verify", json={
+        "tool_name": "write_file",
+        "args": {"path": os.path.join(root, "notes.md")},
+        "session_id": "pg",
+    })
+    assert r.json()["allowed"] is True, r.json()["reason"]
+
+
+def test_path_guard_denies_a_write_outside_the_zone(path_guard_client, tmp_path):
+    client, _ = path_guard_client
+    outside = os.path.realpath(str(tmp_path / "elsewhere" / "secrets"))
+    r = client.post("/verify", json={
+        "tool_name": "write_file",
+        "args": {"path": outside},
+        "session_id": "pg",
+    })
+    assert r.json()["allowed"] is False
+
+
+def test_path_guard_denies_a_destination_it_cannot_read(path_guard_client, tmp_path):
+    """An unrecognised destination key must not walk past allowed_paths.
+
+    classify_intent routes any tool named for a write verb into WriteFile, so
+    a tool that calls its destination something other than path/file/filename
+    reaches path_guard with nothing to check. Waving it through defeats the
+    whole mode — and the allowlist branch already denies the equivalent empty
+    command rather than allowing it.
+    """
+    client, _ = path_guard_client
+    r = client.post("/verify", json={
+        "tool_name": "save_output",
+        "args": {"destination": str(tmp_path / "elsewhere" / "loot"), "content": "x"},
+        "session_id": "pg",
+    })
+    body = r.json()
+    assert body["intent"] == "WriteFile"
+    assert body["allowed"] is False
+    assert "destination" in body["reason"]
+
+
+def test_path_guard_denies_an_empty_path_value(path_guard_client):
+    client, _ = path_guard_client
+    r = client.post("/verify", json={
+        "tool_name": "write_file",
+        "args": {"path": ""},
+        "session_id": "pg",
+    })
+    assert r.json()["allowed"] is False


### PR DESCRIPTION
## Problem

`path_guard` reads the destination from three fixed keys and **allows** the call when none of them is present:

```python
path = str(args.get("path", args.get("file", args.get("filename", ""))))
if not path:
    return True, "no path specified"
```

`classify_intent` routes any tool whose name contains a write verb (`write`, `create`, `append`, `save`, `put`) into `WriteFile`, which the shipped `config/ape/policy.yaml` puts under `path_guard`. So a tool that names its destination anything else — `dest`, `target`, `output_path`, `destination` — reaches the guard with nothing to check and is waved through, never compared against `allowed_paths`.

```
tool_name: save_output
args:      {"destination": "/etc/cron.d/backdoor", "content": "..."}
→ intent WriteFile, decision allow, reason "no path specified"
```

The `allowlist` branch immediately above already treats the equivalent case the other way:

```python
command = args.get("command", args.get("cmd", ""))
if not command:
    return False, "empty command denied"
```

Two modes in the same function, same situation, opposite answers — and the guard is the one that fails open.

## Fix

Deny, and name the keys that were looked for so an operator can either fix the tool contract or change the mode.

**Behaviour change:** a tool classified as `WriteFile` that genuinely carries no destination argument now gets denied instead of allowed. That is the intended direction for a guard mode, and the reason string says exactly what to do about it.

## Tests

`ape/tests/test_main.py` gains a `path_guard` block — the mode had no coverage at all:
- write inside the zone is allowed (positive control; skipped on Windows since the `allowed_paths` prefix match is POSIX-separator only and APE ships as a Linux container);
- write outside the zone is denied;
- **a destination under an unrecognised key is denied** — the regression;
- an empty `path` value is denied.

On `main` the last two fail. Full APE suite: 47 passed, 1 skipped.