### PR TITLE
fix(support-bundle): redact collected files with the same secret set as .env

### DIFF
--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -2,7 +2,17 @@
 set -euo pipefail
 
 TOOL_VERSION="1"
-REDACTION_VERSION="1"
+REDACTION_VERSION="2"
+
+# Key-name substrings that mark a value as secret, shared by BOTH redactors in
+# this script: redact_file (every collected file) and write_redacted_env (.env).
+# They must not drift — validation/compose-config.txt is `docker compose
+# config` output, which renders every environment value, so anything the file
+# redactor misses ships in cleartext inside the archive users attach to public
+# issues. USER|EMAIL|BEARER are here because .env.schema.json marks N8N_USER,
+# LANGFUSE_INIT_USER_EMAIL and LANGFUSE_MINIO_ROOT_USER secret:true; this
+# mirrors that set and the CLI's config-show masking.
+ODS_SUPPORT_SECRET_WORDS="KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL|USER|EMAIL|BEARER"
 DEFAULT_LOG_TAIL=200
 MAX_LOG_CONTAINERS=25
 
@@ -125,7 +135,7 @@ redact_file() {
     local file="$1"
     [[ -f "$file" ]] || return 0
 
-    "$PYTHON_CMD" - "$file" <<'PY'
+    "$PYTHON_CMD" - "$file" "$ODS_SUPPORT_SECRET_WORDS" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -136,7 +146,7 @@ try:
 except OSError:
     raise SystemExit(0)
 
-secret_word = r"(?:KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)"
+secret_word = f"(?:{sys.argv[2]})"
 
 patterns = [
     (re.compile(r"(?i)(Bearer\s+)[A-Za-z0-9._~+/=-]+"), r"\1[REDACTED]"),
@@ -208,18 +218,14 @@ write_redacted_env() {
         return 0
     fi
 
-    "$PYTHON_CMD" - "$env_path" "$out_path" <<'PY'
+    "$PYTHON_CMD" - "$env_path" "$out_path" "$ODS_SUPPORT_SECRET_WORDS" <<'PY'
 import re
 import sys
 from pathlib import Path
 
 src = Path(sys.argv[1])
 dest = Path(sys.argv[2])
-# USER|EMAIL|BEARER cover schema secret:true keys the old pattern missed —
-# N8N_USER, LANGFUSE_INIT_USER_EMAIL, LANGFUSE_MINIO_ROOT_USER — which are
-# published in cleartext when this env.redacted is shared on a public issue.
-# Match .env.schema.json's secret set / the CLI's config-show masking.
-secret = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL|USER|EMAIL|BEARER)", re.I)
+secret = re.compile(f"({sys.argv[3]})", re.I)
 
 lines = []
 for line in src.read_text(encoding="utf-8", errors="replace").splitlines():

--- a/ods/tests/test-support-bundle.sh
+++ b/ods/tests/test-support-bundle.sh
@@ -189,6 +189,61 @@ else
     pass "raw test secret is absent from bundle directory"
 fi
 
+# ---------------------------------------------------------------------------
+# redact_file (every collected file) must use the same secret-word set as
+# write_redacted_env (.env only). validation/compose-config.txt is
+# `docker compose config` output, which renders every environment value, so a
+# narrower file redactor ships those values in the archive users attach to
+# public issues.
+# ---------------------------------------------------------------------------
+FAKE_DOCKER_DIR="$TMP_DIR/fake-docker"
+mkdir -p "$FAKE_DOCKER_DIR"
+cat > "$FAKE_DOCKER_DIR/docker" <<STUB
+#!/usr/bin/env bash
+# Stand in for a collected command whose output echoes resolved env values,
+# the way \`docker compose config\` renders the whole environment block.
+case "\$1" in
+  compose) exit 1 ;;
+  info)
+    echo "N8N_USER=$SECRET_VALUE"
+    echo "LANGFUSE_MINIO_ROOT_USER=$SECRET_VALUE"
+    echo "LANGFUSE_INIT_USER_EMAIL=$SECRET_VALUE"
+    echo "DASHBOARD_API_KEY=$SECRET_VALUE"
+    ;;
+  *) echo "fake docker" ;;
+esac
+exit 0
+STUB
+chmod +x "$FAKE_DOCKER_DIR/docker"
+
+COLLECTED_DIR="$TMP_DIR/out-collected"
+if ODS_SUPPORT_BUNDLE_BASH="$BASH_WRAPPER" \
+   ODS_SUPPORT_BUNDLE_DOCKER="$FAKE_DOCKER_DIR/docker" \
+   bash "$SUPPORT_SCRIPT" --output "$COLLECTED_DIR" --no-logs --json > "$TMP_DIR/collected.json"; then
+    pass "support bundle command succeeds with a stubbed docker"
+else
+    fail "support bundle command failed with a stubbed docker"
+fi
+
+COLLECTED_BUNDLE="$(python3 - "$TMP_DIR/collected.json" <<'PY'
+import json, sys
+print(json.load(open(sys.argv[1]))["bundle_dir"])
+PY
+)"
+
+if grep -R "$SECRET_VALUE" "$COLLECTED_BUNDLE" >/dev/null 2>&1; then
+    fail "collected command output leaked a schema-secret value into the bundle"
+    grep -Rl "$SECRET_VALUE" "$COLLECTED_BUNDLE" | sed 's/^/    /'
+else
+    pass "collected command output is redacted with the shared secret-word set"
+fi
+
+if grep -q "DASHBOARD_API_KEY=\[REDACTED\]" "$COLLECTED_BUNDLE/docker/info.txt"; then
+    pass "file redactor still covers the original keyword set"
+else
+    fail "file redactor stopped redacting DASHBOARD_API_KEY"
+fi
+
 EVIDENCE_PATH="$BUNDLE_DIR/manifest/evidence.json"
 if [[ -f "$EVIDENCE_PATH" ]] && python3 -m json.tool "$EVIDENCE_PATH" >/dev/null; then
     pass "evidence.json is valid JSON"


### PR DESCRIPTION
## Problem

`scripts/ods-support-bundle.sh` has two redactors with two different secret-word sets.

`write_redacted_env` (`.env` only) was already widened, with this comment:

> `USER|EMAIL|BEARER` cover schema `secret:true` keys the old pattern missed — `N8N_USER`, `LANGFUSE_INIT_USER_EMAIL`, `LANGFUSE_MINIO_ROOT_USER` — which are published in cleartext when this `env.redacted` is shared on a public issue.

`redact_file` — which runs over **every other file in the archive** (`collect_shell` output, `copy_if_exists` copies, `write_file` content) — kept the narrow set:

```python
secret_word = r"(?:KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)"
```

That is the path that matters most. `validation/compose-config.txt` is the rendered compose config, which prints every environment value; `docker/info.txt`, `diagnostics/ods-doctor.log` and the container logs capture command output the same way. So the exact keys the `.env` redactor was fixed for shipped in cleartext one directory over, inside the archive users are told to attach to public issues.

Reproduced on `main` with a stubbed docker whose `info` echoes resolved env values:

```
--- docker/info.txt on main ---
N8N_USER=support-bundle-super-secret
LANGFUSE_MINIO_ROOT_USER=support-bundle-super-secret
DASHBOARD_API_KEY=[REDACTED]
```

## Fix

Define the word set once (`ODS_SUPPORT_SECRET_WORDS`) and pass it to both redactors as argv, so they cannot drift again. `REDACTION_VERSION` goes to `2` so a bundle records which set produced it.

Over-masking is the intended direction here — the same trade the `.env` redactor and `ods config show` already make.

## Tests

`tests/test-support-bundle.sh` gains a run with a stubbed `docker` whose output echoes resolved env values, then asserts:
- no schema-secret value survives anywhere in the collected bundle (fails on `main`);
- `DASHBOARD_API_KEY` is still redacted, so the original keyword set was not lost.