### PR TITLE
fix(token-spy): count MEMORY.md as its own workspace section

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -489,6 +489,12 @@ WORKSPACE_FILE_MAP = {
     "USER.md": "workspace_user_chars",
     "HEARTBEAT.md": "workspace_heartbeat_chars",
     "BOOTSTRAP.md": "workspace_bootstrap_chars",
+    # Every marker here is also a section boundary: a file's content is measured
+    # up to the next KNOWN marker, so omitting one does not merely lose its
+    # bucket — it folds that file's whole body into the bucket of whichever
+    # workspace file precedes it. Keep in step with the usage table columns and
+    # providers/anthropic.py's WORKSPACE_FILE_MAP.
+    "MEMORY.md": "workspace_memory_chars",
 }
 
 

--- a/ods/extensions/services/token-spy/tests/test_system_prompt_analysis.py
+++ b/ods/extensions/services/token-spy/tests/test_system_prompt_analysis.py
@@ -1,0 +1,86 @@
+"""Token Spy system-prompt breakdown tests.
+
+analyze_system_prompt measures each workspace file from its own marker up to
+the next KNOWN marker, so the marker table is a section-boundary table, not
+just a list of metrics. A file missing from it silently folds its whole body
+into the preceding file's bucket.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def token_spy_main():
+    sys.path.insert(0, str(TOKEN_SPY_DIR))
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_main_{uuid4().hex}", TOKEN_SPY_DIR / "main.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _project_context(*sections: tuple[str, str]) -> list[dict]:
+    """Render the workspace injection shape: '## FILE.md\\n\\n<body>\\n\\n'."""
+    text = "# Project Context\n\n"
+    for name, body in sections:
+        text += f"## {name}\n{body}\n"
+    text += "## Runtime\n\nruntime notes\n"
+    return [{"type": "text", "text": text}]
+
+
+def test_every_marker_gets_its_own_bucket(token_spy_main):
+    soul = "s" * 400
+    memory = "m" * 900
+    heartbeat = "h" * 200
+
+    result = token_spy_main.analyze_system_prompt(_project_context(
+        ("SOUL.md", soul),
+        ("MEMORY.md", memory),
+        ("HEARTBEAT.md", heartbeat),
+    ))
+
+    # A missing marker is not a missing metric — it is a missing boundary, so
+    # SOUL.md would otherwise absorb the whole MEMORY.md body as well.
+    assert result["workspace_soul_chars"] == len(soul) + 1
+    assert result["workspace_memory_chars"] == len(memory) + 1
+    assert result["workspace_heartbeat_chars"] == len(heartbeat) + 1
+
+
+def test_marker_table_matches_the_provider_breakdown(token_spy_main):
+    """The proxy route and the provider abstraction must agree on the set.
+
+    They feed the same usage columns, so a file counted by one and not the
+    other reports different numbers for the same prompt depending on which
+    path served the request.
+    """
+    # Imported through the package: anthropic.py uses relative imports.
+    sys.path.insert(0, str(TOKEN_SPY_DIR))
+    module = importlib.import_module("providers.anthropic")
+
+    assert (token_spy_main.WORKSPACE_FILE_MAP
+            == module.AnthropicProvider.WORKSPACE_FILE_MAP)
+
+
+def test_base_prompt_excludes_every_workspace_bucket(token_spy_main):
+    """Whatever the markers account for must come off the base prompt."""
+    blocks = _project_context(("MEMORY.md", "m" * 500))
+    result = token_spy_main.analyze_system_prompt(blocks)
+
+    accounted = sum(
+        value for key, value in result.items()
+        if key.startswith("workspace_") or key == "skill_injection_chars"
+    )
+    assert result["base_prompt_chars"] == (
+        result["system_prompt_total_chars"] - accounted
+    )
+    assert result["workspace_memory_chars"] > 0


### PR DESCRIPTION
## Problem

`analyze_system_prompt` (the live Anthropic proxy route, `main.py:673`) measures each workspace file **from its own marker up to the next _known_ marker**:

```python
all_file_names = list(WORKSPACE_FILE_MAP.keys())
...
content_end = file_positions[i + 1][0] if i + 1 < len(file_positions) else len(after_ctx)
```

So `WORKSPACE_FILE_MAP` is a **section-boundary table**, not just a list of metrics. `MEMORY.md` is missing from it, while `providers/anthropic.py:41` and both usage schemas (`db.py:58`, `db_postgres.py:167`) carry it.

The consequence is not a metric that reads zero — it is a metric attributed to the **wrong file**. Without `MEMORY.md` as a boundary, its entire body folds into whichever workspace file precedes it in the prompt.

Measured on `main` with a 400-char SOUL.md followed by a 900-char MEMORY.md:

```
workspace_soul_chars = 1315   (expected 401)
```

The agent's memories are silently billed to SOUL.md, and the two breakdowns in this service disagree about the same prompt depending on which path served the request.

## Fix

Add the marker. One line, restoring parity with the provider map and the usage columns.

## Tests

New `tests/test_system_prompt_analysis.py` — the function had no coverage:
- each marker gets its own bucket, with SOUL.md/MEMORY.md/HEARTBEAT.md adjacent (this is the misattribution case);
- `main.WORKSPACE_FILE_MAP` equals `AnthropicProvider.WORKSPACE_FILE_MAP`, so the two paths cannot drift again;
- `base_prompt_chars` still nets out every workspace bucket.

On `main` the first two fail. Full token-spy suite: 23 passed.

Independent of #2099, which fixes the SQLite insert for the same column.