### PR TITLE
fix(installer): close the redaction gaps in the compose failure report

### DIFF
--- a/ods/installers/lib/compose-failure-report.sh
+++ b/ods/installers/lib/compose-failure-report.sh
@@ -52,7 +52,11 @@ _ods_report_redact_stream() {
     local env_file="${1:-}"
     awk -v env_file="$env_file" '
         BEGIN {
-            secret_re = "(key|token|secret|password|pass|salt|auth|credential)"
+            # user|email|bearer are here for the same reason scripts/
+            # ods-support-bundle.sh carries them: .env.schema.json marks
+            # N8N_USER, LANGFUSE_INIT_USER_EMAIL and LANGFUSE_MINIO_ROOT_USER
+            # secret:true, and this report is written to be posted on an issue.
+            secret_re = "(key|token|secret|password|pass|salt|auth|credential|user|email|bearer)"
             if (env_file != "") {
                 while ((getline line < env_file) > 0) {
                     sub(/\r$/, "", line)
@@ -170,9 +174,12 @@ write_compose_failure_report() {
             echo "docker command not found"
         fi
         echo ""
-        echo "Installer log tail"
+        echo "Installer log tail (redacted)"
         if [[ -f "$log_file" ]]; then
-            tail -n 160 "$log_file"
+            # The log is installer output, so it carries whatever the phases
+            # echoed — including .env values. It goes in the same shareable
+            # file as the compose config, so it gets the same treatment.
+            tail -n 160 "$log_file" | _ods_report_redact_stream "$env_file"
         else
             echo "installer log unavailable"
         fi

--- a/ods/tests/test-compose-failure-report.sh
+++ b/ods/tests/test-compose-failure-report.sh
@@ -21,6 +21,16 @@ FAIL=0
 pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
 fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
 
+assert_not_contains() {
+    local file="$1" needle="$2" label="$3"
+    if grep -Fq -- "$needle" "$file"; then
+        fail "$label"
+        echo "    unexpected: $needle"
+    else
+        pass "$label"
+    fi
+}
+
 assert_contains() {
     local file="$1" needle="$2" label="$3"
     if grep -Fq -- "$needle" "$file"; then
@@ -53,6 +63,8 @@ LITELLM_PORT=39040
 SEARXNG_PORT=39888
 DASHBOARD_API_KEY=super-secret-dashboard-key
 OPENCLAW_TOKEN=super-secret-openclaw-token
+N8N_USER=ods-owner-alice
+LANGFUSE_INIT_USER_EMAIL=alice@example.com
 EOF
 
 cat > "$INSTALL_DIR/.compose-flags" <<'EOF'
@@ -63,6 +75,7 @@ COMPOSE_LOG="$INSTALL_DIR/logs/compose-up.log"
 cat > "$COMPOSE_LOG" <<'EOF'
 Image ghcr.io/ggml-org/llama.cpp:server-cuda-b8648 Pulling
 Error response from daemon: failed to resolve reference "ghcr.io/ggml-org/llama.cpp:server-cuda-b8648": not found
+Rendering n8n config with N8N_USER=ods-owner-alice
 EOF
 
 cat > "$TMP_DIR/bin/docker" <<'EOF'
@@ -86,6 +99,10 @@ if [[ "$1" == "compose" ]]; then
     echo "    environment:"
     echo "      DASHBOARD_API_KEY: super-secret-dashboard-key"
     echo "      OPENCLAW_TOKEN: super-secret-openclaw-token"
+    echo "  n8n:"
+    echo "    environment:"
+    echo "      N8N_USER: ods-owner-alice"
+    echo "      LANGFUSE_INIT_USER_EMAIL: alice@example.com"
     exit 0
   fi
   if [[ "$*" == *" ps -a"* ]]; then
@@ -133,6 +150,15 @@ assert_contains "$report_path" "- dashboard:39001" "report includes port checks"
 assert_contains "$report_path" "Docker version" "report includes docker version section"
 assert_contains "$report_path" "Compose config tail (redacted)" "report includes redacted compose config section"
 assert_contains "$report_path" "DASHBOARD_API_KEY: [REDACTED]" "report redacts compose config secret fields"
+
+# .env.schema.json marks N8N_USER / LANGFUSE_INIT_USER_EMAIL /
+# LANGFUSE_MINIO_ROOT_USER secret:true. This report exists to be posted on an
+# issue, so its keyword set has to cover them like the support bundle's does.
+assert_contains "$report_path" "N8N_USER: [REDACTED]" "report redacts schema-secret user fields"
+assert_contains "$report_path" "LANGFUSE_INIT_USER_EMAIL: [REDACTED]" "report redacts schema-secret email fields"
+# The installer log lands in the same shareable file as the compose config.
+assert_not_contains "$report_path" "ods-owner-alice" "installer log tail is redacted too"
+assert_not_contains "$report_path" "alice@example.com" "schema-secret email value never appears"
 if grep -Fq "super-secret-dashboard-key" "$report_path" || grep -Fq "super-secret-openclaw-token" "$report_path"; then
     fail "report leaks sensitive compose config values"
 else


### PR DESCRIPTION
## Problem

`write_compose_failure_report` produces a file whose own header says *"Review before posting publicly"*, and the installer prints its path whenever compose startup fails — it exists to be attached to an issue. Two things reached it unredacted.

**1. The keyword set stops short.**

```awk
secret_re = "(key|token|secret|password|pass|salt|auth|credential)"
```

No `user|email|bearer`, so the schema-secret keys `N8N_USER`, `LANGFUSE_INIT_USER_EMAIL` and `LANGFUSE_MINIO_ROOT_USER` (`.env.schema.json`, `secret: true`) survive the rendered `docker compose config` output. The same set gates the harvested-value pass, so those values are not scrubbed anywhere else in the report either. `scripts/ods-support-bundle.sh` already carries the wider set for exactly these keys.

**2. The installer log tail is piped in raw.**

```bash
tail -n 160 "$log_file"
```

It is installer output — it carries whatever the phases echoed, including env values — and it lands in the same shareable file as the compose config, which *is* filtered.

## Fix

Add `user|email|bearer` to the keyword set, and run the log tail through `_ods_report_redact_stream` like every other captured stream.

## Tests

`tests/test-compose-failure-report.sh` gains `N8N_USER` / `LANGFUSE_INIT_USER_EMAIL` to the `.env` fixture, the compose-config stub, and the installer log, then asserts both keys redact and neither value appears anywhere in the report.

Note the fixture values (`ods-owner-alice`, `alice@example.com`) deliberately contain no secret keyword — with a value like `super-secret-…` the line-level rule fires on the *value* and the key-name coverage goes untested.

All four new assertions fail on `main`. Suite: 17 passed.