### PR TITLE
fix(dashboard-api): report non-JSON Token Spy responses as content-type warnings

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -155,12 +155,16 @@ async def _fetch_token_spy_metrics() -> None:
                                len(data), total_out)
                 else:
                     logger.debug("Token Spy returned status %d", resp.status)
+    # ContentTypeError derives from ClientError, so it must be listed first:
+    # behind the broad handler it can never run, and a Token Spy response that
+    # is reachable but not JSON would be reported as "unavailable" at debug
+    # level instead of as the misconfiguration it is.
+    except aiohttp.ContentTypeError as e:
+        logger.warning("Token Spy returned unexpected content type: %s", e)
     except aiohttp.ClientError as e:
         logger.debug("Token Spy unavailable: %s", e)
     except asyncio.TimeoutError:
         logger.debug("Token Spy request timed out after 5s")
-    except aiohttp.ContentTypeError as e:
-        logger.warning("Token Spy returned unexpected content type: %s", e)
 
 
 async def collect_metrics():

--- a/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
@@ -1,5 +1,6 @@
 """Tests for agent_monitor.py — throughput metrics and data classes."""
 
+import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -189,8 +190,13 @@ class TestFetchTokenSpyMetrics:
             await agent_monitor._fetch_token_spy_metrics()
 
     @pytest.mark.asyncio
-    async def test_content_type_error_handled(self, monkeypatch):
-        """When Token Spy returns unexpected content type, no exception raised."""
+    async def test_content_type_error_handled(self, monkeypatch, caplog):
+        """A non-JSON Token Spy response is reported as a content-type warning.
+
+        ContentTypeError is a ClientError subclass, so it only reaches its own
+        handler when that handler is listed first. Behind the broad handler the
+        failure is silently downgraded to a debug "unavailable" line.
+        """
         monkeypatch.setattr(agent_monitor, "TOKEN_SPY_URL", "http://token-spy:8080")
         monkeypatch.setattr(agent_monitor, "TOKEN_SPY_API_KEY", "")
 
@@ -211,8 +217,13 @@ class TestFetchTokenSpyMetrics:
         mock_session_cm.__aenter__ = AsyncMock(return_value=mock_http)
         mock_session_cm.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("aiohttp.ClientSession", return_value=mock_session_cm):
-            await agent_monitor._fetch_token_spy_metrics()
+        with caplog.at_level(logging.WARNING, logger="agent_monitor"):
+            with patch("aiohttp.ClientSession", return_value=mock_session_cm):
+                await agent_monitor._fetch_token_spy_metrics()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "non-JSON Token Spy response must be logged as a warning"
+        assert "unexpected content type" in warnings[0].getMessage()
 
 
 class TestClusterStatusRefresh:


### PR DESCRIPTION
## Problem

`_fetch_token_spy_metrics()` listed its exception handlers in this order:

```python
except aiohttp.ClientError as e:        # broad
    logger.debug("Token Spy unavailable: %s", e)
except asyncio.TimeoutError:
    ...
except aiohttp.ContentTypeError as e:   # never reached
    logger.warning("Token Spy returned unexpected content type: %s", e)
```

`aiohttp.ContentTypeError` subclasses `ClientResponseError` → `ClientError`, so the content-type handler is dead code. A Token Spy container that is reachable and answers `200` with a non-JSON body (proxy error page, HTML login redirect, wrong `TOKEN_SPY_URL` pointing at another service) is reported at **debug** level as "Token Spy unavailable" instead of the **warning** that names the actual problem — so the operator sees empty agent metrics with nothing in the logs at default verbosity.

## Fix

Order the specific handler ahead of the broad one, with a comment recording why the order matters.

## Test

`test_content_type_error_handled` previously only asserted "does not raise", which passed with the handler dead. It now asserts the WARNING record is emitted.

Verified red on the pre-fix module (`assert []`) and green after.