### PR TITLE
fix(lemonade): keep audio calls inside the classified-error contract

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -98,6 +98,27 @@ def classify_status(status_code: int) -> str:
     return "request_rejected"
 
 
+def _classified_error(exc: httpx.HTTPError) -> LemonadeClientError:
+    """Map an httpx failure onto the client's classified error contract.
+
+    Every public method must fail with LemonadeClientError: callers such as
+    the GPU router branch on ``exc.kind`` and catch nothing else, so a raw
+    httpx transport error escaping a request method becomes an unhandled 500
+    instead of a reported "unreachable" provider.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        payload = _json_payload(exc.response)
+        return LemonadeClientError(
+            classify_status(exc.response.status_code),
+            _payload_message(payload) or exc.response.text or str(exc),
+            status_code=exc.response.status_code,
+            payload=payload,
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        return LemonadeClientError("timeout", str(exc))
+    return LemonadeClientError("provider_unreachable", str(exc))
+
+
 class LemonadeClient:
     """Async client for the Lemonade API paths ODS depends on."""
 
@@ -161,19 +182,8 @@ class LemonadeClient:
             response.raise_for_status()
             payload = response.json() if response.content else {}
             return payload if isinstance(payload, dict) else {"data": payload}
-        except httpx.HTTPStatusError as exc:
-            payload = _json_payload(exc.response)
-            message = _payload_message(payload) or exc.response.text or str(exc)
-            raise LemonadeClientError(
-                classify_status(exc.response.status_code),
-                message,
-                status_code=exc.response.status_code,
-                payload=payload,
-            ) from exc
-        except httpx.TimeoutException as exc:
-            raise LemonadeClientError("timeout", str(exc)) from exc
-        except httpx.RequestError as exc:
-            raise LemonadeClientError("provider_unreachable", str(exc)) from exc
+        except httpx.HTTPError as exc:
+            raise _classified_error(exc) from exc
         except ValueError as exc:
             raise LemonadeClientError("invalid_response", str(exc)) from exc
 
@@ -226,14 +236,17 @@ class LemonadeClient:
 
     async def speech(self, model: str, text: str, *, voice: str = "af_heart") -> bytes:
         client = await self._ensure_client()
-        response = await client.post(
-            self.api_url("audio/speech"),
-            json={"model": model, "input": text, "voice": voice},
-            headers=self.auth_headers(),
-            timeout=self.settings.timeout,
-        )
-        response.raise_for_status()
-        return response.content
+        try:
+            response = await client.post(
+                self.api_url("audio/speech"),
+                json={"model": model, "input": text, "voice": voice},
+                headers=self.auth_headers(),
+                timeout=self.settings.timeout,
+            )
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPError as exc:
+            raise _classified_error(exc) from exc
 
     async def transcribe_wav(self, model: str, wav_bytes: bytes, *, filename: str = "audio.wav") -> dict[str, Any]:
         client = await self._ensure_client()
@@ -248,14 +261,8 @@ class LemonadeClient:
             response.raise_for_status()
             payload = response.json() if response.content else {}
             return payload if isinstance(payload, dict) else {"data": payload}
-        except httpx.HTTPStatusError as exc:
-            payload = _json_payload(exc.response)
-            raise LemonadeClientError(
-                classify_status(exc.response.status_code),
-                _payload_message(payload) or exc.response.text or str(exc),
-                status_code=exc.response.status_code,
-                payload=payload,
-            ) from exc
+        except httpx.HTTPError as exc:
+            raise _classified_error(exc) from exc
 
 
 def _json_payload(response: httpx.Response) -> dict[str, Any]:

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -171,3 +171,82 @@ async def test_explicit_timeout_override_is_applied():
     await client.aclose()
 
     assert seen["timeout"].get("read") == 5.0
+
+
+@pytest.mark.asyncio
+async def test_speech_classifies_transport_failures():
+    # speech() bypassed _request_json, so an unreachable Lemonade raised a raw
+    # httpx.ConnectError. Callers only catch LemonadeClientError, which turned
+    # a reportable "provider_unreachable" into an unhandled 500.
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.speech("kokoro", "hello")
+
+    assert exc.value.kind == "provider_unreachable"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_speech_classifies_timeouts():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.speech("kokoro", "hello")
+
+    assert exc.value.kind == "timeout"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_speech_classifies_http_status_errors():
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": {"message": "no such voice"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.speech("kokoro", "hello")
+
+    assert exc.value.kind == "not_found"
+    assert exc.value.status_code == 404
+    assert "no such voice" in str(exc.value)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transcribe_wav_classifies_transport_failures():
+    # transcribe_wav() classified HTTP status errors only, so connection and
+    # timeout failures escaped as raw httpx errors.
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.transcribe_wav("whisper", b"RIFF")
+
+    assert exc.value.kind == "provider_unreachable"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_speech_returns_audio_bytes_on_success():
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"\x00\x01audio")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    assert await adapter.speech("kokoro", "hello") == b"\x00\x01audio"
+    await client.aclose()


### PR DESCRIPTION
## Problem

`LemonadeClient` documents itself as failing with `LemonadeClientError`, and that is what callers rely on — `routers/gpu.py` branches on `exc.kind` (`provider_unreachable`/`timeout`) and catches nothing else.

Two methods were outside that contract:

- **`speech()`** had no `try`/`except` at all. `client.post(...)` and `raise_for_status()` raised raw `httpx.ConnectError`, `httpx.ReadTimeout` or `httpx.HTTPStatusError`.
- **`transcribe_wav()`** caught only `httpx.HTTPStatusError`, so connection and timeout failures still escaped raw.

So an unreachable or slow Lemonade backend surfaced as an unhandled 500 with an httpx traceback rather than the reported "provider unreachable" state the rest of the client produces.

## Fix

Extract the existing `_request_json` classification into `_classified_error()` and route every `httpx.HTTPError` (status, timeout, transport) through it from all three request paths. Behaviour of `_request_json` is unchanged — `httpx.HTTPError` is the common base of `HTTPStatusError` and `RequestError`, and the classifier preserves the same order (status → timeout → unreachable).

## Tests

Five cases added in `tests/test_lemonade_client.py` covering `speech()` transport/timeout/status classification, `transcribe_wav()` transport classification, and the success path.

Verified red on the pre-fix module (4 failures) and green after.