### PR TITLE
fix(nvidia-topo): rank every NVLink connection above PCIe

### DIFF
--- a/ods/installers/lib/nvidia-topo.sh
+++ b/ods/installers/lib/nvidia-topo.sh
@@ -18,9 +18,20 @@
 
 link_rank() {
   case "$1" in
-  NV4 | NV6 | NV8 | NV12 | NV18)  echo 100 ;;   # NVLink gen2/3
+  # nvidia-smi reports NV<n>, where n is the number of NVLink connections
+  # between the pair. Rank on n instead of an enumerated list: driver and
+  # board generations keep introducing counts the list never had (NV5, NV9,
+  # NV10, NV16, NV24...), and an unlisted one fell through to rank 0 — below
+  # even cross-NUMA PCIe (SYS, rank 10). A genuine NVLink pair then lost GPU
+  # assignment to a PCIe pair.
+  NV[1-9] | NV[1-9][0-9])
+    if [[ "${1#NV}" -ge 4 ]]; then
+      echo 100                                  # NVLink gen2/3, 4+ links
+    else
+      echo 80                                   # NVLink gen1, 1-3 links
+    fi
+    ;;
   XGMI | XGMI2)                   echo 90  ;;   # AMD Infinity Fabric
-  NV1 | NV2 | NV3)                echo 80  ;;   # NVLink gen1
   MIG)                            echo 70  ;;   # MIG instance, same die
   PIX)                            echo 50  ;;   # Same PCIe switch
   PXB)                            echo 40  ;;   # Multiple PCIe switches, same CPU

--- a/ods/tests/test-nvidia-topo.sh
+++ b/ods/tests/test-nvidia-topo.sh
@@ -284,8 +284,55 @@ test_8gpus_nv1_nv2_partial_mesh() {
     fi
 }
 
+# Unit test: link_rank() must rank every NV<n> connection above PCIe.
+# nvidia-smi keeps introducing link counts (NV5, NV9, NV10, NV16, NV24, ...);
+# an enumerated list scores the ones it never heard of at 0, below cross-NUMA
+# PCIe, which inverts GPU pairing for real NVLink hardware.
+test_link_rank_covers_all_nvlink_counts() {
+    echo -e "${BLU}Testing: link_rank()/link_label() NVLink coverage${NC}"
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    source "$TOPO_SCRIPT"
+
+    local failures=""
+    local sys_rank pix_rank nv link rank label
+    sys_rank=$(link_rank SYS)
+    pix_rank=$(link_rank PIX)
+
+    for nv in NV1 NV2 NV3 NV4 NV5 NV6 NV7 NV8 NV9 NV10 NV12 NV16 NV18 NV24; do
+        rank=$(link_rank "$nv")
+        label=$(link_label "$nv")
+        [[ "$rank" -gt "$sys_rank" ]] || failures+=" ${nv}:rank=${rank}<=SYS"
+        [[ "$rank" -gt "$pix_rank" ]] || failures+=" ${nv}:rank=${rank}<=PIX"
+        [[ "$label" == "NVLink" ]] || failures+=" ${nv}:label=${label}"
+    done
+
+    # Higher link counts must not rank below lower ones.
+    [[ "$(link_rank NV18)" -ge "$(link_rank NV1)" ]] || failures+=" NV18<NV1"
+    [[ "$(link_rank NV24)" -ge "$(link_rank NV3)" ]] || failures+=" NV24<NV3"
+
+    # Existing ranks are unchanged.
+    for link in "NV1 80" "NV2 80" "NV3 80" "NV4 100" "NV6 100" "NV8 100" \
+                "NV12 100" "NV18 100" "XGMI 90" "MIG 70" "PIX 50" "PXB 40" \
+                "PHB 30" "NODE 20" "SYS 10" "SOC 10" "X 0" "" ; do
+        [[ -n "$link" ]] || continue
+        rank=$(link_rank "${link%% *}")
+        [[ "$rank" == "${link##* }" ]] || failures+=" ${link%% *}:rank=${rank}!=${link##* }"
+    done
+
+    if [[ -z "$failures" ]]; then
+        echo -e "${GRN}✓ PASS: every NV<n> outranks PCIe and known ranks are stable${NC}"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗ FAIL: link_rank regressions:${failures}${NC}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
 # Main test runner
 echo -e "${MAG}=== NVIDIA Topology Detection Tests ===${NC}\n"
+
+test_link_rank_covers_all_nvlink_counts
 
 test_1gpu_pcie
 test_4gpus_soc


### PR DESCRIPTION
## Problem

`link_rank()` matched an enumerated list of NVLink values:

```bash
NV4 | NV6 | NV8 | NV12 | NV18)  echo 100 ;;   # NVLink gen2/3
NV1 | NV2 | NV3)                echo 80  ;;   # NVLink gen1
```

`nvidia-smi topo -m` reports `NV<n>` where **n is the number of NVLink connections in the pair**, and driver/board generations keep producing counts this list never had — `NV5`, `NV7`, `NV9`, `NV10`, `NV16`, `NV24`. Those fell through to `*) echo 0`.

Rank 0 is **below cross-NUMA PCIe** (`SYS` = 10) and below every other PCIe relationship. The rank flows into `.links[].rank` in the topology JSON, which `installers/phases/03-features.sh` loads into `LINK_RANK` and feeds to `scripts/assign_gpus.py` and `get_rank()`. So on hardware with an unlisted link count, a real NVLink pair is scored worse than a PCIe pair and loses multi-GPU assignment — while `link_label()` (which uses `NV*`) still reports the pair as "NVLink", so the mismatch is invisible in the topology output.

## Fix

Rank on the parsed link count rather than an enumerated list: `NV1`–`NV3` → 80, `NV4`+ → 100. Every previously enumerated value keeps its exact rank; `NV0` and non-numeric `NV` strings still fall through to 0.

## Test

`tests/test-nvidia-topo.sh` gains a `link_rank()`/`link_label()` unit test asserting (a) every `NV1`–`NV24` outranks `SYS` and `PIX`, (b) higher counts never rank below lower ones, (c) all previously enumerated ranks are unchanged.

Red on the pre-fix lib (`NV5/NV7/NV9/NV10/NV16/NV24 rank=0 <= SYS`), green after; the 7 existing fixture tests still pass.