### PR TITLE
refactor(routing): make Lemonade rendering single-owner

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5786,42 +5786,117 @@ class AgentHandler(BaseHTTPRequestHandler):
         if not llm_model_name:
             json_response(self, 400, {"error": "model_id could not be resolved"})
             return
-        env["GGUF_FILE"] = target_gguf
-        env["LLM_MODEL"] = llm_model_name
-        _upsert_env_value(env_path, "GGUF_FILE", target_gguf)
-        _upsert_env_value(env_path, "LLM_MODEL", llm_model_name)
-
-        if _live_runtime_has_model(env, target_gguf) is not True:
-            _restart_windows_lemonade(env)
-
-        lemonade_host, lemonade_port = _lemonade_runtime_address(env)
-        lemonade_model_id = _resolve_lemonade_model_id(
-            env,
-            target_gguf,
-            host=lemonade_host,
-            port=lemonade_port,
-        )
-        if not lemonade_model_id:
+        previous_env = dict(env)
+        lemonade_path = INSTALL_DIR / "config" / "litellm" / "lemonade.yaml"
+        try:
+            env_snapshot = _snapshot_text_file(env_path)
+            lemonade_snapshot = _snapshot_text_file(lemonade_path)
+        except Exception:
+            logger.exception("Windows Lemonade runtime ensure could not snapshot active state")
             json_response(
                 self,
                 500,
-                {"error": f"Could not resolve Lemonade model ID for {target_gguf}"},
+                {"error": "Windows Lemonade runtime ensure could not snapshot active state"},
             )
             return
 
-        env["LEMONADE_MODEL"] = lemonade_model_id
-        _upsert_env_value(env_path, "LEMONADE_MODEL", lemonade_model_id)
-        _write_lemonade_config(INSTALL_DIR, target_gguf, lemonade_model_id)
-        json_response(
-            self,
-            200,
-            {
-                "status": "configured",
-                "model_id": model_id or llm_model_name,
-                "gguf_file": target_gguf,
-                "lemonade_model_id": lemonade_model_id,
-            },
-        )
+        mutation_started = False
+        try:
+            mutation_started = True
+            env["GGUF_FILE"] = target_gguf
+            env["LLM_MODEL"] = llm_model_name
+            _upsert_env_value(env_path, "GGUF_FILE", target_gguf)
+            _upsert_env_value(env_path, "LLM_MODEL", llm_model_name)
+
+            if _live_runtime_has_model(env, target_gguf) is not True:
+                _restart_windows_lemonade(env)
+
+            lemonade_host, lemonade_port = _lemonade_runtime_address(env)
+            lemonade_model_id = _resolve_lemonade_model_id(
+                env,
+                target_gguf,
+                host=lemonade_host,
+                port=lemonade_port,
+            )
+            if not lemonade_model_id:
+                raise RuntimeError(
+                    f"Could not resolve Lemonade model ID for {target_gguf}"
+                )
+
+            env["LEMONADE_MODEL"] = lemonade_model_id
+            _upsert_env_value(env_path, "LEMONADE_MODEL", lemonade_model_id)
+            _write_lemonade_config(INSTALL_DIR, target_gguf, lemonade_model_id)
+            json_response(
+                self,
+                200,
+                {
+                    "status": "configured",
+                    "model_id": model_id or llm_model_name,
+                    "gguf_file": target_gguf,
+                    "lemonade_model_id": lemonade_model_id,
+                },
+            )
+        except Exception:
+            logger.exception("Windows Lemonade runtime ensure failed")
+            rolled_back = False
+            rollback_errors: list[str] = []
+            if mutation_started:
+                try:
+                    _restore_text_file(env_path, env_snapshot)
+                    _restore_text_file(lemonade_path, lemonade_snapshot)
+                except Exception:
+                    logger.exception(
+                        "Windows Lemonade runtime ensure could not restore active files"
+                    )
+                    rollback_errors.append("active files could not be restored")
+
+                previous_gguf = str(previous_env.get("GGUF_FILE") or "").strip()
+                previous_llm_model = str(
+                    previous_env.get("LLM_MODEL") or previous_gguf
+                ).strip()
+                previous_lemonade_model = str(
+                    previous_env.get("LEMONADE_MODEL") or ""
+                ).strip()
+                if not rollback_errors and previous_gguf:
+                    try:
+                        _restart_windows_lemonade(previous_env)
+                        rollback_proof = _wait_for_model_readiness(
+                            previous_env,
+                            model_id=previous_llm_model,
+                            gguf_file=previous_gguf,
+                            llm_model_name=previous_llm_model,
+                            lemonade_model_id=previous_lemonade_model,
+                            attempts=12,
+                            initial_delay=0,
+                            interval=2,
+                            return_proof=True,
+                        )
+                        rolled_back = bool(rollback_proof)
+                        if not rolled_back:
+                            rollback_errors.append(
+                                "previous model readiness/completion proof failed"
+                            )
+                    except Exception:
+                        logger.exception(
+                            "Windows Lemonade runtime ensure rollback could not be proved"
+                        )
+                        rollback_errors.append(
+                            "previous runtime could not be restarted and proved"
+                        )
+                elif not previous_gguf:
+                    rollback_errors.append("previous GGUF identity was unavailable")
+
+            payload = {
+                "error": (
+                    "Windows Lemonade runtime ensure failed; previous model restored"
+                    if rolled_back
+                    else "Windows Lemonade runtime ensure failed; previous model restoration could not be proved"
+                ),
+                "rolled_back": rolled_back,
+            }
+            if rollback_errors:
+                payload["rollback_error"] = "; ".join(rollback_errors)
+            json_response(self, 500, payload)
 
     def _do_model_activate(
         self,
@@ -8465,7 +8540,6 @@ def _write_lemonade_config(
     must reference the exact ID, not a wildcard passthrough.
     Mirrors bootstrap-upgrade.sh lines 369-382.
     """
-    config_path = install_dir / "config" / "litellm" / "lemonade.yaml"
     # Read from .env via load_env, NOT os.environ. The host-agent systemd
     # unit does not source .env as an EnvironmentFile, so os.environ is
     # unreliable for installer-written values; falling back to the legacy
@@ -8483,7 +8557,7 @@ def _write_lemonade_config(
     if env.get("AMD_INFERENCE_LOCATION", "").lower() == "host":
         lemonade_port = env.get("AMD_INFERENCE_PORT", "8080") or "8080"
         lemonade_api_base = f"http://host.docker.internal:{lemonade_port}/api/v1"
-    if _render_runtime_config(
+    if not _render_runtime_config(
         install_dir,
         "litellm-lemonade",
         gguf_file=gguf_file,
@@ -8493,31 +8567,11 @@ def _write_lemonade_config(
         ods_mode=ods_mode,
         gpu_backend=gpu_backend,
     ):
-        logger.info(
-            "Wrote lemonade.yaml via runtime renderer for model: %s",
-            lemonade_model_id,
-        )
-        return
-
-    content = (
-        "model_list:\n"
-        "  - model_name: \"*\"\n"
-        "    litellm_params:\n"
-        f"      model: openai/{lemonade_model_id}\n"
-        f"      api_base: {lemonade_api_base}\n"
-        f"      api_key: {lemonade_api_key}\n"
-        "      extra_body:\n"
-        "        chat_template_kwargs:\n"
-        "          enable_thinking: false\n"
-        "\n"
-        "litellm_settings:\n"
-        "  drop_params: true\n"
-        "  set_verbose: false\n"
-        "  request_timeout: 900\n"
-        "  stream_timeout: 900\n"
+        raise RuntimeError("Failed to render required litellm-lemonade config")
+    logger.info(
+        "Wrote lemonade.yaml via runtime renderer for model: %s",
+        lemonade_model_id,
     )
-    _atomic_write_text(config_path, content)
-    logger.info("Wrote lemonade.yaml for model: %s", lemonade_model_id)
 
 
 def _write_windows_native_litellm_config(install_dir: Path, gguf_file: str, env: dict):

--- a/ods/config/generated-config-contracts.json
+++ b/ods/config/generated-config-contracts.json
@@ -221,22 +221,15 @@
       "target_paths": [
         "config/litellm/lemonade.yaml"
       ],
+      "writer_marker": "ODS-CONTRACT-WRITER: litellm-lemonade",
       "writers": [
         {
           "platform": "canonical-renderer",
           "path": "scripts/render-runtime-configs.py"
         },
         {
-          "platform": "linux",
-          "path": "installers/phases/06-directories.sh"
-        },
-        {
-          "platform": "upgrade",
-          "path": "scripts/bootstrap-upgrade.sh"
-        },
-        {
-          "platform": "runtime",
-          "path": "bin/ods-host-agent.py"
+          "platform": "checked-in-template",
+          "path": "config/litellm/lemonade.yaml"
         }
       ],
       "invariants": [
@@ -253,10 +246,22 @@
           "needle": "LITELLM_LEMONADE_API_KEY"
         },
         {
-          "id": "bootstrap-writes-extra-model-alias",
+          "id": "bootstrap-supplies-extra-model-alias",
           "type": "file_contains",
           "path": "scripts/bootstrap-upgrade.sh",
           "needle": "extra."
+        },
+        {
+          "id": "windows-lemonade-delegates-to-canonical-renderer",
+          "type": "file_contains",
+          "path": "installers/windows/lib/env-generator.ps1",
+          "needle": "render-runtime-configs.py"
+        },
+        {
+          "id": "windows-lemonade-can-bootstrap-renderer-python",
+          "type": "file_contains",
+          "path": "installers/windows/lib/env-generator.ps1",
+          "needle": "Install-WindowsODSRuntimeConfigPython"
         }
       ]
     },

--- a/ods/config/litellm/lemonade.yaml
+++ b/ods/config/litellm/lemonade.yaml
@@ -1,3 +1,4 @@
+# ODS-CONTRACT-WRITER: litellm-lemonade
 model_list:
   # Lemonade exposes models as "extra.<GGUF_FILENAME>" — the wildcard
   # passthrough (openai/*) does NOT work because it forwards the friendly

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -5,12 +5,15 @@ import importlib.util
 import http.client
 import io
 import json
+import shutil
 import subprocess
 import sys
 import threading
 from pathlib import Path
 
 import pytest
+
+_real_subprocess_run = subprocess.run
 
 # Import the host agent module from bin/ using importlib.
 # The module has an ``if __name__ == "__main__":`` guard so no server starts.
@@ -61,6 +64,15 @@ def _isolate_opencode_config(monkeypatch, tmp_path):
         lambda: {"system": _mod.platform.system(), "active": False},
     )
     monkeypatch.setattr(_mod, "_opencode_installed", lambda: False)
+
+
+@pytest.fixture(autouse=True)
+def _install_runtime_renderer(tmp_path):
+    """Exercise host-agent rendering through the shipped canonical script."""
+    source = _agent_path.parents[1] / "scripts" / "render-runtime-configs.py"
+    target = tmp_path / "scripts" / "render-runtime-configs.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
 
 
 def test_host_agent_backlog_handles_dashboard_poll_bursts():
@@ -733,17 +745,20 @@ class TestWriteLemonadeConfig:
         assert "request_timeout: 900" in content
         assert "stream_timeout: 900" in content
 
-    def test_fallback_writer_keeps_long_model_timeouts(self, monkeypatch, tmp_path):
+    def test_renderer_failure_preserves_existing_config(self, monkeypatch, tmp_path):
         litellm_dir = tmp_path / "config" / "litellm"
         litellm_dir.mkdir(parents=True)
+        config = litellm_dir / "lemonade.yaml"
+        config.write_text("known-good\n", encoding="utf-8")
         monkeypatch.setattr(_mod, "_render_runtime_config", lambda *args, **kwargs: False)
 
-        _write_lemonade_config(tmp_path, "fallback-model.gguf")
+        with pytest.raises(
+            RuntimeError,
+            match="Failed to render required litellm-lemonade config",
+        ):
+            _write_lemonade_config(tmp_path, "fallback-model.gguf")
 
-        content = (litellm_dir / "lemonade.yaml").read_text()
-        assert "model: openai/extra.fallback-model.gguf" in content
-        assert "request_timeout: 900" in content
-        assert "stream_timeout: 900" in content
+        assert config.read_text(encoding="utf-8") == "known-good\n"
 
     def test_reads_lemonade_key_from_env_file_when_process_env_unset(
         self, monkeypatch, tmp_path,
@@ -800,7 +815,7 @@ class TestSwitchboardRuntimeConfig:
         self, monkeypatch, tmp_path,
     ):
         renderer = tmp_path / "scripts" / "render-runtime-configs.py"
-        renderer.parent.mkdir(parents=True)
+        renderer.parent.mkdir(parents=True, exist_ok=True)
         renderer.write_text("# renderer placeholder\n", encoding="utf-8")
         calls = []
 
@@ -2023,6 +2038,10 @@ def _write_model_activation_fixture(
     models_dir.mkdir(parents=True)
     llama_dir.mkdir(parents=True)
     litellm_dir.mkdir(parents=True)
+    renderer_source = _agent_path.parents[1] / "scripts" / "render-runtime-configs.py"
+    renderer_target = install_dir / "scripts" / "render-runtime-configs.py"
+    renderer_target.parent.mkdir(parents=True)
+    shutil.copyfile(renderer_source, renderer_target)
 
     (models_dir / "new-model.gguf").write_text("model", encoding="utf-8")
     (config_dir / "model-library.json").write_text(
@@ -2659,6 +2678,8 @@ class TestModelActivateRollback:
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
 
         def fake_run(cmd, **_kwargs):
+            if cmd and cmd[0] == sys.executable:
+                return _real_subprocess_run(cmd, **_kwargs)
             if cmd and cmd[0] == "curl" and cmd[-1].endswith("/models"):
                 stdout = json.dumps({
                     "data": [{"id": "extra.new-model.gguf"}]
@@ -2738,6 +2759,8 @@ class TestModelActivateRollback:
         )
 
         def fake_run(cmd, **_kwargs):
+            if cmd and cmd[0] == sys.executable:
+                return _real_subprocess_run(cmd, **_kwargs)
             if cmd and cmd[0] == "curl" and cmd[-1].endswith("/models"):
                 return subprocess.CompletedProcess(
                     cmd,
@@ -3014,6 +3037,8 @@ class TestModelActivateRollback:
 
         def fake_run(cmd, **_kwargs):
             calls.append(cmd)
+            if cmd and cmd[0] == sys.executable:
+                return _real_subprocess_run(cmd, **_kwargs)
             if cmd and cmd[0] == "curl" and cmd[-1].endswith("/models"):
                 stdout = json.dumps({
                     "data": [{"id": "extra.new-model.gguf"}]
@@ -3111,6 +3136,77 @@ class TestModelActivateRollback:
         assert "LLM_MODEL=target-model" in updated_env
         assert "LEMONADE_MODEL=Modern-Model" in updated_env
         assert "model: openai/Modern-Model" in lemonade_yaml.read_text(encoding="utf-8")
+
+    def test_windows_lemonade_runtime_ensure_rolls_back_renderer_failure(
+        self, tmp_path, monkeypatch,
+    ):
+        install_dir, env_path, _env_text, _models_ini, _ini_text, lemonade_yaml, _yaml_text = (
+            _write_model_activation_fixture(
+                tmp_path,
+                gpu_backend="amd",
+                lemonade=True,
+                lemonade_api_key="sk-inline-from-env-file-67890",
+            )
+        )
+        old_env = (
+            "ODS_MODE=lemonade\r\n"
+            "GPU_BACKEND=amd\r\n"
+            "LLM_BACKEND=lemonade\r\n"
+            "AMD_INFERENCE_RUNTIME=lemonade\r\n"
+            "AMD_INFERENCE_LOCATION=host\r\n"
+            "AMD_INFERENCE_PORT=8080\r\n"
+            "GGUF_FILE=old-model.gguf\r\n"
+            "LLM_MODEL=old-model\r\n"
+            "LEMONADE_MODEL=Old-Model\r\n"
+            "CTX_SIZE=2048\r\n"
+            "LITELLM_LEMONADE_API_KEY=sk-inline-from-env-file-67890\r\n"
+        ).encode()
+        old_yaml = b"model_list:\r\n  - model_name: old\r\n"
+        env_path.write_bytes(old_env)
+        lemonade_yaml.write_bytes(old_yaml)
+        restarts = []
+        readiness_calls = []
+
+        def record_restart(env):
+            restarts.append(env["GGUF_FILE"])
+
+        def prove_previous(env, **kwargs):
+            readiness_calls.append((dict(env), dict(kwargs)))
+            return {
+                "identity": "Old-Model",
+                "contextLength": 2048,
+                "contextVerified": True,
+                "verifiedAt": "2026-07-25T00:00:00+00:00",
+            }
+
+        def fail_renderer(*_args, **_kwargs):
+            raise RuntimeError("simulated renderer failure")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(_mod, "_live_runtime_has_model", lambda *_args, **_kwargs: False)
+        monkeypatch.setattr(_mod, "_restart_windows_lemonade", record_restart)
+        monkeypatch.setattr(_mod, "_resolve_lemonade_model_id", lambda *_args, **_kwargs: "Modern-Model")
+        monkeypatch.setattr(_mod, "_write_lemonade_config", fail_renderer)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", prove_previous)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_windows_lemonade_runtime_ensure(
+            handler,
+            model_id="target-model",
+            gguf_file="new-model.gguf",
+        )
+
+        assert handler.response_code == 500
+        assert handler.parse_response()["rolled_back"] is True
+        assert restarts == ["new-model.gguf", "old-model.gguf"]
+        assert env_path.read_bytes() == old_env
+        assert lemonade_yaml.read_bytes() == old_yaml
+        assert len(readiness_calls) == 1
+        assert readiness_calls[0][1]["gguf_file"] == "old-model.gguf"
+        assert readiness_calls[0][1]["lemonade_model_id"] == "Old-Model"
+        assert readiness_calls[0][1]["return_proof"] is True
 
     def test_windows_native_llama_activation_uses_plain_health_and_litellm_local(
         self, tmp_path, monkeypatch,

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -992,7 +992,6 @@ ENV_EOF
         # lemonade config regardless of which model the install resolves to.
         # bootstrap-upgrade.sh mirrors this when it regenerates the file
         # after a hot-swap.
-        _renderer_ok=false
         _renderer_py="${ODS_PYTHON_CMD:-}"
         if [[ -z "$_renderer_py" && -f "$SCRIPT_DIR/lib/python-cmd.sh" ]]; then
             . "$SCRIPT_DIR/lib/python-cmd.sh"
@@ -1001,56 +1000,30 @@ ENV_EOF
         if [[ -z "$_renderer_py" ]]; then
             _renderer_py="python3"
         fi
-        if [[ -f "$SCRIPT_DIR/scripts/render-runtime-configs.py" ]] && command -v "$_renderer_py" >/dev/null 2>&1; then
-            if "$_renderer_py" "$SCRIPT_DIR/scripts/render-runtime-configs.py" \
-                --surface litellm-lemonade \
-                --ods-mode lemonade \
-                --gpu-backend amd \
-                --gguf-file "$_active_gguf" \
-                --lemonade-model-id "$_lemonade_model_id" \
-                --lemonade-api-base "$LEMONADE_CONTAINER_API_BASE_VALUE" \
-                --litellm-key "$LITELLM_LEMONADE_API_KEY" \
-                --output-root "$INSTALL_DIR" \
-                --write >> "$LOG_FILE" 2>&1; then
-                _renderer_ok=true
-            else
-                warn "Runtime config renderer failed for Lemonade; falling back to inline writer"
-            fi
+        if [[ ! -f "$SCRIPT_DIR/scripts/render-runtime-configs.py" ]] \
+            || ! command -v "$_renderer_py" >/dev/null 2>&1; then
+            error "Runtime config renderer is unavailable for Lemonade"
+            return 1
         fi
-        if [[ "$_renderer_ok" != "true" ]]; then
-            cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
-model_list:
-  - model_name: default
-    litellm_params:
-      model: openai/$(if [[ -n "$_lemonade_model_id" ]]; then echo "$_lemonade_model_id"; else echo "extra.${_active_gguf}"; fi)
-      api_base: ${LEMONADE_CONTAINER_API_BASE_VALUE}
-      api_key: ${LITELLM_LEMONADE_API_KEY}
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
-
-  - model_name: "*"
-    litellm_params:
-      model: openai/$(if [[ -n "$_lemonade_model_id" ]]; then echo "$_lemonade_model_id"; else echo "extra.${_active_gguf}"; fi)
-      api_base: ${LEMONADE_CONTAINER_API_BASE_VALUE}
-      api_key: ${LITELLM_LEMONADE_API_KEY}
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
-
-litellm_settings:
-  drop_params: true
-  set_verbose: false
-  request_timeout: 900
-  stream_timeout: 900
-LITELLM_EOF
+        if ! "$_renderer_py" "$SCRIPT_DIR/scripts/render-runtime-configs.py" \
+            --surface litellm-lemonade \
+            --ods-mode lemonade \
+            --gpu-backend amd \
+            --gguf-file "$_active_gguf" \
+            --lemonade-model-id "$_lemonade_model_id" \
+            --lemonade-api-base "$LEMONADE_CONTAINER_API_BASE_VALUE" \
+            --litellm-key "$LITELLM_LEMONADE_API_KEY" \
+            --output-root "$INSTALL_DIR" \
+            --write >> "$LOG_FILE" 2>&1; then
+            error "Runtime config renderer failed for Lemonade"
+            return 1
         fi
         if [[ -n "$_lemonade_model_id" ]]; then
             ai_ok "Generated LiteLLM config for external Lemonade (model: ${_lemonade_model_id})"
         else
             ai_ok "Generated LiteLLM config for Lemonade (model: extra.${_active_gguf})"
         fi
-        unset _renderer_ok _renderer_py
+        unset _renderer_py
     fi
 
     # Materialize router inputs before Compose can interpret file bind mounts.

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -83,6 +83,191 @@ function Write-Utf8NoBom {
     [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
 }
 
+function Get-WindowsODSRuntimeConfigRenderer {
+    [CmdletBinding()]
+    param(
+        [string]$InstallDir = ""
+    )
+
+    $candidates = New-Object 'System.Collections.Generic.List[string]'
+    if (-not [string]::IsNullOrWhiteSpace($InstallDir)) {
+        [void]$candidates.Add((Join-Path (Join-Path $InstallDir "scripts") "render-runtime-configs.py"))
+    }
+    if (-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+        $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+        [void]$candidates.Add((Join-Path (Join-Path $repoRoot "scripts") "render-runtime-configs.py"))
+    }
+
+    $seen = @{}
+    foreach ($candidate in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        if ($seen.ContainsKey($candidate)) { continue }
+        $seen[$candidate] = $true
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return $candidate
+        }
+    }
+
+    throw "Runtime config renderer not found for Windows Lemonade route."
+}
+
+function Test-WindowsODSRuntimeConfigPythonCandidate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$PrefixArgs = @()
+    )
+
+    if ([string]::IsNullOrWhiteSpace($FilePath)) {
+        return $false
+    }
+
+    $commandPath = $FilePath
+    $resolvedCommand = Get-Command $FilePath -CommandType Application -ErrorAction SilentlyContinue
+    if ($resolvedCommand -and $resolvedCommand.Source) {
+        $commandPath = $resolvedCommand.Source
+    }
+    if ($commandPath -match '\\WindowsApps\\python3?\.exe$') {
+        return $false
+    }
+
+    $probeArgs = @($PrefixArgs) + @("-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)")
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "SilentlyContinue"
+        & $FilePath @probeArgs 2>&1 | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+function New-WindowsODSRuntimeConfigPythonCandidate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$PrefixArgs = @()
+    )
+
+    [pscustomobject]@{
+        FilePath = $FilePath
+        PrefixArgs = @($PrefixArgs)
+    }
+}
+
+function Resolve-WindowsODSRuntimeConfigPython {
+    [CmdletBinding()]
+    param()
+
+    $candidateFiles = New-Object 'System.Collections.Generic.List[string]'
+    $candidateRoots = New-Object 'System.Collections.Generic.List[string]'
+    if (-not [string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        [void]$candidateRoots.Add((Join-Path $env:LOCALAPPDATA "Programs\Python"))
+    }
+    foreach ($root in @($env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+        if (-not [string]::IsNullOrWhiteSpace($root)) { [void]$candidateRoots.Add($root) }
+    }
+
+    foreach ($root in $candidateRoots) {
+        if ([string]::IsNullOrWhiteSpace($root) -or -not (Test-Path -LiteralPath $root)) { continue }
+        Get-ChildItem -LiteralPath $root -Directory -Filter "Python*" -ErrorAction SilentlyContinue |
+            ForEach-Object {
+                $exe = Join-Path $_.FullName "python.exe"
+                if (Test-Path -LiteralPath $exe -PathType Leaf) { [void]$candidateFiles.Add($exe) }
+            }
+    }
+
+    $sharedResolver = Get-Command Get-ODSPythonDownloadCommand -ErrorAction SilentlyContinue
+    if ($sharedResolver) {
+        $resolved = Get-ODSPythonDownloadCommand
+        if ($resolved -and (Test-WindowsODSRuntimeConfigPythonCandidate -FilePath $resolved.FilePath -PrefixArgs @($resolved.PrefixArgs))) {
+            return (New-WindowsODSRuntimeConfigPythonCandidate -FilePath $resolved.FilePath -PrefixArgs @($resolved.PrefixArgs))
+        }
+    }
+
+    $candidates = @(
+        @{ FilePath = "python3"; PrefixArgs = @() },
+        @{ FilePath = "python"; PrefixArgs = @() },
+        @{ FilePath = "py"; PrefixArgs = @("-3") }
+    )
+
+    $seen = @{}
+    foreach ($candidateFile in $candidateFiles) {
+        $key = $candidateFile.ToLowerInvariant()
+        if ($seen.ContainsKey($key)) { continue }
+        $seen[$key] = $true
+        if (Test-WindowsODSRuntimeConfigPythonCandidate -FilePath $candidateFile) {
+            return (New-WindowsODSRuntimeConfigPythonCandidate -FilePath $candidateFile)
+        }
+    }
+
+    foreach ($candidate in $candidates) {
+        $filePath = [string]$candidate.FilePath
+        $prefixArgs = @($candidate.PrefixArgs)
+        if (Test-WindowsODSRuntimeConfigPythonCandidate -FilePath $filePath -PrefixArgs $prefixArgs) {
+            return (New-WindowsODSRuntimeConfigPythonCandidate -FilePath $filePath -PrefixArgs $prefixArgs)
+        }
+    }
+
+    return $null
+}
+
+function Install-WindowsODSRuntimeConfigPython {
+    [CmdletBinding()]
+    param()
+
+    $sharedInstaller = Get-Command Install-ODSHostAgentPython -ErrorAction SilentlyContinue
+    if ($sharedInstaller) {
+        $resolved = Install-ODSHostAgentPython
+        if ($resolved -and (Test-WindowsODSRuntimeConfigPythonCandidate -FilePath $resolved.FilePath -PrefixArgs @($resolved.PrefixArgs))) {
+            return (New-WindowsODSRuntimeConfigPythonCandidate -FilePath $resolved.FilePath -PrefixArgs @($resolved.PrefixArgs))
+        }
+    }
+
+    $winget = Get-Command winget -CommandType Application -ErrorAction SilentlyContinue
+    if (-not $winget) {
+        return $null
+    }
+
+    if (Get-Command Write-AIWarn -ErrorAction SilentlyContinue) {
+        Write-AIWarn "Python 3 not found. Installing Python 3.12 via winget for runtime config rendering..."
+    } else {
+        Write-Warning "Python 3 not found. Installing Python 3.12 via winget for runtime config rendering..."
+    }
+
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "SilentlyContinue"
+        & winget install --exact --id Python.Python.3.12 --silent --disable-interactivity --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+
+    $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+    $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+    $env:PATH = "$machinePath;$userPath"
+    return (Resolve-WindowsODSRuntimeConfigPython)
+}
+
+function Get-WindowsODSRuntimeConfigPython {
+    [CmdletBinding()]
+    param()
+
+    $resolved = Resolve-WindowsODSRuntimeConfigPython
+    if ($resolved) { return $resolved }
+
+    $installed = Install-WindowsODSRuntimeConfigPython
+    if ($installed) { return $installed }
+
+    throw "Python 3 is required to render Windows Lemonade LiteLLM config and could not be installed automatically."
+}
+
 function Write-WindowsODSLemonadeLiteLlmConfig {
     [CmdletBinding()]
     param(
@@ -102,38 +287,39 @@ function Write-WindowsODSLemonadeLiteLlmConfig {
     if ($ModelId -match '[\r\n]') {
         throw "Lemonade model ID cannot contain line breaks."
     }
+    if ($ApiKey -match '[\r\n]') {
+        throw "Lemonade API key cannot contain line breaks."
+    }
+    $parsedPort = 0
+    if (-not [int]::TryParse($Port, [ref]$parsedPort) -or $parsedPort -lt 1 -or $parsedPort -gt 65535) {
+        throw "Lemonade port must be an integer in 1..65535."
+    }
 
     $litellmDir = Join-Path (Join-Path $InstallDir "config") "litellm"
     New-Item -ItemType Directory -Path $litellmDir -Force | Out-Null
-    $lemonadeApiBase = "http://host.docker.internal:$Port/api/v1"
-    $lemonadeConfig = @"
-model_list:
-  - model_name: default
-    litellm_params:
-      model: openai/$ModelId
-      api_base: $lemonadeApiBase
-      api_key: $ApiKey
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
+    $renderer = Get-WindowsODSRuntimeConfigRenderer -InstallDir $InstallDir
+    $python = Get-WindowsODSRuntimeConfigPython
+    $lemonadeApiBase = "http://host.docker.internal:$parsedPort/api/v1"
+    $renderArgs = @($python.PrefixArgs) + @(
+        $renderer,
+        "--surface", "litellm-lemonade",
+        "--ods-mode", "lemonade",
+        "--gpu-backend", "amd",
+        "--lemonade-model-id", $ModelId,
+        "--lemonade-api-base", $lemonadeApiBase,
+        "--litellm-key", $ApiKey,
+        "--output-root", $InstallDir,
+        "--write"
+    )
+    $renderOutput = & $python.FilePath @renderArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Runtime config renderer failed for Windows Lemonade route: $($renderOutput -join "`n")"
+    }
 
-  - model_name: "*"
-    litellm_params:
-      model: openai/$ModelId
-      api_base: $lemonadeApiBase
-      api_key: $ApiKey
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
-
-litellm_settings:
-  drop_params: true
-  set_verbose: false
-  request_timeout: 900
-  stream_timeout: 900
-"@
     $configPath = Join-Path $litellmDir "lemonade.yaml"
-    Write-Utf8NoBom -Path $configPath -Content $lemonadeConfig
+    if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+        throw "Runtime config renderer did not create $configPath"
+    }
     return $configPath
 }
 

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -322,6 +322,10 @@ snapshot_active_model_config() {
         : > "$ACTIVE_CONFIG_SNAPSHOT_DIR/models.ini.missing"
     fi
 
+    snapshot_file_state \
+        "$INSTALL_DIR/config/litellm/lemonade.yaml" \
+        "$ACTIVE_CONFIG_SNAPSHOT_DIR/litellm-lemonade" || return 1
+
     if [[ "$include_windows_lemonade" == "true" ]]; then
         snapshot_file_state \
             "$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template" \
@@ -352,6 +356,10 @@ restore_active_model_config() {
         rm -f "$MODELS_INI"
     fi
 
+    restore_file_state \
+        "$ACTIVE_CONFIG_SNAPSHOT_DIR/litellm-lemonade" \
+        "$INSTALL_DIR/config/litellm/lemonade.yaml" || return 1
+
     if [[ -f "$ACTIVE_CONFIG_SNAPSHOT_DIR/windows-lemonade.included" ]]; then
         restore_file_state \
             "$ACTIVE_CONFIG_SNAPSHOT_DIR/windows-lemonade/hermes-template" \
@@ -378,7 +386,15 @@ discard_active_model_config_snapshot() {
 restore_docker_llama_server_after_swap_failure() {
     local health_url="${1:-}"
     local compose_arg_count=0
+    local previous_gguf previous_gpu_backend previous_model_id
     local rollback_healthy=false
+
+    previous_gguf="$(snapshot_env_value GGUF_FILE)"
+    previous_gpu_backend="$(snapshot_env_value GPU_BACKEND | tr '[:upper:]' '[:lower:]')"
+    previous_model_id="$(snapshot_env_value LEMONADE_MODEL)"
+    if [[ -z "$previous_model_id" && -n "$previous_gguf" ]]; then
+        previous_model_id="extra.${previous_gguf}"
+    fi
 
     log "Restoring previous active model config after Docker llama-server swap failure..."
     if ! restore_active_model_config; then
@@ -411,6 +427,22 @@ restore_docker_llama_server_after_swap_failure() {
     done
 
     if [[ "$rollback_healthy" == "true" ]]; then
+        if [[ "$previous_gpu_backend" == "amd" ]] \
+            && $DOCKER_CMD ps --filter name=ods-litellm --format '{{.Names}}' 2>/dev/null | grep -q ods-litellm; then
+            local restored_litellm_port
+            restored_litellm_port="$(read_env_value LITELLM_PORT)"
+            [[ -n "$restored_litellm_port" ]] || restored_litellm_port="4000"
+            log "Restarting LiteLLM with the restored Lemonade route..."
+            if ! $DOCKER_CMD restart ods-litellm 2>&1 \
+                || ! verify_model_completion_route \
+                    "http://127.0.0.1:${restored_litellm_port}/v1" \
+                    "$previous_model_id" \
+                    "$(read_env_value LITELLM_KEY)" \
+                    "restored LiteLLM route"; then
+                log "WARNING: previous runtime is healthy, but its restored LiteLLM route could not be proved."
+                return 1
+            fi
+        fi
         log "Rollback complete: llama-server is healthy with the previous active model config."
         return 0
     fi
@@ -1389,7 +1421,7 @@ refresh_windows_lemonade_litellm_after_swap() {
     [[ -n "$model_id" ]] || return 1
 
     local litellm_dir litellm_config lemonade_port lemonade_api_base lemonade_api_key
-    local renderer_script renderer_py renderer_ok=false
+    local renderer_script renderer_py
     litellm_dir="$INSTALL_DIR/config/litellm"
     litellm_config="$litellm_dir/lemonade.yaml"
     lemonade_port="$(read_env_value AMD_INFERENCE_PORT)"
@@ -1406,57 +1438,22 @@ refresh_windows_lemonade_litellm_after_swap() {
         . "$INSTALL_DIR/lib/python-cmd.sh"
         renderer_py="$(ods_detect_python_cmd 2>/dev/null || true)"
     fi
-    if [[ -n "$renderer_py" && -f "$renderer_script" ]]; then
-        if "$renderer_py" "$renderer_script" \
-            --surface litellm-lemonade \
-            --ods-mode lemonade \
-            --gpu-backend amd \
-            --gguf-file "$FULL_GGUF_FILE" \
-            --lemonade-model-id "$model_id" \
-            --lemonade-api-base "$lemonade_api_base" \
-            --litellm-key "$lemonade_api_key" \
-            --output-root "$INSTALL_DIR" \
-            --write >/dev/null 2>&1; then
-            renderer_ok=true
-        fi
+    if [[ -z "$renderer_py" || ! -f "$renderer_script" ]]; then
+        log "ERROR: runtime config renderer is unavailable for Windows Lemonade"
+        return 1
     fi
-
-    if [[ "$renderer_ok" != "true" ]]; then
-        local litellm_tmp="${litellm_config}.tmp.$$"
-        if ! cat > "$litellm_tmp" << LITELLM_WINDOWS_LEMONADE_EOF
-model_list:
-  - model_name: default
-    litellm_params:
-      model: openai/${model_id}
-      api_base: ${lemonade_api_base}
-      api_key: ${lemonade_api_key}
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
-
-  - model_name: "*"
-    litellm_params:
-      model: openai/${model_id}
-      api_base: ${lemonade_api_base}
-      api_key: ${lemonade_api_key}
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
-
-litellm_settings:
-  drop_params: true
-  set_verbose: false
-  request_timeout: 900
-  stream_timeout: 900
-LITELLM_WINDOWS_LEMONADE_EOF
-        then
-            rm -f "$litellm_tmp"
-            return 1
-        fi
-        mv "$litellm_tmp" "$litellm_config" || {
-            rm -f "$litellm_tmp"
-            return 1
-        }
+    if ! "$renderer_py" "$renderer_script" \
+        --surface litellm-lemonade \
+        --ods-mode lemonade \
+        --gpu-backend amd \
+        --gguf-file "$FULL_GGUF_FILE" \
+        --lemonade-model-id "$model_id" \
+        --lemonade-api-base "$lemonade_api_base" \
+        --litellm-key "$lemonade_api_key" \
+        --output-root "$INSTALL_DIR" \
+        --write >/dev/null 2>&1; then
+        log "ERROR: runtime config renderer failed for Windows Lemonade"
+        return 1
     fi
 
     grep -Fq "model: openai/${model_id}" "$litellm_config" || return 1
@@ -1578,6 +1575,45 @@ verify_windows_lemonade_downstream_route() {
     done
 
     log "ERROR: ${route_label} did not complete through ${route_base} with model ${model_id}."
+    return 1
+}
+
+verify_model_completion_route() {
+    local route_base="${1:-}" model_id="${2:-}" route_key="${3:-}" route_label="${4:-model route}"
+    local attempts request_timeout request_body response escaped_model
+    [[ -n "$route_base" && -n "$model_id" ]] || return 1
+
+    escaped_model="${model_id//\\/\\\\}"
+    escaped_model="${escaped_model//\"/\\\"}"
+    request_body="{\"model\":\"${escaped_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with OK.\"}],\"max_tokens\":4,\"temperature\":0,\"stream\":false}"
+    attempts="${ODS_MODEL_ROUTE_ATTEMPTS:-12}"
+    case "$attempts" in ''|*[!0-9]*|0) attempts=12 ;; esac
+    request_timeout="${ODS_MODEL_ROUTE_TIMEOUT:-120}"
+    case "$request_timeout" in ''|*[!0-9]*|0) request_timeout=120 ;; esac
+
+    log "Verifying ${route_label} with an exact-model completion through ${route_base}..."
+    for _route_i in $(seq 1 "$attempts"); do
+        if [[ -n "$route_key" ]]; then
+            response="$(curl -fsS --max-time "$request_timeout" -X POST \
+                "${route_base%/}/chat/completions" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${route_key}" \
+                -d "$request_body" 2>/dev/null || true)"
+        else
+            response="$(curl -fsS --max-time "$request_timeout" -X POST \
+                "${route_base%/}/chat/completions" \
+                -H "Content-Type: application/json" \
+                -d "$request_body" 2>/dev/null || true)"
+        fi
+        if grep -q '"choices"[[:space:]]*:' <<<"$response" \
+            && ! grep -q '"error"[[:space:]]*:' <<<"$response"; then
+            log "Verified ${route_label} with model ${model_id}."
+            return 0
+        fi
+        sleep 2
+    done
+
+    log "ERROR: ${route_label} did not complete with model ${model_id}."
     return 1
 }
 
@@ -2566,12 +2602,11 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
 
     if $_healthy; then
         log "SUCCESS: llama-server is running with $FULL_LLM_MODEL"
-        HOT_SWAP_VERIFIED=true
-        discard_active_model_config_snapshot
         # Regenerate lemonade.yaml with the new model ID and restart LiteLLM.
         # Lemonade exposes models as "extra.<GGUF_FILE>" — the config must
         # reference the exact ID, not a wildcard passthrough.
-        if $DOCKER_CMD ps --filter name=ods-litellm --format '{{.Names}}' 2>/dev/null | grep -q ods-litellm; then
+        if [[ "$_gpu_backend" == "amd" ]] \
+            && $DOCKER_CMD ps --filter name=ods-litellm --format '{{.Names}}' 2>/dev/null | grep -q ods-litellm; then
             _lemonade_model_id="$(read_env_value LEMONADE_MODEL)"
             if ! lemonade_model_id_matches_gguf "$_lemonade_model_id" "$FULL_GGUF_FILE"; then
                 _resolved_lemonade_model_id="$(resolve_live_lemonade_model_id "${OLLAMA_PORT:-8080}" "$FULL_GGUF_FILE" || true)"
@@ -2612,7 +2647,6 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
             if [[ "$_amd_location" == "host" ]]; then
                 _lemonade_api_base="http://host.docker.internal:${_amd_port}/api/v1"
             fi
-            _renderer_ok=false
             _renderer_script="$INSTALL_DIR/scripts/render-runtime-configs.py"
             _renderer_py="${ODS_PYTHON_CMD:-}"
             if [[ -z "$_renderer_py" && -f "$INSTALL_DIR/lib/python-cmd.sh" ]]; then
@@ -2622,8 +2656,9 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
             if [[ -z "$_renderer_py" ]]; then
                 _renderer_py="python3"
             fi
-            if [[ -f "$_renderer_script" ]] && command -v "$_renderer_py" >/dev/null 2>&1; then
-                if "$_renderer_py" "$_renderer_script" \
+            if [[ ! -f "$_renderer_script" ]] \
+                || ! command -v "$_renderer_py" >/dev/null 2>&1 \
+                || ! "$_renderer_py" "$_renderer_script" \
                     --surface litellm-lemonade \
                     --ods-mode lemonade \
                     --gpu-backend amd \
@@ -2633,43 +2668,58 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
                     --litellm-key "$LITELLM_LEMONADE_API_KEY" \
                     --output-root "$INSTALL_DIR" \
                     --write >/dev/null 2>&1; then
-                    _renderer_ok=true
-                else
-                    log "WARNING: Runtime config renderer failed for LiteLLM; falling back to inline writer"
+                log "ERROR: runtime config renderer failed for the Lemonade route"
+                _rollback_status="Previous active model config restore was attempted; inspect the logs before retrying."
+                if restore_docker_llama_server_after_swap_failure "$_health_url"; then
+                    _rollback_status="Previous active model config restored and llama-server is healthy; re-run to retry the full-model swap."
                 fi
+                write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+                    "Full model downloaded and verified, but ODS could not render the Lemonade route. ${_rollback_status}"
+                exit 1
             fi
-            if [[ "$_renderer_ok" != "true" ]]; then
-                cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_UPGRADE_EOF
-model_list:
-  - model_name: default
-    litellm_params:
-      model: openai/${_lemonade_model_id}
-      api_base: ${_lemonade_api_base}
-      api_key: ${LITELLM_LEMONADE_API_KEY}
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
-
-  - model_name: "*"
-    litellm_params:
-      model: openai/${_lemonade_model_id}
-      api_base: ${_lemonade_api_base}
-      api_key: ${LITELLM_LEMONADE_API_KEY}
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
-
-litellm_settings:
-  drop_params: true
-  set_verbose: false
-  request_timeout: 900
-  stream_timeout: 900
-LITELLM_UPGRADE_EOF
-            fi
-            unset _renderer_ok _renderer_script _renderer_py _lemonade_api_base _lemonade_model_id _resolved_lemonade_model_id _amd_location _amd_port
+            unset _renderer_script _renderer_py _lemonade_api_base _lemonade_model_id _resolved_lemonade_model_id _amd_location _amd_port
             log "Restarting LiteLLM to pick up model change..."
-            $DOCKER_CMD restart ods-litellm 2>&1 || log "WARNING: LiteLLM restart failed (non-fatal)"
+            _litellm_port="$(read_env_value LITELLM_PORT)"
+            [[ -n "$_litellm_port" ]] || _litellm_port="4000"
+            if ! $DOCKER_CMD restart ods-litellm 2>&1 \
+                || ! verify_model_completion_route \
+                    "http://127.0.0.1:${_litellm_port}/v1" \
+                    "$(read_env_value LEMONADE_MODEL)" \
+                    "$(read_env_value LITELLM_KEY)" \
+                    "promoted LiteLLM route"; then
+                log "ERROR: LiteLLM did not reload and complete through the promoted Lemonade route"
+                _rollback_status="Previous active model config restore was attempted; inspect the logs before retrying."
+                if restore_docker_llama_server_after_swap_failure "$_health_url"; then
+                    _rollback_status="Previous active model config and routed model restored; re-run to retry the full-model swap."
+                fi
+                write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+                    "Full model downloaded and verified, but ODS could not prove the promoted LiteLLM route. ${_rollback_status}"
+                exit 1
+            fi
+            unset _litellm_port
+        elif [[ "$_gpu_backend" == "amd" ]]; then
+            _direct_model="$(read_env_value LEMONADE_MODEL)"
+            [[ -n "$_direct_model" ]] || _direct_model="extra.${FULL_GGUF_FILE}"
+            _direct_port="$(read_env_value AMD_INFERENCE_PORT)"
+            [[ -n "$_direct_port" ]] || _direct_port="8080"
+            if ! verify_model_completion_route \
+                "http://127.0.0.1:${_direct_port}/api/v1" \
+                "$_direct_model" \
+                "$(read_env_value LITELLM_LEMONADE_API_KEY)" \
+                "promoted Lemonade route"; then
+                log "ERROR: Lemonade did not complete with the promoted model"
+                _rollback_status="Previous active model config restore was attempted; inspect the logs before retrying."
+                if restore_docker_llama_server_after_swap_failure "$_health_url"; then
+                    _rollback_status="Previous active model config restored and llama-server is healthy; re-run to retry the full-model swap."
+                fi
+                write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+                    "Full model downloaded and verified, but Lemonade did not complete with it. ${_rollback_status}"
+                exit 1
+            fi
+            unset _direct_model _direct_port
         fi
+        HOT_SWAP_VERIFIED=true
+        discard_active_model_config_snapshot
         # Recreate OpenClaw so inject-token.js picks up the new GGUF_FILE/LLM_MODEL
         # from .env. A restart alone won't work — env vars are baked in at container
         # creation time, and inject-token.js builds the Lemonade model name from them.

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import stat
 import sys
+import tempfile
+import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Callable
@@ -24,6 +27,48 @@ DEFAULT_CONTEXT = 131072
 DEFAULT_HERMES_MAX_TOKENS = 1024
 DEFAULT_LITELLM_KEY = "sk-lemonade"
 NO_KEY = "no-key"
+
+
+def atomic_write_text(target: Path, content: str) -> None:
+    """Replace a generated config without exposing a truncated live file."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # Generated YAML is bind-mounted into LiteLLM and must remain readable
+    # when the image runs as a non-root UID. Preserve an existing mode and use
+    # the checked-in template's 0644 mode only when recreating a missing file.
+    mode = 0o644
+    try:
+        if target.is_file():
+            mode = stat.S_IMODE(target.stat().st_mode)
+    except OSError:
+        pass
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=target.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, mode)
+
+        last_error: PermissionError | None = None
+        for attempt in range(10):
+            try:
+                os.replace(tmp_path, target)
+                last_error = None
+                break
+            except PermissionError as exc:
+                last_error = exc
+                if attempt < 9:
+                    time.sleep(0.05 * (attempt + 1))
+        if last_error is not None:
+            raise last_error
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 @dataclass(frozen=True)
@@ -237,6 +282,7 @@ litellm_settings:
 
 
 def render_litellm_lemonade(inputs: RenderInputs) -> RenderedFile:
+    # ODS-CONTRACT-WRITER: litellm-lemonade
     model = lemonade_model_id(inputs)
     api_base = inputs.lemonade_api_base.rstrip("/") or "http://llama-server:8080/api/v1"
     content = f"""model_list:
@@ -561,8 +607,7 @@ def render(args: argparse.Namespace) -> dict[str, object]:
         output_root = Path(args.output_root)
         for item in files:
             target = output_root / item.path
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(ensure_trailing_newline(item.content), encoding="utf-8")
+            atomic_write_text(target, ensure_trailing_newline(item.content))
             written.append(str(target))
     return {
         "version": "1",

--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -12,7 +12,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PATH = ROOT / "config" / "generated-config-contracts.json"
 VALID_INVARIANTS = {"file_contains", "yaml_text_contains", "json_path_enum_contains"}
-WRITER_SOURCE_SUFFIXES = {".py", ".ps1", ".sh"}
+WRITER_SOURCE_SUFFIXES = {".py", ".ps1", ".sh", ".yaml"}
 
 
 class Issues:

--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -356,8 +356,10 @@ if ((${#_lemonade_ps_cmd[@]} > 0)); then
         Remove-Item -LiteralPath $probeRoot -Recurse -Force -ErrorAction SilentlyContinue
         $programFiles = Join-Path $probeRoot "Program Files"
         $programFilesX86 = Join-Path $probeRoot "Program Files (x86)"
+        $localAppData = Join-Path $probeRoot "LocalAppData"
         ${env:ProgramFiles} = $programFiles
         ${env:ProgramFiles(x86)} = $programFilesX86
+        $env:LOCALAPPDATA = $localAppData
         $script:LEMONADE_EXE = Join-Path (Join-Path (Join-Path $programFiles "Lemonade Server") "bin") "lemonade-server.exe"
         $x86Exe = Join-Path (Join-Path (Join-Path $programFilesX86 "Lemonade Server") "bin") "LemonadeServer.exe"
         New-Item -ItemType Directory -Path (Split-Path $x86Exe) -Force | Out-Null

--- a/ods/tests/test-bootstrap-upgrade-docker-rollback.sh
+++ b/ods/tests/test-bootstrap-upgrade-docker-rollback.sh
@@ -28,7 +28,7 @@ trap 'rm -rf "$tmp"' EXIT
 fakebin="$tmp/bin"
 install_dir="$tmp/install"
 docker_calls="$tmp/docker-calls.log"
-mkdir -p "$fakebin" "$install_dir/data/models" "$install_dir/config/llama-server"
+mkdir -p "$fakebin" "$install_dir/data/models" "$install_dir/config/llama-server" "$install_dir/config/litellm"
 
 cat > "$fakebin/curl" <<'EOF'
 #!/usr/bin/env bash
@@ -84,7 +84,11 @@ case "${1:-}" in
             exit 0
         fi
         if [[ " $* " == *" up -d --force-recreate --no-deps llama-server "* ]]; then
-            printf 'compose-up:%s\n' "$(env_value GGUF_FILE)" >> "${ODS_FAKE_DOCKER_LOG:?}"
+            active_gguf="$(env_value GGUF_FILE)"
+            printf 'compose-up:%s\n' "$active_gguf" >> "${ODS_FAKE_DOCKER_LOG:?}"
+            if [[ "$active_gguf" == "Full.gguf" ]]; then
+                printf 'model_list:\n  - model_name: promoted\n' > config/litellm/lemonade.yaml
+            fi
             exit 0
         fi
         exit 0
@@ -128,6 +132,11 @@ load-on-startup = true
 n-ctx = 8192
 EOF
 
+cat > "$install_dir/config/litellm/lemonade.yaml" <<'EOF'
+model_list:
+  - model_name: bootstrap
+EOF
+
 cat > "$install_dir/.compose-flags" <<'EOF'
 -f docker-compose.base.yml -f docker-compose.nvidia.yml
 EOF
@@ -159,6 +168,8 @@ grep -q '^CTX_SIZE=8192$' "$install_dir/.env" \
     || fail "Docker hot-swap failure must restore previous CTX_SIZE"
 grep -q 'filename = Bootstrap.gguf' "$install_dir/config/llama-server/models.ini" \
     || fail "Docker hot-swap failure must restore previous models.ini"
+grep -q 'model_name: bootstrap' "$install_dir/config/litellm/lemonade.yaml" \
+    || fail "Docker hot-swap failure must restore the previous Lemonade route"
 grep -q 'compose-up:Full.gguf' "$docker_calls" \
     || fail "test did not exercise the full-model compose recreate"
 grep -q 'compose-up:Bootstrap.gguf' "$docker_calls" \

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -29,7 +29,7 @@ assert_in_order() {
     shift 2
     local previous=0 pattern line
     for pattern in "$@"; do
-        line="$(grep -nF "$pattern" <<<"$block" | head -1 | cut -d: -f1 || true)"
+        line="$(grep -nF -- "$pattern" <<<"$block" | head -1 | cut -d: -f1 || true)"
         [[ -n "$line" ]] || fail "$label is missing ordered step: $pattern"
         (( line > previous )) || fail "$label has out-of-order step: $pattern"
         previous="$line"
@@ -248,6 +248,8 @@ assert_in_order "$windows_lemonade_block" "Windows Lemonade main path" \
 pass "Windows Lemonade verifies the exact downstream route before commit"
 
 snapshot_block="$(function_block snapshot_active_model_config | grep -v '^[[:space:]]*#')"
+grep -qF '"$ACTIVE_CONFIG_SNAPSHOT_DIR/litellm-lemonade"' <<<"$snapshot_block" \
+    || fail "every model transaction must snapshot the canonical Lemonade route"
 grep -qF 'extensions/services/hermes/cli-config.yaml.template' <<<"$snapshot_block" \
     || fail "Windows Lemonade transaction must snapshot the Hermes template"
 grep -qF 'data/hermes/config.yaml' <<<"$snapshot_block" \
@@ -258,6 +260,8 @@ grep -qF 'windows-lemonade.included' <<<"$snapshot_block" \
     || fail "dependent snapshots must be explicitly scoped to Windows Lemonade"
 
 restore_block="$(function_block restore_active_model_config | grep -v '^[[:space:]]*#')"
+grep -qF '"$ACTIVE_CONFIG_SNAPSHOT_DIR/litellm-lemonade"' <<<"$restore_block" \
+    || fail "every model rollback must restore the canonical Lemonade route"
 grep -qF 'windows-lemonade/hermes-template' <<<"$restore_block" \
     || fail "Windows Lemonade rollback must restore the Hermes template"
 grep -qF 'windows-lemonade/hermes-live' <<<"$restore_block" \
@@ -270,7 +274,7 @@ litellm_refresh_block="$(function_block refresh_windows_lemonade_litellm_after_s
 grep -qF -- '--lemonade-model-id "$model_id"' <<<"$litellm_refresh_block" \
     || fail "Windows Lemonade LiteLLM renderer must receive the exact resolved model ID"
 grep -qF 'model: openai/${model_id}' <<<"$litellm_refresh_block" \
-    || fail "Windows Lemonade LiteLLM fallback must use the exact resolved model ID"
+    || fail "Windows Lemonade rendered config must verify the exact resolved model ID"
 grep -qF '$DOCKER_CMD restart ods-litellm' <<<"$litellm_refresh_block" \
     || fail "Windows Lemonade must reload LiteLLM after regenerating its config"
 
@@ -391,6 +395,41 @@ for injected_failure in native model-id litellm hermes openclaw openclaw-env rec
     fi
 done
 pass "Windows Lemonade activation rolls back every injected post-swap failure"
+
+docker_swap_block="$(awk '
+    /^elif \[\[ -n "\$DOCKER_CMD" \]\] && \$DOCKER_CMD ps/ { in_block=1 }
+    in_block { print }
+    in_block && /^elif \[\[ -f "\$INSTALL_DIR\/data\/\.llama-server\.pid" \]\]/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+grep -qF 'if [[ "$_gpu_backend" == "amd" ]]' <<<"$docker_swap_block" \
+    || fail "Docker Lemonade route rendering must be gated to the AMD backend"
+assert_in_order "$docker_swap_block" "Docker model transaction commit" \
+    '--surface litellm-lemonade' \
+    '$DOCKER_CMD restart ods-litellm' \
+    'verify_model_completion_route' \
+    'HOT_SWAP_VERIFIED=true' \
+    'discard_active_model_config_snapshot'
+pass "Docker model transaction commits only after renderer, reload, and completion proof"
+
+docker_rollback_block="$(function_block restore_docker_llama_server_after_swap_failure | grep -v '^[[:space:]]*#')"
+assert_in_order "$docker_rollback_block" "Docker model transaction rollback" \
+    'previous_model_id="$(snapshot_env_value LEMONADE_MODEL)"' \
+    'restore_active_model_config' \
+    'compose_recreate_llama_server_with_retry' \
+    '$DOCKER_CMD restart ods-litellm' \
+    'verify_model_completion_route'
+pass "Docker rollback restores and proves the previous routed model"
+
+completion_route_block="$(function_block verify_model_completion_route | grep -v '^[[:space:]]*#')"
+grep -qF '"choices"[[:space:]]*:' <<<"$completion_route_block" \
+    || fail "model route proof must require a completion choices payload"
+grep -qF '"error"[[:space:]]*:' <<<"$completion_route_block" \
+    || fail "model route proof must reject an error payload"
+grep -qF 'ODS_MODEL_ROUTE_ATTEMPTS' <<<"$completion_route_block" \
+    || fail "model route proof must expose a bounded attempt count"
+grep -qF 'ODS_MODEL_ROUTE_TIMEOUT' <<<"$completion_route_block" \
+    || fail "model route proof must expose a bounded request timeout"
+pass "Docker model route proof is bounded and rejects error responses"
 
 grep -qF 'switchboard_mode="$(read_env_value ODS_MODEL_SWITCHBOARD' <<<"$active_code" \
     || fail "Hermes post-swap patch helper must read switchboard mode"

--- a/ods/tests/test-generated-config-contracts.sh
+++ b/ods/tests/test-generated-config-contracts.sh
@@ -7,7 +7,8 @@ python3 -m py_compile "$ROOT_DIR/scripts/validate-generated-configs.py"
 python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$ROOT_DIR/config/generated-config-contracts.json"
 
 missing_writer_contract="$(mktemp)"
-trap 'rm -f "$missing_writer_contract"' EXIT
+missing_lemonade_writer_contract="$(mktemp)"
+trap 'rm -f "$missing_writer_contract" "$missing_lemonade_writer_contract"' EXIT
 python3 - "$ROOT_DIR/config/generated-config-contracts.json" "$missing_writer_contract" <<'PY'
 import json
 import sys
@@ -26,6 +27,27 @@ target.write_text(json.dumps(contract), encoding="utf-8")
 PY
 if python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$missing_writer_contract" >/dev/null 2>&1; then
     echo "[FAIL] writer marker validation accepted an incomplete ownership inventory" >&2
+    exit 1
+fi
+
+python3 - "$ROOT_DIR/config/generated-config-contracts.json" "$missing_lemonade_writer_contract" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+contract = json.loads(source.read_text(encoding="utf-8"))
+surface = next(item for item in contract["surfaces"] if item["id"] == "litellm-lemonade")
+surface["writers"] = [
+    writer
+    for writer in surface["writers"]
+    if writer["path"] != "config/litellm/lemonade.yaml"
+]
+target.write_text(json.dumps(contract), encoding="utf-8")
+PY
+if python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$missing_lemonade_writer_contract" >/dev/null 2>&1; then
+    echo "[FAIL] Lemonade writer validation accepted an incomplete ownership inventory" >&2
     exit 1
 fi
 

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -3,15 +3,28 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from types import ModuleType
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "render-runtime-configs.py"
+
+
+def load_renderer_module() -> ModuleType:
+    name = "ods_render_runtime_configs_test"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def run_renderer(*args: str) -> dict[str, object]:
@@ -380,6 +393,37 @@ def test_write_mode_writes_under_output_root() -> None:
         assert payload["mode"] == "write"
         assert target.exists()
         assert "openai/extra.Written.gguf" in target.read_text(encoding="utf-8")
+        if os.name != "nt":
+            assert target.stat().st_mode & 0o777 == 0o644
+        assert not list(target.parent.glob(f".{target.name}.*.tmp"))
+
+
+def test_atomic_write_failure_preserves_known_good_config() -> None:
+    renderer = load_renderer_module()
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "lemonade.yaml"
+        target.write_text("known-good\n", encoding="utf-8")
+        original_replace = renderer.os.replace
+        original_sleep = renderer.time.sleep
+
+        def fail_replace(*_args, **_kwargs) -> None:
+            raise PermissionError("injected replace failure")
+
+        renderer.os.replace = fail_replace
+        renderer.time.sleep = lambda _seconds: None
+        try:
+            try:
+                renderer.atomic_write_text(target, "new-route\n")
+            except PermissionError as exc:
+                assert "injected replace failure" in str(exc)
+            else:
+                raise AssertionError("fault injection did not fail the replace")
+        finally:
+            renderer.os.replace = original_replace
+            renderer.time.sleep = original_sleep
+
+        assert target.read_text(encoding="utf-8") == "known-good\n"
+        assert not list(target.parent.glob(f".{target.name}.*.tmp"))
 
 
 def main() -> int:
@@ -402,6 +446,7 @@ def main() -> int:
         test_hermes_uses_lemonade_model_id_for_amd,
         test_perplexica_default_model_matches_route,
         test_write_mode_writes_under_output_root,
+        test_atomic_write_failure_preserves_known_good_config,
     ]
     for test in tests:
         test()

--- a/ods/tests/test-runtime-config-wiring.py
+++ b/ods/tests/test-runtime-config-wiring.py
@@ -13,20 +13,21 @@ def read(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8", errors="replace")
 
 
-def test_linux_installer_uses_renderer_with_fallback() -> None:
+def test_linux_installer_uses_renderer_as_sole_writer() -> None:
     text = read("installers/phases/06-directories.sh")
     assert "scripts/render-runtime-configs.py" in text
     assert "--surface litellm-lemonade" in text
-    assert "LITELLM_EOF" in text
-    assert "falling back to inline writer" in text
+    assert "LITELLM_EOF" not in text
+    assert "falling back to inline writer" not in text
 
 
-def test_bootstrap_upgrade_uses_renderer_with_fallback() -> None:
+def test_bootstrap_upgrade_uses_renderer_as_sole_writer() -> None:
     text = read("scripts/bootstrap-upgrade.sh")
     assert "scripts/render-runtime-configs.py" in text
     assert "--surface litellm-lemonade" in text
-    assert "LITELLM_UPGRADE_EOF" in text
-    assert "falling back to inline writer" in text
+    assert "LITELLM_UPGRADE_EOF" not in text
+    assert "LITELLM_WINDOWS_LEMONADE_EOF" not in text
+    assert "falling back to inline writer" not in text
 
 
 def test_bootstrap_upgrade_promotes_lemonade_model_id() -> None:
@@ -37,14 +38,34 @@ def test_bootstrap_upgrade_promotes_lemonade_model_id() -> None:
     assert 'json_has_id "$models_json" "$model_id"' in text
 
 
-def test_host_agent_uses_renderer_with_fallback() -> None:
+def test_host_agent_uses_renderer_as_sole_writer() -> None:
     text = read("bin/ods-host-agent.py")
     assert "def _render_runtime_config" in text
     assert "--surface" in text
     assert '"--lemonade-model-id"' in text
     assert "litellm-lemonade" in text
     assert "Runtime config renderer failed" in text
-    assert "model_list:\\n" in text
+    lemonade_writer = text.split("def _write_lemonade_config(", 1)[1].split(
+        "def _write_windows_native_litellm_config(", 1
+    )[0]
+    assert "model_list:\\n" not in lemonade_writer
+
+
+def test_windows_lemonade_uses_renderer_as_sole_writer() -> None:
+    text = read("installers/windows/lib/env-generator.ps1")
+    assert "scripts" in text
+    assert "render-runtime-configs.py" in text
+    assert '"litellm-lemonade"' in text
+    assert '"--lemonade-model-id"' in text
+    assert "Install-WindowsODSRuntimeConfigPython" in text
+    assert "sys.version_info >= (3, 8)" in text
+    assert "IsNullOrWhiteSpace($env:LOCALAPPDATA)" in text
+    assert 'Join-Path $env:LOCALAPPDATA "Programs\\Python"' in text
+    assert "winget install --exact --id Python.Python.3.12" in text
+    lemonade_writer = text.split("function Write-WindowsODSLemonadeLiteLlmConfig", 1)[
+        1
+    ].split("function Set-WindowsODSLemonadeModelConfiguration", 1)[0]
+    assert "model_list:" not in lemonade_writer
 
 
 def test_openclaw_receives_persisted_lemonade_model_id() -> None:
@@ -66,10 +87,11 @@ def test_cloud_callers_do_not_render_local_switchboard() -> None:
 
 def main() -> int:
     for test in (
-        test_linux_installer_uses_renderer_with_fallback,
-        test_bootstrap_upgrade_uses_renderer_with_fallback,
+        test_linux_installer_uses_renderer_as_sole_writer,
+        test_bootstrap_upgrade_uses_renderer_as_sole_writer,
         test_bootstrap_upgrade_promotes_lemonade_model_id,
-        test_host_agent_uses_renderer_with_fallback,
+        test_host_agent_uses_renderer_as_sole_writer,
+        test_windows_lemonade_uses_renderer_as_sole_writer,
         test_openclaw_receives_persisted_lemonade_model_id,
         test_cloud_callers_do_not_render_local_switchboard,
     ):


### PR DESCRIPTION
## Summary
- make the canonical runtime renderer the sole serializer for dynamic Lemonade LiteLLM routes across Linux install, bootstrap upgrade, Windows AMD/Lemonade, and host-agent recovery paths
- remove inline YAML fallbacks so renderer failures fail closed and model activation can restore the previous known-good route
- make runtime config writes atomic while preserving existing file modes and keeping new bind-mounted configs readable
- bootstrap Windows renderer Python safely: require Python >=3.8, reject WindowsApps aliases, tolerate unset Windows env roots, and install Python 3.12 with winget when needed
- lock ownership with generated-config ledger and wiring contracts so Lemonade route writers cannot drift again

## Verification
- exact head: `5508f72eb2bf52cab5ae464de38c6aabf58b8b9d`
- local Windows/Git Bash battery: renderer/dashboard pytest `196 passed, 1 skipped`; runtime wiring `7 passed`; generated-config contracts passed; Windows LLM endpoint passed; bootstrap hot-swap contracts passed; Docker rollback passed; external Lemonade contracts passed; AMD/Lemonade contracts `64 passed`; Ruff, py_compile, and `git diff --check` passed
- Tower2 fresh clone at exact SHA: `197 passed`; runtime wiring passed; generated-config contracts passed; hot-swap/rollback/external/AMD contracts passed; Ruff, py_compile, and diff check passed
- Tower2 evidence log: `/home/michael/ods-pr-2113-clean-final-5508f72e.QVRq0X/ods/pr-2113-verify-5508f72eb2bf52cab5ae464de38c6aabf58b8b9d.log`
- GitHub CI: all PR checks green for exact SHA, including Ubuntu and Windows PowerShell lint, Linux integration smoke, dashboard, mypy, Ruff, shellcheck, matrix smoke, secret scan, and env validation
- Independent review: Kepler reported `NO BLOCKERS for exact SHA 5508f72eb2bf52cab5ae464de38c6aabf58b8b9d`

Co-authored-by: Lightheartdevs <Lightheartdevs@users.noreply.github.com>