### PR TITLE
fix(dashboard-api): stop templates rejecting extensions with no declared GPU backends

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -67,8 +67,13 @@ def _gpu_backend_error(service_id: str) -> str | None:
     if not service_config or GPU_BACKEND == "apple":
         return None
 
-    gpu_backends = service_config.get("gpu_backends", ["amd", "nvidia", "apple"])
-    if "all" in gpu_backends or GPU_BACKEND in gpu_backends:
+    # gpu_backends is optional in the manifest schema, and both config.py and
+    # the catalog generator store an undeclared list as []. An empty list means
+    # "no declared restriction", exactly as _compute_extension_status treats it
+    # — reading it as "supports nothing" would make the Extensions page and the
+    # template gate disagree about the same extension.
+    gpu_backends = service_config.get("gpu_backends") or []
+    if not gpu_backends or "all" in gpu_backends or GPU_BACKEND in gpu_backends:
         return None
     return f"requires one of {gpu_backends}; current backend is {GPU_BACKEND}"
 

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -1328,3 +1328,54 @@ def test_apply_template_blocking_calls_run_in_to_thread():
             f"{callee}() is called directly (without asyncio.to_thread). "
             f"All blocking helpers must run in the thread pool."
         )
+
+
+# --- GPU compatibility parity with the Extensions page ---
+
+
+def test_gpu_backend_error_treats_undeclared_backends_as_unrestricted():
+    """An empty gpu_backends list means "no declared restriction".
+
+    gpu_backends is optional in the manifest schema, and config.py stores an
+    undeclared list as []. _compute_extension_status already reads [] as
+    unrestricted, so reading it as "supports nothing" here made the Extensions
+    page and the template gate disagree about the same extension.
+    """
+    from routers.templates import _gpu_backend_error
+
+    with (
+        patch("routers.templates.SERVICES", {"no-decl": {"port": 1234, "gpu_backends": []}}),
+        patch("routers.templates.GPU_BACKEND", "nvidia"),
+    ):
+        assert _gpu_backend_error("no-decl") is None
+
+    # A declared list is still enforced.
+    with (
+        patch("routers.templates.SERVICES", {"cuda-only": {"gpu_backends": ["nvidia"]}}),
+        patch("routers.templates.GPU_BACKEND", "amd"),
+    ):
+        assert _gpu_backend_error("cuda-only") is not None
+
+
+@pytest.mark.asyncio
+async def test_template_preview_does_not_flag_undeclared_backends_incompatible():
+    """Preview must not mark an extension incompatible that Extensions shows as usable."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["no-decl"],
+    }]
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates.SERVICES", {"no-decl": {"port": 1234, "gpu_backends": []}}),
+        patch("routers.templates.EXTENSION_CATALOG", []),
+        patch("routers.templates.GPU_BACKEND", "nvidia"),
+        patch("helpers.get_cached_services", return_value=[]),
+    ):
+        from routers.templates import preview_template
+        result = await preview_template("test-tmpl", api_key="test")
+
+    assert result["changes"]["incompatible"] == []
+    assert result["changes"]["to_enable"] == ["no-decl"]
+    assert result["warnings"] == []


### PR DESCRIPTION
## Problem

`service.gpu_backends` is **optional** in `service-manifest.v1.json` (`required` is `id, name, port, type, category`). Two places disagree about what an undeclared list means.

`config.py` loads such a service as supported everywhere:

```python
supported = service.get("gpu_backends", ["amd", "nvidia", "apple"])   # inclusion decision
...
"gpu_backends": service.get("gpu_backends", []),                        # what it stores
```

`routers/extensions.py` reads the stored `[]` as "no declared restriction":

```python
gpu_backends = ext.get("gpu_backends", [])
if gpu_backends and "all" not in gpu_backends and GPU_BACKEND not in gpu_backends:
    return "incompatible"
```

`routers/templates.py` read the same `[]` as "supports nothing":

```python
gpu_backends = service_config.get("gpu_backends", ["amd", "nvidia", "apple"])  # dead default
if "all" in gpu_backends or GPU_BACKEND in gpu_backends:
    return None
return f"requires one of {gpu_backends}; ..."   # → "requires one of []"
```

The `.get` default never fires, because config.py always writes the key. So for an extension whose manifest omits `gpu_backends`:

- Extensions page → usable
- `POST /api/templates/{id}/preview` → listed under **incompatible**, with warning `requires one of []; current backend is nvidia`
- `POST /api/templates/{id}/apply` → **skipped**, and the same rule aborts activation of any template service that depends on it with a 424

All bundled manifests happen to declare the field, so this hits user/third-party extensions installed from the library or authored locally.

## Fix

Treat an empty or absent list as unrestricted in `_gpu_backend_error`, matching `_compute_extension_status`. A declared list is still enforced unchanged.

## Tests

- `test_gpu_backend_error_treats_undeclared_backends_as_unrestricted` — unit coverage of both directions.
- `test_template_preview_does_not_flag_undeclared_backends_incompatible` — the extension lands in `to_enable` with no warning.

Red on the pre-fix router (2 failures), green after; the other 31 tests in the file are unaffected.