### PR TITLE
fix(deps): resolve image ARGs the way the builder does

### DIFF
--- a/ods/scripts/check-dependency-pins.py
+++ b/ods/scripts/check-dependency-pins.py
@@ -64,13 +64,25 @@ def _rel(path: Path, root: Path = ROOT) -> str:
 
 
 def _resolve_vars(value: str, defaults: dict[str, str]) -> str:
+    """Expand ``${VAR}`` / ``${VAR:-fallback}`` the way the builder does.
+
+    A declared value wins over an inline fallback: with ``ARG TAG=1.2.3``,
+    Docker builds ``base:${TAG:-9.9.9}`` as ``base:1.2.3``. Returning the
+    fallback first made this gate record and enforce an image tag the build
+    never pulls — the exact documented-vs-built drift it exists to catch.
+    """
+
     def replace(match: re.Match[str]) -> str:
         name = match.group("braced") or match.group("plain") or ""
         default = match.group("default")
+        declared = defaults.get(name)
+        # ``:-`` substitutes when unset *or* empty; ``-`` only when unset.
+        if declared is not None and (declared != "" or match.group("op") == "-"):
+            return declared
         if default is not None:
             return default
-        if name in defaults:
-            return defaults[name]
+        if declared is not None:
+            return declared
         return match.group(0)
 
     return VAR_RE.sub(replace, value)

--- a/ods/tests/test-dependency-pins.py
+++ b/ods/tests/test-dependency-pins.py
@@ -178,6 +178,43 @@ def test_extension_library_sha_tags_are_rejected() -> None:
     )
 
 
+def test_declared_arg_wins_over_inline_fallback() -> None:
+    """A declared ARG must beat an inline ${VAR:-fallback}, as Docker resolves it.
+
+    With `ARG TAG=1.2.3`, Docker builds `FROM base:${TAG:-9.9.9}` as
+    `base:1.2.3`. Returning the fallback made the gate record and enforce an
+    image the build never pulls.
+    """
+    module = load_module()
+
+    assert module._resolve_vars("base:${TAG:-9.9.9}", {"TAG": "1.2.3"}) == "base:1.2.3"
+    assert module._resolve_vars("base:${TAG-9.9.9}", {"TAG": "1.2.3"}) == "base:1.2.3"
+    # `:-` also substitutes on an empty declared value; plain `-` does not.
+    assert module._resolve_vars("base:${TAG:-9.9.9}", {"TAG": ""}) == "base:9.9.9"
+    assert module._resolve_vars("base:${TAG-9.9.9}", {"TAG": ""}) == "base:"
+    # Undeclared names still fall back to the inline default.
+    assert module._resolve_vars("base:${TAG:-9.9.9}", {}) == "base:9.9.9"
+    assert module._resolve_vars("base:${TAG}", {"TAG": "1.2.3"}) == "base:1.2.3"
+    # An undeclared name with no default stays unresolved so validate_refs errors.
+    assert module._resolve_vars("base:${TAG}", {}) == "base:${TAG}"
+
+
+def test_dockerfile_from_uses_declared_arg_value() -> None:
+    module = load_module()
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        dockerfile = root / "Dockerfile"
+        dockerfile.write_text(
+            "ARG RUNTIME_TAG=1.2.3\nFROM example/runtime:${RUNTIME_TAG:-9.9.9}\n",
+            encoding="utf-8",
+        )
+
+        refs = module._dockerfile_image_refs(dockerfile, root)
+
+    assert [ref.value for ref in refs] == ["example/runtime:1.2.3"]
+
+
 def main() -> int:
     tests = [
         test_repo_dependency_lock_passes,
@@ -187,6 +224,8 @@ def main() -> int:
         test_ephemeral_sha256_length_tags_are_rejected,
         test_sha256_digest_pins_are_allowed,
         test_extension_library_sha_tags_are_rejected,
+        test_declared_arg_wins_over_inline_fallback,
+        test_dockerfile_from_uses_declared_arg_value,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Problem

`_resolve_vars()` consulted the inline fallback **before** the declared `ARG` value:

```python
default = match.group("default")
if default is not None:
    return default          # ← wins even when the ARG declares a value
if name in defaults:
    return defaults[name]
```

Docker resolves it the other way round. Given

```dockerfile
ARG RUNTIME_TAG=1.2.3
FROM example/runtime:${RUNTIME_TAG:-9.9.9}
```

the build pulls `example/runtime:1.2.3`, but the gate reported `example/runtime:9.9.9`. The consequence is worse than a false failure: whoever adds such a `FROM` is told to record `9.9.9` in `dependency-lock.json`, the gate then passes, and the lock permanently documents an image the build never pulls — the documented-vs-built drift this gate exists to catch.

No `FROM` in the tree uses a `:-` fallback today, so this is a latent inversion in the release gate rather than a live mismatch — but the gate is exactly the place that must not be wrong when someone does.

## Fix

Prefer the declared value, preserving shell substitution semantics:

| expression | `TAG` declared | result |
|---|---|---|
| `${TAG:-d}` | `1.2.3` | `1.2.3` |
| `${TAG:-d}` | `""` | `d` (`:-` substitutes on empty) |
| `${TAG-d}` | `""` | `""` (plain `-` only on unset) |
| `${TAG:-d}` | undeclared | `d` |
| `${TAG}` | undeclared | unresolved → existing "does not resolve to a default" error |

## Tests

`tests/test-dependency-pins.py` gains `test_declared_arg_wins_over_inline_fallback` (the table above) and `test_dockerfile_from_uses_declared_arg_value` (end-to-end through `_dockerfile_image_refs`).

Red on the pre-fix script, green after; the 7 existing tests and `scripts/check-dependency-pins.py` on the real tree still pass.