### PR TITLE
fix(dashboard-api): keep a malformed GGUF file_type inside the degrade contract

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -210,6 +210,13 @@ def inspect_gguf(path: Path | str, max_metadata_bytes: int = 8 * 1024 * 1024) ->
             metadata[key] = _read_value(reader, value_type)
 
         file_type = metadata.get("general.file_type")
+        # general.file_type is a uint32 in every real export, but a malformed
+        # one can store an array — and _read_array returns a list or dict.
+        # Indexing _FILE_TYPE_LABELS with an unhashable key raises TypeError,
+        # which is outside this parser's caught set and would escape the
+        # degrade-to-unknown contract as a 500 in the callers.
+        if not isinstance(file_type, int) or isinstance(file_type, bool):
+            file_type = None
         architecture = metadata.get("general.architecture", "unknown")
         result.update({
             "readable": True,

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -230,6 +230,36 @@ def test_missing_file_type_yields_unknown_quantization(tmp_path):
     assert result["quantization"] == "unknown"
 
 
+def test_array_file_type_degrades_to_unknown(tmp_path):
+    # A malformed export storing file_type as an array made the label lookup
+    # index _FILE_TYPE_LABELS with a list. TypeError is outside the parser's
+    # caught set, so it escaped the degrade-to-unknown contract entirely.
+    path = _write(tmp_path, "arrft.gguf", build_gguf([
+        ("general.architecture", STR, "llama"),
+        ("general.file_type", ARR, (U32, [15, 15])),
+    ]))
+
+    result = inspect_gguf(path)
+
+    assert result["readable"] is True
+    assert result["file_type"] is None
+    assert result["quantization"] == "unknown"
+    assert result["architecture"] == "llama"
+    # The raw value is still preserved for callers that want to inspect it.
+    assert result["metadata"]["general.file_type"] == [15, 15]
+
+
+def test_string_file_type_degrades_to_unknown(tmp_path):
+    path = _write(tmp_path, "strft.gguf", build_gguf([
+        ("general.file_type", STR, "Q4_K_M"),
+    ]))
+
+    result = inspect_gguf(path)
+
+    assert result["file_type"] is None
+    assert result["quantization"] == "unknown"
+
+
 def test_non_string_architecture_degrades_to_unknown(tmp_path):
     # A malformed export storing architecture as an int must not leak the int.
     path = _write(tmp_path, "weird.gguf", build_gguf([


### PR DESCRIPTION
## Problem

`inspect_gguf()` documents itself as *"Return normalized GGUF metadata, degrading to `unknown` on failure"* and catches `(OSError, UnicodeDecodeError, ValueError, struct.error)` to honour that.

`general.file_type` is a uint32 in every real export, but the parser accepts whatever the file declares. A GGUF that stores it as an **array** parses into a Python `list` (that is what `_read_array` returns), and then:

```python
"quantization": _FILE_TYPE_LABELS.get(file_type, ...)
```

raises `TypeError: cannot use 'list' as a dict key (unhashable type: 'list')` — outside the caught set. The exception escapes `inspect_gguf` entirely and propagates to `performance_oracle.py:945` / `:1286`, turning a bad model file into a 500 instead of a row with `quantization: unknown`.

Users supply their own GGUFs, so a truncated download or a non-conforming third-party export is the realistic trigger. This is the same failure shape already fixed for `general.architecture` (`test_non_string_architecture_degrades_to_unknown`).

## Fix

Treat a non-integer `file_type` the way a non-string `architecture` is already treated: report `file_type: None` / `quantization: "unknown"`, and keep the raw value in `metadata` for anyone who wants to inspect it. Booleans are excluded too, since `bool` is an `int` subclass and `_FILE_TYPE_LABELS[True]` would resolve to the `1` → `F16` label.

## Tests

- `test_array_file_type_degrades_to_unknown` — the TypeError case; also asserts the rest of the record still parses and the raw array survives in `metadata`.
- `test_string_file_type_degrades_to_unknown` — a string `file_type` no longer leaks through as the quantization label.

Red on the pre-fix module (2 failures, `TypeError` at `gguf_inspector.py:221`), green after; the 27 existing tests are unaffected.