### PR TITLE
feat(n8n): add web-page-to-knowledge-base template

### DIFF
--- a/ods/config/n8n/catalog.json
+++ b/ods/config/n8n/catalog.json
@@ -2,6 +2,20 @@
   "version": "2",
   "workflows": [
     {
+      "id": "webpage-to-kb",
+      "file": "webpage-to-kb.json",
+      "name": "Web Page to Knowledge Base",
+      "description": "Fetch a web page and add its text to your RAG knowledge base",
+      "icon": "Globe",
+      "category": "productivity",
+      "dependencies": [
+        "embeddings",
+        "qdrant"
+      ],
+      "setupTime": "3 minutes",
+      "featured": false
+    },
+    {
       "id": "m4-deterministic-voice",
       "file": "08-m4-deterministic-voice.json",
       "name": "M4 Deterministic Voice",

--- a/ods/config/n8n/webpage-to-kb.json
+++ b/ods/config/n8n/webpage-to-kb.json
@@ -1,0 +1,33 @@
+{
+  "name": "Web Page to Knowledge Base",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Web Page to Knowledge Base\n\nTemplate for ingesting a web page into your RAG knowledge base.\n\nSuggested flow:\n1. Set the target URL.\n2. HTTP Request node fetches the page.\n3. HTML Extract node pulls the readable text.\n4. Split the text into chunks.\n5. POST each chunk to the embeddings service (http://embeddings:80/embed).\n6. Upsert the vectors into Qdrant (http://qdrant:6333).\n\nRequires the embeddings and qdrant services enabled.",
+        "height": 320,
+        "width": 460
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "webpage-to-kb"
+  },
+  "tags": []
+}


### PR DESCRIPTION
## Summary

Adds a new n8n starter workflow, "Web Page to Knowledge Base", and registers it in the workflow catalog. It's a starting point for pulling a web page into the RAG knowledge base (embeddings + qdrant): a manual trigger plus a sticky note that lays out the steps (fetch URL → extract text → chunk → embed → upsert to Qdrant). Same two-node starter shape as the existing templates, so it stays consistent with the rest of `config/n8n/`.

Two files, no code or behavior change to any service.

## Changed Surface

- [ ] Docs / templates only

## Risk And Validation

- Risk level: Low

Checks run:

- `webpage-to-kb.json` parses as valid JSON; structure matches the other templates (`meta.templateId`, `settings.executionOrder`)
- `catalog.json` parses; 19 workflows, new entry present, no duplicate ids or files
- Declared dependencies `embeddings` and `qdrant` are real service ids
- No file-mode changes (both files `100644`)

## Notes For Reviewers

Kept as a starter template (trigger + guided sticky note) to match the existing 18 templates rather than shipping a fully wired flow. Happy to build it out into a runnable workflow if that's preferred.