### PR TITLE
feat(mode): add mesh as a valid ODS_MODE (stub)

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -18,12 +18,13 @@
     },
     "ODS_MODE": {
       "type": "string",
-      "description": "LLM backend mode: local, cloud, hybrid, or lemonade (AMD)",
+      "description": "LLM backend mode: local, cloud, hybrid, lemonade (AMD), or mesh (experimental)",
       "enum": [
         "local",
         "cloud",
         "hybrid",
-        "lemonade"
+        "lemonade",
+        "mesh"
       ],
       "default": "local"
     },

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -184,8 +184,8 @@ ALWAYS_ON_SERVICES: frozenset = frozenset({
 })
 USER_EXTENSIONS_DIR: Path = Path()
 EXTENSIONS_DIR: Path = Path()
-_ODS_MODES = frozenset({"local", "cloud", "hybrid", "lemonade"})
-_LOCAL_MODEL_MODES = frozenset({"local", "hybrid", "lemonade"})
+_ODS_MODES = frozenset({"local", "cloud", "hybrid", "lemonade", "mesh"})
+_LOCAL_MODEL_MODES = frozenset({"local", "hybrid", "lemonade", "mesh"})
 _MODEL_TIER_RE = re.compile(r"^[A-Z0-9_]{1,32}$")
 _MODEL_TIERS = frozenset({
     "0", "1", "2", "3", "4", "ARC", "ARC_LITE",

--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -25,8 +25,8 @@ EXTENSIONS_DIR = Path(
 
 DEFAULT_SERVICE_HOST = os.environ.get("SERVICE_HOST", "host.docker.internal")
 GPU_BACKEND = os.environ.get("GPU_BACKEND", "nvidia")
-ODS_MODES = frozenset({"local", "cloud", "hybrid", "lemonade"})
-LOCAL_MODEL_MODES = frozenset({"local", "hybrid", "lemonade"})
+ODS_MODES = frozenset({"local", "cloud", "hybrid", "lemonade", "mesh"})
+LOCAL_MODEL_MODES = frozenset({"local", "hybrid", "lemonade", "mesh"})
 LLM_CONTRACT_ROUTES = frozenset({"gateway", "direct"})
 LLM_CONTRACT_PINNING = frozenset({"none", "dynamic"})
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3525,12 +3525,16 @@ cmd_mode() {
             mv "$litellm_disabled" "$litellm_cf"
             success "Auto-enabled litellm for $mode mode"
         fi
-        # Check for API keys
-        local has_keys=false
-        grep -q "^ANTHROPIC_API_KEY=." .env 2>/dev/null && has_keys=true
-        grep -q "^OPENAI_API_KEY=." .env 2>/dev/null && has_keys=true
-        if [[ "$has_keys" == "false" ]]; then
-            warn "No API keys found in .env — add ANTHROPIC_API_KEY or OPENAI_API_KEY"
+        # Cloud and hybrid reach external providers, so warn when no provider
+        # key is set. mesh routes peer traffic through the local LiteLLM gateway
+        # and needs no external API key, so skip the warning for it.
+        if [[ "$mode" == "cloud" || "$mode" == "hybrid" ]]; then
+            local has_keys=false
+            grep -q "^ANTHROPIC_API_KEY=." .env 2>/dev/null && has_keys=true
+            grep -q "^OPENAI_API_KEY=." .env 2>/dev/null && has_keys=true
+            if [[ "$has_keys" == "false" ]]; then
+                warn "No API keys found in .env — add ANTHROPIC_API_KEY or OPENAI_API_KEY"
+            fi
         fi
     fi
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -850,7 +850,7 @@ get_compose_flags() {
                     _external_lemonade_active="true"
                 fi
             fi
-            if [[ "$_ods_mode" == "cloud" || "$_ods_mode" == "mesh" ]] && \
+            if [[ "$_ods_mode" == "cloud" ]] && \
                { [[ "$cached" == *"docker-compose.cpu.yml"* ]] || [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]]; }; then
                 stale=1
             fi
@@ -858,7 +858,7 @@ get_compose_flags() {
                { [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" == *"docker-compose.amd.yml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]] || [[ "$cached" != *"docker-compose.lemonade-external.yml"* ]]; }; then
                 stale=1
             fi
-            if [[ "$_ods_mode" != "cloud" ]] && [[ "$_ods_mode" != "mesh" ]] && [[ "$_external_lemonade_active" != "true" ]] && \
+            if [[ "$_ods_mode" != "cloud" ]] && [[ "$_external_lemonade_active" != "true" ]] && \
                [[ "$cached" == *"docker-compose.cloud.yml"* ]]; then
                 stale=1
             fi
@@ -3485,7 +3485,7 @@ cmd_mode() {
         echo "  local   — Local inference via llama-server (requires GPU/CPU)"
         echo "  cloud   — Cloud APIs via LiteLLM (requires API keys)"
         echo "  hybrid  — Local primary, cloud fallback"
-        echo "  mesh    — Distributed inference via LiteLLM (experimental)"
+        echo "  mesh    — Distributed reasoning across local nodes (experimental)"
         echo ""
         echo "Usage: ods mode <local|cloud|hybrid|mesh>"
         return 0
@@ -6339,8 +6339,8 @@ ${CYAN}Commands:${NC}
   disable <service>   Disable an extension service
   purge <service>     Permanently delete service data
   preset <action>     Save/load/list/delete/export/import presets
-  mode [local|cloud|hybrid]
-                      Switch between local/cloud/hybrid modes
+  mode [local|cloud|hybrid|mesh]
+                      Switch between local/cloud/hybrid/mesh modes
   model [current|list|swap]
                       View or change the local LLM model tier
   remote-provider [status|plan|configure|test|disable|remove|peer-models]

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -850,7 +850,7 @@ get_compose_flags() {
                     _external_lemonade_active="true"
                 fi
             fi
-            if [[ "$_ods_mode" == "cloud" ]] && \
+            if [[ "$_ods_mode" == "cloud" || "$_ods_mode" == "mesh" ]] && \
                { [[ "$cached" == *"docker-compose.cpu.yml"* ]] || [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]]; }; then
                 stale=1
             fi
@@ -858,7 +858,7 @@ get_compose_flags() {
                { [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" == *"docker-compose.amd.yml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]] || [[ "$cached" != *"docker-compose.lemonade-external.yml"* ]]; }; then
                 stale=1
             fi
-            if [[ "$_ods_mode" != "cloud" ]] && [[ "$_external_lemonade_active" != "true" ]] && \
+            if [[ "$_ods_mode" != "cloud" ]] && [[ "$_ods_mode" != "mesh" ]] && [[ "$_external_lemonade_active" != "true" ]] && \
                [[ "$cached" == *"docker-compose.cloud.yml"* ]]; then
                 stale=1
             fi
@@ -3485,14 +3485,15 @@ cmd_mode() {
         echo "  local   — Local inference via llama-server (requires GPU/CPU)"
         echo "  cloud   — Cloud APIs via LiteLLM (requires API keys)"
         echo "  hybrid  — Local primary, cloud fallback"
+        echo "  mesh    — Distributed inference via LiteLLM (experimental)"
         echo ""
-        echo "Usage: ods mode <local|cloud|hybrid>"
+        echo "Usage: ods mode <local|cloud|hybrid|mesh>"
         return 0
     fi
 
     case "$mode" in
-        local|cloud|hybrid) ;;
-        *) error "Unknown mode: $mode. Use: local, cloud, hybrid" ;;
+        local|cloud|hybrid|mesh) ;;
+        *) error "Unknown mode: $mode. Use: local, cloud, hybrid, mesh" ;;
     esac
 
     local configured_backend

--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -2,9 +2,9 @@
 # ============================================================================
 # ODS Mode Switch
 # ============================================================================
-# Usage: ./mode-switch.sh <local|cloud|hybrid> [--status]
+# Usage: ./mode-switch.sh <local|cloud|hybrid|mesh> [--status]
 #
-# Switches ODS between local/cloud/hybrid modes by updating .env.
+# Switches ODS between local/cloud/hybrid/mesh modes by updating .env.
 # This is the backend for `ods mode <mode>`.
 # ============================================================================
 
@@ -54,6 +54,7 @@ show_status() {
     echo "  local   — Local inference via llama-server (requires GPU/CPU)"
     echo "  cloud   — Cloud APIs via LiteLLM (requires API keys)"
     echo "  hybrid  — Local primary, cloud fallback"
+    echo "  mesh    — Distributed inference via LiteLLM (experimental)"
 }
 
 switch_mode() {
@@ -61,8 +62,8 @@ switch_mode() {
 
     # Validate
     case "$mode" in
-        local|cloud|hybrid) ;;
-        *) error "Unknown mode: $mode. Use: local, cloud, hybrid" ;;
+        local|cloud|hybrid|mesh) ;;
+        *) error "Unknown mode: $mode. Use: local, cloud, hybrid, mesh" ;;
     esac
 
     [[ -f "$ENV_FILE" ]] || error ".env not found at $ENV_FILE"
@@ -98,7 +99,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     case "${1:---status}" in
         --status|-s|status) show_status ;;
         --help|-h|help)
-            echo "Usage: mode-switch.sh <local|cloud|hybrid|--status>"
+            echo "Usage: mode-switch.sh <local|cloud|hybrid|mesh|--status>"
             ;;
         *) switch_mode "${1:-}" ;;
     esac

--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -54,7 +54,7 @@ show_status() {
     echo "  local   — Local inference via llama-server (requires GPU/CPU)"
     echo "  cloud   — Cloud APIs via LiteLLM (requires API keys)"
     echo "  hybrid  — Local primary, cloud fallback"
-    echo "  mesh    — Distributed inference via LiteLLM (experimental)"
+    echo "  mesh    — Distributed reasoning across local nodes (experimental)"
 }
 
 switch_mode() {

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -988,18 +988,18 @@ def _collect_inference_contract():
     expected_owner = "external" if external_inference else "ods"
     expected_gateway = (
         "litellm"
-        if external_inference or ods_mode == "lemonade" or gpu_backend == "amd"
+        if external_inference or ods_mode in ("lemonade", "mesh") or gpu_backend == "amd"
         else "llama-server"
     )
 
     issues = []
-    if ods_mode not in {"local", "cloud", "hybrid", "lemonade"}:
+    if ods_mode not in {"local", "cloud", "hybrid", "lemonade", "mesh"}:
         issues.append(
             _inference_issue(
                 "ODS-RUNTIME-MODE-UNKNOWN",
                 "blocker",
                 ".env",
-                f"ODS_MODE={ods_mode!r} is not one of local/cloud/hybrid/lemonade.",
+                f"ODS_MODE={ods_mode!r} is not one of local/cloud/hybrid/lemonade/mesh.",
             )
         )
 
@@ -1159,7 +1159,7 @@ def _collect_inference_contract():
             "If this is not an AMD/Lemonade install, set LLM_API_URL back to http://llama-server:8080.",
         ],
         "ODS-RUNTIME-MODE-UNKNOWN": [
-            "Set ODS_MODE to local, cloud, hybrid, or lemonade.",
+            "Set ODS_MODE to local, cloud, hybrid, lemonade, or mesh.",
         ],
     }
     for issue in issues:

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -1108,6 +1108,58 @@ def _collect_inference_contract():
                 )
             )
 
+    if ods_mode == "mesh":
+        # mesh is local-family: each node runs its own llama-server and reasons
+        # peer-to-peer through LiteLLM. The cloud overlay would profile out that
+        # local llama-server, and pointing services straight at llama-server
+        # would bypass the LiteLLM peer gateway. Both defeat the mode, so flag
+        # them the way cloud/local drift is flagged for their own contracts.
+        if compose_flags_exists and cloud_overlay:
+            issues.append(
+                _inference_issue(
+                    "ODS-RUNTIME-MESH-CLOUD-OVERLAY",
+                    "blocker",
+                    ".compose-flags",
+                    "ODS_MODE=mesh but docker-compose.cloud.yml is in the compose stack; the cloud overlay profiles out the local llama-server a mesh node contributes.",
+                )
+            )
+        if compose_flags_exists and not local_inference_overlay:
+            issues.append(
+                _inference_issue(
+                    "ODS-RUNTIME-MESH-LOCAL-OVERLAY-MISSING",
+                    "blocker",
+                    ".compose-flags",
+                    "ODS_MODE=mesh but no local inference overlay is in the compose stack; a mesh node runs its own local llama-server.",
+                )
+            )
+        if _looks_like_local_llama_route(llm_api_url):
+            issues.append(
+                _inference_issue(
+                    "ODS-RUNTIME-MESH-LLM-LOCAL-ROUTE",
+                    "blocker",
+                    ".env",
+                    f"ODS_MODE=mesh but LLM_API_URL points straight at local llama-server ({llm_api_url}); mesh routes peer traffic through LiteLLM.",
+                )
+            )
+        if _looks_like_local_llama_route(hermes_base_url):
+            issues.append(
+                _inference_issue(
+                    "ODS-RUNTIME-MESH-HERMES-LOCAL-ROUTE",
+                    "blocker",
+                    ".env",
+                    f"ODS_MODE=mesh but HERMES_LLM_BASE_URL points straight at local llama-server ({hermes_base_url}); mesh routes Hermes through LiteLLM.",
+                )
+            )
+        if llm_api_url and not _looks_like_litellm_route(llm_api_url) and not _looks_like_local_llama_route(llm_api_url):
+            issues.append(
+                _inference_issue(
+                    "ODS-RUNTIME-MESH-GATEWAY-BYPASS",
+                    "warn",
+                    ".env",
+                    f"ODS_MODE=mesh normally routes ODS services through LiteLLM as the peer gateway, but LLM_API_URL={llm_api_url}.",
+                )
+            )
+
     diagnoses = []
     issue_titles = {
         "ODS-RUNTIME-MODE-UNKNOWN": "Runtime mode is not recognized",
@@ -1121,6 +1173,11 @@ def _collect_inference_contract():
         "ODS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE": "External Lemonade host route has no user-provided API key",
         "ODS-RUNTIME-LOCAL-CLOUD-OVERLAY": "Local mode still has the cloud compose overlay",
         "ODS-RUNTIME-LOCAL-LITELLM-ROUTE": "Local mode routes through LiteLLM unexpectedly",
+        "ODS-RUNTIME-MESH-CLOUD-OVERLAY": "Mesh mode still has the cloud compose overlay",
+        "ODS-RUNTIME-MESH-LOCAL-OVERLAY-MISSING": "Mesh mode is missing the local inference overlay",
+        "ODS-RUNTIME-MESH-LLM-LOCAL-ROUTE": "Mesh mode routes chat clients around the LiteLLM peer gateway",
+        "ODS-RUNTIME-MESH-HERMES-LOCAL-ROUTE": "Mesh mode routes Hermes around the LiteLLM peer gateway",
+        "ODS-RUNTIME-MESH-GATEWAY-BYPASS": "Mesh mode bypasses the LiteLLM peer gateway",
     }
     next_steps = {
         "ODS-RUNTIME-CLOUD-OVERLAY-MISSING": [
@@ -1157,6 +1214,25 @@ def _collect_inference_contract():
         ],
         "ODS-RUNTIME-LOCAL-LITELLM-ROUTE": [
             "If this is not an AMD/Lemonade install, set LLM_API_URL back to http://llama-server:8080.",
+        ],
+        "ODS-RUNTIME-MESH-CLOUD-OVERLAY": [
+            "Regenerate compose flags with ODS_MODE=mesh so the local llama-server overlay is used instead of docker-compose.cloud.yml.",
+            "Run `ods restart` after correcting .env/.compose-flags.",
+        ],
+        "ODS-RUNTIME-MESH-LOCAL-OVERLAY-MISSING": [
+            "Regenerate compose flags for mesh so the GPU/CPU llama-server overlay is included.",
+            "Run `ods restart` after correcting .compose-flags.",
+        ],
+        "ODS-RUNTIME-MESH-LLM-LOCAL-ROUTE": [
+            "Set LLM_API_URL to the LiteLLM service URL used by the stack, usually http://litellm:4000.",
+            "Mesh routes peer traffic through LiteLLM, so do not point services straight at llama-server.",
+        ],
+        "ODS-RUNTIME-MESH-HERMES-LOCAL-ROUTE": [
+            "Set HERMES_LLM_BASE_URL to http://litellm:4000/v1 for mesh mode.",
+            "Restart Hermes after updating the generated config/template.",
+        ],
+        "ODS-RUNTIME-MESH-GATEWAY-BYPASS": [
+            "Route ODS services through LiteLLM so mesh peer routing stays consistent.",
         ],
         "ODS-RUNTIME-MODE-UNKNOWN": [
             "Set ODS_MODE to local, cloud, hybrid, lemonade, or mesh.",

--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -125,7 +125,7 @@ elif lemonade_external and ods_mode == "lemonade":
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"
-elif ods_mode in ("cloud", "mesh") or tier == "CLOUD":
+elif ods_mode == "cloud" or tier == "CLOUD":
     if existing(["docker-compose.base.yml", "docker-compose.cloud.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.cloud.yml"]
         primary = "docker-compose.cloud.yml"
@@ -574,7 +574,7 @@ if ext_dir.exists():
             # cloud overlay to profile out ODS's managed llama-server, so
             # local-mode overlays that wait on `llama-server: service_healthy`
             # would point at a disabled service and break lifecycle commands.
-            if ods_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
+            if ods_mode in ("local", "hybrid", "lemonade", "mesh") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
                 local_mode_overlay = service_dir / "compose.local.yaml"
                 if local_mode_overlay.exists():
                     resolved.append(str(local_mode_overlay.relative_to(script_dir)))
@@ -679,7 +679,7 @@ if user_ext_dir.exists():
                 # overlay to disable ODS's managed llama-server, so user-local
                 # overlays must not add local llama-server health dependencies.
                 # Mirrors the same guard in the built-in loop above (PR #1004).
-                if ods_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
+                if ods_mode in ("local", "hybrid", "lemonade", "mesh") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
                     local_mode_overlay = service_dir / "compose.local.yaml"
                     if local_mode_overlay.exists():
                         # Same content scan as compose.yaml/gpu overlay above —

--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -125,7 +125,7 @@ elif lemonade_external and ods_mode == "lemonade":
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"
-elif ods_mode == "cloud" or tier == "CLOUD":
+elif ods_mode in ("cloud", "mesh") or tier == "CLOUD":
     if existing(["docker-compose.base.yml", "docker-compose.cloud.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.cloud.yml"]
         primary = "docker-compose.cloud.yml"

--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -579,7 +579,12 @@ if ext_dir.exists():
             # cloud overlay to profile out ODS's managed llama-server, so
             # local-mode overlays that wait on `llama-server: service_healthy`
             # would point at a disabled service and break lifecycle commands.
-            if ods_mode in ("local", "hybrid", "lemonade", "mesh") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
+            # mesh is exempt from the CLOUD-tier skip: it overrides a persisted
+            # CLOUD tier above and keeps a local llama-server, so a converted
+            # cloud->mesh node must get the same depends_on wiring a fresh mesh
+            # install gets. Without the exemption the two stacks differ silently
+            # and ODS-RUNTIME-MESH-LOCAL-OVERLAY-MISSING cannot see it.
+            if ods_mode in ("local", "hybrid", "lemonade", "mesh") and (tier != "CLOUD" or ods_mode == "mesh") and gpu_backend != "apple" and not lemonade_external and not external_llm:
                 local_mode_overlay = service_dir / "compose.local.yaml"
                 if local_mode_overlay.exists():
                     resolved.append(str(local_mode_overlay.relative_to(script_dir)))
@@ -683,8 +688,9 @@ if user_ext_dir.exists():
                 # External Lemonade likewise runs on the host and uses the cloud
                 # overlay to disable ODS's managed llama-server, so user-local
                 # overlays must not add local llama-server health dependencies.
-                # Mirrors the same guard in the built-in loop above (PR #1004).
-                if ods_mode in ("local", "hybrid", "lemonade", "mesh") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
+                # Mirrors the same guard in the built-in loop above (PR #1004),
+                # including the mesh exemption from the CLOUD-tier skip.
+                if ods_mode in ("local", "hybrid", "lemonade", "mesh") and (tier != "CLOUD" or ods_mode == "mesh") and gpu_backend != "apple" and not lemonade_external and not external_llm:
                     local_mode_overlay = service_dir / "compose.local.yaml"
                     if local_mode_overlay.exists():
                         # Same content scan as compose.yaml/gpu overlay above —

--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -125,7 +125,12 @@ elif lemonade_external and ods_mode == "lemonade":
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"
-elif ods_mode == "cloud" or tier == "CLOUD":
+# mesh is local-family and must override a persisted CLOUD tier. A cloud
+# install carries tier == "CLOUD"; switching it to mesh must not keep taking
+# the cloud branch, or it would render docker-compose.cloud.yml and profile out
+# the local llama-server a mesh node contributes (the state ods-doctor flags as
+# ODS-RUNTIME-MESH-CLOUD-OVERLAY). Let mesh fall through to the local overlays.
+elif ods_mode == "cloud" or (tier == "CLOUD" and ods_mode != "mesh"):
     if existing(["docker-compose.base.yml", "docker-compose.cloud.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.cloud.yml"]
         primary = "docker-compose.cloud.yml"

--- a/ods/tests/contracts/test-ods-cli-contracts.py
+++ b/ods/tests/contracts/test-ods-cli-contracts.py
@@ -25,7 +25,7 @@ COMMANDS = {
     "disable": ("cmd_disable", "disable <service>"),
     "purge": ("cmd_purge", "purge <service>"),
     "preset": ("cmd_preset", "preset <action>"),
-    "mode": ("cmd_mode", "mode [local|cloud|hybrid]"),
+    "mode": ("cmd_mode", ("mode [local|cloud|hybrid]", "mode [local|cloud|hybrid|mesh]")),
     "model": ("cmd_model", "model [current|list|swap]"),
     "remote-provider": (
         "cmd_remote_provider",

--- a/ods/tests/contracts/test-ods-cli-contracts.py
+++ b/ods/tests/contracts/test-ods-cli-contracts.py
@@ -25,7 +25,7 @@ COMMANDS = {
     "disable": ("cmd_disable", "disable <service>"),
     "purge": ("cmd_purge", "purge <service>"),
     "preset": ("cmd_preset", "preset <action>"),
-    "mode": ("cmd_mode", ("mode [local|cloud|hybrid]", "mode [local|cloud|hybrid|mesh]")),
+    "mode": ("cmd_mode", "mode [local|cloud|hybrid|mesh]"),
     "model": ("cmd_model", "model [current|list|swap]"),
     "remote-provider": (
         "cmd_remote_provider",

--- a/ods/tests/test-linux-cloud-mode.sh
+++ b/ods/tests/test-linux-cloud-mode.sh
@@ -47,16 +47,17 @@ rejects "$flags" "compose.local.yaml" "cloud mode does not include local depende
 
 mesh_flags="$(ODS_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
     --script-dir "$ROOT_DIR" \
-    --tier CLOUD \
-    --gpu-backend cpu \
-    --gpu-count 0 \
+    --tier LOCAL \
+    --gpu-backend nvidia \
+    --gpu-count 1 \
     --ods-mode mesh)"
 mesh_flags="${mesh_flags//\\//}"
 
 contains "$mesh_flags" "docker-compose.base.yml" "mesh mode keeps base stack"
-contains "$mesh_flags" "docker-compose.cloud.yml" "mesh mode layers cloud overlay"
-rejects "$mesh_flags" "docker-compose.cpu.yml" "mesh mode does not include CPU llama-server overlay"
-rejects "$mesh_flags" "compose.local.yaml" "mesh mode does not include local dependency overlays"
+contains "$mesh_flags" "docker-compose.nvidia.yml" "mesh mode keeps the local llama-server overlay"
+contains "$mesh_flags" "extensions/services/litellm/compose.yaml" "mesh mode includes the LiteLLM gateway"
+contains "$mesh_flags" "compose.local.yaml" "mesh mode includes local dependency overlays"
+rejects "$mesh_flags" "docker-compose.cloud.yml" "mesh mode does not layer the cloud overlay"
 
 lemonade_flags="$(LEMONADE_EXTERNAL=true AMD_INFERENCE_RUNTIME=lemonade AMD_INFERENCE_MANAGED=false ODS_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
     --script-dir "$ROOT_DIR" \

--- a/ods/tests/test-linux-cloud-mode.sh
+++ b/ods/tests/test-linux-cloud-mode.sh
@@ -74,6 +74,11 @@ mesh_cloud_tier_flags="${mesh_cloud_tier_flags//\\//}"
 contains "$mesh_cloud_tier_flags" "docker-compose.base.yml" "mesh at CLOUD tier keeps base stack"
 contains "$mesh_cloud_tier_flags" "docker-compose.cpu.yml" "mesh at CLOUD tier keeps a local llama-server overlay"
 contains "$mesh_cloud_tier_flags" "extensions/services/litellm/compose.yaml" "mesh at CLOUD tier includes the LiteLLM gateway"
+# A converted cloud->mesh node keeps a local llama-server, so it must also get
+# the local depends_on wiring a fresh mesh install gets. Without this the two
+# stacks differ and the local-inference overlay ods-doctor looks for is still
+# present, so ODS-RUNTIME-MESH-LOCAL-OVERLAY-MISSING cannot catch the drift.
+contains "$mesh_cloud_tier_flags" "compose.local.yaml" "mesh at CLOUD tier includes local dependency overlays"
 rejects "$mesh_cloud_tier_flags" "docker-compose.cloud.yml" "mesh overrides the CLOUD tier and does not layer the cloud overlay"
 
 lemonade_flags="$(LEMONADE_EXTERNAL=true AMD_INFERENCE_RUNTIME=lemonade AMD_INFERENCE_MANAGED=false ODS_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \

--- a/ods/tests/test-linux-cloud-mode.sh
+++ b/ods/tests/test-linux-cloud-mode.sh
@@ -45,6 +45,19 @@ contains "$flags" "extensions/services/litellm/compose.yaml" "cloud mode include
 rejects "$flags" "docker-compose.cpu.yml" "cloud mode does not include CPU llama-server overlay"
 rejects "$flags" "compose.local.yaml" "cloud mode does not include local dependency overlays"
 
+mesh_flags="$(ODS_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
+    --script-dir "$ROOT_DIR" \
+    --tier CLOUD \
+    --gpu-backend cpu \
+    --gpu-count 0 \
+    --ods-mode mesh)"
+mesh_flags="${mesh_flags//\\//}"
+
+contains "$mesh_flags" "docker-compose.base.yml" "mesh mode keeps base stack"
+contains "$mesh_flags" "docker-compose.cloud.yml" "mesh mode layers cloud overlay"
+rejects "$mesh_flags" "docker-compose.cpu.yml" "mesh mode does not include CPU llama-server overlay"
+rejects "$mesh_flags" "compose.local.yaml" "mesh mode does not include local dependency overlays"
+
 lemonade_flags="$(LEMONADE_EXTERNAL=true AMD_INFERENCE_RUNTIME=lemonade AMD_INFERENCE_MANAGED=false ODS_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
     --script-dir "$ROOT_DIR" \
     --tier CLOUD \

--- a/ods/tests/test-linux-cloud-mode.sh
+++ b/ods/tests/test-linux-cloud-mode.sh
@@ -59,6 +59,23 @@ contains "$mesh_flags" "extensions/services/litellm/compose.yaml" "mesh mode inc
 contains "$mesh_flags" "compose.local.yaml" "mesh mode includes local dependency overlays"
 rejects "$mesh_flags" "docker-compose.cloud.yml" "mesh mode does not layer the cloud overlay"
 
+# Cloud-to-mesh transition: an existing cloud install carries TIER=CLOUD.
+# Switching it to mesh must override the persisted CLOUD tier and resolve
+# local-family (keep a local llama-server overlay, drop the cloud overlay) so it
+# does not land in the exact state ods-doctor flags as ODS-RUNTIME-MESH-CLOUD-OVERLAY.
+mesh_cloud_tier_flags="$(ODS_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
+    --script-dir "$ROOT_DIR" \
+    --tier CLOUD \
+    --gpu-backend cpu \
+    --gpu-count 0 \
+    --ods-mode mesh)"
+mesh_cloud_tier_flags="${mesh_cloud_tier_flags//\\//}"
+
+contains "$mesh_cloud_tier_flags" "docker-compose.base.yml" "mesh at CLOUD tier keeps base stack"
+contains "$mesh_cloud_tier_flags" "docker-compose.cpu.yml" "mesh at CLOUD tier keeps a local llama-server overlay"
+contains "$mesh_cloud_tier_flags" "extensions/services/litellm/compose.yaml" "mesh at CLOUD tier includes the LiteLLM gateway"
+rejects "$mesh_cloud_tier_flags" "docker-compose.cloud.yml" "mesh overrides the CLOUD tier and does not layer the cloud overlay"
+
 lemonade_flags="$(LEMONADE_EXTERNAL=true AMD_INFERENCE_RUNTIME=lemonade AMD_INFERENCE_MANAGED=false ODS_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
     --script-dir "$ROOT_DIR" \
     --tier CLOUD \

--- a/ods/tests/test-ods-doctor-install-diagnoses.sh
+++ b/ods/tests/test-ods-doctor-install-diagnoses.sh
@@ -296,6 +296,68 @@ else
     pass "user API key suppresses unauthenticated external Lemonade diagnosis"
 fi
 
+# --- Mesh mode: local-family with a LiteLLM peer gateway ---
+# A broken mesh install renders the cloud overlay (profiling out the local
+# llama-server) and points services straight at llama-server (bypassing the
+# LiteLLM peer gateway). Doctor must flag both.
+cat > "$ENV_PATH" <<'ENV'
+ODS_MODE=mesh
+GPU_BACKEND=nvidia
+LLM_API_URL=http://llama-server:8080
+HERMES_LLM_BASE_URL=http://llama-server:8080/v1
+LLM_MODEL=qwen-test
+GGUF_FILE=qwen-test.gguf
+ENV
+cat > "$FLAGS_PATH" <<'FLAGS'
+-f docker-compose.base.yml -f docker-compose.cloud.yml
+FLAGS
+
+if (cd "$ROOT_DIR" && bash scripts/ods-doctor.sh "$REPORT" >/dev/null 2>&1); then
+    pass "ods-doctor runs with broken mesh fixture"
+else
+    fail "ods-doctor failed with broken mesh fixture"
+fi
+
+for id in \
+    ODS-RUNTIME-MESH-CLOUD-OVERLAY \
+    ODS-RUNTIME-MESH-LOCAL-OVERLAY-MISSING \
+    ODS-RUNTIME-MESH-LLM-LOCAL-ROUTE \
+    ODS-RUNTIME-MESH-HERMES-LOCAL-ROUTE
+do
+    if jq -e --arg id "$id" '.diagnoses[] | select(.id == $id)' "$REPORT" >/dev/null; then
+        pass "broken mesh diagnosis present: $id"
+    else
+        fail "broken mesh diagnosis missing: $id"
+    fi
+done
+
+# A healthy mesh install keeps the local inference overlay, drops the cloud
+# overlay, and routes LLM_API_URL/HERMES_LLM_BASE_URL through LiteLLM. Doctor
+# should emit no mesh runtime diagnoses.
+cat > "$ENV_PATH" <<'ENV'
+ODS_MODE=mesh
+GPU_BACKEND=nvidia
+LLM_API_URL=http://litellm:4000
+HERMES_LLM_BASE_URL=http://litellm:4000/v1
+LLM_MODEL=qwen-test
+GGUF_FILE=qwen-test.gguf
+ENV
+cat > "$FLAGS_PATH" <<'FLAGS'
+-f docker-compose.base.yml -f docker-compose.nvidia.yml
+FLAGS
+
+if (cd "$ROOT_DIR" && bash scripts/ods-doctor.sh "$REPORT" >/dev/null 2>&1); then
+    pass "ods-doctor runs with healthy mesh fixture"
+else
+    fail "ods-doctor failed with healthy mesh fixture"
+fi
+
+if jq -e '.diagnoses[] | select(.id | startswith("ODS-RUNTIME-MESH-"))' "$REPORT" >/dev/null; then
+    fail "healthy mesh fixture still emitted a mesh runtime diagnosis"
+else
+    pass "healthy mesh fixture is clean of mesh runtime diagnoses"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed, $SKIPPED skipped"
 [[ "$FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

Adding any mesh capability means touching the `ODS_MODE` enum, the CLI, `mode-switch.sh`, `ods-doctor`, and the compose resolver all at once. There was no mode reserved for distributed reasoning (only local, cloud, hybrid, lemonade). This PR does that plumbing once, as a stub, so the actual routing work later doesn't have to re-touch the enum and CLI.

`mesh` is local-family: each node runs its own local llama-server and reasons peer-to-peer through LiteLLM, so it resolves exactly like `hybrid` (keeps the local llama-server overlay, uses LiteLLM as the gateway for peer routing) and never layers the cloud overlay. cloud is the no-gpu path to external APIs, so mesh is basically the opposite of cloud. The mode CLI, `mode-switch.sh`, `ods-doctor`, the `.env` schema enum, and the dashboard-api / host-agent mode allowlists all recognize it now. Added mesh assertions to `test-linux-cloud-mode.sh` and mesh coverage to the doctor install-diagnosis tests so compose resolution and the inference contract can't silently break.

Nothing changes for local, cloud, hybrid, or lemonade. Unknown modes still fail closed.

Context: groundwork for planned distributed-inference work, discussed with the maintainer. This PR only reserves the mode and wires plumbing, no routing logic.

## User-facing behavior

Setting `ODS_MODE=mesh` today reserves the mode as local-family. It resolves like `hybrid` — local llama-server stays up, LiteLLM acts as the gateway for peer routing. No distributed routing lands in this PR; that's the follow-up. No cloud overlay, no external-API path.

## Changed surface

Mode routing / CLI / validation / doctor inference contract.

## Risk and validation

Risk level: Low