### PR TITLE
fix(setup): reconcile ods-proxy owner readiness

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Windows CLI Enable/Disable Tests
         run: bash tests/test-windows-cli-enable-disable.sh
 
+      - name: CLI Enable Compose Reconciliation Tests
+        run: bash tests/test-cli-enable-compose-reconciliation.sh
+
       - name: Windows Missing Service Hint Tests
         run: bash tests/test-windows-missing-service-hints.sh
 

--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -522,8 +522,17 @@ def _ods_proxy_service() -> Optional[dict]:
     dashboard-api loads extension manifests at process startup, but `ods
     enable ods-proxy` flips compose.yaml.disabled to compose.yaml while this
     process is still running. Owner-card readiness must see that transition
-    without requiring an operator to restart dashboard-api manually.
+    without requiring an operator to restart dashboard-api manually. The
+    inverse transition must also invalidate a service cached before disable.
     """
+    proxy_dir = EXTENSIONS_DIR / "ods-proxy"
+    if any(
+        (proxy_dir / name).exists()
+        for name in ("compose.yaml.disabled", "compose.yml.disabled")
+    ):
+        SERVICES.pop("ods-proxy", None)
+        return None
+
     service = SERVICES.get("ods-proxy")
     if service:
         return service
@@ -559,7 +568,10 @@ def _ods_proxy_lan_ready() -> tuple[bool, str]:
                 return True, ""
             return False, f"ods-proxy health returned HTTP {status}"
     except (OSError, TimeoutError, urllib.error.URLError) as exc:
-        return False, f"ods-proxy is enabled but not reachable: {exc}"
+        return (
+            False,
+            f"ods-proxy is configured but not reachable in the active stack: {exc}",
+        )
 
 
 def _owner_card_requires_lan_proxy(payload: GenerateRequest) -> bool:

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -388,6 +388,31 @@ def test_owner_card_status_reports_proxy_state(
     }
 
 
+def test_ods_proxy_readiness_reports_unreachable_active_stack(
+    magic_link_module, monkeypatch
+):
+    # The shared fixture replaces readiness with an always-ready stub for API
+    # tests. Reload here to exercise the implementation itself.
+    actual_readiness = importlib.reload(magic_link_module)._ods_proxy_lan_ready
+    monkeypatch.setattr(
+        magic_link_module,
+        "_ods_proxy_service",
+        lambda: {"host": "ods-proxy", "port": 80, "health": "/health"},
+    )
+
+    def fail_urlopen(_url, timeout):
+        assert timeout == 1.0
+        raise magic_link_module.urllib.error.URLError("Name or service not known")
+
+    monkeypatch.setattr(magic_link_module.urllib.request, "urlopen", fail_urlopen)
+
+    ready, reason = actual_readiness()
+
+    assert ready is False
+    assert "configured but not reachable in the active stack" in reason
+    assert "Name or service not known" in reason
+
+
 def test_ods_proxy_service_refreshes_stale_manifest_cache(
     magic_link_module, monkeypatch
 ):
@@ -435,6 +460,23 @@ def test_ods_proxy_service_keeps_disabled_state(magic_link_module, monkeypatch):
         "load_extension_manifests",
         fake_load_extension_manifests,
     )
+
+    assert magic_link_module._ods_proxy_service() is None
+    assert "ods-proxy" not in magic_link_module.SERVICES
+
+
+def test_ods_proxy_service_invalidates_cached_service_after_disable(
+    magic_link_module, monkeypatch, tmp_path
+):
+    proxy_dir = tmp_path / "ods-proxy"
+    proxy_dir.mkdir()
+    (proxy_dir / "compose.yaml.disabled").write_text("services: {}\n")
+    monkeypatch.setattr(magic_link_module, "EXTENSIONS_DIR", tmp_path)
+    magic_link_module.SERVICES["ods-proxy"] = {
+        "host": "ods-proxy",
+        "port": 80,
+        "health": "/health",
+    }
 
     assert magic_link_module._ods_proxy_service() is None
     assert "ods-proxy" not in magic_link_module.SERVICES

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2384,12 +2384,44 @@ function Update-ComposeFlags {
     )
 
     $flagsFile = Join-Path $InstallDir ".compose-flags"
-    if (-not (Test-Path $flagsFile)) {
-        Write-AIWarn "No .compose-flags file found -- skipping update."
-        return
+    $flagsExisted = Test-Path -LiteralPath $flagsFile
+    $originalContent = if ($flagsExisted) {
+        Get-Content -LiteralPath $flagsFile -Raw
+    } else {
+        $null
+    }
+    $existing = @()
+    if ($flagsExisted) {
+        $raw = $originalContent
+        if (-not [string]::IsNullOrWhiteSpace($raw)) {
+            $existing = @($raw.Trim() -split "\s+" | Where-Object { $_ })
+        } else {
+            Write-AIWarn ".compose-flags is empty -- recovering the active stack before $Action."
+        }
     }
 
-    $existing = @((Get-Content $flagsFile -Raw).Trim() -split "\s+" | Where-Object { $_ })
+    if ($existing.Count -eq 0) {
+        # The filesystem fallback in Get-ComposeFlags cannot reconstruct the
+        # complete Windows stack. It does not know which AMD/tier overlays or
+        # per-service GPU fragments the installer selected. Only the launch
+        # receipt is a lossless recovery source.
+        $launchRecord = Join-Path (Join-Path $InstallDir "logs") "compose-launch.txt"
+        if (Test-Path -LiteralPath $launchRecord) {
+            $composeFlagsLine = Get-Content -LiteralPath $launchRecord -ErrorAction SilentlyContinue |
+                Where-Object { $_ -match "^compose_flags=" } |
+                Select-Object -First 1
+            if ($composeFlagsLine) {
+                $receiptFlags = ($composeFlagsLine -replace "^compose_flags=", "").Trim()
+                if (-not [string]::IsNullOrWhiteSpace($receiptFlags)) {
+                    $existing = @($receiptFlags -split "\s+" | Where-Object { $_ })
+                    Write-AIWarn "Recovered the active stack from logs\compose-launch.txt."
+                }
+            }
+        }
+        if ($existing.Count -eq 0) {
+            throw "Could not safely recover the complete Windows compose stack before $Action $ServiceId. Run the installer in place to regenerate .compose-flags."
+        }
+    }
 
     # Every fragment under extensions/services/<ServiceId>/ belongs to the
     # toggled service: compose.yaml and any per-backend overlay beside it.
@@ -2426,7 +2458,19 @@ function Update-ComposeFlags {
 
     $newContent = $tokens -join " "
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-    [System.IO.File]::WriteAllText($flagsFile, $newContent, $utf8NoBom)
+    $tempFile = "$flagsFile.$PID.tmp"
+    try {
+        [System.IO.File]::WriteAllText($tempFile, $newContent, $utf8NoBom)
+        Move-Item -LiteralPath $tempFile -Destination $flagsFile -Force
+    } catch {
+        Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+        if ($flagsExisted) {
+            [System.IO.File]::WriteAllText($flagsFile, [string]$originalContent, $utf8NoBom)
+        } else {
+            Remove-Item -LiteralPath $flagsFile -Force -ErrorAction SilentlyContinue
+        }
+        throw
+    }
     Write-AI "Updated .compose-flags ($Action $ServiceId)"
 }
 
@@ -2640,10 +2684,26 @@ function Invoke-Enable {
     $disabledPath = Join-Path $svcDir "compose.yaml.disabled"
 
     if (Test-Path $composePath) {
+        $staleDisabledBackup = $null
+        if (Test-Path $disabledPath) {
+            $staleDisabledBackup = "$disabledPath.$PID.stale"
+            Move-Item -LiteralPath $disabledPath -Destination $staleDisabledBackup -Force
+        }
         # The compose fragment can be present while a stale .compose-flags file
         # still omits it (for example after an interrupted in-place update).
         # Reconcile the active project even when no rename is required.
-        Update-ComposeFlags -ServiceId $ServiceId -Action "enable"
+        try {
+            Update-ComposeFlags -ServiceId $ServiceId -Action "enable"
+        } catch {
+            if ($staleDisabledBackup -and (Test-Path $staleDisabledBackup)) {
+                Move-Item -LiteralPath $staleDisabledBackup -Destination $disabledPath -Force
+            }
+            throw
+        }
+        if ($staleDisabledBackup) {
+            Remove-Item -LiteralPath $staleDisabledBackup -Force -ErrorAction SilentlyContinue
+            Write-AIWarn "Removed stale disabled marker for $ServiceId."
+        }
         Write-AISuccess "$ServiceId is already enabled."
         Write-AI "Run '.\ods.ps1 start $ServiceId' to launch it."
         return
@@ -2651,7 +2711,14 @@ function Invoke-Enable {
 
     if (Test-Path $disabledPath) {
         Rename-Item -LiteralPath $disabledPath -NewName "compose.yaml" -Force
-        Update-ComposeFlags -ServiceId $ServiceId -Action "enable"
+        try {
+            Update-ComposeFlags -ServiceId $ServiceId -Action "enable"
+        } catch {
+            if ((Test-Path $composePath) -and -not (Test-Path $disabledPath)) {
+                Rename-Item -LiteralPath $composePath -NewName "compose.yaml.disabled" -Force
+            }
+            throw
+        }
         Write-AISuccess "$ServiceId enabled."
         Write-AI "Run '.\ods.ps1 start $ServiceId' to launch it."
         return
@@ -2705,7 +2772,10 @@ function Invoke-Disable {
     $composePath  = Join-Path $svcDir "compose.yaml"
     $disabledPath = Join-Path $svcDir "compose.yaml.disabled"
 
-    if (Test-Path $disabledPath) {
+    if ((Test-Path $disabledPath) -and -not (Test-Path $composePath)) {
+        # Disabling is also an idempotent repair: remove a stale service entry
+        # from the persisted project even when the marker already says disabled.
+        Update-ComposeFlags -ServiceId $ServiceId -Action "disable"
         Write-AISuccess "$ServiceId is already disabled."
         return
     }
@@ -2748,8 +2818,27 @@ function Invoke-Disable {
     }
 
     # Rename and refresh flags regardless of Docker state.
+    $staleDisabledBackup = $null
+    if (Test-Path $disabledPath) {
+        $staleDisabledBackup = "$disabledPath.$PID.stale"
+        Move-Item -LiteralPath $disabledPath -Destination $staleDisabledBackup -Force
+    }
     Rename-Item -LiteralPath $composePath -NewName "compose.yaml.disabled" -Force
-    Update-ComposeFlags -ServiceId $ServiceId -Action "disable"
+    try {
+        Update-ComposeFlags -ServiceId $ServiceId -Action "disable"
+    } catch {
+        if ((Test-Path $disabledPath) -and -not (Test-Path $composePath)) {
+            Rename-Item -LiteralPath $disabledPath -NewName "compose.yaml" -Force
+        }
+        if ($staleDisabledBackup -and (Test-Path $staleDisabledBackup)) {
+            Move-Item -LiteralPath $staleDisabledBackup -Destination $disabledPath -Force
+        }
+        throw
+    }
+    if ($staleDisabledBackup) {
+        Remove-Item -LiteralPath $staleDisabledBackup -Force -ErrorAction SilentlyContinue
+        Write-AIWarn "Removed stale disabled marker before disabling $ServiceId."
+    }
     Write-AISuccess "$ServiceId disabled."
     Write-AI "Data preserved. Run '.\ods.ps1 enable $ServiceId' to re-enable."
 }

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2427,12 +2427,22 @@ function Update-ComposeFlags {
     # toggled service: compose.yaml and any per-backend overlay beside it.
     $ownedByService = "extensions[/\\]services[/\\]$([regex]::Escape($ServiceId))[/\\]"
 
+    $ownedFragments = New-Object System.Collections.Generic.List[string]
+    $ownedInsertAt = $null
     $tokens = New-Object System.Collections.Generic.List[string]
     for ($i = 0; $i -lt $existing.Count; $i++) {
         if ($existing[$i] -eq "-f" -and ($i + 1) -lt $existing.Count) {
             $path = $existing[$i + 1]
             $i++
-            if ($path -match $ownedByService) { continue }
+            if ($path -match $ownedByService) {
+                if ($null -eq $ownedInsertAt) {
+                    $ownedInsertAt = $tokens.Count
+                }
+                if (-not $ownedFragments.Contains($path)) {
+                    [void]$ownedFragments.Add($path)
+                }
+                continue
+            }
             [void]$tokens.Add("-f")
             [void]$tokens.Add($path)
             continue
@@ -2443,16 +2453,31 @@ function Update-ComposeFlags {
     if ($Action -eq "enable") {
         $svcDir = Join-Path (Join-Path (Join-Path $InstallDir "extensions") "services") $ServiceId
         if (Test-Path (Join-Path $svcDir "compose.yaml")) {
+            $serviceEntries = New-Object System.Collections.Generic.List[string]
+            [void]$serviceEntries.Add("-f")
+            [void]$serviceEntries.Add("extensions/services/$ServiceId/compose.yaml")
+            foreach ($fragment in $ownedFragments) {
+                if ($fragment -match "compose\.ya?ml$") { continue }
+                $fragmentPath = Join-Path $InstallDir $fragment
+                if (Test-Path -LiteralPath $fragmentPath -PathType Leaf) {
+                    [void]$serviceEntries.Add("-f")
+                    [void]$serviceEntries.Add($fragment)
+                }
+            }
             # tier0 and override are appended last by the installer so they win
             # the merge; the new fragment has to land ahead of them.
             $insertAt = $tokens.Count
-            for ($j = 0; $j -lt $tokens.Count - 1; $j++) {
-                if ($tokens[$j] -eq "-f" -and $tokens[$j + 1] -match "docker-compose\.(tier0|override)\.yml$") {
-                    $insertAt = $j
-                    break
+            if ($null -ne $ownedInsertAt) {
+                $insertAt = [int]$ownedInsertAt
+            } else {
+                for ($j = 0; $j -lt $tokens.Count - 1; $j++) {
+                    if ($tokens[$j] -eq "-f" -and $tokens[$j + 1] -match "docker-compose\.(tier0|override)\.yml$") {
+                        $insertAt = $j
+                        break
+                    }
                 }
             }
-            $tokens.InsertRange($insertAt, [string[]]@("-f", "extensions/services/$ServiceId/compose.yaml"))
+            $tokens.InsertRange($insertAt, [string[]]$serviceEntries.ToArray())
         }
     }
 

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2640,6 +2640,10 @@ function Invoke-Enable {
     $disabledPath = Join-Path $svcDir "compose.yaml.disabled"
 
     if (Test-Path $composePath) {
+        # The compose fragment can be present while a stale .compose-flags file
+        # still omits it (for example after an interrupted in-place update).
+        # Reconcile the active project even when no rename is required.
+        Update-ComposeFlags -ServiceId $ServiceId -Action "enable"
         Write-AISuccess "$ServiceId is already enabled."
         Write-AI "Run '.\ods.ps1 start $ServiceId' to launch it."
         return

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -2668,6 +2668,14 @@ cmd_enable() {
     fi
 
     if [[ -f "$cf" ]]; then
+        # An interrupted update can leave the compose fragment active while
+        # the persisted stack still omits it. Treat enable as an idempotent
+        # reconciliation operation on every platform.
+        _regenerate_compose_flags
+        if [[ -f "$disabled" ]]; then
+            rm -f "$disabled"
+            warn "Removed stale disabled marker for $service_id."
+        fi
         success "$service_id is already enabled."
     elif [[ -f "$disabled" ]]; then
         mv "$disabled" "$cf"

--- a/ods/tests/test-cli-enable-compose-reconciliation.sh
+++ b/ods/tests/test-cli-enable-compose-reconciliation.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression: `ods enable` must repair a stale compose cache even when the
+# extension's compose.yaml is already active.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+make_install() {
+    local install_dir="$1"
+    mkdir -p \
+        "$install_dir/lib" \
+        "$install_dir/scripts" \
+        "$install_dir/extensions/services/ods-proxy"
+
+    cp "$ROOT_DIR/ods-cli" "$install_dir/ods-cli"
+    cp "$ROOT_DIR/lib/service-registry.sh" "$install_dir/lib/"
+    cp "$ROOT_DIR/lib/python-cmd.sh" "$install_dir/lib/"
+    cat > "$install_dir/scripts/resolve-compose-stack.sh" <<'RESOLVER'
+#!/usr/bin/env bash
+set -euo pipefail
+script_dir=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --script-dir) script_dir="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+flags="-f docker-compose.base.yml"
+if [[ -f "$script_dir/extensions/services/ods-proxy/compose.yaml" ]]; then
+    flags="$flags -f extensions/services/ods-proxy/compose.yaml"
+fi
+printf '%s\n' "$flags"
+RESOLVER
+    chmod +x "$install_dir/scripts/resolve-compose-stack.sh"
+    cp "$ROOT_DIR/extensions/services/ods-proxy/compose.yaml" \
+        "$install_dir/extensions/services/ods-proxy/"
+
+    # Keep the fixture focused on compose reconciliation. Core dependency
+    # availability is covered by the registry/enable dependency tests.
+    sed 's/depends_on: \[dashboard, dashboard-api, open-webui\]/depends_on: []/' \
+        "$ROOT_DIR/extensions/services/ods-proxy/manifest.yaml" \
+        > "$install_dir/extensions/services/ods-proxy/manifest.yaml"
+
+    printf 'services: {}\n' > "$install_dir/docker-compose.base.yml"
+    printf '%s\n' \
+        'GPU_BACKEND=cpu' \
+        'GPU_COUNT=1' \
+        'ODS_MODE=local' \
+        'TIER=1' \
+        > "$install_dir/.env"
+}
+
+for cache_state in stale empty missing; do
+    install_dir="$TMP_DIR/$cache_state"
+    make_install "$install_dir"
+    case "$cache_state" in
+        stale) printf '%s\n' '-f docker-compose.base.yml' > "$install_dir/.compose-flags" ;;
+        empty) : > "$install_dir/.compose-flags" ;;
+        missing) ;;
+    esac
+
+    ODS_HOME="$install_dir" bash "$install_dir/ods-cli" enable ods-proxy >/dev/null
+    first="$(cat "$install_dir/.compose-flags")"
+    [[ "$first" == *"-f docker-compose.base.yml"* ]] \
+        || fail "$cache_state cache recovery dropped the base compose file"
+    [[ "$first" == *"-f extensions/services/ods-proxy/compose.yaml"* ]] \
+        || fail "$cache_state cache recovery omitted ods-proxy"
+
+    ODS_HOME="$install_dir" bash "$install_dir/ods-cli" enable ods-proxy >/dev/null
+    second="$(cat "$install_dir/.compose-flags")"
+    [[ "$second" == "$first" ]] \
+        || fail "$cache_state cache reconciliation was not idempotent"
+    [[ "$(grep -o 'extensions/services/ods-proxy/compose.yaml' \
+        "$install_dir/.compose-flags" | wc -l)" -eq 1 ]] \
+        || fail "$cache_state cache reconciliation duplicated ods-proxy"
+done
+
+pass "Linux enable reconciles stale, empty, and missing compose caches"
+
+dual_dir="$TMP_DIR/dual-marker"
+make_install "$dual_dir"
+cp "$dual_dir/extensions/services/ods-proxy/compose.yaml" \
+    "$dual_dir/extensions/services/ods-proxy/compose.yaml.disabled"
+printf '%s\n' '-f docker-compose.base.yml' > "$dual_dir/.compose-flags"
+
+ODS_HOME="$dual_dir" bash "$dual_dir/ods-cli" enable ods-proxy >/dev/null
+[[ -f "$dual_dir/extensions/services/ods-proxy/compose.yaml" ]] \
+    || fail "dual-marker repair removed the active compose fragment"
+[[ ! -e "$dual_dir/extensions/services/ods-proxy/compose.yaml.disabled" ]] \
+    || fail "dual-marker repair left the stale disabled marker"
+grep -q -- '-f extensions/services/ods-proxy/compose.yaml' \
+    "$dual_dir/.compose-flags" \
+    || fail "dual-marker repair did not add ods-proxy to the active stack"
+
+pass "Linux enable normalizes a dual compose-marker state"

--- a/ods/tests/test-windows-cli-enable-disable.sh
+++ b/ods/tests/test-windows-cli-enable-disable.sh
@@ -432,6 +432,22 @@ if [[ -n "$PS_BIN" ]]; then
         $before = ($original -split "\s+" | Sort-Object) -join " "
         $after  = ($afterEnable -split "\s+" | Sort-Object) -join " "
         if ($before -ne $after) { throw "disable+enable round trip changed the token set" }
+
+        # Re-running enable on an already-active service is now a repair path,
+        # so it must preserve the service-selected installer GPU overlay.
+        $beforeComfyuiRepair = $afterEnable
+        Update-ComposeFlags -ServiceId "comfyui" -Action "enable"
+        $afterComfyuiRepair = (Get-Content $flagsFile -Raw).Trim()
+        if ($afterComfyuiRepair -notmatch "comfyui/compose\.nvidia\.yaml") {
+            throw "already-enabled repair dropped the toggled service overlay"
+        }
+        $overlayCount = ([regex]::Matches($afterComfyuiRepair, "comfyui/compose\.nvidia\.yaml")).Count
+        if ($overlayCount -ne 1) {
+            throw "already-enabled repair duplicated the toggled service overlay"
+        }
+        if ($beforeComfyuiRepair -ne $afterComfyuiRepair) {
+            throw "already-enabled repair reordered or rewrote the active service stack"
+        }
     '; then
         pass "Update-ComposeFlags preserves other services overlays and token order"
     else
@@ -512,9 +528,16 @@ else
 
     # Pull the functions under test straight out of ods.ps1.
     extract_fn() {
-        # Top-level functions open with `function <Name> {` and close on a
-        # column-0 brace. [{] keeps the brace literal without an awk escape.
-        awk -v fn="^function $1 [{]" '$0 ~ fn, /^}/' "$ODS_PS1"
+        awk -v fn="^function $1 [{]" '
+            $0 ~ fn { printing = 1 }
+            printing {
+                print
+                opens = gsub(/\{/, "{")
+                closes = gsub(/\}/, "}")
+                depth += opens - closes
+                if (depth == 0) { exit }
+            }
+        ' "$ODS_PS1"
     }
 
     HARNESS="$PSTMP/harness.ps1"
@@ -581,7 +604,7 @@ EOF
         local script="$PSTMP/case.ps1"
         cat "$HARNESS" > "$script"
         echo "$snippet" >> "$script"
-        TEST_INSTALL_DIR="$install_dir" "$PS_BIN" -NoProfile -File "$script" 2>&1
+        TEST_INSTALL_DIR="$install_dir" "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$script" 2>&1
     }
 
     # ── Case 1: disable is refused while an enabled extension depends on it ────

--- a/ods/tests/test-windows-cli-enable-disable.sh
+++ b/ods/tests/test-windows-cli-enable-disable.sh
@@ -53,16 +53,17 @@ pass "Test-ODSInstallFiles helper present"
 info "Static: Invoke-Enable uses Test-ODSInstallFiles, not Test-Install"
 # Extract the Invoke-Enable function body and assert it doesn't call Test-Install
 awk '/^function Invoke-Enable/,/^}/' "$ODS_PS1" \
-    | grep -q 'Test-ODSInstallFiles' \
+    | grep 'Test-ODSInstallFiles' >/dev/null \
     || fail "Invoke-Enable does not call Test-ODSInstallFiles"
-awk '/^function Invoke-Enable/,/^}/' "$ODS_PS1" \
-    | grep -qv 'Test-Install[^F]' \
-    || fail "Invoke-Enable still calls Test-Install (requires Docker)"
+if awk '/^function Invoke-Enable/,/^}/' "$ODS_PS1" \
+    | grep 'Test-Install[^F]' >/dev/null; then
+    fail "Invoke-Enable still calls Test-Install (requires Docker)"
+fi
 pass "Invoke-Enable uses Docker-free Test-ODSInstallFiles"
 
 info "Static: Invoke-Disable uses Test-ODSInstallFiles, not Test-Install"
 awk '/^function Invoke-Disable/,/^}/' "$ODS_PS1" \
-    | grep -q 'Test-ODSInstallFiles' \
+    | grep 'Test-ODSInstallFiles' >/dev/null \
     || fail "Invoke-Disable does not call Test-ODSInstallFiles"
 pass "Invoke-Disable uses Docker-free Test-ODSInstallFiles"
 
@@ -79,7 +80,7 @@ pass "Invoke-Disable gracefully skips stop when Docker is offline"
 info "Static: Rename+flags update runs regardless of Docker state in Invoke-Disable"
 # The Rename-Item call must appear AFTER the docker-offline else branch
 awk '/^function Invoke-Disable/,/^}/' "$ODS_PS1" \
-    | grep -q 'Rename-Item.*compose.yaml.disabled' \
+    | grep 'Rename-Item.*compose.yaml.disabled' >/dev/null \
     || fail "Rename-Item not found in Invoke-Disable body"
 pass "Rename + flags update unconditional in Invoke-Disable"
 
@@ -459,31 +460,31 @@ pass "Get-EnabledDependents helper present"
 
 info "Static: Invoke-Enable cascades into disabled dependencies"
 awk '/^function Invoke-Enable/,/^}/' "$ODS_PS1" \
-    | grep -q 'Get-DisabledDependencies' \
+    | grep 'Get-DisabledDependencies' >/dev/null \
     || fail "Invoke-Enable does not resolve disabled dependencies"
 awk '/^function Invoke-Enable/,/^}/' "$ODS_PS1" \
-    | grep -q 'Invoke-Enable -ServiceId \$dep -AsDependency' \
+    | grep 'Invoke-Enable -ServiceId \$dep -AsDependency' >/dev/null \
     || fail "Invoke-Enable does not recursively enable its dependencies"
 pass "Invoke-Enable enables disabled dependencies first"
 
 info "Static: Invoke-Enable guards against manifest dependency cycles"
 awk '/^function Invoke-Enable/,/^}/' "$ODS_PS1" \
-    | grep -q '_EnableVisited' \
+    | grep '_EnableVisited' >/dev/null \
     || fail "Invoke-Enable has no cycle guard"
 pass "Invoke-Enable has a cycle guard"
 
 info "Static: Invoke-Disable refuses when enabled extensions still depend on the target"
 awk '/^function Invoke-Disable/,/^}/' "$ODS_PS1" \
-    | grep -q 'Get-EnabledDependents' \
+    | grep 'Get-EnabledDependents' >/dev/null \
     || fail "Invoke-Disable does not check reverse dependents"
 awk '/^function Invoke-Disable/,/^}/' "$ODS_PS1" \
-    | grep -q 'These enabled extensions depend on' \
+    | grep 'These enabled extensions depend on' >/dev/null \
     || fail "Invoke-Disable has no dependent-refusal message"
 pass "Invoke-Disable checks reverse dependents"
 
 info "Static: Invoke-Disable exposes a -Force escape hatch"
 awk '/^function Invoke-Disable/,/^}/' "$ODS_PS1" \
-    | grep -q '\[switch\]\$Force' \
+    | grep '\[switch\]\$Force' >/dev/null \
     || fail "Invoke-Disable has no -Force switch"
 grep -q 'Test-ForceArgument' "$ODS_PS1" \
     || fail "Dispatcher cannot detect -Force"
@@ -527,6 +528,7 @@ else
         echo 'function Write-AISuccess { param($Message) Write-Host "OK: $Message" }'
         echo 'function Test-ODSInstallFiles { }'
         # Exercise the real reconciliation logic against each temporary install.
+        extract_fn Get-ComposeFlags
         extract_fn Update-ComposeFlags
         # Keep Docker out of the test: force the offline branch of Invoke-Disable.
         echo 'function docker { $global:LASTEXITCODE = 1 }'
@@ -552,6 +554,9 @@ else
         local root="$1" id="$2" svc_category="$3" deps="$4" state="$5"
         local dir="$root/extensions/services/$id"
         mkdir -p "$dir"
+        if [[ ! -e "$root/.compose-flags" ]]; then
+            printf '%s' '--env-file .env -f docker-compose.base.yml' > "$root/.compose-flags"
+        fi
         cat > "$dir/manifest.yaml" <<EOF
 schema_version: ods.services.v1
 
@@ -645,6 +650,136 @@ EOF
     [[ $(grep -o 'extensions/services/ods-proxy/compose.yaml' "$C3B/.compose-flags" | wc -l) -eq 1 ]] \
         || fail "enable duplicated the ods-proxy compose fragment; flags: $flags3b"
     pass "enable repairs stale compose flags without duplicate entries"
+
+    # ── Case 3c: empty/missing caches recover before reconciliation ───────────
+    info "PowerShell: enable recovers empty and missing .compose-flags"
+    for cache_state in empty missing; do
+        C3C="$PSTMP/case3c-$cache_state"
+        make_service "$C3C" ods-proxy optional "" enabled
+        mkdir -p "$C3C/logs"
+        printf '%s\n' \
+            'compose_flags=--env-file .env -f docker-compose.base.yml -f installers/windows/docker-compose.windows-amd.yml -f extensions/services/n8n/compose.yaml -f docker-compose.override.yml' \
+            > "$C3C/logs/compose-launch.txt"
+        if [[ "$cache_state" == "empty" ]]; then
+            : > "$C3C/.compose-flags"
+        else
+            rm -f "$C3C/.compose-flags"
+        fi
+
+        out3c=$(run_ps "$C3C" 'Invoke-Enable -ServiceId "ods-proxy"' || true)
+        expected3c='--env-file .env -f docker-compose.base.yml -f installers/windows/docker-compose.windows-amd.yml -f extensions/services/n8n/compose.yaml -f extensions/services/ods-proxy/compose.yaml -f docker-compose.override.yml'
+        actual3c=$(cat "$C3C/.compose-flags")
+        [[ "$actual3c" == "$expected3c" ]] \
+            || fail "$cache_state cache recovery lost or reordered compose flags; output: $out3c; flags: $actual3c"
+    done
+    pass "enable recovers empty/missing caches and preserves the launch stack"
+
+    # ── Case 3c.1: never synthesize a partial Windows stack ──────────────────
+    info "PowerShell: missing recovery receipt fails closed"
+    for cache_state in empty missing; do
+        C3C_FAIL="$PSTMP/case3c-no-receipt-$cache_state"
+        make_service "$C3C_FAIL" ods-proxy optional "" disabled
+        if [[ "$cache_state" == "empty" ]]; then
+            : > "$C3C_FAIL/.compose-flags"
+        else
+            rm -f "$C3C_FAIL/.compose-flags"
+        fi
+
+        out3c_fail=$(run_ps "$C3C_FAIL" '
+try { Invoke-Enable -ServiceId "ods-proxy" } catch { Write-Host $_.Exception.Message }' || true)
+        echo "$out3c_fail" | grep "Could not safely recover the complete Windows compose stack" >/dev/null \
+            || fail "$cache_state cache without a receipt did not fail closed; output: $out3c_fail"
+        [[ ! -e "$C3C_FAIL/extensions/services/ods-proxy/compose.yaml" ]] \
+            || fail "$cache_state cache failure left ods-proxy enabled"
+        [[ -f "$C3C_FAIL/extensions/services/ods-proxy/compose.yaml.disabled" ]] \
+            || fail "$cache_state cache failure did not restore the disabled marker"
+        if [[ "$cache_state" == "empty" ]]; then
+            [[ -f "$C3C_FAIL/.compose-flags" && ! -s "$C3C_FAIL/.compose-flags" ]] \
+                || fail "empty cache was not preserved exactly after recovery failure"
+        else
+            [[ ! -e "$C3C_FAIL/.compose-flags" ]] \
+                || fail "missing cache was synthesized after recovery failure"
+        fi
+    done
+    pass "missing recovery receipts preserve the exact prior cache and marker state"
+
+    # ── Case 3d: explicit commands normalize dual marker states ───────────────
+    info "PowerShell: enable/disable normalize dual compose markers"
+    C3D_ENABLE="$PSTMP/case3d-enable"
+    make_service "$C3D_ENABLE" ods-proxy optional "" enabled
+    cp "$C3D_ENABLE/extensions/services/ods-proxy/compose.yaml" \
+        "$C3D_ENABLE/extensions/services/ods-proxy/compose.yaml.disabled"
+    printf '%s' '--env-file .env -f docker-compose.base.yml' > "$C3D_ENABLE/.compose-flags"
+    out3d_enable=$(run_ps "$C3D_ENABLE" 'Invoke-Enable -ServiceId "ods-proxy"' || true)
+    [[ -f "$C3D_ENABLE/extensions/services/ods-proxy/compose.yaml" ]] \
+        || fail "enable removed the active marker in a dual-marker state; output: $out3d_enable"
+    [[ ! -e "$C3D_ENABLE/extensions/services/ods-proxy/compose.yaml.disabled" ]] \
+        || fail "enable left the stale disabled marker; output: $out3d_enable"
+
+    C3D_DISABLE="$PSTMP/case3d-disable"
+    make_service "$C3D_DISABLE" ods-proxy optional "" enabled
+    cp "$C3D_DISABLE/extensions/services/ods-proxy/compose.yaml" \
+        "$C3D_DISABLE/extensions/services/ods-proxy/compose.yaml.disabled"
+    printf '%s' '--env-file .env -f docker-compose.base.yml -f extensions/services/ods-proxy/compose.yaml' \
+        > "$C3D_DISABLE/.compose-flags"
+    out3d_disable=$(run_ps "$C3D_DISABLE" 'Invoke-Disable -ServiceId "ods-proxy"' || true)
+    [[ ! -e "$C3D_DISABLE/extensions/services/ods-proxy/compose.yaml" ]] \
+        || fail "disable left the active marker in a dual-marker state; output: $out3d_disable"
+    [[ -f "$C3D_DISABLE/extensions/services/ods-proxy/compose.yaml.disabled" ]] \
+        || fail "disable did not preserve a disabled compose fragment; output: $out3d_disable"
+    ! grep -q 'extensions/services/ods-proxy/compose.yaml' "$C3D_DISABLE/.compose-flags" \
+        || fail "disable left ods-proxy in compose flags; output: $out3d_disable"
+    pass "enable/disable normalize dual compose markers"
+
+    # ── Case 3e: already-disabled is an inverse cache repair ──────────────────
+    info "PowerShell: disable repairs stale flags for an already-disabled service"
+    C3E="$PSTMP/case3e"
+    make_service "$C3E" ods-proxy optional "" disabled
+    printf '%s' '--env-file .env -f docker-compose.base.yml -f extensions/services/ods-proxy/compose.yaml' \
+        > "$C3E/.compose-flags"
+    out3e=$(run_ps "$C3E" 'Invoke-Disable -ServiceId "ods-proxy"' || true)
+    ! grep -q 'extensions/services/ods-proxy/compose.yaml' "$C3E/.compose-flags" \
+        || fail "already-disabled repair left ods-proxy in compose flags; output: $out3e"
+    pass "already-disabled repair removes stale compose flags"
+
+    # ── Case 3f: marker changes roll back when cache reconciliation fails ─────
+    info "PowerShell: enable/disable restore markers after cache failure"
+    C3F_ENABLE="$PSTMP/case3f-enable"
+    make_service "$C3F_ENABLE" ods-proxy optional "" disabled
+    out3f_enable=$(run_ps "$C3F_ENABLE" '
+function Update-ComposeFlags { param($ServiceId, $Action) throw "forced cache failure" }
+try { Invoke-Enable -ServiceId "ods-proxy" } catch { Write-Host $_.Exception.Message }' || true)
+    [[ ! -e "$C3F_ENABLE/extensions/services/ods-proxy/compose.yaml" ]] \
+        || fail "failed enable left the service active; output: $out3f_enable"
+    [[ -f "$C3F_ENABLE/extensions/services/ods-proxy/compose.yaml.disabled" ]] \
+        || fail "failed enable did not restore the disabled marker; output: $out3f_enable"
+
+    C3F_DISABLE="$PSTMP/case3f-disable"
+    make_service "$C3F_DISABLE" ods-proxy optional "" enabled
+    out3f_disable=$(run_ps "$C3F_DISABLE" '
+function Update-ComposeFlags { param($ServiceId, $Action) throw "forced cache failure" }
+try { Invoke-Disable -ServiceId "ods-proxy" } catch { Write-Host $_.Exception.Message }' || true)
+    [[ -f "$C3F_DISABLE/extensions/services/ods-proxy/compose.yaml" ]] \
+        || fail "failed disable did not restore the active marker; output: $out3f_disable"
+    [[ ! -e "$C3F_DISABLE/extensions/services/ods-proxy/compose.yaml.disabled" ]] \
+        || fail "failed disable left the disabled marker behind; output: $out3f_disable"
+    pass "cache failures roll back compose marker changes"
+
+    # Exercise the real atomic cache writer by blocking its temporary path.
+    C3F_ATOMIC="$PSTMP/case3f-atomic"
+    make_service "$C3F_ATOMIC" ods-proxy optional "" disabled
+    printf '%s' '--env-file .env -f docker-compose.base.yml' > "$C3F_ATOMIC/.compose-flags"
+    out3f_atomic=$(run_ps "$C3F_ATOMIC" '
+$blockedTemp = "$InstallDir/.compose-flags.$PID.tmp"
+New-Item -ItemType Directory -Path $blockedTemp -Force | Out-Null
+try { Invoke-Enable -ServiceId "ods-proxy" } catch { Write-Host $_.Exception.Message }' || true)
+    [[ "$(cat "$C3F_ATOMIC/.compose-flags")" == '--env-file .env -f docker-compose.base.yml' ]] \
+        || fail "atomic writer failure changed the original cache; output: $out3f_atomic"
+    [[ ! -e "$C3F_ATOMIC/extensions/services/ods-proxy/compose.yaml" ]] \
+        || fail "atomic writer failure left the service active; output: $out3f_atomic"
+    [[ -f "$C3F_ATOMIC/extensions/services/ods-proxy/compose.yaml.disabled" ]] \
+        || fail "atomic writer failure did not restore the marker; output: $out3f_atomic"
+    pass "atomic cache write failure preserves the prior cache and marker"
 
     # ── Case 4: core dependencies are never treated as disabled ───────────────
     # Core services live in docker-compose.base.yml and own no compose.yaml,

--- a/ods/tests/test-windows-cli-enable-disable.sh
+++ b/ods/tests/test-windows-cli-enable-disable.sh
@@ -526,8 +526,8 @@ else
         echo 'function Write-AIError { param($Message) Write-Host "ERROR: $Message" }'
         echo 'function Write-AISuccess { param($Message) Write-Host "OK: $Message" }'
         echo 'function Test-ODSInstallFiles { }'
-        # Accepts both the no-arg and the -ServiceId/-Action call shapes.
-        echo 'function Update-ComposeFlags { param($ServiceId, $Action) }'
+        # Exercise the real reconciliation logic against each temporary install.
+        extract_fn Update-ComposeFlags
         # Keep Docker out of the test: force the offline branch of Invoke-Disable.
         echo 'function docker { $global:LASTEXITCODE = 1 }'
         echo '$script:_EnableVisited = @()'
@@ -629,6 +629,22 @@ EOF
             || fail "enable hermes-proxy did not transitively enable $svc; output: $out3"
     done
     pass "enable resolved the transitive dependency chain"
+
+    # ── Case 3b: enable repairs stale flags for an active compose fragment ─────
+    # An interrupted update can leave compose.yaml active while .compose-flags
+    # omits the service. Re-running enable must be an idempotent repair.
+    info "PowerShell: enable reconciles stale .compose-flags"
+    C3B="$PSTMP/case3b"
+    make_service "$C3B" ods-proxy optional "" enabled
+    printf '%s' '--env-file .env -f docker-compose.base.yml' > "$C3B/.compose-flags"
+
+    out3b=$(run_ps "$C3B" 'Invoke-Enable -ServiceId "ods-proxy"' || true)
+    flags3b=$(cat "$C3B/.compose-flags")
+    [[ "$flags3b" == *"-f extensions/services/ods-proxy/compose.yaml"* ]] \
+        || fail "enable did not repair stale compose flags; output: $out3b; flags: $flags3b"
+    [[ $(grep -o 'extensions/services/ods-proxy/compose.yaml' "$C3B/.compose-flags" | wc -l) -eq 1 ]] \
+        || fail "enable duplicated the ods-proxy compose fragment; flags: $flags3b"
+    pass "enable repairs stale compose flags without duplicate entries"
 
     # ── Case 4: core dependencies are never treated as disabled ───────────────
     # Core services live in docker-compose.base.yml and own no compose.yaml,


### PR DESCRIPTION
## Summary

Owner-card creation could remain disabled even when `ods-proxy` had an active `compose.yaml`. Extension marker state, the persisted Compose project, and the Dashboard API manifest cache could diverge after an interrupted update or repeated enable/disable operation.

This change makes extension activation an idempotent reconciliation operation, preserves the exact Windows stack selected by the installer, and makes owner-card readiness follow the active extension state.

## Root cause

1. Windows `Invoke-Enable` returned early when `compose.yaml` already existed and did not repair stale `.compose-flags`.
2. Linux `ods enable` had the same already-enabled early-return gap.
3. A stale `compose.yaml.disabled` could coexist with the active fragment.
4. Dashboard API could retain cached `ods-proxy` metadata after disable.
5. A missing or empty Windows cache could not be safely reconstructed by scanning files because installer-selected AMD, tier, override, and per-service GPU overlays are not derivable from the filesystem alone.

## Contract and invariants

| Invariant | Implementation |
|---|---|
| Repeated enable is idempotent | Reconciles the requested service and prevents duplicate `-f` entries |
| Unrelated stack order is stable | Edits only fragments owned by the requested service |
| Windows installer choices are preserved | Missing/empty caches recover only from `logs/compose-launch.txt` |
| Unsafe recovery fails closed | Without a complete receipt, cache and marker state are restored exactly |
| Marker and cache changes are transactional | Rename/write failures roll back both states |
| Disable is an inverse repair | Removes stale service flags even when already disabled |
| Disabled state invalidates API cache | `compose.y*ml.disabled` removes cached `ods-proxy` metadata |
| Readiness proves runtime availability | LAN owner-card readiness requires a successful proxy health response |
| Public owner-card mode is unchanged | `ODS_PUBLIC_URL` flows do not require `ods-proxy` |

## Changed surface

- Windows CLI: service-scoped `.compose-flags` reconciliation, atomic writes, exact rollback, dual-marker normalization, and lossless launch-receipt recovery.
- Linux CLI: already-enabled reconciliation and dual-marker normalization.
- Dashboard API: forward and inverse `ods-proxy` manifest-cache refresh.
- CI: dedicated Linux reconciliation contract plus expanded Windows PowerShell behavioral coverage.

No environment variables, API schemas, token semantics, public URL routing, or frontend contracts changed.

## Adversarial coverage

- Clean state and normal enable/disable.
- Existing installation with stale cache.
- Repeated enable and already-disabled repair.
- Empty and missing `.compose-flags`.
- Empty/missing cache without a trustworthy launch receipt.
- Dual active/disabled compose markers.
- Unrelated AMD, tier, override, extension, and GPU overlay ordering.
- Offline Docker operation.
- Dependency chain, disabled dependent, cycle, and `-Force` behavior.
- Forced reconciliation failure and atomic-write failure rollback.
- Dashboard API cache after both enable and disable.

## Validation

Exact head: `646d49582e567e6b0a9f8c44e9600df751f2a2d7`

| Check | Result |
|---|---|
| Dashboard API full suite | `1895 passed, 2 skipped` |
| Dashboard frontend | `232 passed`; production build passed |
| Magic-link focused suite | `58 passed` |
| Windows CLI behavioral suite, PowerShell 7 | Passed |
| Windows CLI behavioral suite, Windows PowerShell 5.1 | Passed |
| Linux CLI reconciliation contract | Passed |
| Linux/CPU Compose render with `ods-proxy` | Passed |
| Windows/AMD Compose render with `ods-proxy` | Passed |
| macOS/Apple Compose render with `ods-proxy` | Passed |
| PowerShell and Bash parsers | Passed |
| Ruff, ShellCheck, Python compile, workflow YAML | Passed |
| `git diff --check` | Passed |

The prior GitHub head also completed `Test Linux / integration-smoke` and the full reported CI rollup successfully. The rebased head includes the same behavior plus the adversarial fixes above and is awaiting its new CI receipt.

## Runtime reproduction

On the reported Windows AMD installation, `compose.yaml` was active while `ods-proxy` was absent from the persisted Compose project. Reconciliation added the missing fragment, started `ods-proxy` healthy, returned HTTP 200 from `/health`, changed owner-card status to `ready: true`, and enabled owner-card creation without reinstalling ODS or deleting data.

## Scope

This PR is limited to extension marker/Compose-cache consistency and owner-card readiness. It does not redesign general extension dependency transactions, change GPU overlay selection, or alter invitation and magic-link semantics.
