### PR TITLE
fix(dashboard-api): bound model picks to the usable share of unified memory

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -685,18 +685,30 @@ def _selector_required_memory_gb(model: dict[str, Any]) -> float:
     return round(max(declared, size_gb + context_kv_gb), 2)
 
 
+def _has_unified_memory(gpu_info: Optional[GPUInfo]) -> bool:
+    """Return whether the detected GPU shares its memory pool with the host.
+
+    The reported `memory_type` is the authoritative signal: `gpu.py` sets it to
+    "unified" for Apple Silicon and for any AMD APU whose GTT pool dwarfs its
+    carve-out VRAM, whatever the sysfs product name happens to be. Backend and
+    name are kept as fallbacks for surrogate GPUInfo records built from runtime
+    contracts that predate the field.
+    """
+    if not gpu_info:
+        return False
+    return (
+        normalize_key(gpu_info.gpu_backend) == "apple"
+        or normalize_key(getattr(gpu_info, "memory_type", "")) == "unified"
+        or "strix-halo" in normalize_key(gpu_info.name)
+    )
+
+
 def _matching_runtime_profile(model: dict[str, Any], gpu_info: Optional[GPUInfo],
                               system_ram_gb: int | None = None) -> dict[str, Any] | None:
     if not gpu_info:
         return None
     backend = normalize_key(gpu_info.gpu_backend)
-    memory_type = (
-        "unified"
-        if backend == "apple"
-        or normalize_key(getattr(gpu_info, "memory_type", "")) == "unified"
-        or "strix-halo" in normalize_key(gpu_info.name)
-        else "discrete"
-    )
+    memory_type = "unified" if _has_unified_memory(gpu_info) else "discrete"
     host_arch = _normalize_host_arch(platform.machine())
     vram_gb = float(gpu_info.memory_total_mb or 0) / 1024.0
     ram_gb = system_ram_gb if system_ram_gb is not None else _system_ram_gb()
@@ -743,8 +755,10 @@ def _usable_model_memory_gb(gpu_info: Optional[GPUInfo]) -> float:
     if not gpu_info:
         return 0.0
     total_gb = gpu_info.memory_total_mb / 1024
-    backend = normalize_key(gpu_info.gpu_backend)
-    if backend == "apple" or "strix-halo" in normalize_key(gpu_info.name):
+    if _has_unified_memory(gpu_info):
+        # Unified memory is shared with the OS, Docker services and the KV
+        # cache, so only a bounded share is available to the weights. Matches
+        # the installer's own selector (scripts/select-model.py).
         return max(total_gb * 0.55, 2.0)
     return total_gb
 

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -16,7 +16,7 @@ from performance_oracle import (
 )
 
 
-def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia"):
+def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia", memory_type="discrete"):
     return GPUInfo(
         name=name,
         memory_used_mb=1024,
@@ -24,6 +24,7 @@ def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia"):
         memory_percent=12.5,
         utilization_percent=0,
         temperature_c=40,
+        memory_type=memory_type,
         gpu_backend=backend,
     )
 
@@ -984,6 +985,56 @@ def test_pre_download_ranker_prefers_capable_8gb_model_over_bootstrap(data_dir):
     ranked = rank_pre_download_models(catalog, _gpu(total_mb=8188), profile="qwen", limit=2)
 
     assert ranked[0]["id"] == "qwen3.5-9b-q4"
+
+
+def _unified_memory_catalog():
+    return [
+        {
+            "id": "qwen3.5-32b-q4",
+            "name": "Qwen 3.5 32B",
+            "gguf_file": "Qwen3.5-32B-Q4_K_M.gguf",
+            "size_mb": 20000,
+            "vram_required_gb": 24,
+            "context_length": 32768,
+            "quantization": "Q4_K_M",
+            "specialty": "General",
+            "description": "Large model",
+            "llm_model_name": "qwen3.5-32b",
+        },
+        {
+            "id": "qwen3.5-12b-q4",
+            "name": "Qwen 3.5 12B",
+            "gguf_file": "Qwen3.5-12B-Q4_K_M.gguf",
+            "size_mb": 8000,
+            "vram_required_gb": 12,
+            "context_length": 32768,
+            "quantization": "Q4_K_M",
+            "specialty": "General",
+            "description": "Mid model",
+            "llm_model_name": "qwen3.5-12b",
+        },
+    ]
+
+
+def test_pre_download_ranker_bounds_unreported_unified_memory_apu(data_dir):
+    # gpu.py flags an AMD APU as unified whenever its GTT pool dwarfs the VRAM
+    # carve-out, and the reported name is whatever sysfs product_name says --
+    # not necessarily "Strix Halo". The whole 32GB pool is shared with the OS,
+    # so only a bounded share may back the weights, exactly as the installer's
+    # own selector does for unified hosts.
+    apu = _gpu(name="AMD Radeon 780M Graphics", total_mb=32768, backend="amd", memory_type="unified")
+
+    ranked = rank_pre_download_models(_unified_memory_catalog(), apu, profile="qwen", limit=2)
+
+    assert ranked[0]["id"] == "qwen3.5-12b-q4"
+
+
+def test_pre_download_ranker_uses_full_pool_for_discrete_memory(data_dir):
+    discrete = _gpu(name="AMD Radeon RX 7900 XTX", total_mb=32768, backend="amd")
+
+    ranked = rank_pre_download_models(_unified_memory_catalog(), discrete, profile="qwen", limit=2)
+
+    assert ranked[0]["id"] == "qwen3.5-32b-q4"
 
 
 def test_pre_download_ranker_accounts_for_long_context_kv_on_4gb_gpu(data_dir, tmp_path):


### PR DESCRIPTION
## Problem

`_usable_model_memory_gb()` treats the whole reported memory pool as available to model weights unless the backend is `apple` or the GPU name literally contains `strix-halo`:

```python
if backend == "apple" or "strix-halo" in normalize_key(gpu_info.name):
    return max(total_gb * 0.55, 2.0)
return total_gb
```

But `gpu.py` already decides this properly and records it. It flags an AMD APU as unified whenever the GTT pool dwarfs the VRAM carve-out, then reports `memory_type="unified"` with whatever `sysfs` `product_name` says as the name — commonly `AMD Radeon 780M Graphics`, `AMD Radeon Graphics`, etc. (`gpu.py:104-140`).

Those hosts fall through to `return total_gb`, so a 32 GB shared pool is sized as if it were 32 GB of dedicated VRAM. The ranker then recommends a model whose weights plus KV cache leave nothing for the OS, Docker services and the runtime.

Two places in the same file already disagreed: `_matching_runtime_profile()` derives unified-ness from three signals including `memory_type`, while `_usable_model_memory_gb()` only had two. The installer's own selector (`scripts/select-model.py:134-144`) treats `memory_type == "unified"` as authoritative and applies the 55% share — so dashboard and installer recommend different models on the same host.

## Fix

Extract one `_has_unified_memory()` predicate that trusts the reported `memory_type` first (keeping backend/name as fallbacks for surrogate `GPUInfo` records built from runtime contracts), and use it for both the runtime-profile match and the capacity calculation.

## Tests

`tests/test_performance_oracle.py`:
- `test_pre_download_ranker_bounds_unreported_unified_memory_apu` — a 32 GB `memory_type="unified"` APU named `AMD Radeon 780M Graphics` no longer picks the 24 GB-class model. **Fails on `main`** (`assert 'qwen3.5-32b-q4' == 'qwen3.5-12b-q4'`).
- `test_pre_download_ranker_uses_full_pool_for_discrete_memory` — the same 32 GB pool reported as `discrete` still picks the large model, proving `memory_type` is the discriminator and not just a smaller cap.

Full `dashboard-api` suite: 1881 passed (the one failure is a pre-existing Windows symlink-privilege test, unrelated).