### PR TITLE
fix(dashboard-api): stop recommending models the catalog has retired

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -204,6 +204,17 @@ def _install_recommendation_flag(raw: dict[str, Any]) -> bool:
     return normalize_key(raw.get("install_recommendation", True)) not in {"", "0", "false", "off", "no"}
 
 
+def _agent_recommendation_allowed(model: dict[str, Any]) -> bool:
+    """Keep fleet-blocked models visible without promoting them as picks."""
+    compatibility = model.get("app_compatibility")
+    if not isinstance(compatibility, dict):
+        return True
+    viability = compatibility.get("agent_viability")
+    if isinstance(viability, dict):
+        viability = viability.get("status")
+    return normalize_key(viability) != "not-agent-viable"
+
+
 def normalize_catalog_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
     """Convert config/model-library.json entries to the oracle shape."""
     if not isinstance(raw, dict):
@@ -1197,6 +1208,8 @@ def rank_pre_download_models(catalog: list[dict[str, Any]], gpu_info: Optional[G
             continue
         if not model.get("install_recommendation", True):
             continue
+        if not _agent_recommendation_allowed(model):
+            continue
         if not _family_allowed_for_profile(model, normalized_profile):
             continue
         runtime_profile = _matching_runtime_profile(model, gpu_info, system_ram_gb)
@@ -1218,6 +1231,12 @@ def rank_pre_download_models(catalog: list[dict[str, Any]], gpu_info: Optional[G
             model for model in catalog
             if (not installable_only or model.get("gguf_url"))
             and model.get("install_recommendation", True)
+            and _agent_recommendation_allowed(model)
+            and _family_allowed_for_profile(model, normalized_profile)
+        ] or [
+            model for model in catalog
+            if (not installable_only or model.get("gguf_url"))
+            and _agent_recommendation_allowed(model)
             and _family_allowed_for_profile(model, normalized_profile)
         ] or [
             model for model in catalog

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -192,6 +192,18 @@ def _model_aliases(model: dict[str, Any]) -> set[str]:
     return {alias for alias in aliases if alias}
 
 
+def _install_recommendation_flag(raw: dict[str, Any]) -> bool:
+    """Return whether the catalog still offers this entry as an install pick.
+
+    The library keeps superseded models so an existing install keeps working
+    and the UI can still describe what is on disk, but marks them
+    ``install_recommendation: false`` so nothing steers a new user onto them.
+    Absent means recommendable. Mirrors ``value_enabled`` in
+    scripts/select-model.py so a string "false" reads the same in both.
+    """
+    return normalize_key(raw.get("install_recommendation", True)) not in {"", "0", "false", "off", "no"}
+
+
 def normalize_catalog_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
     """Convert config/model-library.json entries to the oracle shape."""
     if not isinstance(raw, dict):
@@ -252,6 +264,7 @@ def normalize_catalog_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
         "context_limit_known": context_limit_known,
         "specialty": raw.get("specialty", "General"),
         "description": raw.get("description", ""),
+        "install_recommendation": _install_recommendation_flag(raw),
         "quantization": raw.get("quantization"),
         "architecture": raw.get("architecture", "dense"),
         "active_params_b": raw.get("active_params_b"),
@@ -1182,6 +1195,8 @@ def rank_pre_download_models(catalog: list[dict[str, Any]], gpu_info: Optional[G
     for model in catalog:
         if installable_only and not model.get("gguf_url"):
             continue
+        if not model.get("install_recommendation", True):
+            continue
         if not _family_allowed_for_profile(model, normalized_profile):
             continue
         runtime_profile = _matching_runtime_profile(model, gpu_info, system_ram_gb)
@@ -1196,7 +1211,15 @@ def rank_pre_download_models(catalog: list[dict[str, Any]], gpu_info: Optional[G
         })
 
     if not candidates:
+        # Degrade in the same order as scripts/select-model.py: relax the fit
+        # first, then the retirement flag, and only then the profile -- a host
+        # that fits nothing still gets a concrete suggestion.
         fallback_pool = [
+            model for model in catalog
+            if (not installable_only or model.get("gguf_url"))
+            and model.get("install_recommendation", True)
+            and _family_allowed_for_profile(model, normalized_profile)
+        ] or [
             model for model in catalog
             if (not installable_only or model.get("gguf_url")) and _family_allowed_for_profile(model, normalized_profile)
         ] or catalog

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -1318,6 +1318,88 @@ def test_jamba_reasoning_3b_catalog_profile_fits_4gb_at_agent_context(data_dir, 
     assert model["recommended"] is False
 
 
+def test_pre_download_ranker_skips_retired_catalog_entries(data_dir):
+    # The library keeps superseded models so an existing install keeps working,
+    # and marks them install_recommendation: false so nothing steers a new user
+    # onto them. The retired entry here scores higher (Code beats General, and
+    # it is the larger file), so only the flag can keep it out of the pick.
+    catalog = [
+        {
+            "id": "qwen2.5-coder-3b-128k-q4",
+            "name": "Qwen 2.5 Coder 3B",
+            "gguf_file": "Qwen2.5-Coder-3B-Q4_K_M.gguf",
+            "gguf_url": "https://example.invalid/coder.gguf",
+            "size_mb": 1930,
+            "vram_required_gb": 4,
+            "context_length": 131072,
+            "quantization": "Q4_K_M",
+            "specialty": "Code",
+            "description": "Superseded coder model",
+            "llm_model_name": "qwen2.5-coder-3b",
+            "install_recommendation": False,
+        },
+        {
+            "id": "qwen3.5-2b-q4",
+            "name": "Qwen 3.5 2B",
+            "gguf_file": "Qwen3.5-2B-Q4_K_M.gguf",
+            "gguf_url": "https://example.invalid/qwen.gguf",
+            "size_mb": 1500,
+            "vram_required_gb": 3,
+            "context_length": 8192,
+            "quantization": "Q4_K_M",
+            "specialty": "General",
+            "description": "Current model",
+            "llm_model_name": "qwen3.5-2b",
+        },
+    ]
+    normalized = [normalize_catalog_entry(entry) for entry in catalog]
+
+    ranked = rank_pre_download_models(normalized, _gpu(total_mb=4096), profile="qwen", limit=2)
+
+    assert [model["id"] for model in ranked] == ["qwen3.5-2b-q4"]
+
+
+def test_pre_download_ranker_falls_back_to_retired_entry_when_nothing_else_fits(data_dir):
+    # A retired entry is still better than no suggestion at all, so it stays in
+    # the fallback pool once the recommendable pool is empty.
+    catalog = [normalize_catalog_entry({
+        "id": "qwen2.5-1.5b-instruct-q4",
+        "name": "Qwen 2.5 1.5B",
+        "gguf_file": "Qwen2.5-1.5B-Q4_K_M.gguf",
+        "gguf_url": "https://example.invalid/legacy.gguf",
+        "size_mb": 1120,
+        "vram_required_gb": 3,
+        "context_length": 32768,
+        "quantization": "Q4_K_M",
+        "specialty": "Fast",
+        "description": "Only entry in this library",
+        "llm_model_name": "qwen2.5-1.5b",
+        "install_recommendation": False,
+    })]
+
+    ranked = rank_pre_download_models(catalog, _gpu(total_mb=4096), profile="qwen", limit=2)
+
+    assert [model["id"] for model in ranked] == ["qwen2.5-1.5b-instruct-q4"]
+
+
+def test_real_catalog_recommendations_are_never_retired_entries(data_dir):
+    raw_catalog = _official_model_catalog()
+    retired = {
+        model["id"] for model in raw_catalog
+        if model.get("install_recommendation") is False
+    }
+    assert retired, "expected the shipped catalog to retire at least one entry"
+    catalog = [entry for entry in (normalize_catalog_entry(raw) for raw in raw_catalog) if entry]
+
+    for total_mb in (4096, 8188, 12288, 24576):
+        ranked = rank_pre_download_models(
+            catalog, _gpu(total_mb=total_mb), profile="qwen", limit=3
+        )
+        offered = {model["id"] for model in ranked}
+
+        assert not offered & retired, f"{total_mb}MB GPU was offered retired entries: {sorted(offered & retired)}"
+
+
 def test_pre_download_ranker_falls_back_to_smallest_model_without_gpu_info(data_dir):
     catalog = [
         _model(),


### PR DESCRIPTION
## Problem

`config/model-library.json` keeps superseded entries so an existing install keeps working and the UI can still describe what is on disk, and marks **32 of its 52 models** `install_recommendation: false` so nothing steers a new user onto them.

`scripts/select-model.py` honors that flag (`install_recommendation_allowed()`). The dashboard never saw it:

- `normalize_catalog_entry()` did not copy `install_recommendation` into the oracle shape at all, so the field was gone before any ranking happened.
- `rank_pre_download_models()` only filtered on `gguf_url`.

So the two rankers disagree on identical hardware:

| GPU | `select-model.py --installable-only` | dashboard `rank_pre_download_models` (top 3) |
|---|---|---|
| 4 GB | `qwen3.5-2b` | `qwen2.5-coder-1.5b-128k-q4` ❌, `qwen2.5-coder-3b-128k-q4` ❌, `granite3.3-2b-instruct-q4` ❌ |
| 8 GB | `qwen3.5-9b` | `qwen2.5-coder-3b-128k-q4` ❌, `qwen2.5-coder-1.5b-128k-q4` ❌, `qwen3.5-9b-q4` |
| 12 GB | — | `phi4-q4`, `qwen2.5-coder-3b-128k-q4` ❌, `qwen3.5-9b-q4` |
| 24 GB | — | `qwen3.5-27b-q4`, `deepseek-r1-32b-q4`, `mistral-nemo-12b-instruct-q4` ❌ |

(❌ = `install_recommendation: false`)

It is not a near miss. Retired entries carry `Code` (4.4) and `Long Context` specialties, which outweigh `General` (3.8) in the scoring table both rankers share — so on the smaller cards they took the *top* recommendation slot precisely because they were retired-but-unfiltered.

`recommended_entry` feeds the "Recommended" badge and `recommendationAlternatives` in the models payload, so this is what a fresh dashboard user is told to install.

## Fix

- `_install_recommendation_flag()` carries the flag through `normalize_catalog_entry()`, mirroring `value_enabled()` in `select-model.py` so a string `"false"` reads the same in both.
- `rank_pre_download_models()` skips retired entries, and degrades in the same order as `select-model.py`: relax the fit first, then the retirement flag, then the profile — a host that fits nothing still gets a concrete suggestion.

Retired models stay listed in the library payload; only the recommendation changes. After the fix the dashboard's top pick matches the installer exactly (4 GB → `qwen3.5-2b-q4`, 8 GB → `qwen3.5-9b-q4`).

## Tests

`tests/test_performance_oracle.py`:
- `test_pre_download_ranker_skips_retired_catalog_entries` — retired entry scores higher (Code beats General, larger file) so only the flag can keep it out. **Fails on `main`.**
- `test_real_catalog_recommendations_are_never_retired_entries` — runs the shipped catalog across 4/8/12/24 GB. **Fails on `main`** with `4096MB GPU was offered retired entries: ['granite3.3-2b-instruct-q4', 'qwen2.5-coder-1.5b-128k-q4', 'qwen2.5-coder-3b-128k-q4']`.
- `test_pre_download_ranker_falls_back_to_retired_entry_when_nothing_else_fits` — pins the degrade path so the filter can't turn into "no suggestion at all".

Full `dashboard-api` suite: 1882 passed (the one failure is a pre-existing Windows symlink-privilege test, unrelated).