### PR TITLE
fix(dashboard-api): keep coder-next out of unified-memory recommendations

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -685,6 +685,20 @@ def _selector_required_memory_gb(model: dict[str, Any]) -> float:
     return round(max(declared, size_gb + context_kv_gb), 2)
 
 
+# qwen3-coder-next Q4_K_M decodes every token as `?` on unified-memory
+# backends: verified on DGX Spark / GB10 aarch64 and again on Strix Halo, with
+# Qwen3.6-35B-A3B serving cleanly on the same build and hardware. See the
+# NV_ULTRA and SH_LARGE blocks in installers/lib/tier-map.sh for the full
+# write-up. The installer routes around it in scripts/select-model.py; keep it
+# out of the dashboard's recommendations too rather than pointing a user at a
+# 48.5GB download that cannot produce readable output on their machine.
+_UNIFIED_MEMORY_EXCLUDED_MODELS = frozenset({"qwen3-coder-next"})
+
+
+def _excluded_on_unified_memory(model: dict[str, Any]) -> bool:
+    return normalize_key(model.get("llm_model_name")) in _UNIFIED_MEMORY_EXCLUDED_MODELS
+
+
 def _has_unified_memory(gpu_info: Optional[GPUInfo]) -> bool:
     """Return whether the detected GPU shares its memory pool with the host.
 
@@ -1134,10 +1148,13 @@ def rank_pre_download_models(catalog: list[dict[str, Any]], gpu_info: Optional[G
 
     normalized_profile = _model_profile(explicit_profile=profile)
     capacity_gb = _usable_model_memory_gb(gpu_info) if gpu_info else 4.0
+    unified_memory = _has_unified_memory(gpu_info)
 
     candidates = []
     for model in catalog:
         if installable_only and not model.get("gguf_url"):
+            continue
+        if unified_memory and _excluded_on_unified_memory(model):
             continue
         if not _family_allowed_for_profile(model, normalized_profile):
             continue
@@ -1155,7 +1172,12 @@ def rank_pre_download_models(catalog: list[dict[str, Any]], gpu_info: Optional[G
     if not candidates:
         fallback_pool = [
             model for model in catalog
-            if (not installable_only or model.get("gguf_url")) and _family_allowed_for_profile(model, normalized_profile)
+            if (not installable_only or model.get("gguf_url"))
+            and not (unified_memory and _excluded_on_unified_memory(model))
+            and _family_allowed_for_profile(model, normalized_profile)
+        ] or [
+            model for model in catalog
+            if not (unified_memory and _excluded_on_unified_memory(model))
         ] or catalog
         fallback = min(fallback_pool, key=lambda m: float(m.get("vram_required_gb") or 999))
         candidates = [{"model": fallback, "score": -1.0}]

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -685,18 +685,30 @@ def _selector_required_memory_gb(model: dict[str, Any]) -> float:
     return round(max(declared, size_gb + context_kv_gb), 2)
 
 
+def _has_unified_memory(gpu_info: Optional[GPUInfo]) -> bool:
+    """Return whether the detected GPU shares its memory pool with the host.
+
+    The reported `memory_type` is the authoritative signal: `gpu.py` sets it to
+    "unified" for Apple Silicon and for any AMD APU whose GTT pool dwarfs its
+    carve-out VRAM, whatever the sysfs product name happens to be. Backend and
+    name are kept as fallbacks for surrogate GPUInfo records built from runtime
+    contracts that predate the field.
+    """
+    if not gpu_info:
+        return False
+    return (
+        normalize_key(gpu_info.gpu_backend) == "apple"
+        or normalize_key(getattr(gpu_info, "memory_type", "")) == "unified"
+        or "strix-halo" in normalize_key(gpu_info.name)
+    )
+
+
 def _matching_runtime_profile(model: dict[str, Any], gpu_info: Optional[GPUInfo],
                               system_ram_gb: int | None = None) -> dict[str, Any] | None:
     if not gpu_info:
         return None
     backend = normalize_key(gpu_info.gpu_backend)
-    memory_type = (
-        "unified"
-        if backend == "apple"
-        or normalize_key(getattr(gpu_info, "memory_type", "")) == "unified"
-        or "strix-halo" in normalize_key(gpu_info.name)
-        else "discrete"
-    )
+    memory_type = "unified" if _has_unified_memory(gpu_info) else "discrete"
     host_arch = _normalize_host_arch(platform.machine())
     vram_gb = float(gpu_info.memory_total_mb or 0) / 1024.0
     ram_gb = system_ram_gb if system_ram_gb is not None else _system_ram_gb()
@@ -743,8 +755,10 @@ def _usable_model_memory_gb(gpu_info: Optional[GPUInfo]) -> float:
     if not gpu_info:
         return 0.0
     total_gb = gpu_info.memory_total_mb / 1024
-    backend = normalize_key(gpu_info.gpu_backend)
-    if backend == "apple" or "strix-halo" in normalize_key(gpu_info.name):
+    if _has_unified_memory(gpu_info):
+        # Unified memory is shared with the OS, Docker services and the KV
+        # cache, so only a bounded share is available to the weights. Matches
+        # the installer's own selector (scripts/select-model.py).
         return max(total_gb * 0.55, 2.0)
     return total_gb
 

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -16,7 +16,7 @@ from performance_oracle import (
 )
 
 
-def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia"):
+def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia", memory_type="discrete"):
     return GPUInfo(
         name=name,
         memory_used_mb=1024,
@@ -24,6 +24,7 @@ def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia"):
         memory_percent=12.5,
         utilization_percent=0,
         temperature_c=40,
+        memory_type=memory_type,
         gpu_backend=backend,
     )
 
@@ -984,6 +985,56 @@ def test_pre_download_ranker_prefers_capable_8gb_model_over_bootstrap(data_dir):
     ranked = rank_pre_download_models(catalog, _gpu(total_mb=8188), profile="qwen", limit=2)
 
     assert ranked[0]["id"] == "qwen3.5-9b-q4"
+
+
+def _unified_memory_catalog():
+    return [
+        {
+            "id": "qwen3.5-32b-q4",
+            "name": "Qwen 3.5 32B",
+            "gguf_file": "Qwen3.5-32B-Q4_K_M.gguf",
+            "size_mb": 20000,
+            "vram_required_gb": 24,
+            "context_length": 32768,
+            "quantization": "Q4_K_M",
+            "specialty": "General",
+            "description": "Large model",
+            "llm_model_name": "qwen3.5-32b",
+        },
+        {
+            "id": "qwen3.5-12b-q4",
+            "name": "Qwen 3.5 12B",
+            "gguf_file": "Qwen3.5-12B-Q4_K_M.gguf",
+            "size_mb": 8000,
+            "vram_required_gb": 12,
+            "context_length": 32768,
+            "quantization": "Q4_K_M",
+            "specialty": "General",
+            "description": "Mid model",
+            "llm_model_name": "qwen3.5-12b",
+        },
+    ]
+
+
+def test_pre_download_ranker_bounds_unreported_unified_memory_apu(data_dir):
+    # gpu.py flags an AMD APU as unified whenever its GTT pool dwarfs the VRAM
+    # carve-out, and the reported name is whatever sysfs product_name says --
+    # not necessarily "Strix Halo". The whole 32GB pool is shared with the OS,
+    # so only a bounded share may back the weights, exactly as the installer's
+    # own selector does for unified hosts.
+    apu = _gpu(name="AMD Radeon 780M Graphics", total_mb=32768, backend="amd", memory_type="unified")
+
+    ranked = rank_pre_download_models(_unified_memory_catalog(), apu, profile="qwen", limit=2)
+
+    assert ranked[0]["id"] == "qwen3.5-12b-q4"
+
+
+def test_pre_download_ranker_uses_full_pool_for_discrete_memory(data_dir):
+    discrete = _gpu(name="AMD Radeon RX 7900 XTX", total_mb=32768, backend="amd")
+
+    ranked = rank_pre_download_models(_unified_memory_catalog(), discrete, profile="qwen", limit=2)
+
+    assert ranked[0]["id"] == "qwen3.5-32b-q4"
 
 
 def test_pre_download_ranker_accounts_for_long_context_kv_on_4gb_gpu(data_dir, tmp_path):

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -1037,6 +1037,60 @@ def test_pre_download_ranker_uses_full_pool_for_discrete_memory(data_dir):
     assert ranked[0]["id"] == "qwen3.5-32b-q4"
 
 
+def _unified_host_gpu(backend, name):
+    return _gpu(name=name, total_mb=126976, backend=backend, memory_type="unified")
+
+
+def test_real_catalog_never_recommends_coder_next_on_unified_memory(data_dir):
+    # qwen3-coder-next Q4_K_M decodes every token as `?` on unified-memory
+    # backends -- see the NV_ULTRA and SH_LARGE blocks in tier-map.sh. The
+    # installer substitutes it away; the dashboard must not offer it either.
+    catalog = [entry for entry in (normalize_catalog_entry(raw) for raw in _official_model_catalog()) if entry]
+
+    for backend, name in (("amd", "AMD Radeon Graphics"), ("nvidia", "NVIDIA GB10")):
+        ranked = rank_pre_download_models(
+            catalog, _unified_host_gpu(backend, name), profile="qwen", limit=3, system_ram_gb=128
+        )
+        offered = [model["llm_model_name"] for model in ranked]
+
+        assert "qwen3-coder-next" not in offered, f"{name} was offered coder-next: {offered}"
+
+
+def test_real_catalog_still_recommends_coder_next_on_discrete_vram(data_dir):
+    # The exclusion is unified-memory-specific: coder-next serves correctly on
+    # a discrete card with the VRAM to hold it.
+    catalog = [entry for entry in (normalize_catalog_entry(raw) for raw in _official_model_catalog()) if entry]
+
+    ranked = rank_pre_download_models(
+        catalog, _gpu(name="NVIDIA RTX 6000 Ada", total_mb=98304), profile="qwen", limit=3, system_ram_gb=128
+    )
+
+    assert "qwen3-coder-next" in [model["llm_model_name"] for model in ranked]
+
+
+def test_unified_memory_exclusion_still_returns_a_fallback(data_dir):
+    # An excluded model must never leave the ranker with nothing to say.
+    catalog = [normalize_catalog_entry({
+        "id": "qwen3-coder-next-q4",
+        "name": "Qwen 3 Coder Next",
+        "family": "qwen",
+        "gguf_file": "qwen3-coder-next-Q4_K_M.gguf",
+        "gguf_url": "https://example.invalid/coder-next.gguf",
+        "size_mb": 48500,
+        "vram_required_gb": 52,
+        "context_length": 131072,
+        "quantization": "Q4_K_M",
+        "specialty": "Code",
+        "llm_model_name": "qwen3-coder-next",
+    })]
+
+    ranked = rank_pre_download_models(
+        catalog, _unified_host_gpu("amd", "AMD Radeon Graphics"), profile="qwen", limit=3, system_ram_gb=128
+    )
+
+    assert [model["id"] for model in ranked] == ["qwen3-coder-next-q4"]
+
+
 def test_pre_download_ranker_accounts_for_long_context_kv_on_4gb_gpu(data_dir, tmp_path):
     catalog = [
         {


### PR DESCRIPTION
> Stacked on #2122 — the diff here is the last commit only. Both touch `performance_oracle.py` but different functions; happy to rebase if #2122 lands differently.

## Problem

`qwen3-coder-next` Q4_K_M decodes **every token as `?`** on unified-memory backends. This is a verified, documented finding, not a suspicion — from `installers/lib/tier-map.sh`:

> NV_ULTRA on aarch64 (DGX Spark / GB10): qwen3-coder-next MoE Q4_K_M produces all-`?` tokens on every chat completion against llama.cpp b9014 on Blackwell-aarch64 (SHA256 verifies, server starts cleanly, decode rate is normal, but every token is `?`). Verified bug is coder-next-specific, not a general MoE kernel bug: Qwen3.6-35B-A3B (UD-Q4_K_M) serves cleanly on the same build, same hardware.

> Strix Halo (AMD Ryzen AI MAX+ 395, 124GB unified) hits the same MoE-on-unified-memory pathology […] Verified on strix-halo 2026-05-19: bootstrap-upgrade downloaded the 48.5GB coder-next-Q4_K_M.gguf, stalled at 91%, and the model would not have worked on this hardware even if the download completed.

The installer acts on this — `scripts/select-model.py`'s `arch_policy_model()` substitutes Qwen3.6-35B-A3B via the `spark-aarch64-nv-ultra-a3b-v1` / `unified-memory-coder-next-a3b-v1` policies. The dashboard's `rank_pre_download_models()` has no equivalent, so on the same hosts:

| Host | `select-model.py --installable-only` | dashboard top 3 (on `main`) |
|---|---|---|
| Strix Halo 124 GB unified | `qwen3.6-35b-a3b` | **`qwen3-coder-next-q4`**, `qwen3.5-122b-a10b-q4`, `llama4-scout-q4` |
| Spark GB10 128 GB unified | `qwen3.6-35b-a3b` | **`qwen3-coder-next-q4`**, `qwen3.5-122b-a10b-q4`, `llama4-scout-q4` |

It takes the *top* slot on both: `Code` (4.4) is the highest specialty weight and 48.5 GB maxes the capability term. So a Strix Halo or Spark owner opening the models page is pointed at a 48.5 GB download that cannot produce readable output on their machine.

## Fix

Skip the entry while ranking on a unified-memory host, keyed on `llm_model_name` the same way `select-model.py`'s `is_spark_aarch64_excluded_model()` is. The exclusion is left out of the last-resort fallback tier so the ranker still returns something rather than nothing.

This is deliberately an exclusion, not a port of the installer's substitution policy — the ranker already picks the best remaining fit, and duplicating installer policy in the dashboard is one more thing to drift.

After the fix, unified hosts get `deepseek-r1-70b-q4`, `qwen3.5-35b-a3b-q4`, `qwen3.6-35b-a3b-ud-q4`; a discrete RTX 6000 Ada 96 GB still gets `qwen3-coder-next-q4` first, since coder-next is fine there.

## Tests

`tests/test_performance_oracle.py`, all against the shipped catalog:
- `test_real_catalog_never_recommends_coder_next_on_unified_memory` — both AMD and NVIDIA unified hosts. **Fails on the base branch**: `AMD Radeon Graphics was offered coder-next: ['qwen3-coder-next', 'deepseek-r1-distill-llama-70b', 'qwen3.5-35b-a3b']`.
- `test_real_catalog_still_recommends_coder_next_on_discrete_vram` — pins that the exclusion is unified-memory-specific and doesn't quietly retire the model everywhere.
- `test_unified_memory_exclusion_still_returns_a_fallback` — an excluded model must never leave the ranker with nothing to say.

Full `dashboard-api` suite: 1884 passed (the one failure is a pre-existing Windows symlink-privilege test, unrelated).