### PR TITLE
fix(compose): keep llama.cpp runtime tunables on the Intel and Arc overlays

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -56,6 +56,7 @@ test: ## Run unit and contract tests
 	@echo "=== Overlay/plist contracts ==="
 	@bash tests/contracts/test-overlay-map-coherence.sh
 	@bash tests/contracts/test-plist-log-paths.sh
+	@python3 tests/contracts/test-llama-runtime-tunables.py
 	@echo ""
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh

--- a/ods/docker-compose.arc.yml
+++ b/ods/docker-compose.arc.yml
@@ -55,6 +55,15 @@ services:
       - "${N_GPU_LAYERS:-99}"
       - --ctx-size
       - "${CTX_SIZE:-32768}"
+      # Compose replaces `command` wholesale rather than merging it, so the
+      # documented runtime tunables have to be repeated here or they go inert
+      # on this overlay.
+      - --batch-size
+      - "${LLAMA_BATCH_SIZE:-2048}"
+      - --threads
+      - "${LLAMA_THREADS:-4}"
+      - --parallel
+      - "${LLAMA_PARALLEL:-1}"
       - --metrics
     deploy:
       resources:

--- a/ods/docker-compose.intel.yml
+++ b/ods/docker-compose.intel.yml
@@ -37,6 +37,15 @@ services:
       - "${N_GPU_LAYERS:-99}"
       - --ctx-size
       - "${CTX_SIZE:-32768}"
+      # Compose replaces `command` wholesale rather than merging it, so the
+      # documented runtime tunables have to be repeated here or they go inert
+      # on this overlay.
+      - --batch-size
+      - "${LLAMA_BATCH_SIZE:-2048}"
+      - --threads
+      - "${LLAMA_THREADS:-4}"
+      - --parallel
+      - "${LLAMA_PARALLEL:-1}"
       - --metrics
     deploy:
       resources:

--- a/ods/tests/contracts/test-llama-runtime-tunables.py
+++ b/ods/tests/contracts/test-llama-runtime-tunables.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""llama.cpp runtime tunable parity across compose overlays.
+
+Docker Compose replaces a `command` sequence wholesale instead of merging it
+with the base file's. Any overlay that overrides llama-server's command
+therefore has to repeat every flag it still wants, and a flag left out makes
+its documented .env tunable silently inert on that backend only.
+
+This checks that every overlay whose llama-server command is a llama.cpp
+invocation carries the same flag set as docker-compose.base.yml, and that each
+tunable is wired to the .env variable the schema documents.
+
+The AMD overlays are exempt: their llama-server runs Lemonade (`serve ...`),
+a different binary with its own argument surface.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+try:
+    import yaml
+except ModuleNotFoundError as exc:
+    print(f"[FAIL] Missing Python dependency: {exc}")
+    raise SystemExit(1)
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+BASE_FILE = ROOT_DIR / "docker-compose.base.yml"
+SCHEMA_FILE = ROOT_DIR / ".env.schema.json"
+
+# Flags whose value must stay operator-tunable through .env. The base file is
+# the source of truth for which variable backs each one.
+TUNABLE_FLAGS = ("--ctx-size", "--batch-size", "--threads", "--parallel")
+VAR_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)")
+
+
+def llama_command(path: Path) -> list[str] | None:
+    document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    service = (document.get("services") or {}).get("llama-server") or {}
+    command = service.get("command")
+    if not isinstance(command, list):
+        return None
+    return [str(item) for item in command]
+
+
+def is_llama_cpp_invocation(command: list[str]) -> bool:
+    """Lemonade overlays start with a `serve` subcommand; llama.cpp takes flags."""
+    return bool(command) and command[0].startswith("-")
+
+
+def flag_values(command: list[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for index, token in enumerate(command):
+        if token.startswith("--"):
+            following = command[index + 1] if index + 1 < len(command) else ""
+            values[token] = "" if following.startswith("--") else following
+    return values
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    base_command = llama_command(BASE_FILE)
+    if base_command is None:
+        print(f"[FAIL] {BASE_FILE.name} does not define a llama-server command list")
+        return 1
+    base_values = flag_values(base_command)
+
+    schema_properties = json.loads(SCHEMA_FILE.read_text(encoding="utf-8")).get("properties", {})
+    for flag in TUNABLE_FLAGS:
+        if flag not in base_values:
+            errors.append(f"{BASE_FILE.name}: base command no longer sets {flag}")
+            continue
+        variables = VAR_RE.findall(base_values[flag])
+        if not variables:
+            errors.append(f"{BASE_FILE.name}: {flag} is hardcoded to {base_values[flag]!r}, not .env-tunable")
+            continue
+        for variable in variables:
+            if variable not in schema_properties:
+                errors.append(f".env.schema.json: {flag} uses undocumented variable {variable}")
+
+    for path in sorted(ROOT_DIR.glob("docker-compose*.yml")):
+        if path == BASE_FILE:
+            continue
+        command = llama_command(path)
+        if command is None or not is_llama_cpp_invocation(command):
+            continue
+        values = flag_values(command)
+        for flag in base_values:
+            if flag not in values:
+                errors.append(
+                    f"{path.name}: llama-server command drops {flag}; compose replaces the "
+                    f"whole list, so it is lost on this backend"
+                )
+                continue
+            if flag not in TUNABLE_FLAGS:
+                continue
+            # The overlay may pick its own default, but it must stay tunable
+            # through the same .env variable the base file uses.
+            expected = set(VAR_RE.findall(base_values[flag]))
+            actual = set(VAR_RE.findall(values[flag]))
+            if expected and not expected & actual:
+                errors.append(
+                    f"{path.name}: {flag} is {values[flag]!r}, which ignores "
+                    f"{'/'.join(sorted(expected))} from {BASE_FILE.name}"
+                )
+
+    if errors:
+        print("[FAIL] llama.cpp runtime tunable parity")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("[PASS] llama.cpp runtime tunables survive every compose overlay")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Docker Compose **replaces** a `command` sequence when merging files — it does not append to the base file's. So any overlay that overrides `llama-server`'s command has to repeat every flag it still wants.

`docker-compose.arc.yml` and `docker-compose.intel.yml` re-declare the command to set their own `--n-gpu-layers ${N_GPU_LAYERS:-99}` and `--ctx-size ${CTX_SIZE:-32768}`, and in doing so silently drop three flags the base file sets:

```
base:  --model … --host 0.0.0.0 --port 8080 --n-gpu-layers 999 --ctx-size …        --batch-size ${LLAMA_BATCH_SIZE:-2048} --threads ${LLAMA_THREADS:-4}        --parallel ${LLAMA_PARALLEL:-1} --metrics

arc:   --model … --host 0.0.0.0 --port 8080 --n-gpu-layers … --ctx-size … --metrics
intel: --model … --host 0.0.0.0 --port 8080 --n-gpu-layers … --ctx-size … --metrics
```

All three are documented, schema-validated operator tunables:

| variable | `.env.schema.json` |
|---|---|
| `LLAMA_BATCH_SIZE` | "llama.cpp prompt processing batch size…" (default 2048) |
| `LLAMA_THREADS` | "CPU threads for llama.cpp non-GPU work." (default 4) |
| `LLAMA_PARALLEL` | "llama.cpp `--parallel` request slots…" (default 1) |

They are listed in `.env.example:193-195`, and `installers/phases/06-directories.sh:755` writes `LLAMA_PARALLEL` into every generated `.env`. On an Intel or Arc install, setting any of them did nothing — the variable was never referenced by the resolved command — while every other backend honored it. `docker-compose.cpu.yml` keeps all three, so this is specific to the two SYCL overlays.

## Fix

Restore the three flags on both overlays. Each keeps its own `--n-gpu-layers` / `--ctx-size` choices; only the dropped tunables come back.

## Tests

New `tests/contracts/test-llama-runtime-tunables.py`, wired into `make test` beside the other overlay contracts. It compares every overlay whose `llama-server` command is a llama.cpp invocation against the base file's flag set, and additionally checks each tunable is still wired to the `.env` variable the schema documents (an overlay may pick a different default, but not hardcode the value). The AMD overlays are skipped by design — their `llama-server` runs Lemonade (`serve …`), a different binary with its own argument surface.

On `main` it reports exactly the regression:

```
[FAIL] llama.cpp runtime tunable parity
  - docker-compose.arc.yml: llama-server command drops --batch-size; compose replaces the whole list, so it is lost on this backend
  - docker-compose.arc.yml: llama-server command drops --threads; …
  - docker-compose.arc.yml: llama-server command drops --parallel; …
  - docker-compose.intel.yml: llama-server command drops --batch-size; …
  - docker-compose.intel.yml: llama-server command drops --threads; …
  - docker-compose.intel.yml: llama-server command drops --parallel; …
```

Also green: `tests/contracts/test-overlay-map-coherence.sh`, `scripts/validate-golden-paths.py`.