### PR TITLE
feat(routing): add remote provider route state

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -93,6 +93,24 @@ OPEN_WEBUI_LLM_BASE_URL=
 OPEN_WEBUI_LLM_API_KEY=
 # LLM_URL=                  # Optional dashboard-api diagnostics override; normally follows LLM_API_URL
 
+# Remote GPU provider metadata. Remote routing is active only when
+# ODS_MODE=cloud and REMOTE_LLM_ENABLED=true. Provider API keys, peer tokens,
+# SSH identities, and CA material are write-only lifecycle inputs; do not put
+# them in .env.
+REMOTE_LLM_ENABLED=false
+REMOTE_LLM_TRANSPORT=
+REMOTE_LLM_BASE_URL=
+REMOTE_LLM_MODEL=
+REMOTE_LLM_TLS_CA_FILE=
+REMOTE_LLM_SSH_HOST=
+REMOTE_LLM_SSH_USER=
+REMOTE_LLM_SSH_PORT=
+REMOTE_LLM_SSH_INFERENCE_HOST=
+REMOTE_LLM_SSH_INFERENCE_PORT=
+REMOTE_LLM_SSH_CONTROL_HOST=
+REMOTE_LLM_SSH_CONTROL_PORT=
+REMOTE_ODS_PEER_URL=
+
 # ODS Talk image attachment vision backend. Leave empty to use the local
 # inference backend. May be a host root (http://host:8080) or an
 # OpenAI-compatible base URL (http://host:8080/v1 or /api/v1).

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -55,6 +55,76 @@
       "type": "string",
       "description": "LLM base URL used by dashboard-api functional diagnostics. Leave empty to follow LLM_API_URL inside the Docker network."
     },
+    "REMOTE_LLM_ENABLED": {
+      "type": "string",
+      "description": "Explicit remote-provider switch. Remote routing is valid only with ODS_MODE=cloud.",
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
+      "default": "false"
+    },
+    "REMOTE_LLM_TRANSPORT": {
+      "type": "string",
+      "description": "Remote provider transport profile: direct HTTPS or SSH transport.",
+      "enum": [
+        "",
+        "direct",
+        "ssh"
+      ],
+      "default": ""
+    },
+    "REMOTE_LLM_BASE_URL": {
+      "type": "string",
+      "description": "Remote OpenAI-compatible provider API root. The renderer normalizes host roots to /v1."
+    },
+    "REMOTE_LLM_MODEL": {
+      "type": "string",
+      "description": "Concrete remote model ID advertised by the provider."
+    },
+    "REMOTE_LLM_TLS_CA_FILE": {
+      "type": "string",
+      "description": "Optional private CA path for the remote provider transport. CA material is not stored in .env."
+    },
+    "REMOTE_LLM_SSH_HOST": {
+      "type": "string",
+      "description": "Explicit SSH server host used by the remote provider transport."
+    },
+    "REMOTE_LLM_SSH_USER": {
+      "type": "string",
+      "description": "Explicit SSH user used by the remote provider transport."
+    },
+    "REMOTE_LLM_SSH_PORT": {
+      "type": "integer",
+      "description": "SSH server port used by the remote provider transport.",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "REMOTE_LLM_SSH_INFERENCE_HOST": {
+      "type": "string",
+      "description": "Inference address as seen from the SSH server for SSH transport."
+    },
+    "REMOTE_LLM_SSH_INFERENCE_PORT": {
+      "type": "integer",
+      "description": "Inference port as seen from the SSH server for SSH transport.",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "REMOTE_LLM_SSH_CONTROL_HOST": {
+      "type": "string",
+      "description": "Optional ODS peer-control address as seen from the SSH server."
+    },
+    "REMOTE_LLM_SSH_CONTROL_PORT": {
+      "type": "integer",
+      "description": "Optional ODS peer-control port as seen from the SSH server.",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "REMOTE_ODS_PEER_URL": {
+      "type": "string",
+      "description": "Optional paired ODS control-plane root for authenticated ODS peer lifecycle support."
+    },
     "LLM_BACKEND": {
       "type": "string",
       "description": "Inference backend: llama-server or lemonade",

--- a/ods/config/generated-config-contracts.json
+++ b/ods/config/generated-config-contracts.json
@@ -322,6 +322,37 @@
       ]
     },
     {
+      "id": "remote-routing-state",
+      "label": "Remote provider routing receipt",
+      "target_paths": [
+        "data/remote-provider/routing-state.json"
+      ],
+      "writers": [
+        {
+          "platform": "canonical-renderer",
+          "path": "scripts/render-runtime-configs.py"
+        }
+      ],
+      "invariants": [
+        {
+          "id": "renderer-emits-remote-routing-state",
+          "type": "file_contains",
+          "path": "scripts/render-runtime-configs.py",
+          "needle": "def render_remote_routing_state"
+        },
+        {
+          "id": "schema-covers-remote-switch",
+          "type": "json_path_enum_contains",
+          "path": ".env.schema.json",
+          "json_path": "properties.REMOTE_LLM_ENABLED.enum",
+          "values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
       "id": "perplexica",
       "label": "Perplexica settings and default chat model",
       "target_paths": [

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import stat
 import sys
 import tempfile
@@ -27,6 +28,9 @@ DEFAULT_CONTEXT = 131072
 DEFAULT_HERMES_MAX_TOKENS = 1024
 DEFAULT_LITELLM_KEY = "sk-lemonade"
 NO_KEY = "no-key"
+PUBLIC_MODEL_ALIAS = "ods/current"
+REMOTE_PROVIDER_EGRESS_BASE_URL = "http://remote-provider-egress:8091/v1"
+REMOTE_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,255}$")
 
 
 def atomic_write_text(target: Path, content: str) -> None:
@@ -83,6 +87,10 @@ class RenderInputs:
     litellm_key: str
     opencode_port: int
     context_length: int
+    remote_llm_enabled: bool = False
+    remote_llm_transport: str = ""
+    remote_llm_base_url: str = ""
+    remote_llm_model: str = ""
     # Switchboard rollout mode: legacy | observe | enabled (plan section 8)
     switchboard_mode: str = "observe"
 
@@ -96,6 +104,24 @@ class RenderedFile:
 
 def ensure_trailing_newline(text: str) -> str:
     return text if text.endswith("\n") else f"{text}\n"
+
+
+def yaml_scalar(value: str) -> str:
+    """Emit a JSON string, which is also a safe YAML scalar."""
+    return json.dumps(value)
+
+
+def normalize_openai_base_url(value: str) -> str:
+    base_url = value.strip().rstrip("/")
+    if not base_url:
+        return ""
+    if base_url.endswith("/v1") or base_url.endswith("/api/v1"):
+        return base_url
+    return f"{base_url}/v1"
+
+
+def remote_route_enabled(inputs: RenderInputs) -> bool:
+    return inputs.remote_llm_enabled
 
 
 def lemonade_model_id(inputs: RenderInputs) -> str:
@@ -184,6 +210,43 @@ litellm_settings:
 
 
 def render_litellm_cloud(inputs: RenderInputs) -> RenderedFile:
+    if remote_route_enabled(inputs):
+        model = inputs.remote_llm_model.strip()
+        model_param = yaml_scalar(f"openai/{model}")
+        egress_base = yaml_scalar(REMOTE_PROVIDER_EGRESS_BASE_URL)
+        content = f"""model_list:
+  # Stable public alias used by ODS consumers. Provider credentials stay in
+  # remote-provider-egress, never in LiteLLM YAML or generated public config.
+  - model_name: {PUBLIC_MODEL_ALIAS}
+    litellm_params:
+      model: {model_param}
+      api_base: {egress_base}
+      api_key: not-needed
+
+  - model_name: default
+    litellm_params:
+      model: {model_param}
+      api_base: {egress_base}
+      api_key: not-needed
+
+  - model_name: {yaml_scalar(model)}
+    litellm_params:
+      model: {model_param}
+      api_base: {egress_base}
+      api_key: not-needed
+
+router_settings:
+  routing_strategy: simple-shuffle
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+"""
+        return RenderedFile("litellm-cloud", "config/litellm/cloud.yaml", content)
+
     content = """model_list:
   # Stable public alias used by Switchboard-aware ODS consumers.
   - model_name: ods/current
@@ -423,6 +486,13 @@ def render_env(inputs: RenderInputs) -> RenderedFile:
             "OPEN_WEBUI_LLM_BASE_URL=http://litellm:4000",
             f"OPEN_WEBUI_LLM_API_KEY={inputs.litellm_key}",
         ])
+    if remote_route_enabled(inputs):
+        lines.extend([
+            "REMOTE_LLM_ENABLED=true",
+            f"REMOTE_LLM_TRANSPORT={inputs.remote_llm_transport}",
+            f"REMOTE_LLM_BASE_URL={normalize_openai_base_url(inputs.remote_llm_base_url)}",
+            f"REMOTE_LLM_MODEL={inputs.remote_llm_model}",
+        ])
     return RenderedFile("env", ".env.generated", "\n".join(lines) + "\n")
 
 
@@ -510,6 +580,39 @@ def render_model_router_endpoints(inputs: RenderInputs) -> RenderedFile:
     )
 
 
+def render_remote_routing_state(inputs: RenderInputs) -> RenderedFile:
+    enabled = remote_route_enabled(inputs)
+    provider = None
+    if enabled:
+        provider = {
+            "capability": "openai-compatible",
+            "baseUrl": normalize_openai_base_url(inputs.remote_llm_base_url),
+            "model": inputs.remote_llm_model.strip(),
+            "transport": inputs.remote_llm_transport,
+        }
+    payload = {
+        "schema": "ods.remote-routing-state.v1",
+        "enabled": enabled,
+        "mode": inputs.ods_mode,
+        "provider": provider,
+        "projection": {
+            "publicModel": PUBLIC_MODEL_ALIAS,
+            "gateway": "litellm-cloud",
+            "egressBaseUrl": REMOTE_PROVIDER_EGRESS_BASE_URL,
+            "consumerRoute": "gateway",
+        },
+        "status": {
+            "proven": False,
+            "reason": "pending-provider-handshake" if enabled else "disabled",
+        },
+    }
+    return RenderedFile(
+        "remote-routing-state",
+        "data/remote-provider/routing-state.json",
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    )
+
+
 RENDERERS: dict[str, Callable[[RenderInputs], RenderedFile]] = {
     "env": render_env,
     "opencode": render_opencode,
@@ -522,7 +625,12 @@ RENDERERS: dict[str, Callable[[RenderInputs], RenderedFile]] = {
     "hermes": render_hermes,
     "litellm-switchboard": render_litellm_switchboard,
     "model-router-endpoints": render_model_router_endpoints,
+    "remote-routing-state": render_remote_routing_state,
 }
+
+
+def parse_remote_enabled(value: str) -> bool:
+    return value.strip().lower() == "true"
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -543,6 +651,24 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--litellm-key", default=DEFAULT_LITELLM_KEY)
     parser.add_argument("--opencode-port", type=int, default=3003)
     parser.add_argument("--context-length", type=int, default=DEFAULT_CONTEXT)
+    parser.add_argument(
+        "--remote-llm-enabled",
+        choices=["", "true", "false"],
+        default=os.environ.get("REMOTE_LLM_ENABLED", "false").strip().lower(),
+    )
+    parser.add_argument(
+        "--remote-llm-transport",
+        choices=["", "direct", "ssh"],
+        default=os.environ.get("REMOTE_LLM_TRANSPORT", ""),
+    )
+    parser.add_argument(
+        "--remote-llm-base-url",
+        default=os.environ.get("REMOTE_LLM_BASE_URL", ""),
+    )
+    parser.add_argument(
+        "--remote-llm-model",
+        default=os.environ.get("REMOTE_LLM_MODEL", ""),
+    )
     parser.add_argument("--format", choices=["json", "paths"], default="json")
     parser.add_argument("--output-root", default=".", help="Root directory used with --write")
     parser.add_argument("--write", action="store_true", help="Write rendered files under --output-root")
@@ -553,6 +679,7 @@ def select_surfaces(
     surface: str,
     ods_mode: str = "local",
     switchboard_mode: str = "observe",
+    remote_llm_enabled: bool = False,
 ) -> list[str]:
     if surface == "all":
         mode_surface = {
@@ -571,8 +698,34 @@ def select_surfaces(
         ]
         if switchboard_mode == "enabled" and ods_mode != "cloud":
             surfaces.append("litellm-switchboard")
+        if remote_llm_enabled:
+            surfaces.append("remote-routing-state")
         return surfaces
     return [surface]
+
+
+def validate_remote_inputs(inputs: RenderInputs) -> None:
+    if not remote_route_enabled(inputs):
+        return
+    if inputs.ods_mode != "cloud":
+        raise ValueError("remote LLM routing requires ODS_MODE=cloud")
+    if inputs.remote_llm_transport not in {"direct", "ssh"}:
+        raise ValueError("remote LLM routing requires REMOTE_LLM_TRANSPORT=direct or ssh")
+    if not inputs.remote_llm_base_url.strip():
+        raise ValueError("remote LLM routing requires REMOTE_LLM_BASE_URL")
+    if not inputs.remote_llm_model.strip():
+        raise ValueError("remote LLM routing requires REMOTE_LLM_MODEL")
+    for label, value in {
+        "REMOTE_LLM_BASE_URL": inputs.remote_llm_base_url,
+        "REMOTE_LLM_MODEL": inputs.remote_llm_model,
+    }.items():
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise ValueError(f"remote LLM routing rejects control characters in {label}")
+    if REMOTE_MODEL_ID_RE.fullmatch(inputs.remote_llm_model.strip()) is None:
+        raise ValueError(
+            "remote LLM routing requires a provider model id without spaces "
+            "or shell metacharacters"
+        )
 
 
 def render(args: argparse.Namespace) -> dict[str, object]:
@@ -588,7 +741,12 @@ def render(args: argparse.Namespace) -> dict[str, object]:
         litellm_key=args.litellm_key,
         opencode_port=args.opencode_port,
         context_length=args.context_length,
+        remote_llm_enabled=parse_remote_enabled(args.remote_llm_enabled),
+        remote_llm_transport=args.remote_llm_transport,
+        remote_llm_base_url=args.remote_llm_base_url,
+        remote_llm_model=args.remote_llm_model,
     )
+    validate_remote_inputs(inputs)
     if args.surface == "litellm-switchboard" and inputs.ods_mode == "cloud":
         raise ValueError(
             "litellm-switchboard is local-runtime-only and cannot be rendered "
@@ -600,6 +758,7 @@ def render(args: argparse.Namespace) -> dict[str, object]:
             args.surface,
             inputs.ods_mode,
             inputs.switchboard_mode,
+            inputs.remote_llm_enabled,
         )
     ]
     written: list[str] = []

--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -318,6 +318,153 @@ _valid_http_endpoint() {
     }
 }
 
+_http_authority() {
+    local value="$1" remainder
+    remainder="${value#*://}"
+    printf '%s' "${remainder%%[/?]*}"
+}
+
+_http_host() {
+    local authority="$1" host
+    if [[ "$authority" =~ ^\[([^]]+)\](:[0-9]+)?$ ]]; then
+        host="${BASH_REMATCH[1]}"
+    else
+        host="${authority%%:*}"
+    fi
+    printf '%s' "${host,,}"
+}
+
+_remote_base_path_allowed() {
+    local value="$1" remainder path
+    [[ "$value" != *"?"* ]] || return 1
+    remainder="${value#*://}"
+    if [[ "$remainder" == */* ]]; then
+        path="/${remainder#*/}"
+    else
+        path="/"
+    fi
+    while [[ "$path" == */ && "$path" != "/" ]]; do
+        path="${path%/}"
+    done
+    [[ "$path" == "/" || "$path" == "/v1" || "$path" == "/api/v1" ]]
+}
+
+_remote_direct_host_allowed() {
+    local host="$1"
+    case "$host" in
+        localhost|localhost.*|0|0.0.0.0|127.*|169.254.*)
+            return 1
+            ;;
+    esac
+    [[ "$host" != "::" && "$host" != "::1" && "$host" != fe80:* ]]
+}
+
+remote_text_keys=(
+    REMOTE_LLM_TRANSPORT
+    REMOTE_LLM_BASE_URL
+    REMOTE_LLM_MODEL
+    REMOTE_LLM_TLS_CA_FILE
+    REMOTE_LLM_SSH_HOST
+    REMOTE_LLM_SSH_USER
+    REMOTE_LLM_SSH_INFERENCE_HOST
+    REMOTE_LLM_SSH_CONTROL_HOST
+    REMOTE_ODS_PEER_URL
+)
+for key in "${remote_text_keys[@]}"; do
+    val="${ENV_MAP[$key]-}"
+    if [[ -n "$val" && "$val" =~ [[:cntrl:]] ]]; then
+        contract_errors+=(
+          "$key: control characters are not allowed in remote provider metadata (line ${ENV_LINE[$key]:-?})"
+        )
+    fi
+done
+
+remote_enabled="${ENV_MAP[REMOTE_LLM_ENABLED]-}"
+remote_transport="${ENV_MAP[REMOTE_LLM_TRANSPORT]-}"
+remote_base="${ENV_MAP[REMOTE_LLM_BASE_URL]-}"
+remote_base_lc="${remote_base,,}"
+while [[ "$remote_base_lc" == */ ]]; do
+    remote_base_lc="${remote_base_lc%/}"
+done
+remote_model="${ENV_MAP[REMOTE_LLM_MODEL]-}"
+
+if [[ -n "$remote_base" ]]; then
+    if ! _valid_http_endpoint "$remote_base_lc"; then
+        contract_errors+=(
+          "REMOTE_LLM_BASE_URL: expected an HTTP(S) OpenAI-compatible provider base URL (line ${ENV_LINE[REMOTE_LLM_BASE_URL]:-?})"
+        )
+    elif ! _remote_base_path_allowed "$remote_base_lc"; then
+        contract_errors+=(
+          "REMOTE_LLM_BASE_URL: expected a provider root, /v1, or /api/v1 base path without query parameters (line ${ENV_LINE[REMOTE_LLM_BASE_URL]:-?})"
+        )
+    fi
+fi
+
+if [[ -n "${ENV_MAP[REMOTE_ODS_PEER_URL]-}" ]]; then
+    remote_peer_lc="${ENV_MAP[REMOTE_ODS_PEER_URL],,}"
+    while [[ "$remote_peer_lc" == */ ]]; do
+        remote_peer_lc="${remote_peer_lc%/}"
+    done
+    if ! _valid_http_endpoint "$remote_peer_lc"; then
+        contract_errors+=(
+          "REMOTE_ODS_PEER_URL: expected an HTTP(S) ODS peer control-plane root (line ${ENV_LINE[REMOTE_ODS_PEER_URL]:-?})"
+        )
+    fi
+fi
+
+if [[ -n "$remote_model" && ! "$remote_model" =~ ^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,255}$ ]]; then
+    contract_errors+=(
+      "REMOTE_LLM_MODEL: expected a concrete provider model id without spaces or shell metacharacters (line ${ENV_LINE[REMOTE_LLM_MODEL]:-?})"
+    )
+fi
+
+if [[ "$remote_enabled" == "true" ]]; then
+    if [[ "${ENV_MAP[ODS_MODE]-local}" != "cloud" ]]; then
+        contract_errors+=(
+          "REMOTE_LLM_ENABLED: remote routing is active only when ODS_MODE=cloud (line ${ENV_LINE[REMOTE_LLM_ENABLED]:-?})"
+        )
+    fi
+    if [[ "$remote_transport" != "direct" && "$remote_transport" != "ssh" ]]; then
+        contract_errors+=(
+          "REMOTE_LLM_TRANSPORT: remote routing requires direct or ssh transport (line ${ENV_LINE[REMOTE_LLM_TRANSPORT]:-?})"
+        )
+    fi
+    if [[ -z "$remote_base" ]]; then
+        contract_errors+=(
+          "REMOTE_LLM_BASE_URL: remote routing requires a provider base URL (line ${ENV_LINE[REMOTE_LLM_BASE_URL]:-?})"
+        )
+    fi
+    if [[ -z "$remote_model" ]]; then
+        contract_errors+=(
+          "REMOTE_LLM_MODEL: remote routing requires a concrete provider model id (line ${ENV_LINE[REMOTE_LLM_MODEL]:-?})"
+        )
+    fi
+
+    if [[ "$remote_transport" == "direct" && -n "$remote_base" ]]; then
+        if [[ "$remote_base_lc" != https://* ]]; then
+            contract_errors+=(
+              "REMOTE_LLM_BASE_URL: direct remote transport requires HTTPS in this provider slice (line ${ENV_LINE[REMOTE_LLM_BASE_URL]:-?})"
+            )
+        fi
+        remote_host="$(_http_host "$(_http_authority "$remote_base_lc")")"
+        if ! _remote_direct_host_allowed "$remote_host"; then
+            contract_errors+=(
+              "REMOTE_LLM_BASE_URL: direct remote transport must not target loopback or link-local addresses from LiteLLM's container namespace (line ${ENV_LINE[REMOTE_LLM_BASE_URL]:-?})"
+            )
+        fi
+    fi
+
+    if [[ "$remote_transport" == "ssh" ]]; then
+        for key in REMOTE_LLM_SSH_HOST REMOTE_LLM_SSH_USER REMOTE_LLM_SSH_PORT REMOTE_LLM_SSH_INFERENCE_HOST REMOTE_LLM_SSH_INFERENCE_PORT; do
+            if [[ -z "${ENV_MAP[$key]-}" ]]; then
+                contract_errors+=(
+                  "$key: SSH remote transport requires this value (line ${ENV_LINE[REMOTE_LLM_TRANSPORT]:-?})"
+                )
+            fi
+        done
+    fi
+fi
+
 embedding_model="${ENV_MAP[EMBEDDING_MODEL]-BAAI/bge-base-en-v1.5}"
 embedding_model_lower="${embedding_model,,}"
 embedding_artifact_name="${embedding_model_lower##*/}"

--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -218,6 +218,7 @@ def main(argv: list[str]) -> int:
             "litellm-lemonade",
             "litellm-switchboard",
             "model-router-endpoints",
+            "remote-routing-state",
             "perplexica",
             "hermes",
         }

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -109,6 +109,127 @@ def test_cloud_enabled_never_renders_local_switchboard() -> None:
     assert "model-router" not in cloud
 
 
+def test_remote_cloud_projection_uses_internal_egress_and_state_receipt() -> None:
+    payload = run_renderer(
+        "--surface",
+        "all",
+        "--ods-mode",
+        "cloud",
+        "--remote-llm-enabled",
+        "true",
+        "--remote-llm-transport",
+        "direct",
+        "--remote-llm-base-url",
+        "https://gpu.example.test",
+        "--remote-llm-model",
+        "qwen/remote:latest",
+    )
+    surfaces = {item["surface"] for item in payload["files"]}
+    assert "litellm-cloud" in surfaces
+    assert "remote-routing-state" in surfaces
+    assert "litellm-switchboard" not in surfaces
+
+    cloud = file_by_surface(payload, "litellm-cloud")["content"]
+    assert "model_name: ods/current" in cloud
+    assert 'model: "openai/qwen/remote:latest"' in cloud
+    assert 'model_name: "qwen/remote:latest"' in cloud
+    assert 'api_base: "http://remote-provider-egress:8091/v1"' in cloud
+    assert "api_key: not-needed" in cloud
+    assert "https://gpu.example.test" not in cloud
+    assert "REMOTE_LLM_API_KEY" not in cloud
+
+    env_content = file_by_surface(payload, "env")["content"]
+    assert "REMOTE_LLM_ENABLED=true" in env_content
+    assert "REMOTE_LLM_TRANSPORT=direct" in env_content
+    assert "REMOTE_LLM_BASE_URL=https://gpu.example.test/v1" in env_content
+    assert "REMOTE_LLM_MODEL=qwen/remote:latest" in env_content
+
+    state = json.loads(file_by_surface(payload, "remote-routing-state")["content"])
+    assert state["schema"] == "ods.remote-routing-state.v1"
+    assert state["enabled"] is True
+    assert state["mode"] == "cloud"
+    assert state["provider"] == {
+        "baseUrl": "https://gpu.example.test/v1",
+        "capability": "openai-compatible",
+        "model": "qwen/remote:latest",
+        "transport": "direct",
+    }
+    assert state["projection"] == {
+        "consumerRoute": "gateway",
+        "egressBaseUrl": "http://remote-provider-egress:8091/v1",
+        "gateway": "litellm-cloud",
+        "publicModel": "ods/current",
+    }
+    assert state["status"] == {
+        "proven": False,
+        "reason": "pending-provider-handshake",
+    }
+    assert "key" not in json.dumps(state).lower()
+
+
+def test_remote_routing_state_disabled_receipt_has_no_provider() -> None:
+    payload = run_renderer("--surface", "remote-routing-state")
+    state = json.loads(file_by_surface(payload, "remote-routing-state")["content"])
+    assert state["enabled"] is False
+    assert state["provider"] is None
+    assert state["status"] == {"proven": False, "reason": "disabled"}
+    assert "REMOTE_LLM_API_KEY" not in json.dumps(state)
+
+
+def test_remote_projection_requires_cloud_mode() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--surface",
+            "all",
+            "--ods-mode",
+            "local",
+            "--remote-llm-enabled",
+            "true",
+            "--remote-llm-transport",
+            "direct",
+            "--remote-llm-base-url",
+            "https://gpu.example.test/v1",
+            "--remote-llm-model",
+            "qwen-remote",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.returncode == 2
+    assert "ODS_MODE=cloud" in proc.stderr
+
+
+def test_remote_projection_rejects_unsafe_model_id() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--surface",
+            "all",
+            "--ods-mode",
+            "cloud",
+            "--remote-llm-enabled",
+            "true",
+            "--remote-llm-transport",
+            "direct",
+            "--remote-llm-base-url",
+            "https://gpu.example.test/v1",
+            "--remote-llm-model",
+            "bad model; touch nope",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.returncode == 2
+    assert "model id without spaces" in proc.stderr
+
+
 def test_explicit_cloud_switchboard_render_fails_closed() -> None:
     proc = subprocess.run(
         [
@@ -432,6 +553,10 @@ def main() -> int:
         test_switchboard_surface_gated_on_enabled_mode,
         test_all_selects_one_mode_config,
         test_cloud_enabled_never_renders_local_switchboard,
+        test_remote_cloud_projection_uses_internal_egress_and_state_receipt,
+        test_remote_routing_state_disabled_receipt_has_no_provider,
+        test_remote_projection_requires_cloud_mode,
+        test_remote_projection_rejects_unsafe_model_id,
         test_explicit_cloud_switchboard_render_fails_closed,
         test_native_local_projection_uses_host_route_and_concrete_model,
         test_checked_in_mode_configs_match_renderer,

--- a/ods/tests/test-validate-env.sh
+++ b/ods/tests/test-validate-env.sh
@@ -325,6 +325,109 @@ for quantized_model in 'someone/bge-m3-Q4_K_M' 'someone/bge-m3-q8_0' 'someone/bg
     fi
 done
 
+# 16. Remote provider metadata is valid only as an explicit cloud-mode route.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/remote-direct.env"
+cat >> "$TMP_DIR/remote-direct.env" <<'EOF'
+ODS_MODE=cloud
+REMOTE_LLM_ENABLED=true
+REMOTE_LLM_TRANSPORT=direct
+REMOTE_LLM_BASE_URL=https://gpu.example.test
+REMOTE_LLM_MODEL=qwen/remote:latest
+EOF
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/remote-direct.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 0 ]]; then
+    pass "Remote direct provider metadata is valid in cloud mode"
+else
+    fail "Remote direct provider metadata should be valid in cloud mode"
+fi
+
+cp "$TMP_DIR/valid.env" "$TMP_DIR/remote-local.env"
+cat >> "$TMP_DIR/remote-local.env" <<'EOF'
+ODS_MODE=local
+REMOTE_LLM_ENABLED=true
+REMOTE_LLM_TRANSPORT=direct
+REMOTE_LLM_BASE_URL=https://gpu.example.test/v1
+REMOTE_LLM_MODEL=qwen-remote
+EOF
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/remote-local.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]] && echo "$out" | grep -q "ODS_MODE=cloud"; then
+    pass "Remote provider activation is rejected outside cloud mode"
+else
+    fail "Remote provider activation should be rejected outside cloud mode"
+fi
+
+# 17. Direct remote URLs fail closed for plaintext, loopback, credentials,
+# query strings, and unexpected base paths.
+for invalid_remote_url in 'http://gpu.example.test/v1' 'https://127.0.0.1:8000/v1' 'https://user:secret@gpu.example.test/v1' 'https://gpu.example.test/v1?tenant=ods' 'https://gpu.example.test/proxy'; do
+    cp "$TMP_DIR/valid.env" "$TMP_DIR/invalid-remote-url.env"
+    cat >> "$TMP_DIR/invalid-remote-url.env" <<EOF
+ODS_MODE=cloud
+REMOTE_LLM_ENABLED=true
+REMOTE_LLM_TRANSPORT=direct
+REMOTE_LLM_BASE_URL=$invalid_remote_url
+REMOTE_LLM_MODEL=qwen-remote
+EOF
+    set +e
+    out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/invalid-remote-url.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+    r=$?
+    set -e
+    if [[ $r -eq 2 ]] && echo "$out" | grep -q "REMOTE_LLM_BASE_URL"; then
+        pass "Unsafe direct remote URL is rejected: $invalid_remote_url"
+    else
+        fail "Unsafe direct remote URL should be rejected: $invalid_remote_url"
+    fi
+done
+
+# 18. SSH transport requires explicit host/user/port and inference endpoint
+# metadata, while allowing the remote-side provider URL to be plain HTTP.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/remote-ssh.env"
+cat >> "$TMP_DIR/remote-ssh.env" <<'EOF'
+ODS_MODE=cloud
+REMOTE_LLM_ENABLED=true
+REMOTE_LLM_TRANSPORT=ssh
+REMOTE_LLM_BASE_URL=http://remote-inference.internal:8000/v1
+REMOTE_LLM_MODEL=qwen-remote
+REMOTE_LLM_SSH_HOST=gpu.example.test
+REMOTE_LLM_SSH_USER=ods
+REMOTE_LLM_SSH_PORT=22
+REMOTE_LLM_SSH_INFERENCE_HOST=127.0.0.1
+REMOTE_LLM_SSH_INFERENCE_PORT=8000
+EOF
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/remote-ssh.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 0 ]]; then
+    pass "Remote SSH transport metadata is valid with required fields"
+else
+    fail "Remote SSH transport metadata should be valid with required fields"
+fi
+
+cp "$TMP_DIR/remote-ssh.env" "$TMP_DIR/remote-ssh-missing.env"
+sed -i.bak '/REMOTE_LLM_SSH_INFERENCE_PORT=/d' "$TMP_DIR/remote-ssh-missing.env"
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/remote-ssh-missing.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]] && echo "$out" | grep -q "REMOTE_LLM_SSH_INFERENCE_PORT"; then
+    pass "Remote SSH transport rejects missing inference port"
+else
+    fail "Remote SSH transport should reject missing inference port"
+fi
+
+# 19. Remote provider secrets are not ordinary env settings in this slice.
+if ! grep -q "REMOTE_LLM_API_KEY" "$ROOT_DIR/.env.schema.json" "$ROOT_DIR/.env.example"; then
+    pass "Remote provider API key is absent from schema and .env.example"
+else
+    fail "Remote provider API key must not be added as an ordinary .env field"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
﻿## Summary

Adds the first dormant remote-provider routing slice on top of current `main`:

- adds validated non-secret `REMOTE_LLM_*` / `REMOTE_ODS_PEER_URL` metadata keys to the env schema and example
- extends the canonical runtime config renderer with cloud-only remote projection for `ods/current`, `default`, and the concrete provider model
- emits a sanitized `data/remote-provider/routing-state.json` receipt owned by the canonical renderer
- keeps the real provider URL out of LiteLLM YAML by projecting through `remote-provider-egress`, and does not add `REMOTE_LLM_API_KEY` as an ordinary `.env` field
- adds env and renderer tests for cloud-only activation, unsafe direct URL rejection, SSH metadata requirements, model-id injection rejection, and generated-config ledger coverage

## Safety Notes

Remote routing remains opt-in and dormant. It only renders when explicitly requested with `ODS_MODE=cloud` and `REMOTE_LLM_ENABLED=true`; default local/cloud/hybrid/lemonade checked-in templates are unchanged. Secret custody and the actual egress service are intentionally left for the next provider slice.

## Validation

- `python ods/tests/test-render-runtime-configs.py`
- `C:\Program Files\Git\bin\bash.exe ods/tests/test-validate-env.sh` (`41 passed, 0 failed`)
- `python ods/scripts/validate-generated-configs.py ods/config/generated-config-contracts.json`
- `C:\Program Files\Git\bin\bash.exe ods/tests/test-generated-config-contracts.sh`
- `python -m json.tool ods/.env.schema.json`
- `python -m json.tool ods/config/generated-config-contracts.json`
- `python -m py_compile ods/scripts/render-runtime-configs.py ods/scripts/validate-generated-configs.py`
- `python -m ruff check ods/scripts/render-runtime-configs.py ods/scripts/validate-generated-configs.py ods/tests/test-render-runtime-configs.py`
- `C:\Program Files\Git\bin\bash.exe -n ods/scripts/validate-env.sh`
- `C:\Program Files\Git\bin\bash.exe -n ods/tests/test-validate-env.sh`
- `git diff --check`

Local ShellCheck was not installed; GitHub/Tower2 validation should cover it.
