### PR TITLE
fix(windows): apply LLAMA_REASONING on native llama-server launches

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -52,6 +52,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
 	@bash tests/contracts/test-windows-hermes-config-patching.sh
+	@bash tests/contracts/test-llama-reasoning-format.sh
 	@echo ""
 	@echo "=== Overlay/plist contracts ==="
 	@bash tests/contracts/test-overlay-map-coherence.sh

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -715,6 +715,18 @@ if ($dryRun) {
                     $parts = $_ -split '=', 2
                     $_llamaEnv[$parts[0].Trim()] = $parts[1].Trim().Trim('"')
                 }
+                # Map the .env values (off/on/auto) onto llama-server's own
+                # vocabulary, the same way scripts/bootstrap-upgrade.sh does for
+                # its Windows hot-swap. Defaulting to off keeps thinking models
+                # from spending the whole token budget on internal reasoning.
+                $_reasoning = $_llamaEnv["LLAMA_REASONING"]
+                if (-not $_reasoning) { $_reasoning = "off" }
+                switch ($_reasoning) {
+                    "off"   { $_reasoningFmt = "none" }
+                    "on"    { $_reasoningFmt = "deepseek" }
+                    default { $_reasoningFmt = $_reasoning }
+                }
+                $llamaArgs += @("--reasoning-format", $_reasoningFmt)
                 if ($_llamaEnv["LLAMA_ARG_FLASH_ATTN"]) { $llamaArgs += @("--flash-attn", $_llamaEnv["LLAMA_ARG_FLASH_ATTN"]) }
                 if ($_llamaEnv["LLAMA_ARG_CACHE_TYPE_K"]) { $llamaArgs += @("--cache-type-k", $_llamaEnv["LLAMA_ARG_CACHE_TYPE_K"]) }
                 if ($_llamaEnv["LLAMA_ARG_CACHE_TYPE_V"]) { $llamaArgs += @("--cache-type-v", $_llamaEnv["LLAMA_ARG_CACHE_TYPE_V"]) }

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1363,12 +1363,25 @@ function Start-NativeInferenceServer {
             return
         }
 
+        # Map the .env values (off/on/auto) onto llama-server's own vocabulary,
+        # the same way scripts/bootstrap-upgrade.sh does for its Windows
+        # hot-swap. Defaulting to off keeps thinking models from spending the
+        # whole token budget on internal reasoning.
+        $reasoning = $envVars["LLAMA_REASONING"]
+        if (-not $reasoning) { $reasoning = "off" }
+        switch ($reasoning) {
+            "off"   { $reasoningFmt = "none" }
+            "on"    { $reasoningFmt = "deepseek" }
+            default { $reasoningFmt = $reasoning }
+        }
+
         $llamaArgs = @(
             "--model", $modelPath,
             "--host", $bindAddr,
             "--port", [string]$script:LEMONADE_PORT,
             "--n-gpu-layers", "999",
-            "--ctx-size", $ctxSize
+            "--ctx-size", $ctxSize,
+            "--reasoning-format", $reasoningFmt
         )
         if ($envVars["LLAMA_ARG_FLASH_ATTN"]) { $llamaArgs += @("--flash-attn", $envVars["LLAMA_ARG_FLASH_ATTN"]) }
         if ($envVars["LLAMA_ARG_CACHE_TYPE_K"]) { $llamaArgs += @("--cache-type-k", $envVars["LLAMA_ARG_CACHE_TYPE_K"]) }

--- a/ods/tests/contracts/test-llama-reasoning-format.sh
+++ b/ods/tests/contracts/test-llama-reasoning-format.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Contract: every native llama.cpp launcher pins --reasoning-format.
+#
+# LLAMA_REASONING is documented in .env.schema.json as "off (default) | auto |
+# on. Off prevents thinking models from consuming the entire token budget on
+# internal reasoning." llama.cpp has its own default, so a launcher that never
+# passes --reasoning-format does not merely ignore the operator's setting -- it
+# leaves reasoning at whatever the llama.cpp build prefers, which is the
+# behaviour the default exists to prevent.
+#
+# Docker is exempt: docker-compose.base.yml passes LLAMA_ARG_REASONING into the
+# container environment, which llama.cpp reads natively.
+#
+# The .env values (off/on/auto) are not llama.cpp's vocabulary, so each
+# launcher also has to map them; the check below requires both the flag and the
+# mapping input.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAILURES=0
+
+fail() {
+    echo "[FAIL] $*" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+native_launchers=(
+    bin/ods-host-agent.py
+    installers/macos/install-macos.sh
+    installers/macos/ods-macos.sh
+    scripts/bootstrap-upgrade.sh
+    installers/windows/install-windows.ps1
+    installers/windows/ods.ps1
+)
+
+for target in "${native_launchers[@]}"; do
+    path="$ROOT_DIR/$target"
+    if [[ ! -f "$path" ]]; then
+        fail "$target is missing; update this contract if the launcher moved"
+        continue
+    fi
+    if ! grep -q -- '--reasoning-format' "$path"; then
+        fail "$target starts llama-server without --reasoning-format; LLAMA_REASONING is ignored and thinking mode falls back to the llama.cpp default"
+        continue
+    fi
+    if ! grep -q 'LLAMA_REASONING' "$path"; then
+        fail "$target passes --reasoning-format but never reads LLAMA_REASONING, so the documented setting has no effect"
+        continue
+    fi
+    pass "$target pins --reasoning-format from LLAMA_REASONING"
+done
+
+# Docker's route is the container environment rather than an argv flag.
+if grep -q 'LLAMA_ARG_REASONING=${LLAMA_REASONING' "$ROOT_DIR/docker-compose.base.yml"; then
+    pass "docker-compose.base.yml forwards LLAMA_REASONING to the container environment"
+else
+    fail "docker-compose.base.yml no longer forwards LLAMA_REASONING as LLAMA_ARG_REASONING"
+fi
+
+if (( FAILURES > 0 )); then
+    echo ""
+    echo "[FAIL] llama.cpp reasoning-format contract"
+    exit 1
+fi
+
+echo ""
+echo "[PASS] every llama.cpp launch path applies LLAMA_REASONING"


### PR DESCRIPTION
## Problem

`.env.schema.json` documents the setting and why it exists:

> `LLAMA_REASONING` — "llama.cpp reasoning/thinking mode: off (default) | auto | on. **Off prevents thinking models from consuming the entire token budget on internal reasoning.**"

llama.cpp has its own default for `--reasoning-format`, so a launcher that never passes the flag does not merely ignore the operator's setting — it leaves reasoning at whatever the build prefers, which is exactly the outcome the ODS default exists to prevent.

Coverage today:

| launcher | applies `LLAMA_REASONING` |
|---|---|
| `docker-compose.base.yml:52` | ✅ via `LLAMA_ARG_REASONING` container env |
| `bin/ods-host-agent.py:10097` | ✅ |
| `installers/macos/install-macos.sh` / `ods-macos.sh` | ✅ |
| `scripts/bootstrap-upgrade.sh` — **Windows** PowerShell block, line 1173 | ✅ |
| `installers/windows/install-windows.ps1` | ❌ |
| `installers/windows/ods.ps1` | ❌ |

Note the third and fourth rows: Windows already has one launcher that handles this correctly and two that don't. That asymmetry within the same platform is what makes it an oversight rather than a deliberate exclusion.

## Fix

Read and map the value exactly the way `bootstrap-upgrade.sh`'s Windows block already does — `off` → `none`, `on` → `deepseek`, anything else passes through, absent defaults to `off` — so all three Windows paths agree with each other and with macOS, the host agent and Docker.

**Behaviour change worth calling out:** on a Windows native install this moves reasoning from the llama.cpp build default to `--reasoning-format none`. That is the documented ODS default and what every other platform already does, but it is a real change for anyone who was relying on the unset behaviour — flagging it rather than burying it.

## Tests

New `tests/contracts/test-llama-reasoning-format.sh`, wired into `make test`. It requires each native launcher to pass **both** `--reasoning-format` and to read `LLAMA_REASONING` — the `.env` values (`off`/`on`/`auto`) are not llama.cpp's vocabulary, so passing the flag without the mapping input would be just as broken. Docker is asserted on its own route (the `LLAMA_ARG_REASONING` env forward) since it has no argv flag.

On `main`:

```
[FAIL] installers/windows/install-windows.ps1 starts llama-server without --reasoning-format; LLAMA_REASONING is ignored and thinking mode falls back to the llama.cpp default
[FAIL] installers/windows/ods.ps1 starts llama-server without --reasoning-format; …
```

All seven pass with the fix. Also green: `tests/test-windows-installer-flags.sh` (30 passed), `tests/contracts/test-windows-llm-model-readiness.sh` (14 passed). Both `.ps1` files re-verified with `[System.Management.Automation.Language.Parser]::ParseFile` (0 parse errors).