### PR TITLE
feat(remote): add provider egress policy contract

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -162,6 +162,7 @@ jobs:
           bash tests/contracts/test-preflight-fixtures.sh
           bash tests/test-preflight-resolver-bug.sh
           python3 tests/contracts/test-network-exposure-contracts.py
+          python3 tests/contracts/test-remote-provider-egress-policy.py
 
       - name: Linux install preflight tests
         run: |

--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -1,0 +1,43 @@
+"""Remote provider support package.
+
+This package is intentionally stdlib-only so installer, host-agent, and future
+egress-service code can share the same contract without adding runtime deps.
+"""
+
+from .policy import (  # noqa: F401
+    ACTIVATION_RECEIPT_SCHEMA,
+    DEFAULT_POLICY_PATH,
+    FORBIDDEN_PUBLIC_SECRET_ENV,
+    INTERNAL_EGRESS_BASE_URL,
+    PUBLIC_MODEL_ALIAS,
+    REDACTED,
+    REMOTE_ROUTE_SCHEMA,
+    SCHEMA,
+    PolicyError,
+    load_policy,
+    normalize_provider_base_url,
+    plan_route,
+    public_activation_receipt,
+    redacted_secret_refs,
+    validate_public_env_keys,
+    validate_remote_model_id,
+)
+
+__all__ = [
+    "ACTIVATION_RECEIPT_SCHEMA",
+    "DEFAULT_POLICY_PATH",
+    "FORBIDDEN_PUBLIC_SECRET_ENV",
+    "INTERNAL_EGRESS_BASE_URL",
+    "PUBLIC_MODEL_ALIAS",
+    "REDACTED",
+    "REMOTE_ROUTE_SCHEMA",
+    "SCHEMA",
+    "PolicyError",
+    "load_policy",
+    "normalize_provider_base_url",
+    "plan_route",
+    "public_activation_receipt",
+    "redacted_secret_refs",
+    "validate_public_env_keys",
+    "validate_remote_model_id",
+]

--- a/ods/bin/remote_provider/policy.py
+++ b/ods/bin/remote_provider/policy.py
@@ -1,0 +1,362 @@
+"""Remote provider egress policy helpers.
+
+The helpers in this module are deliberately inert: they normalize and classify
+configuration, produce public receipts, and reject unsafe public config, but
+they never open sockets or read secret material. The future egress service owns
+network I/O and private credential loading.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_POLICY_PATH = ROOT / "config" / "remote-provider-egress-policy.json"
+SCHEMA = "ods.remote-provider-egress-policy.v1"
+REMOTE_ROUTE_SCHEMA = "ods.remote-provider-route.v1"
+ACTIVATION_RECEIPT_SCHEMA = "ods.remote-provider-activation-receipt.v1"
+PUBLIC_MODEL_ALIAS = "ods/current"
+INTERNAL_EGRESS_BASE_URL = "http://remote-provider-egress:8091/v1"
+REDACTED = "[REDACTED]"
+
+REMOTE_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,255}$")
+LOCAL_HOSTNAMES = {
+    "gateway.docker.internal",
+    "host.docker.internal",
+    "localhost",
+    "localhost.localdomain",
+}
+REQUIRED_SSH_FIELDS = (
+    "REMOTE_LLM_SSH_HOST",
+    "REMOTE_LLM_SSH_USER",
+    "REMOTE_LLM_SSH_PORT",
+    "REMOTE_LLM_SSH_INFERENCE_HOST",
+    "REMOTE_LLM_SSH_INFERENCE_PORT",
+)
+FORBIDDEN_PUBLIC_SECRET_ENV = frozenset(
+    {
+        "REMOTE_LLM_API_KEY",
+        "REMOTE_ODS_PEER_TOKEN",
+        "REMOTE_LLM_SSH_PRIVATE_KEY",
+        "REMOTE_LLM_SSH_KEY_FILE",
+        "REMOTE_LLM_SSH_KNOWN_HOSTS",
+        "REMOTE_LLM_TLS_CA_PEM",
+        "REMOTE_LLM_TLS_CLIENT_CERT",
+        "REMOTE_LLM_TLS_CLIENT_KEY",
+    }
+)
+
+
+class PolicyError(ValueError):
+    """Raised when remote-provider metadata violates the egress policy."""
+
+
+def _has_control_chars(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 for char in value)
+
+
+def _string(value: object) -> str:
+    return str(value or "").strip()
+
+
+def load_policy(path: str | Path = DEFAULT_POLICY_PATH) -> dict[str, Any]:
+    """Load and minimally validate the checked-in policy document."""
+    policy_path = Path(path)
+    payload = json.loads(policy_path.read_text(encoding="utf-8"))
+    if payload.get("schema") != SCHEMA:
+        raise PolicyError(f"{policy_path} does not declare {SCHEMA}")
+    if payload.get("version") != 1:
+        raise PolicyError(f"{policy_path} must be version 1")
+    egress = payload.get("egress_service")
+    if not isinstance(egress, dict):
+        raise PolicyError(f"{policy_path} is missing egress_service")
+    if egress.get("internal_base_url") != INTERNAL_EGRESS_BASE_URL:
+        raise PolicyError("remote-provider egress internal URL drifted")
+    if egress.get("public_model_alias") != PUBLIC_MODEL_ALIAS:
+        raise PolicyError("remote-provider public model alias drifted")
+    return payload
+
+
+def _transport_url_policy(policy: Mapping[str, Any], transport: str) -> Mapping[str, Any]:
+    transports = policy.get("transports")
+    if not isinstance(transports, Mapping):
+        raise PolicyError("policy is missing transports")
+    transport_policy = transports.get(transport)
+    if not isinstance(transport_policy, Mapping):
+        raise PolicyError(f"unsupported remote transport: {transport}")
+    url_policy = transport_policy.get("provider_base_url")
+    if not isinstance(url_policy, Mapping):
+        raise PolicyError(f"{transport} transport is missing provider_base_url policy")
+    return url_policy
+
+
+def _classify_forbidden_ip(host: str) -> str:
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return ""
+    if address.version == 4 and str(address) == "255.255.255.255":
+        return "broadcast"
+    if address.is_loopback:
+        return "loopback"
+    if address.is_link_local:
+        return "link_local"
+    if address.is_multicast:
+        return "multicast"
+    if address.is_unspecified:
+        return "unspecified"
+    if address.is_private:
+        return "private"
+    if address.is_reserved:
+        return "reserved"
+    return ""
+
+
+def _normalize_netloc(host: str, port: int | None) -> str:
+    normalized_host = host.lower()
+    if ":" in normalized_host and not normalized_host.startswith("["):
+        normalized_host = f"[{normalized_host}]"
+    if port is None:
+        return normalized_host
+    return f"{normalized_host}:{port}"
+
+
+def normalize_provider_base_url(
+    value: str,
+    *,
+    transport: str,
+    policy: Mapping[str, Any] | None = None,
+) -> str:
+    """Normalize a remote OpenAI-compatible base URL or raise PolicyError."""
+    policy = policy or load_policy()
+    transport_name = transport.strip().lower()
+    url_policy = _transport_url_policy(policy, transport_name)
+    allowed_schemes = set(url_policy.get("schemes") or ())
+    allowed_paths = set(url_policy.get("allowed_paths") or ())
+    default_path = _string(url_policy.get("default_path") or "/v1")
+
+    raw = value.strip()
+    if not raw:
+        raise PolicyError("remote provider base URL is required")
+    if _has_control_chars(raw):
+        raise PolicyError("remote provider base URL contains control characters")
+    if "\\" in raw:
+        raise PolicyError("remote provider base URL must use forward slashes")
+
+    parts = urlsplit(raw)
+    if not parts.scheme or not parts.netloc:
+        raise PolicyError("remote provider base URL must include scheme and host")
+    if parts.scheme.lower() not in allowed_schemes:
+        allowed = ", ".join(sorted(allowed_schemes))
+        raise PolicyError(f"{transport_name} transport requires scheme: {allowed}")
+    if parts.username or parts.password:
+        raise PolicyError("remote provider base URL must not embed credentials")
+    if parts.query:
+        raise PolicyError("remote provider base URL must not include a query string")
+    if parts.fragment:
+        raise PolicyError("remote provider base URL must not include a fragment")
+
+    try:
+        port = parts.port
+    except ValueError as exc:
+        raise PolicyError(f"remote provider base URL has an invalid port: {exc}") from exc
+
+    host = parts.hostname or ""
+    if not host:
+        raise PolicyError("remote provider base URL must include a host")
+    if _has_control_chars(host) or any(char.isspace() for char in host):
+        raise PolicyError("remote provider base URL host is invalid")
+    if "%" in host:
+        raise PolicyError("remote provider base URL host must not include a zone id")
+
+    lower_host = host.lower()
+    if transport_name == "direct":
+        if lower_host in LOCAL_HOSTNAMES or lower_host.endswith(".localhost"):
+            raise PolicyError("direct remote provider URL must not target local hostnames")
+        forbidden_class = _classify_forbidden_ip(lower_host)
+        if forbidden_class:
+            raise PolicyError(
+                f"direct remote provider URL must not use {forbidden_class} IP literals"
+            )
+
+    path = parts.path.rstrip("/")
+    if path in {"", "/"}:
+        path = default_path
+    if path not in allowed_paths:
+        allowed = ", ".join(sorted(allowed_paths))
+        raise PolicyError(f"remote provider base URL path must be one of: {allowed}")
+
+    return urlunsplit(
+        (
+            parts.scheme.lower(),
+            _normalize_netloc(host, port),
+            path,
+            "",
+            "",
+        )
+    )
+
+
+def validate_remote_model_id(model_id: str) -> str:
+    """Return a trimmed remote model id if it is safe for public config."""
+    model = model_id.strip()
+    if not model:
+        raise PolicyError("remote provider model id is required")
+    if _has_control_chars(model):
+        raise PolicyError("remote provider model id contains control characters")
+    if REMOTE_MODEL_ID_RE.fullmatch(model) is None:
+        raise PolicyError(
+            "remote provider model id must not contain spaces or shell metacharacters"
+        )
+    return model
+
+
+def _require_port(env: Mapping[str, object], key: str) -> int:
+    value = _string(env.get(key))
+    if not value:
+        raise PolicyError(f"{key} is required for SSH remote provider transport")
+    try:
+        port = int(value, 10)
+    except ValueError as exc:
+        raise PolicyError(f"{key} must be an integer port") from exc
+    if port < 1 or port > 65535:
+        raise PolicyError(f"{key} must be between 1 and 65535")
+    return port
+
+
+def _require_text(env: Mapping[str, object], key: str) -> str:
+    value = _string(env.get(key))
+    if not value:
+        raise PolicyError(f"{key} is required for SSH remote provider transport")
+    if _has_control_chars(value):
+        raise PolicyError(f"{key} contains control characters")
+    return value
+
+
+def _ssh_metadata(env: Mapping[str, object]) -> dict[str, object]:
+    for key in REQUIRED_SSH_FIELDS:
+        if not _string(env.get(key)):
+            raise PolicyError(f"{key} is required for SSH remote provider transport")
+    metadata: dict[str, object] = {
+        "host": _require_text(env, "REMOTE_LLM_SSH_HOST"),
+        "user": _require_text(env, "REMOTE_LLM_SSH_USER"),
+        "port": _require_port(env, "REMOTE_LLM_SSH_PORT"),
+        "inferenceHost": _require_text(env, "REMOTE_LLM_SSH_INFERENCE_HOST"),
+        "inferencePort": _require_port(env, "REMOTE_LLM_SSH_INFERENCE_PORT"),
+    }
+    control_host = _string(env.get("REMOTE_LLM_SSH_CONTROL_HOST"))
+    control_port = _string(env.get("REMOTE_LLM_SSH_CONTROL_PORT"))
+    if control_host or control_port:
+        metadata["controlHost"] = _require_text(env, "REMOTE_LLM_SSH_CONTROL_HOST")
+        metadata["controlPort"] = _require_port(env, "REMOTE_LLM_SSH_CONTROL_PORT")
+    return metadata
+
+
+def plan_route(
+    env: Mapping[str, object],
+    *,
+    policy: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a safe public route description from non-secret remote metadata."""
+    policy = policy or load_policy()
+    enabled = _string(env.get("REMOTE_LLM_ENABLED")).lower() == "true"
+    mode = _string(env.get("ODS_MODE")) or "local"
+    if not enabled:
+        return {
+            "schema": REMOTE_ROUTE_SCHEMA,
+            "enabled": False,
+            "mode": mode,
+            "transport": None,
+            "provider": None,
+            "ssh": None,
+            "egress": {
+                "internalBaseUrl": INTERNAL_EGRESS_BASE_URL,
+                "publicModel": PUBLIC_MODEL_ALIAS,
+                "consumerRoute": "gateway",
+            },
+        }
+    if mode != "cloud":
+        raise PolicyError("remote provider routing requires ODS_MODE=cloud")
+    transport = _string(env.get("REMOTE_LLM_TRANSPORT")).lower()
+    if transport not in {"direct", "ssh"}:
+        raise PolicyError("REMOTE_LLM_TRANSPORT must be direct or ssh")
+    base_url = normalize_provider_base_url(
+        _string(env.get("REMOTE_LLM_BASE_URL")),
+        transport=transport,
+        policy=policy,
+    )
+    model = validate_remote_model_id(_string(env.get("REMOTE_LLM_MODEL")))
+    ssh = _ssh_metadata(env) if transport == "ssh" else None
+    return {
+        "schema": REMOTE_ROUTE_SCHEMA,
+        "enabled": True,
+        "mode": mode,
+        "transport": transport,
+        "provider": {
+            "capability": "openai-compatible",
+            "baseUrl": base_url,
+            "model": model,
+            "transport": transport,
+        },
+        "ssh": ssh,
+        "egress": {
+            "internalBaseUrl": INTERNAL_EGRESS_BASE_URL,
+            "publicModel": PUBLIC_MODEL_ALIAS,
+            "consumerRoute": "gateway",
+        },
+    }
+
+
+def validate_public_env_keys(env: Mapping[str, object]) -> None:
+    """Reject private remote-provider secret names from public .env surfaces."""
+    present = sorted(key for key in env if key in FORBIDDEN_PUBLIC_SECRET_ENV)
+    if present:
+        names = ", ".join(present)
+        raise PolicyError(f"remote provider secrets are not public env keys: {names}")
+
+
+def redacted_secret_refs(
+    secret_refs: Mapping[str, object] | Iterable[str],
+) -> dict[str, dict[str, object]]:
+    """Return public secret references without exposing any values."""
+    if isinstance(secret_refs, Mapping):
+        names = sorted(str(key) for key, value in secret_refs.items() if _string(value))
+    else:
+        names = sorted(str(name) for name in secret_refs if _string(name))
+    return {
+        name: {
+            "present": True,
+            "value": REDACTED,
+        }
+        for name in names
+    }
+
+
+def public_activation_receipt(
+    route: Mapping[str, Any],
+    *,
+    phase: str,
+    ok: bool,
+    detail: str = "",
+    secret_refs: Mapping[str, object] | Iterable[str] = (),
+) -> dict[str, Any]:
+    """Build a support-bundle-safe activation receipt."""
+    return {
+        "schema": ACTIVATION_RECEIPT_SCHEMA,
+        "ok": bool(ok),
+        "phase": phase,
+        "detail": str(detail),
+        "enabled": bool(route.get("enabled")),
+        "mode": route.get("mode"),
+        "transport": route.get("transport"),
+        "provider": route.get("provider") if route.get("enabled") else None,
+        "egress": route.get("egress"),
+        "secretRefs": redacted_secret_refs(secret_refs),
+    }

--- a/ods/bin/remote_provider/reconciler.py
+++ b/ods/bin/remote_provider/reconciler.py
@@ -1,0 +1,135 @@
+"""Remote provider activation phase sequencing.
+
+This is the same narrow boundary as the model switchboard reconciler: sequence
+adapter calls, classify the first failing phase, and request rollback once the
+commit phase starts. The adapter owns real side effects; this module stays pure
+stdlib and does not perform network I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol
+
+
+PHASES = ("stage", "validate", "commit", "prove")
+
+
+def result(ok: bool, detail: str = "", **extras: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"ok": bool(ok), "detail": str(detail)}
+    payload.update(extras)
+    return payload
+
+
+class ActivationAdapter(Protocol):
+    """Contract implemented by the future egress service activator."""
+
+    kind: str
+
+    def stage(self, env: dict[str, str]) -> dict[str, Any]:
+        """Prepare candidate remote provider state without changing traffic."""
+
+    def validate(self, env: dict[str, str]) -> dict[str, Any]:
+        """Validate metadata, credentials, and transport readiness."""
+
+    def commit(self, env: dict[str, str]) -> dict[str, Any]:
+        """Switch egress service traffic to the candidate provider."""
+
+    def prove(self, env: dict[str, str]) -> dict[str, Any]:
+        """Prove the public alias completes through the committed route."""
+
+    def rollback(self, env: dict[str, str]) -> dict[str, Any]:
+        """Restore the previous committed route."""
+
+
+def _rollback(adapter: ActivationAdapter, env: dict[str, str]) -> dict[str, Any]:
+    try:
+        outcome = adapter.rollback(env)
+    except Exception as exc:
+        return result(False, f"rollback raised: {exc}")
+    if not isinstance(outcome, dict) or "ok" not in outcome:
+        return result(False, "rollback returned a non-contract result")
+    return outcome
+
+
+def run_activation_transaction(
+    adapter: ActivationAdapter,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    """Drive remote-provider activation phases; first failure wins."""
+    committed = False
+    for phase in PHASES:
+        try:
+            outcome = getattr(adapter, phase)(env)
+        except Exception as exc:
+            payload = result(False, f"adapter raised: {exc}", phase=phase)
+            if committed or phase == "commit":
+                payload["rollback"] = _rollback(adapter, env)
+            return payload
+        if not isinstance(outcome, dict) or "ok" not in outcome:
+            payload = result(False, "adapter returned a non-contract result", phase=phase)
+            if committed or phase == "commit":
+                payload["rollback"] = _rollback(adapter, env)
+            return payload
+        if phase == "commit" and outcome.get("ok"):
+            committed = True
+        if not outcome.get("ok"):
+            payload = result(
+                False,
+                str(outcome.get("detail") or f"{phase} failed"),
+                phase=phase,
+            )
+            if committed or phase == "commit":
+                payload["rollback"] = _rollback(adapter, env)
+            return payload
+    return result(True, "remote provider activation proven", phase=PHASES[-1])
+
+
+class FakeActivationAdapter:
+    """Shared transaction fake for remote-provider boundary tests."""
+
+    kind = "fake"
+
+    def __init__(
+        self,
+        plan: dict[str, list[dict[str, Any]]] | None = None,
+        callbacks: dict[str, Callable[[dict[str, str]], None]] | None = None,
+    ) -> None:
+        self.plan = plan or {}
+        self.callbacks = callbacks or {}
+        self.calls: list[str] = []
+
+    def _next(self, op: str, env: dict[str, str]) -> dict[str, Any]:
+        self.calls.append(op)
+        callback = self.callbacks.get(op)
+        if callback is not None:
+            callback(env)
+        queue = self.plan.get(op)
+        if not queue:
+            return result(True, f"{op} default ok")
+        if len(queue) > 1:
+            return queue.pop(0)
+        return queue[0]
+
+    def stage(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("stage", env)
+
+    def validate(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("validate", env)
+
+    def commit(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("commit", env)
+
+    def prove(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("prove", env)
+
+    def rollback(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("rollback", env)
+
+
+__all__ = [
+    "PHASES",
+    "ActivationAdapter",
+    "FakeActivationAdapter",
+    "result",
+    "run_activation_transaction",
+]

--- a/ods/config/remote-provider-egress-policy.json
+++ b/ods/config/remote-provider-egress-policy.json
@@ -1,0 +1,123 @@
+{
+  "version": 1,
+  "schema": "ods.remote-provider-egress-policy.v1",
+  "description": "Dormant remote-provider egress policy. ODS consumers route through the internal egress service; provider URLs, API keys, peer tokens, and SSH/TLS material must not be projected into public config surfaces.",
+  "egress_service": {
+    "service_id": "remote-provider-egress",
+    "internal_base_url": "http://remote-provider-egress:8091/v1",
+    "public_model_alias": "ods/current",
+    "bind_policy": "internal-only",
+    "network_effects_in_policy_module": false
+  },
+  "transports": {
+    "direct": {
+      "description": "Direct provider egress from the ODS egress service to an OpenAI-compatible HTTPS provider.",
+      "provider_base_url": {
+        "schemes": [
+          "https"
+        ],
+        "default_path": "/v1",
+        "allowed_paths": [
+          "/v1",
+          "/api/v1"
+        ],
+        "forbid_credentials": true,
+        "forbid_query": true,
+        "forbid_fragment": true,
+        "forbid_local_hostnames": true,
+        "forbid_ip_literal_classes": [
+          "broadcast",
+          "link_local",
+          "loopback",
+          "multicast",
+          "private",
+          "reserved",
+          "unspecified"
+        ],
+        "dns_resolution_required_by_policy_module": false
+      }
+    },
+    "ssh": {
+      "description": "SSH transport reaches the provider from the remote host side. HTTP provider URLs are allowed only inside the SSH transport boundary.",
+      "required_env": [
+        "REMOTE_LLM_SSH_HOST",
+        "REMOTE_LLM_SSH_USER",
+        "REMOTE_LLM_SSH_PORT",
+        "REMOTE_LLM_SSH_INFERENCE_HOST",
+        "REMOTE_LLM_SSH_INFERENCE_PORT"
+      ],
+      "provider_base_url": {
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "default_path": "/v1",
+        "allowed_paths": [
+          "/v1",
+          "/api/v1"
+        ],
+        "forbid_credentials": true,
+        "forbid_query": true,
+        "forbid_fragment": true,
+        "remote_side_loopback_allowed": true
+      }
+    }
+  },
+  "secret_custody": {
+    "public_env_forbidden": [
+      "REMOTE_LLM_API_KEY",
+      "REMOTE_ODS_PEER_TOKEN",
+      "REMOTE_LLM_SSH_PRIVATE_KEY",
+      "REMOTE_LLM_SSH_KEY_FILE",
+      "REMOTE_LLM_SSH_KNOWN_HOSTS",
+      "REMOTE_LLM_TLS_CA_PEM",
+      "REMOTE_LLM_TLS_CLIENT_CERT",
+      "REMOTE_LLM_TLS_CLIENT_KEY"
+    ],
+    "public_env_allowed": [
+      "REMOTE_LLM_ENABLED",
+      "REMOTE_LLM_TRANSPORT",
+      "REMOTE_LLM_BASE_URL",
+      "REMOTE_LLM_MODEL",
+      "REMOTE_LLM_TLS_CA_FILE",
+      "REMOTE_LLM_SSH_HOST",
+      "REMOTE_LLM_SSH_USER",
+      "REMOTE_LLM_SSH_PORT",
+      "REMOTE_LLM_SSH_INFERENCE_HOST",
+      "REMOTE_LLM_SSH_INFERENCE_PORT",
+      "REMOTE_LLM_SSH_CONTROL_HOST",
+      "REMOTE_LLM_SSH_CONTROL_PORT",
+      "REMOTE_ODS_PEER_URL"
+    ],
+    "redaction_token": "[REDACTED]",
+    "public_receipts_must_redact": true
+  },
+  "activation": {
+    "phases": [
+      "stage",
+      "validate",
+      "commit",
+      "prove"
+    ],
+    "fail_closed_before_commit": true,
+    "rollback_required_after_commit_failure": true,
+    "public_receipt_schema": "ods.remote-provider-activation-receipt.v1"
+  },
+  "evidence": {
+    "safe_public_fields": [
+      "schema",
+      "enabled",
+      "mode",
+      "transport",
+      "provider.capability",
+      "provider.baseUrl",
+      "provider.model",
+      "egress.internalBaseUrl",
+      "egress.publicModel",
+      "phase",
+      "ok",
+      "detail",
+      "secretRefs"
+    ]
+  }
+}

--- a/ods/scripts/release-gate.sh
+++ b/ods/scripts/release-gate.sh
@@ -34,6 +34,7 @@ bash tests/contracts/test-installer-hardening.sh
 bash tests/test-uninstall-compose-flags.sh
 bash tests/test-windows-missing-service-hints.sh
 "$PYTHON_CMD" tests/contracts/test-network-exposure-contracts.py
+"$PYTHON_CMD" tests/contracts/test-remote-provider-egress-policy.py
 
 echo "[gate] smoke"
 bash tests/smoke/linux-amd.sh

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Remote-provider egress policy contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "bin"))
+
+from remote_provider.policy import (  # noqa: E402
+    ACTIVATION_RECEIPT_SCHEMA,
+    FORBIDDEN_PUBLIC_SECRET_ENV,
+    INTERNAL_EGRESS_BASE_URL,
+    PUBLIC_MODEL_ALIAS,
+    REDACTED,
+    SCHEMA,
+    PolicyError,
+    load_policy,
+    normalize_provider_base_url,
+    plan_route,
+    public_activation_receipt,
+    validate_public_env_keys,
+)
+from remote_provider.reconciler import (  # noqa: E402
+    PHASES,
+    FakeActivationAdapter,
+    result,
+    run_activation_transaction,
+)
+
+
+POLICY_PATH = ROOT / "config" / "remote-provider-egress-policy.json"
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def assert_raises_policy_error(func, message: str) -> str:
+    try:
+        func()
+    except PolicyError as exc:
+        return str(exc)
+    raise AssertionError(message)
+
+
+def cloud_direct_env(**overrides: str) -> dict[str, str]:
+    env = {
+        "ODS_MODE": "cloud",
+        "REMOTE_LLM_ENABLED": "true",
+        "REMOTE_LLM_TRANSPORT": "direct",
+        "REMOTE_LLM_BASE_URL": "https://gpu.example.test",
+        "REMOTE_LLM_MODEL": "qwen/remote:latest",
+    }
+    env.update(overrides)
+    return env
+
+
+def cloud_ssh_env(**overrides: str) -> dict[str, str]:
+    env = cloud_direct_env(
+        REMOTE_LLM_TRANSPORT="ssh",
+        REMOTE_LLM_BASE_URL="http://127.0.0.1:8000/v1",
+        REMOTE_LLM_SSH_HOST="gpu.example.test",
+        REMOTE_LLM_SSH_USER="ods",
+        REMOTE_LLM_SSH_PORT="22",
+        REMOTE_LLM_SSH_INFERENCE_HOST="127.0.0.1",
+        REMOTE_LLM_SSH_INFERENCE_PORT="8000",
+    )
+    env.update(overrides)
+    return env
+
+
+def test_policy_document_shape() -> None:
+    policy = load_policy(POLICY_PATH)
+    assert_true(policy["schema"] == SCHEMA, "policy schema must be versioned")
+    assert_true(policy["version"] == 1, "policy version must be 1")
+    assert_true(
+        policy["egress_service"]["internal_base_url"] == INTERNAL_EGRESS_BASE_URL,
+        "egress service internal URL drifted",
+    )
+    assert_true(
+        policy["egress_service"]["public_model_alias"] == PUBLIC_MODEL_ALIAS,
+        "public model alias drifted",
+    )
+    assert_true(
+        policy["activation"]["phases"] == list(PHASES),
+        "activation policy must match reconciler phases",
+    )
+    forbidden = set(policy["secret_custody"]["public_env_forbidden"])
+    assert_true(
+        FORBIDDEN_PUBLIC_SECRET_ENV <= forbidden,
+        "policy must list every forbidden public secret key",
+    )
+    schema_text = (ROOT / ".env.schema.json").read_text(encoding="utf-8")
+    example_text = (ROOT / ".env.example").read_text(encoding="utf-8")
+    for key in forbidden:
+        assert_true(key not in schema_text, f"{key} must not be in public env schema")
+        assert_true(key not in example_text, f"{key} must not be in public env example")
+
+
+def test_direct_normalizes_public_https_roots() -> None:
+    route = plan_route(cloud_direct_env())
+    assert_true(route["enabled"] is True, "remote route should be enabled")
+    assert_true(route["transport"] == "direct", "transport should be direct")
+    assert_true(
+        route["provider"]["baseUrl"] == "https://gpu.example.test/v1",
+        "host root should normalize to /v1",
+    )
+    assert_true(
+        normalize_provider_base_url(
+            "https://GPU.example.test:9443/api/v1/",
+            transport="direct",
+        )
+        == "https://gpu.example.test:9443/api/v1",
+        "direct transport should accept /api/v1",
+    )
+    assert_true(
+        route["egress"] == {
+            "internalBaseUrl": INTERNAL_EGRESS_BASE_URL,
+            "publicModel": PUBLIC_MODEL_ALIAS,
+            "consumerRoute": "gateway",
+        },
+        "route must expose only the internal egress endpoint to consumers",
+    )
+
+
+def test_direct_rejects_unsafe_urls() -> None:
+    unsafe_urls = [
+        "http://gpu.example.test/v1",
+        "https://user:token@gpu.example.test/v1",
+        "https://gpu.example.test/v1?tenant=ods",
+        "https://gpu.example.test/v1#fragment",
+        "https://gpu.example.test\\v1",
+        "https://gpu.example.test/proxy",
+        "https://127.0.0.1:8000/v1",
+        "https://[::1]:8000/v1",
+        "https://10.0.0.5/v1",
+        "https://169.254.1.10/v1",
+        "https://224.0.0.1/v1",
+        "https://255.255.255.255/v1",
+        "https://localhost/v1",
+        "https://host.docker.internal/v1",
+    ]
+    for url in unsafe_urls:
+        assert_raises_policy_error(
+            lambda url=url: plan_route(cloud_direct_env(REMOTE_LLM_BASE_URL=url)),
+            f"direct transport accepted unsafe URL: {url}",
+        )
+
+
+def test_ssh_allows_remote_side_http_with_required_metadata() -> None:
+    route = plan_route(cloud_ssh_env())
+    assert_true(route["enabled"] is True, "SSH remote route should be enabled")
+    assert_true(route["transport"] == "ssh", "transport should be ssh")
+    assert_true(
+        route["provider"]["baseUrl"] == "http://127.0.0.1:8000/v1",
+        "SSH transport should allow remote-side loopback HTTP",
+    )
+    assert_true(route["ssh"]["host"] == "gpu.example.test", "SSH host missing")
+    assert_true(route["ssh"]["port"] == 22, "SSH port must be numeric")
+    assert_true(
+        route["ssh"]["inferencePort"] == 8000,
+        "SSH inference port must be numeric",
+    )
+
+
+def test_ssh_requires_transport_metadata() -> None:
+    env = cloud_ssh_env()
+    del env["REMOTE_LLM_SSH_INFERENCE_PORT"]
+    detail = assert_raises_policy_error(
+        lambda: plan_route(env),
+        "SSH transport accepted missing inference port",
+    )
+    assert_true(
+        "REMOTE_LLM_SSH_INFERENCE_PORT" in detail,
+        "failure should name the missing SSH env key",
+    )
+    assert_raises_policy_error(
+        lambda: plan_route(cloud_ssh_env(REMOTE_LLM_SSH_PORT="70000")),
+        "SSH transport accepted an out-of-range SSH port",
+    )
+
+
+def test_public_env_forbids_remote_secrets() -> None:
+    validate_public_env_keys(
+        {
+            "REMOTE_LLM_ENABLED": "true",
+            "REMOTE_LLM_TRANSPORT": "direct",
+            "REMOTE_LLM_BASE_URL": "https://gpu.example.test/v1",
+            "REMOTE_LLM_MODEL": "qwen-remote",
+        }
+    )
+    detail = assert_raises_policy_error(
+        lambda: validate_public_env_keys(
+            {
+                "REMOTE_LLM_ENABLED": "true",
+                "REMOTE_LLM_API_KEY": "unit-test-provider-token",
+            }
+        ),
+        "public env accepted a provider API key",
+    )
+    assert_true("REMOTE_LLM_API_KEY" in detail, "failure should name the secret key")
+
+
+def test_activation_receipt_redacts_secret_references() -> None:
+    route = plan_route(cloud_direct_env())
+    receipt = public_activation_receipt(
+        route,
+        phase="validate",
+        ok=True,
+        detail="metadata accepted",
+        secret_refs={
+            "REMOTE_LLM_API_KEY": "unit-test-provider-token",
+            "REMOTE_ODS_PEER_TOKEN": "unit-test-peer-token",
+        },
+    )
+    assert_true(receipt["schema"] == ACTIVATION_RECEIPT_SCHEMA, "receipt schema drifted")
+    dumped = json.dumps(receipt, sort_keys=True)
+    assert_true("unit-test-provider-token" not in dumped, "provider token leaked")
+    assert_true("unit-test-peer-token" not in dumped, "peer token leaked")
+    assert_true(REDACTED in dumped, "receipt should carry redacted secret refs")
+    assert_true(
+        receipt["provider"]["baseUrl"] == "https://gpu.example.test/v1",
+        "receipt should keep non-secret provider metadata",
+    )
+
+
+def test_activation_transaction_orders_phases() -> None:
+    adapter = FakeActivationAdapter()
+    outcome = run_activation_transaction(adapter, cloud_direct_env())
+    assert_true(outcome["ok"] is True, "happy path should succeed")
+    assert_true(outcome["phase"] == "prove", "happy path must finish at prove")
+    assert_true(adapter.calls == list(PHASES), "activation phases ran out of order")
+
+
+def test_activation_transaction_fails_closed_and_rolls_back_after_commit() -> None:
+    before_commit = FakeActivationAdapter(
+        {"validate": [result(False, "metadata rejected")]}
+    )
+    failed = run_activation_transaction(before_commit, cloud_direct_env())
+    assert_true(failed["ok"] is False, "validate failure should fail")
+    assert_true(failed["phase"] == "validate", "failure phase should be validate")
+    assert_true(
+        before_commit.calls == ["stage", "validate"],
+        "pre-commit failure should stop before commit",
+    )
+    assert_true("rollback" not in failed, "pre-commit failure must not roll back")
+
+    after_commit = FakeActivationAdapter({"prove": [result(False, "probe failed")]})
+    failed = run_activation_transaction(after_commit, cloud_direct_env())
+    assert_true(failed["ok"] is False, "prove failure should fail")
+    assert_true(failed["phase"] == "prove", "failure phase should be prove")
+    assert_true(
+        after_commit.calls == ["stage", "validate", "commit", "prove", "rollback"],
+        "post-commit failure must roll back once",
+    )
+    assert_true(failed["rollback"]["ok"] is True, "rollback result should be attached")
+
+    commit_failure = FakeActivationAdapter({"commit": [result(False, "swap failed")]})
+    failed = run_activation_transaction(commit_failure, cloud_direct_env())
+    assert_true(failed["ok"] is False, "commit failure should fail")
+    assert_true(failed["phase"] == "commit", "failure phase should be commit")
+    assert_true(
+        commit_failure.calls == ["stage", "validate", "commit", "rollback"],
+        "commit failure must request rollback once",
+    )
+
+
+def main() -> int:
+    tests = [
+        test_policy_document_shape,
+        test_direct_normalizes_public_https_roots,
+        test_direct_rejects_unsafe_urls,
+        test_ssh_allows_remote_side_http_with_required_metadata,
+        test_ssh_requires_transport_metadata,
+        test_public_env_forbids_remote_secrets,
+        test_activation_receipt_redacts_secret_references,
+        test_activation_transaction_orders_phases,
+        test_activation_transaction_fails_closed_and_rolls_back_after_commit,
+    ]
+    for test in tests:
+        test()
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add a versioned dormant `remote-provider-egress-policy.json` contract for provider URL, transport, secret-custody, and activation evidence boundaries.
- Add stdlib-only `remote_provider` helpers for URL normalization, public-env secret rejection, redacted activation receipts, and stage/validate/commit/prove transaction sequencing.
- Add CI/release-gate coverage for the new remote-provider egress policy contract.

## Validation
- Local Windows: `python ods/tests/contracts/test-remote-provider-egress-policy.py`
- Local Windows: `python ods/tests/test-render-runtime-configs.py`
- Local Windows/Git Bash: `ods/tests/test-validate-env.sh` -> 41 passed, 0 failed
- Local Windows/Git Bash: `ods/tests/test-generated-config-contracts.sh`
- Local Windows: `python ods/tests/contracts/test-network-exposure-contracts.py`
- Local Windows: `python -m json.tool ods/config/remote-provider-egress-policy.json`
- Local Windows: `python -m py_compile ods/bin/remote_provider/__init__.py ods/bin/remote_provider/policy.py ods/bin/remote_provider/reconciler.py ods/tests/contracts/test-remote-provider-egress-policy.py`
- Local Windows: `python -m ruff check ods/bin/remote_provider/__init__.py ods/bin/remote_provider/policy.py ods/bin/remote_provider/reconciler.py ods/tests/contracts/test-remote-provider-egress-policy.py`
- Local Windows: `git diff --check`
- Tower2 clean clone exact SHA `2cbd07793d4486cc9c7ef1a20a6f850ddf9a4535`: same focused suite passed; log `/home/michael/ods-pr-remote-egress-policy-2cbd0779.kPq9Hj/pr-remote-egress-policy-2cbd07793d4486cc9c7ef1a20a6f850ddf9a4535.log`

## Notes
- The new policy module is intentionally inert: it performs no network I/O and reads no secret material.
- Provider API keys and peer tokens remain out of `.env.schema.json`, `.env.example`, generated route state, and public receipts.