### PR TITLE
Harden remote provider egress resolution

### DIFF
--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -14,6 +14,7 @@ from .policy import (  # noqa: F401
     REMOTE_ROUTE_SCHEMA,
     SCHEMA,
     PolicyError,
+    classify_forbidden_ip_address,
     load_policy,
     normalize_provider_base_url,
     plan_route,
@@ -33,8 +34,10 @@ from .egress import (  # noqa: F401
     prepare_upstream_request,
     provider_secret_status,
     read_provider_secret,
+    resolve_direct_provider_addresses,
     route_from_state,
     sanitize_forward_headers,
+    validate_direct_provider_resolution,
 )
 
 __all__ = [
@@ -53,6 +56,7 @@ __all__ = [
     "EgressError",
     "PolicyError",
     "UpstreamRequest",
+    "classify_forbidden_ip_address",
     "load_policy",
     "load_route_state",
     "normalize_provider_base_url",
@@ -62,8 +66,10 @@ __all__ = [
     "public_activation_receipt",
     "read_provider_secret",
     "redacted_secret_refs",
+    "resolve_direct_provider_addresses",
     "route_from_state",
     "sanitize_forward_headers",
+    "validate_direct_provider_resolution",
     "validate_public_env_keys",
     "validate_remote_model_id",
 ]

--- a/ods/bin/remote_provider/egress.py
+++ b/ods/bin/remote_provider/egress.py
@@ -7,15 +7,19 @@ request preparation small and easy to test without sockets.
 from __future__ import annotations
 
 import json
+import socket
 from dataclasses import dataclass
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import urlsplit
 
 from .policy import (
     DEFAULT_POLICY_PATH,
     INTERNAL_EGRESS_BASE_URL,
     PUBLIC_MODEL_ALIAS,
     PolicyError,
+    classify_forbidden_ip_address,
     load_policy,
     plan_route,
 )
@@ -29,6 +33,7 @@ FORWARD_PATHS = {
 }
 DEFAULT_MAX_BODY_BYTES = 4 * 1024 * 1024
 DEFAULT_SECRET_PATH = Path("/state/remote-provider/secrets/provider-api-key")
+AddressResolver = Callable[..., list[tuple[Any, ...]]]
 HOP_BY_HOP_HEADERS = {
     "authorization",
     "connection",
@@ -192,6 +197,85 @@ def _join_openai_path(base_url: str, path: str) -> str:
     return f"{base}{suffix}"
 
 
+def _provider_host_port(base_url: str) -> tuple[str, int]:
+    try:
+        parts = urlsplit(base_url)
+        port = parts.port
+    except ValueError as exc:
+        raise EgressError(503, "invalid_route", f"provider URL is invalid: {exc}") from exc
+    host = parts.hostname or ""
+    if not host:
+        raise EgressError(503, "invalid_route", "provider route is missing a host")
+    if port is None:
+        port = 443 if parts.scheme == "https" else 80
+    return host, port
+
+
+def resolve_direct_provider_addresses(
+    base_url: str,
+    *,
+    resolver: AddressResolver = socket.getaddrinfo,
+) -> list[str]:
+    """Resolve a direct provider URL to unique IP addresses for policy checks."""
+    host, port = _provider_host_port(base_url)
+    try:
+        results = resolver(host, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise EgressError(
+            503,
+            "provider_resolution_failed",
+            f"remote provider host could not be resolved: {exc}",
+        ) from exc
+    addresses: list[str] = []
+    seen: set[str] = set()
+    for result in results:
+        if len(result) < 5 or not isinstance(result[4], tuple) or not result[4]:
+            continue
+        address = str(result[4][0])
+        if address and address not in seen:
+            seen.add(address)
+            addresses.append(address)
+    if not addresses:
+        raise EgressError(
+            503,
+            "provider_resolution_empty",
+            "remote provider host did not resolve to any usable addresses",
+        )
+    return addresses
+
+
+def validate_direct_provider_resolution(
+    route: Mapping[str, Any],
+    *,
+    resolver: AddressResolver = socket.getaddrinfo,
+) -> list[str]:
+    """Fail closed when a direct provider resolves to unsafe address space."""
+    if route.get("enabled") is not True or route.get("transport") != "direct":
+        return []
+    provider = route.get("provider")
+    if not isinstance(provider, Mapping):
+        raise EgressError(503, "invalid_route", "provider route is missing")
+    base_url = str(provider.get("baseUrl") or "")
+    host, _port = _provider_host_port(base_url)
+    literal_reason = classify_forbidden_ip_address(host)
+    if literal_reason:
+        raise EgressError(
+            503,
+            "provider_resolution_rejected",
+            f"remote provider URL targets {literal_reason} address space",
+        )
+    addresses = resolve_direct_provider_addresses(base_url, resolver=resolver)
+    for address in addresses:
+        reason = classify_forbidden_ip_address(address)
+        if reason:
+            raise EgressError(
+                503,
+                "provider_resolution_rejected",
+                f"remote provider host resolves to {reason} address space",
+            )
+    return addresses
+
+
 def prepare_upstream_request(
     *,
     method: str,
@@ -263,4 +347,6 @@ __all__ = [
     "read_provider_secret",
     "route_from_state",
     "sanitize_forward_headers",
+    "resolve_direct_provider_addresses",
+    "validate_direct_provider_resolution",
 ]

--- a/ods/bin/remote_provider/policy.py
+++ b/ods/bin/remote_provider/policy.py
@@ -97,7 +97,7 @@ def _transport_url_policy(policy: Mapping[str, Any], transport: str) -> Mapping[
     return url_policy
 
 
-def _classify_forbidden_ip(host: str) -> str:
+def classify_forbidden_ip_address(host: str) -> str:
     try:
         address = ipaddress.ip_address(host)
     except ValueError:
@@ -116,6 +116,8 @@ def _classify_forbidden_ip(host: str) -> str:
         return "private"
     if address.is_reserved:
         return "reserved"
+    if not address.is_global:
+        return "non_global"
     return ""
 
 
@@ -180,7 +182,7 @@ def normalize_provider_base_url(
     if transport_name == "direct":
         if lower_host in LOCAL_HOSTNAMES or lower_host.endswith(".localhost"):
             raise PolicyError("direct remote provider URL must not target local hostnames")
-        forbidden_class = _classify_forbidden_ip(lower_host)
+        forbidden_class = classify_forbidden_ip_address(lower_host)
         if forbidden_class:
             raise PolicyError(
                 f"direct remote provider URL must not use {forbidden_class} IP literals"

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -24,6 +24,7 @@ from remote_provider.egress import (
     provider_secret_status,
     read_provider_secret,
     route_from_state,
+    validate_direct_provider_resolution,
 )
 from remote_provider.policy import DEFAULT_POLICY_PATH, load_policy
 
@@ -120,12 +121,24 @@ async def health() -> dict[str, Any]:
             "route": _safe_route_summary(route),
             "secret": secret,
         }
+    try:
+        resolved_addresses = validate_direct_provider_resolution(route)
+    except EgressError as exc:
+        return {
+            "status": "degraded",
+            "ready": False,
+            "reason": exc.code,
+            "route": _safe_route_summary(route),
+            "resolution": {"ok": False, "reason": exc.code},
+            "secret": secret,
+        }
     if route.get("transport") == "direct" and not secret["configured"]:
         return {
             "status": "degraded",
             "ready": False,
             "reason": "missing_provider_secret",
             "route": _safe_route_summary(route),
+            "resolution": {"ok": True, "addressCount": len(resolved_addresses)},
             "secret": secret,
         }
     return {
@@ -133,6 +146,7 @@ async def health() -> dict[str, Any]:
         "ready": True,
         "reason": "ready",
         "route": _safe_route_summary(route),
+        "resolution": {"ok": True, "addressCount": len(resolved_addresses)},
         "secret": secret,
     }
 
@@ -164,6 +178,7 @@ async def forward(full_path: str, request: Request) -> Response:
     path = "/" + full_path
     try:
         route = _load_route()
+        validate_direct_provider_resolution(route)
         secret = read_provider_secret(SECRET_PATH)
         upstream_request = prepare_upstream_request(
             method=request.method,

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import socket
 import sys
 import tempfile
 from pathlib import Path
@@ -17,6 +18,7 @@ from remote_provider.egress import (  # noqa: E402
     prepare_upstream_request,
     provider_secret_status,
     route_from_state,
+    validate_direct_provider_resolution,
 )
 
 
@@ -66,6 +68,29 @@ def route_state(**provider_overrides: str) -> dict[str, object]:
         },
         "status": {"proven": False, "reason": "pending-provider-handshake"},
     }
+
+
+def resolver_for(*addresses: str):
+    def _resolver(host: str, port: int, *args, **kwargs):
+        results = []
+        for address in addresses:
+            if ":" in address:
+                results.append(
+                    (
+                        socket.AF_INET6,
+                        socket.SOCK_STREAM,
+                        6,
+                        "",
+                        (address, port, 0, 0),
+                    )
+                )
+            else:
+                results.append(
+                    (socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port))
+                )
+        return results
+
+    return _resolver
 
 
 def test_compose_service_is_internal_only_and_hardened() -> None:
@@ -123,6 +148,34 @@ def test_route_state_prepares_direct_provider_request_without_client_auth() -> N
     assert_true("connection" not in {key.lower() for key in upstream.headers}, "hop-by-hop headers must be stripped")
 
 
+def test_direct_resolution_allows_only_global_provider_addresses() -> None:
+    route = route_from_state(route_state())
+    addresses = validate_direct_provider_resolution(
+        route,
+        resolver=resolver_for("93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"),
+    )
+    assert_true(addresses == ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"], "global addresses should be accepted")
+
+
+def test_direct_resolution_rejects_unsafe_dns_answers() -> None:
+    route = route_from_state(route_state())
+    for address in ("10.0.0.5", "127.0.0.1", "169.254.1.10", "224.0.0.1"):
+        assert_egress_error(
+            lambda address=address: validate_direct_provider_resolution(
+                route,
+                resolver=resolver_for(address),
+            ),
+            "provider_resolution_rejected",
+        )
+    assert_egress_error(
+        lambda: validate_direct_provider_resolution(
+            route,
+            resolver=lambda *_args, **_kwargs: [],
+        ),
+        "provider_resolution_empty",
+    )
+
+
 def test_egress_fails_closed_without_secret_or_supported_transport() -> None:
     route = route_from_state(route_state())
     assert_egress_error(
@@ -158,6 +211,7 @@ def test_service_source_avoids_public_env_secret_names() -> None:
     assert_true("REMOTE_LLM_API_KEY" not in text, "app must not read provider key from public env")
     assert_true("ODS_REMOTE_PROVIDER_API_KEY_FILE" in text, "app must read only the provider key file path")
     assert_true("read_provider_secret" in text, "app must use shared secret-file helper")
+    assert_true("validate_direct_provider_resolution" in text, "app must enforce runtime DNS/address policy")
     assert_true(POLICY.exists(), "policy document must exist for mounted service config")
 
 
@@ -167,6 +221,8 @@ def main() -> int:
         test_manifest_and_network_policy_mark_no_lan_exposure,
         test_image_copies_shared_policy_package,
         test_route_state_prepares_direct_provider_request_without_client_auth,
+        test_direct_resolution_allows_only_global_provider_addresses,
+        test_direct_resolution_rejects_unsafe_dns_answers,
         test_egress_fails_closed_without_secret_or_supported_transport,
         test_secret_file_status_is_support_bundle_safe,
         test_service_source_avoids_public_env_secret_names,


### PR DESCRIPTION
## Summary

- Add shared direct-provider DNS/address-policy checks for `remote-provider-egress`.
- Resolve direct provider hosts at the egress boundary and reject loopback, private, link-local, multicast, reserved, broadcast, and other non-global address space before forwarding.
- Surface sanitized `/health` resolution status without exposing provider secrets or resolved addresses.
- Keep provider auth file-backed and continue to strip client auth/hop-by-hop headers before upstream forwarding.

## Validation

Local Windows worktree:
- `python tests\contracts\test-remote-provider-egress-service.py`
- `python tests\contracts\test-remote-provider-egress-policy.py`
- `python tests\test-render-runtime-configs.py`
- `python tests\test-runtime-config-wiring.py`
- `python -m ruff check bin\remote_provider extensions\services\remote-provider-egress\app tests\contracts\test-remote-provider-egress-service.py tests\contracts\test-remote-provider-egress-policy.py`
- `python -m py_compile bin\remote_provider\policy.py bin\remote_provider\egress.py bin\remote_provider\__init__.py extensions\services\remote-provider-egress\app\main.py tests\contracts\test-remote-provider-egress-service.py tests\contracts\test-remote-provider-egress-policy.py`
- `python tests\test-local-image-build-coverage.py`
- `python tests\contracts\test-network-exposure-contracts.py`
- `python scripts\check-dependency-pins.py`
- `python scripts\audit-extensions.py --project-dir .`
- `git diff --check`

Tower2 exact-SHA verification:
- SHA: `9c9a6d16fa5f8af90d8eb7eac8cdaa5187cb647b`
- Host: `Tower2`
- Tooling: Python 3.12.3, jq 1.7, rsync 3.2.7, Docker 29.2.1, Docker Compose v5.1.0
- Passed focused compile/lint/contracts, renderer/runtime wiring, image/exposure/dependency/audit checks, and `bash scripts/release-gate.sh`
- Log: `/home/michael/ods-pr-remote-egress-resolution-9c9a6d16.jO19j0/pr-remote-egress-resolution-9c9a6d16fa5f8af90d8eb7eac8cdaa5187cb647b.log`