### PR TITLE
Add remote provider status endpoint

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -63,7 +63,7 @@ from agent_monitor import collect_metrics
 from routers import (
     workflows, features, setup, updates, agents, privacy, extensions,
     gpu as gpu_router, resources, voice, models as models_router, model_state as model_state_router,
-    model_routes as model_routes_router, templates,
+    model_routes as model_routes_router, remote_provider_status, templates,
     auth as auth_router,
     magic_link,
     oauth_passthrough,
@@ -1094,6 +1094,7 @@ app.include_router(voice.router)
 # Static switchboard state route registers before the dynamic model-ID routes.
 app.include_router(model_state_router.router)
 app.include_router(model_routes_router.router)
+app.include_router(remote_provider_status.router)
 app.include_router(models_router.router)
 app.include_router(templates.router)
 app.include_router(auth_router.router)

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -1,0 +1,227 @@
+"""Read-only remote-provider lifecycle status for Dashboard/CLI consumers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+import httpx
+from fastapi import APIRouter, Depends
+
+from config import DATA_DIR
+from security import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["remote-provider"])
+
+ROUTE_STATE_SCHEMA = "ods.remote-routing-state.v1"
+EGRESS_URL = os.environ.get("REMOTE_PROVIDER_EGRESS_URL", "http://remote-provider-egress:8091")
+EGRESS_TIMEOUT_SECONDS = 3.0
+
+_SAFE_PROVIDER_KEYS = {"capability", "baseUrl", "model", "transport"}
+_SAFE_PROJECTION_KEYS = {"publicModel", "gateway", "egressBaseUrl", "consumerRoute"}
+
+
+def _state_path() -> Path:
+    override = os.environ.get("ODS_REMOTE_PROVIDER_ROUTE_PATH")
+    if override:
+        return Path(override)
+    return Path(DATA_DIR) / "remote-provider" / "routing-state.json"
+
+
+def _safe_string_map(value: Any, keys: set[str]) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    clean: dict[str, str] = {}
+    for key in keys:
+        item = value.get(key)
+        if isinstance(item, str):
+            clean[key] = item
+    return clean
+
+
+def _state_response(
+    *,
+    exists: bool,
+    valid: bool,
+    enabled: bool = False,
+    errors: list[str] | None = None,
+    mode: str | None = None,
+    provider: Mapping[str, Any] | None = None,
+    projection: Mapping[str, Any] | None = None,
+    status: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "exists": exists,
+        "valid": valid,
+        "enabled": enabled,
+        "mode": mode,
+        "provider": _safe_string_map(provider, _SAFE_PROVIDER_KEYS) if enabled else None,
+        "projection": _safe_string_map(projection, _SAFE_PROJECTION_KEYS),
+        "status": {
+            "proven": bool((status or {}).get("proven")),
+            "reason": str((status or {}).get("reason") or "disabled"),
+        },
+        "errors": errors or [],
+    }
+
+
+def _read_route_state() -> dict[str, Any]:
+    path = _state_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _state_response(exists=False, valid=True)
+    except OSError as exc:
+        return _state_response(exists=True, valid=False, errors=[f"read failed: {exc}"])
+
+    try:
+        doc = json.loads(raw)
+    except ValueError as exc:
+        return _state_response(exists=True, valid=False, errors=[f"not valid JSON: {exc}"])
+    if not isinstance(doc, Mapping):
+        return _state_response(exists=True, valid=False, errors=["state root must be an object"])
+    if doc.get("schema") != ROUTE_STATE_SCHEMA:
+        return _state_response(exists=True, valid=False, errors=["unknown routing-state schema"])
+    enabled = doc.get("enabled") is True
+    provider = doc.get("provider")
+    if enabled and not isinstance(provider, Mapping):
+        return _state_response(
+            exists=True,
+            valid=False,
+            enabled=True,
+            errors=["enabled route is missing provider metadata"],
+        )
+    return _state_response(
+        exists=True,
+        valid=True,
+        enabled=enabled,
+        mode=str(doc.get("mode") or "cloud"),
+        provider=provider,
+        projection=doc.get("projection"),
+        status=doc.get("status"),
+    )
+
+
+def _safe_secret_status(value: Any) -> dict[str, Any]:
+    secret = value if isinstance(value, Mapping) else {}
+    raw_bytes = secret.get("bytes")
+    return {
+        "configured": bool(secret.get("configured")),
+        "bytes": raw_bytes if type(raw_bytes) is int or raw_bytes is None else None,
+    }
+
+
+def _sanitize_egress_health(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        return {
+            "reachable": True,
+            "valid": False,
+            "ready": False,
+            "status": "invalid",
+            "reason": "invalid_egress_health",
+            "secret": {"configured": False, "bytes": None},
+            "resolution": None,
+        }
+    resolution = payload.get("resolution")
+    clean_resolution = None
+    if isinstance(resolution, Mapping):
+        clean_resolution = {
+            "ok": bool(resolution.get("ok")),
+            "reason": str(resolution.get("reason") or ""),
+            "addressCount": (
+                resolution.get("addressCount")
+                if type(resolution.get("addressCount")) is int
+                else None
+            ),
+        }
+    return {
+        "reachable": True,
+        "valid": True,
+        "ready": bool(payload.get("ready")),
+        "status": str(payload.get("status") or "unknown"),
+        "reason": str(payload.get("reason") or ""),
+        "secret": _safe_secret_status(payload.get("secret")),
+        "resolution": clean_resolution,
+    }
+
+
+async def _fetch_egress_health() -> dict[str, Any]:
+    url = f"{EGRESS_URL.rstrip('/')}/health"
+    try:
+        async with httpx.AsyncClient(timeout=EGRESS_TIMEOUT_SECONDS) as client:
+            response = await client.get(url)
+    except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as exc:
+        logger.debug("remote-provider-egress health unavailable: %s", exc)
+        return {
+            "reachable": False,
+            "valid": False,
+            "ready": False,
+            "status": "unreachable",
+            "reason": "egress_unreachable",
+            "secret": {"configured": False, "bytes": None},
+            "resolution": None,
+        }
+    except httpx.HTTPError as exc:
+        logger.debug("remote-provider-egress health request failed: %s", exc)
+        return {
+            "reachable": False,
+            "valid": False,
+            "ready": False,
+            "status": "error",
+            "reason": "egress_request_failed",
+            "secret": {"configured": False, "bytes": None},
+            "resolution": None,
+        }
+
+    if response.status_code >= 400:
+        return {
+            "reachable": True,
+            "valid": False,
+            "ready": False,
+            "status": "error",
+            "reason": f"egress_http_{response.status_code}",
+            "secret": {"configured": False, "bytes": None},
+            "resolution": None,
+        }
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    return _sanitize_egress_health(payload)
+
+
+def _overall_status(route_state: Mapping[str, Any], egress: Mapping[str, Any]) -> str:
+    if not route_state.get("valid"):
+        return "invalid"
+    if route_state.get("enabled") is not True:
+        return "disabled"
+    if not egress.get("reachable") or not egress.get("ready"):
+        return "degraded"
+    return "ready"
+
+
+@router.get("/api/remote-provider/status", dependencies=[Depends(verify_api_key)])
+async def remote_provider_status() -> dict[str, Any]:
+    """Return sanitized remote-provider status without mutating configuration."""
+    route_state = _read_route_state()
+    egress = await _fetch_egress_health()
+    return {
+        "status": _overall_status(route_state, egress),
+        "routeState": route_state,
+        "egress": egress,
+        "capabilities": {
+            "inference": bool(route_state.get("enabled")),
+            "odsPeerLifecycle": False,
+        },
+        "availableActions": {
+            "configure": False,
+            "test": bool(route_state.get("enabled")),
+            "disable": bool(route_state.get("enabled")),
+            "remove": bool(route_state.get("exists")),
+        },
+    }

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -537,6 +537,9 @@ class TestApiStorage:
 
     def test_returns_storage_breakdown(self, test_client, monkeypatch):
         from models import DiskUsage
+        from main import _cache
+
+        _cache.invalidate("storage")
         monkeypatch.setattr("main.get_disk_usage", lambda: DiskUsage(
             path="/tmp", used_gb=100.0, total_gb=500.0, percent=20.0,
         ))

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -1,0 +1,189 @@
+"""Tests for dashboard-api remote-provider status."""
+
+from __future__ import annotations
+
+import json
+
+
+def _route_state(model: str = "qwen/remote:latest") -> dict[str, object]:
+    return {
+        "schema": "ods.remote-routing-state.v1",
+        "enabled": True,
+        "mode": "cloud",
+        "provider": {
+            "capability": "openai-compatible",
+            "baseUrl": "https://gpu.example.test/v1",
+            "model": model,
+            "transport": "direct",
+        },
+        "projection": {
+            "publicModel": "ods/current",
+            "gateway": "litellm-cloud",
+            "egressBaseUrl": "http://remote-provider-egress:8091/v1",
+            "consumerRoute": "gateway",
+        },
+        "status": {"proven": False, "reason": "pending-provider-handshake"},
+    }
+
+
+def _patch_state_path(monkeypatch, path):
+    from routers import remote_provider_status as rps
+
+    monkeypatch.setattr(rps, "_state_path", lambda: path)
+    return rps
+
+
+def test_remote_provider_status_requires_auth(test_client):
+    resp = test_client.get("/api/remote-provider/status")
+    assert resp.status_code == 401
+
+
+def test_remote_provider_status_missing_state_is_disabled(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    rps = _patch_state_path(monkeypatch, tmp_path / "missing.json")
+
+    async def fake_fetch():
+        return {
+            "reachable": True,
+            "valid": True,
+            "ready": False,
+            "status": "disabled",
+            "reason": "remote_route_disabled",
+            "secret": {"configured": False, "bytes": 0},
+            "resolution": None,
+        }
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "disabled"
+    assert body["routeState"]["exists"] is False
+    assert body["routeState"]["valid"] is True
+    assert body["routeState"]["provider"] is None
+    assert body["availableActions"]["test"] is False
+
+
+def test_remote_provider_status_sanitizes_egress_secret_health(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text(json.dumps(_route_state()), encoding="utf-8")
+    rps = _patch_state_path(monkeypatch, state_path)
+
+    async def fake_fetch():
+        return rps._sanitize_egress_health(
+            {
+                "status": "ok",
+                "ready": True,
+                "reason": "ready",
+                "secret": {
+                    "configured": True,
+                    "bytes": 24,
+                    "path": "/state/remote-provider/secrets/provider-api-key",
+                    "value": "unit-test-provider-token",
+                },
+                "resolution": {"ok": True, "addressCount": 1},
+            }
+        )
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert body["status"] == "ready"
+    assert body["routeState"]["enabled"] is True
+    assert body["routeState"]["provider"]["model"] == "qwen/remote:latest"
+    assert body["egress"]["secret"] == {"configured": True, "bytes": 24}
+    assert body["egress"]["resolution"] == {
+        "ok": True,
+        "reason": "",
+        "addressCount": 1,
+    }
+    assert "unit-test-provider-token" not in dumped
+    assert "provider-api-key" not in dumped
+    assert body["capabilities"]["odsPeerLifecycle"] is False
+
+
+def test_remote_provider_status_invalid_state_is_diagnostic(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text("{not json", encoding="utf-8")
+    rps = _patch_state_path(monkeypatch, state_path)
+
+    async def fake_fetch():
+        return {
+            "reachable": True,
+            "valid": True,
+            "ready": False,
+            "status": "disabled",
+            "reason": "remote_route_disabled",
+            "secret": {"configured": False, "bytes": 0},
+            "resolution": None,
+        }
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "invalid"
+    assert body["routeState"]["valid"] is False
+    assert body["routeState"]["errors"]
+
+
+def test_remote_provider_status_reports_unreachable_egress(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text(json.dumps(_route_state()), encoding="utf-8")
+    rps = _patch_state_path(monkeypatch, state_path)
+
+    async def fake_fetch():
+        return {
+            "reachable": False,
+            "valid": False,
+            "ready": False,
+            "status": "unreachable",
+            "reason": "egress_unreachable",
+            "secret": {"configured": False, "bytes": None},
+            "resolution": None,
+        }
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["egress"]["reachable"] is False
+    assert body["egress"]["reason"] == "egress_unreachable"


### PR DESCRIPTION
## Summary
- Add an authenticated read-only `/api/remote-provider/status` Dashboard/API endpoint for remote-provider routing and egress health.
- Sanitize route state, egress secret status, and resolution diagnostics so support payloads never expose secret values or file paths.
- Report lifecycle status, capabilities, and currently available actions without mutating configuration.
- Isolate the existing `/api/storage` cache in its unit test so the dashboard sweep is order-independent.

## Validation
- `python -m pytest extensions\services\dashboard-api\tests\test_remote_provider_status.py extensions\services\dashboard-api\tests\test_routers.py extensions\services\dashboard-api\tests\test_main.py extensions\services\dashboard-api\tests\test_config.py` → 173 passed, 1 existing async-mock warning
- `python -m ruff check extensions\services\dashboard-api\routers\remote_provider_status.py extensions\services\dashboard-api\tests\test_remote_provider_status.py extensions\services\dashboard-api\tests\test_main.py extensions\services\dashboard-api\main.py`
- `git diff --check`
- Tower2 immutable SHA validation for `6d4756b24095aefff60f91d4021204dccf479138` passed, including dashboard tests, remote-provider egress contracts, runtime config tests, image build coverage, network exposure contracts, dependency pins, extension audit, and `bash scripts/release-gate.sh`.
  - Log: `/home/michael/ods-pr-remote-provider-status-6d4756b2.XMUPH5/pr-remote-provider-status-6d4756b24095aefff60f91d4021204dccf479138.log`