### PR TITLE
Add remote provider lifecycle operation contract

### DIFF
--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -49,6 +49,12 @@ from .egress import (  # noqa: F401
     sanitize_forward_headers,
     validate_direct_provider_resolution,
 )
+from .lifecycle import (  # noqa: F401
+    LIFECYCLE_ACTIONS,
+    LIFECYCLE_OPERATION_SCHEMA,
+    LifecycleError,
+    plan_lifecycle_operation,
+)
 
 __all__ = [
     "ACTIVATION_RECEIPT_SCHEMA",
@@ -63,12 +69,15 @@ __all__ = [
     "FORBIDDEN_PUBLIC_SECRET_ENV",
     "FORWARD_PATHS",
     "INTERNAL_EGRESS_BASE_URL",
+    "LIFECYCLE_ACTIONS",
+    "LIFECYCLE_OPERATION_SCHEMA",
     "PUBLIC_MODEL_ALIAS",
     "REDACTED",
     "REMOTE_ROUTE_SCHEMA",
     "ROUTING_STATE_SCHEMA",
     "SCHEMA",
     "EgressError",
+    "LifecycleError",
     "PolicyError",
     "SshTunnelSpec",
     "TransportError",
@@ -79,6 +88,7 @@ __all__ = [
     "load_route_state",
     "normalize_provider_base_url",
     "plan_route",
+    "plan_lifecycle_operation",
     "prepare_upstream_request",
     "provider_secret_status",
     "public_activation_receipt",

--- a/ods/bin/remote_provider/lifecycle.py
+++ b/ods/bin/remote_provider/lifecycle.py
@@ -1,0 +1,253 @@
+"""Typed remote-provider lifecycle operation planning.
+
+This module is intentionally side-effect free.  It gives the host-agent and
+Dashboard/API one shared contract for configure/test/disable/remove before
+later slices add file mutation and live probes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .policy import (
+    FORBIDDEN_PUBLIC_SECRET_ENV,
+    PolicyError,
+    plan_route,
+    public_activation_receipt,
+    redacted_secret_refs,
+)
+
+
+LIFECYCLE_OPERATION_SCHEMA = "ods.remote-provider-lifecycle-operation.v1"
+LIFECYCLE_ACTIONS = frozenset({"configure", "test", "disable", "remove"})
+
+_ACTION_PHASE = {
+    "configure": "stage",
+    "test": "validate",
+    "disable": "commit",
+    "remove": "commit",
+}
+_ACTION_DETAIL = {
+    "configure": "remote provider route staged",
+    "test": "remote provider route validated",
+    "disable": "remote provider route disabled",
+    "remove": "remote provider route removed",
+}
+_SECRET_FIELD_TO_REF = {
+    "apiKey": "REMOTE_LLM_API_KEY",
+    "peerToken": "REMOTE_ODS_PEER_TOKEN",
+    "sshPrivateKey": "REMOTE_LLM_SSH_PRIVATE_KEY",
+    "sshKnownHosts": "REMOTE_LLM_SSH_KNOWN_HOSTS",
+    "tlsCaPem": "REMOTE_LLM_TLS_CA_PEM",
+    "tlsClientCert": "REMOTE_LLM_TLS_CLIENT_CERT",
+    "tlsClientKey": "REMOTE_LLM_TLS_CLIENT_KEY",
+}
+_SINGLE_LINE_SECRET_FIELDS = {"apiKey", "peerToken"}
+_SSH_SECRET_FIELDS = {"sshPrivateKey", "sshKnownHosts"}
+
+
+class LifecycleError(PolicyError):
+    """Raised when a lifecycle action request violates the public contract."""
+
+
+def _string(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _mapping(value: object, field: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return value
+    raise LifecycleError(f"{field} must be an object")
+
+
+def _has_control_chars(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 for char in value)
+
+
+def _has_forbidden_multiline_secret_chars(value: str) -> bool:
+    return any(
+        (ord(char) < 32 and char not in "\r\n\t") or ord(char) == 127
+        for char in value
+    )
+
+
+def _reject_public_secret_keys(payload: Mapping[str, Any]) -> None:
+    present = sorted(key for key in payload if key in FORBIDDEN_PUBLIC_SECRET_ENV)
+    if present:
+        names = ", ".join(present)
+        raise LifecycleError(
+            "remote provider secrets must be passed under lifecycle secrets: "
+            f"{names}"
+        )
+
+
+def _read_provider_field(
+    payload: Mapping[str, Any],
+    provider: Mapping[str, Any],
+    key: str,
+    env_name: str,
+) -> str:
+    return _string(provider.get(key) or payload.get(key) or payload.get(env_name))
+
+
+def _read_ssh_field(
+    payload: Mapping[str, Any],
+    ssh: Mapping[str, Any],
+    env_name: str,
+    camel_name: str,
+) -> str:
+    return _string(ssh.get(camel_name) or payload.get(env_name) or payload.get(camel_name))
+
+
+def _route_env(payload: Mapping[str, Any]) -> dict[str, str]:
+    provider = _mapping(payload.get("provider"), "provider")
+    ssh = _mapping(payload.get("ssh"), "ssh")
+    env = {
+        "ODS_MODE": _string(payload.get("mode") or "cloud"),
+        "REMOTE_LLM_ENABLED": "true",
+        "REMOTE_LLM_TRANSPORT": _read_provider_field(
+            payload, provider, "transport", "REMOTE_LLM_TRANSPORT"
+        ).lower(),
+        "REMOTE_LLM_BASE_URL": _read_provider_field(
+            payload, provider, "baseUrl", "REMOTE_LLM_BASE_URL"
+        ),
+        "REMOTE_LLM_MODEL": _read_provider_field(
+            payload, provider, "model", "REMOTE_LLM_MODEL"
+        ),
+    }
+    for env_name, camel_name in (
+        ("REMOTE_LLM_SSH_HOST", "host"),
+        ("REMOTE_LLM_SSH_USER", "user"),
+        ("REMOTE_LLM_SSH_PORT", "port"),
+        ("REMOTE_LLM_SSH_INFERENCE_HOST", "inferenceHost"),
+        ("REMOTE_LLM_SSH_INFERENCE_PORT", "inferencePort"),
+        ("REMOTE_LLM_SSH_CONTROL_HOST", "controlHost"),
+        ("REMOTE_LLM_SSH_CONTROL_PORT", "controlPort"),
+    ):
+        value = _read_ssh_field(payload, ssh, env_name, camel_name)
+        if value:
+            env[env_name] = value
+    return env
+
+
+def _disabled_route(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return plan_route(
+        {
+            "ODS_MODE": _string(payload.get("mode") or "cloud"),
+            "REMOTE_LLM_ENABLED": "false",
+        }
+    )
+
+
+def _validate_secret_value(field: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise LifecycleError(f"secrets.{field} must be a string")
+    secret = value.strip()
+    if not secret:
+        raise LifecycleError(f"secrets.{field} must not be empty")
+    if field in _SINGLE_LINE_SECRET_FIELDS and _has_control_chars(secret):
+        raise LifecycleError(f"secrets.{field} must be a single-line secret")
+    if (
+        field not in _SINGLE_LINE_SECRET_FIELDS
+        and _has_forbidden_multiline_secret_chars(secret)
+    ):
+        raise LifecycleError(f"secrets.{field} contains unsupported control characters")
+    return secret
+
+
+def _secret_refs_for_action(
+    *,
+    action: str,
+    transport: str,
+    secrets: Mapping[str, Any],
+) -> dict[str, str]:
+    if action not in {"configure", "test"}:
+        return {}
+    unknown = sorted(key for key in secrets if key not in _SECRET_FIELD_TO_REF)
+    if unknown:
+        names = ", ".join(unknown)
+        raise LifecycleError(f"unsupported remote-provider secret fields: {names}")
+    if any(key in FORBIDDEN_PUBLIC_SECRET_ENV for key in secrets):
+        raise LifecycleError("remote provider secrets must use lifecycle secret field names")
+    if "apiKey" not in secrets:
+        raise LifecycleError("secrets.apiKey is required for remote-provider validation")
+    required = {"apiKey"}
+    if transport == "ssh":
+        required |= _SSH_SECRET_FIELDS
+    missing = sorted(field for field in required if field not in secrets)
+    if missing:
+        names = ", ".join(f"secrets.{field}" for field in missing)
+        raise LifecycleError(f"{names} required for {transport} remote-provider transport")
+    refs: dict[str, str] = {}
+    for field, value in secrets.items():
+        _validate_secret_value(field, value)
+        refs[field] = _SECRET_FIELD_TO_REF[field]
+    return refs
+
+
+def _write_plan(action: str, secret_refs: Mapping[str, str]) -> dict[str, bool]:
+    return {
+        "routingState": action in {"configure", "disable"},
+        "providerSecret": action == "configure" and "apiKey" in secret_refs,
+        "sshIdentity": action == "configure" and "sshPrivateKey" in secret_refs,
+        "sshKnownHosts": action == "configure" and "sshKnownHosts" in secret_refs,
+        "removesRoutingState": action == "remove",
+        "removesSecrets": action == "remove",
+    }
+
+
+def plan_lifecycle_operation(
+    payload: Mapping[str, Any],
+    *,
+    action: str | None = None,
+) -> dict[str, Any]:
+    """Return the public, redacted lifecycle operation plan for a request."""
+    if not isinstance(payload, Mapping):
+        raise LifecycleError("remote-provider lifecycle payload must be an object")
+    _reject_public_secret_keys(payload)
+    requested_action = _string(action or payload.get("action")).lower()
+    if requested_action not in LIFECYCLE_ACTIONS:
+        allowed = ", ".join(sorted(LIFECYCLE_ACTIONS))
+        raise LifecycleError(f"remote-provider lifecycle action must be one of: {allowed}")
+
+    if requested_action in {"configure", "test"}:
+        route = plan_route(_route_env(payload))
+        transport = str(route.get("transport") or "")
+    else:
+        route = _disabled_route(payload)
+        transport = ""
+
+    secrets = _mapping(payload.get("secrets"), "secrets")
+    secret_refs = _secret_refs_for_action(
+        action=requested_action,
+        transport=transport,
+        secrets=secrets,
+    )
+    redacted_refs = redacted_secret_refs(secret_refs.values())
+    receipt = public_activation_receipt(
+        route,
+        phase=_ACTION_PHASE[requested_action],
+        ok=True,
+        detail=_ACTION_DETAIL[requested_action],
+        secret_refs=secret_refs.values(),
+    )
+    return {
+        "schema": LIFECYCLE_OPERATION_SCHEMA,
+        "action": requested_action,
+        "ok": True,
+        "route": route,
+        "writes": _write_plan(requested_action, secret_refs),
+        "secretRefs": redacted_refs,
+        "receipt": receipt,
+    }
+
+
+__all__ = [
+    "LIFECYCLE_ACTIONS",
+    "LIFECYCLE_OPERATION_SCHEMA",
+    "LifecycleError",
+    "plan_lifecycle_operation",
+]

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -40,6 +40,11 @@ from remote_provider.reconciler import (  # noqa: E402
     result,
     run_activation_transaction,
 )
+from remote_provider.lifecycle import (  # noqa: E402
+    LIFECYCLE_OPERATION_SCHEMA,
+    LifecycleError,
+    plan_lifecycle_operation,
+)
 
 
 POLICY_PATH = ROOT / "config" / "remote-provider-egress-policy.json"
@@ -62,6 +67,14 @@ def assert_raises_transport_error(func, message: str) -> str:
     try:
         func()
     except TransportError as exc:
+        return str(exc)
+    raise AssertionError(message)
+
+
+def assert_raises_lifecycle_error(func, message: str) -> str:
+    try:
+        func()
+    except LifecycleError as exc:
         return str(exc)
     raise AssertionError(message)
 
@@ -367,6 +380,156 @@ def test_activation_transaction_fails_closed_and_rolls_back_after_commit() -> No
     )
 
 
+def test_lifecycle_configure_operation_is_redacted_and_typed() -> None:
+    operation = plan_lifecycle_operation(
+        {
+            "action": "configure",
+            "provider": {
+                "transport": "direct",
+                "baseUrl": "https://GPU.example.test",
+                "model": "qwen/remote:latest",
+            },
+            "secrets": {"apiKey": "unit-test-provider-token"},
+        }
+    )
+    dumped = json.dumps(operation, sort_keys=True)
+    assert_true(operation["schema"] == LIFECYCLE_OPERATION_SCHEMA, "lifecycle schema drifted")
+    assert_true(operation["action"] == "configure", "configure action drifted")
+    assert_true(operation["route"]["provider"]["baseUrl"] == "https://gpu.example.test/v1", "base URL not normalized")
+    assert_true(operation["writes"]["routingState"] is True, "configure must write routing state")
+    assert_true(operation["writes"]["providerSecret"] is True, "configure must write provider secret")
+    assert_true(operation["writes"]["removesSecrets"] is False, "configure must not delete secrets")
+    assert_true("REMOTE_LLM_API_KEY" in operation["secretRefs"], "provider secret ref missing")
+    assert_true(operation["secretRefs"]["REMOTE_LLM_API_KEY"]["value"] == REDACTED, "provider secret not redacted")
+    assert_true(operation["receipt"]["secretRefs"]["REMOTE_LLM_API_KEY"]["value"] == REDACTED, "receipt secret not redacted")
+    assert_true("unit-test-provider-token" not in dumped, "provider secret leaked into lifecycle operation")
+
+
+def test_lifecycle_test_disable_and_remove_write_intent() -> None:
+    validate = plan_lifecycle_operation(
+        {
+            "action": "test",
+            "REMOTE_LLM_TRANSPORT": "direct",
+            "REMOTE_LLM_BASE_URL": "https://gpu.example.test/v1",
+            "REMOTE_LLM_MODEL": "qwen/remote:latest",
+            "secrets": {"apiKey": "unit-test-provider-token"},
+        }
+    )
+    assert_true(validate["receipt"]["phase"] == "validate", "test action should map to validate phase")
+    assert_true(
+        validate["writes"] == {
+            "routingState": False,
+            "providerSecret": False,
+            "sshIdentity": False,
+            "sshKnownHosts": False,
+            "removesRoutingState": False,
+            "removesSecrets": False,
+        },
+        "test action must not persist state",
+    )
+
+    disabled = plan_lifecycle_operation({"action": "disable"})
+    assert_true(disabled["route"]["enabled"] is False, "disable must produce a disabled route")
+    assert_true(disabled["writes"]["routingState"] is True, "disable must write routing state")
+    assert_true(disabled["writes"]["removesSecrets"] is False, "disable must preserve secrets")
+
+    removed = plan_lifecycle_operation({"action": "remove"})
+    assert_true(removed["route"]["enabled"] is False, "remove must produce a disabled public route")
+    assert_true(removed["writes"]["routingState"] is False, "remove should delete, not rewrite, route state")
+    assert_true(removed["writes"]["removesRoutingState"] is True, "remove must delete route state")
+    assert_true(removed["writes"]["removesSecrets"] is True, "remove must delete secret custody files")
+
+
+def test_lifecycle_ssh_operation_tracks_secret_custody_without_leaks() -> None:
+    operation = plan_lifecycle_operation(
+        {
+            "action": "configure",
+            "provider": {
+                "transport": "ssh",
+                "baseUrl": "http://127.0.0.1:8000/v1",
+                "model": "qwen/remote:latest",
+            },
+            "ssh": {
+                "host": "gpu.example.test",
+                "user": "ods",
+                "port": "22",
+                "inferenceHost": "127.0.0.1",
+                "inferencePort": "8000",
+            },
+            "secrets": {
+                "apiKey": "unit-test-provider-token",
+                "sshPrivateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nunit-test-key\n-----END OPENSSH PRIVATE KEY-----",
+                "sshKnownHosts": "gpu.example.test ssh-ed25519 AAAATEST",
+            },
+        }
+    )
+    dumped = json.dumps(operation, sort_keys=True)
+    assert_true(operation["route"]["transport"] == "ssh", "SSH operation transport drifted")
+    assert_true(operation["route"]["ssh"]["host"] == "gpu.example.test", "SSH metadata missing")
+    assert_true(operation["writes"]["sshIdentity"] is True, "SSH configure must write identity custody")
+    assert_true(operation["writes"]["sshKnownHosts"] is True, "SSH configure must write known_hosts custody")
+    for ref in (
+        "REMOTE_LLM_API_KEY",
+        "REMOTE_LLM_SSH_PRIVATE_KEY",
+        "REMOTE_LLM_SSH_KNOWN_HOSTS",
+    ):
+        assert_true(ref in operation["secretRefs"], f"{ref} secret ref missing")
+        assert_true(operation["secretRefs"][ref]["value"] == REDACTED, f"{ref} not redacted")
+    assert_true("unit-test-provider-token" not in dumped, "provider token leaked")
+    assert_true("unit-test-key" not in dumped, "SSH private key leaked")
+    assert_true("AAAATEST" not in dumped, "SSH known_hosts leaked")
+
+
+def test_lifecycle_rejects_unsafe_or_secret_public_inputs() -> None:
+    detail = assert_raises_lifecycle_error(
+        lambda: plan_lifecycle_operation(
+            {
+                "action": "configure",
+                "provider": {
+                    "transport": "direct",
+                    "baseUrl": "https://gpu.example.test/v1",
+                    "model": "qwen/remote:latest",
+                },
+            }
+        ),
+        "configure accepted a missing provider secret",
+    )
+    assert_true("secrets.apiKey" in detail, "missing API key failure should name secrets.apiKey")
+    assert_raises_lifecycle_error(
+        lambda: plan_lifecycle_operation({"action": "rotate"}),
+        "unsupported lifecycle action accepted",
+    )
+    assert_raises_lifecycle_error(
+        lambda: plan_lifecycle_operation(
+            {
+                "action": "configure",
+                "REMOTE_LLM_API_KEY": "unit-test-provider-token",
+                "provider": {
+                    "transport": "direct",
+                    "baseUrl": "https://gpu.example.test/v1",
+                    "model": "qwen/remote:latest",
+                },
+                "secrets": {"apiKey": "unit-test-provider-token"},
+            }
+        ),
+        "public secret env key accepted in lifecycle payload",
+    )
+    assert_raises_policy_error(
+        lambda: plan_lifecycle_operation(
+            {
+                "action": "configure",
+                "provider": {
+                    "transport": "direct",
+                    "baseUrl": "https://127.0.0.1:8000/v1",
+                    "model": "qwen/remote:latest",
+                },
+                "secrets": {"apiKey": "unit-test-provider-token"},
+            }
+        ),
+        "unsafe direct lifecycle provider URL accepted",
+    )
+
+
 def main() -> int:
     tests = [
         test_policy_document_shape,
@@ -380,6 +543,10 @@ def main() -> int:
         test_activation_receipt_redacts_secret_references,
         test_activation_transaction_orders_phases,
         test_activation_transaction_fails_closed_and_rolls_back_after_commit,
+        test_lifecycle_configure_operation_is_redacted_and_typed,
+        test_lifecycle_test_disable_and_remove_write_intent,
+        test_lifecycle_ssh_operation_tracks_secret_custody_without_leaks,
+        test_lifecycle_rejects_unsafe_or_secret_public_inputs,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary
- Add a pure stdlib `remote_provider.lifecycle` operation planner for configure/test/disable/remove.
- Normalize nested Dashboard-shaped payloads and allowed public env-style metadata into the existing remote-provider route contract.
- Return write intent, public route metadata, and activation receipts without exposing provider API keys, SSH private keys, known_hosts data, or peer/TLS secrets.
- Export the lifecycle contract through the shared `remote_provider` package and extend the remote-provider policy contracts.

## Validation
- `python -m ruff check bin\remote_provider\lifecycle.py bin\remote_provider\__init__.py tests\contracts\test-remote-provider-egress-policy.py`
- `python -m py_compile bin\remote_provider\lifecycle.py bin\remote_provider\__init__.py tests\contracts\test-remote-provider-egress-policy.py`
- `python tests\contracts\test-remote-provider-egress-policy.py`
- `python tests\contracts\test-remote-provider-egress-service.py`
- `python tests\test-render-runtime-configs.py`
- `python tests\test-runtime-config-wiring.py`
- `python tests\contracts\test-network-exposure-contracts.py`
- `python scripts\check-dependency-pins.py`
- `python scripts\audit-extensions.py --project-dir .`
- `git diff --cached --check`
- Tower2 immutable SHA validation for `9dea16feed9d1167b13f959ee76b4eb250ddb53d` passed, including lifecycle/policy contracts, egress service contracts, runtime config tests, image build coverage, network exposure contracts, dependency pins, extension audit, and `bash scripts/release-gate.sh`.
  - Log: `/home/michael/ods-pr-remote-provider-lifecycle-9dea16fe.Pf2S6F/pr-remote-provider-lifecycle-9dea16feed9d1167b13f959ee76b4eb250ddb53d.log`