### PR TITLE
Add remote provider lifecycle planning endpoint

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -55,6 +55,16 @@ try:
 except Exception:  # pragma: no cover - import environment dependent
     _switchboard_adapters = None
     _switchboard_reconciler = None
+try:
+    from remote_provider.lifecycle import (
+        LifecycleError as _RemoteProviderLifecycleError,
+        plan_lifecycle_operation as _plan_remote_provider_lifecycle_operation,
+    )
+    from remote_provider.policy import PolicyError as _RemoteProviderPolicyError
+except Exception:  # pragma: no cover - import environment dependent
+    _RemoteProviderLifecycleError = ValueError
+    _RemoteProviderPolicyError = ValueError
+    _plan_remote_provider_lifecycle_operation = None
 
 VERSION = "1.0.0"
 ODS_VERSION = VERSION
@@ -3580,6 +3590,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_model_download_cancel()
         elif self.path == "/v1/model/activate":
             self._handle_model_activate()
+        elif self.path == "/v1/remote-provider/plan":
+            self._handle_remote_provider_plan()
         elif self.path == "/v1/runtime/lemonade/ensure":
             self._handle_windows_lemonade_runtime_ensure()
         elif self.path == "/v1/model/delete":
@@ -3596,6 +3608,31 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_network_wifi_forget()
         else:
             json_response(self, 404, {"error": "Not found"})
+
+    def _handle_remote_provider_plan(self):
+        """Validate a remote-provider lifecycle request without side effects."""
+        if not check_auth(self):
+            return
+        body = read_optional_json_body(self)
+        if body is None:
+            return
+        if _plan_remote_provider_lifecycle_operation is None:
+            json_response(
+                self,
+                501,
+                {"error": "Remote provider lifecycle planner is unavailable"},
+            )
+            return
+        try:
+            plan = _plan_remote_provider_lifecycle_operation(body)
+        except (_RemoteProviderLifecycleError, _RemoteProviderPolicyError) as exc:
+            json_response(self, 400, {"error": str(exc)})
+            return
+        except Exception as exc:
+            logger.exception("remote-provider lifecycle planning failed")
+            json_response(self, 500, {"error": f"Remote provider planning failed: {exc}"})
+            return
+        json_response(self, 200, plan)
 
     def _handle_invalidate_compose_cache(self):
         """Drop the .compose-flags cache file so the next CLI call re-resolves it."""

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -9,9 +9,15 @@ from pathlib import Path
 from typing import Any, Mapping
 
 import httpx
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from config import DATA_DIR
+from host_agent_client import (
+    AgentHTTPError,
+    AgentProtocolError,
+    AgentUnavailable,
+    async_request_json as async_request_agent_json,
+)
 from security import verify_api_key
 
 logger = logging.getLogger(__name__)
@@ -225,3 +231,21 @@ async def remote_provider_status() -> dict[str, Any]:
             "remove": bool(route_state.get("exists")),
         },
     }
+
+
+@router.post("/api/remote-provider/plan", dependencies=[Depends(verify_api_key)])
+async def remote_provider_plan(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate a remote-provider lifecycle request through the host agent."""
+    try:
+        return await async_request_agent_json(
+            "POST",
+            "/v1/remote-provider/plan",
+            payload=payload,
+            timeout=10,
+        )
+    except AgentHTTPError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except AgentUnavailable as exc:
+        raise HTTPException(status_code=503, detail=f"Host agent unreachable: {exc}") from exc
+    except AgentProtocolError as exc:
+        raise HTTPException(status_code=502, detail=f"Invalid host agent response: {exc}") from exc

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1995,6 +1995,65 @@ class _FakeHandler:
         return json.loads(self.wfile.getvalue().decode("utf-8"))
 
 
+class TestRemoteProviderLifecyclePlan:
+    """Direct host-agent tests for remote-provider lifecycle planning."""
+
+    @pytest.fixture(autouse=True)
+    def _auth(self, monkeypatch):
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+
+    def test_plans_redacted_lifecycle_operation(self):
+        payload = {
+            "action": "test",
+            "provider": {
+                "transport": "direct",
+                "baseUrl": "https://gpu.example.test",
+                "model": "qwen/remote:latest",
+            },
+            "secrets": {"apiKey": "unit-test-provider-token"},
+        }
+        handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_plan(handler)
+
+        body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
+        assert handler.response_code == 200
+        assert body["action"] == "test"
+        assert body["route"]["provider"]["baseUrl"] == "https://gpu.example.test/v1"
+        assert body["writes"]["routingState"] is False
+        assert "REMOTE_LLM_API_KEY" in body["secretRefs"]
+        assert "unit-test-provider-token" not in dumped
+
+    def test_rejects_invalid_lifecycle_payload(self):
+        payload = {
+            "action": "configure",
+            "provider": {
+                "transport": "direct",
+                "baseUrl": "https://127.0.0.1:8000/v1",
+                "model": "qwen/remote:latest",
+            },
+            "secrets": {"apiKey": "unit-test-provider-token"},
+        }
+        handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_plan(handler)
+
+        body = handler.parse_response()
+        assert handler.response_code == 400
+        assert "loopback" in body["error"]
+
+    def test_requires_auth(self):
+        handler = _FakeHandler(
+            json.dumps({"action": "disable"}).encode("utf-8"),
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+
+        _mod.AgentHandler._handle_remote_provider_plan(handler)
+
+        assert handler.response_code == 403
+
+
 class TestTailscaleStatus:
     """Direct host-agent tests for /v1/tailscale/status behavior."""
 

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -26,6 +26,18 @@ def _route_state(model: str = "qwen/remote:latest") -> dict[str, object]:
     }
 
 
+def _lifecycle_payload() -> dict[str, object]:
+    return {
+        "action": "test",
+        "provider": {
+            "transport": "direct",
+            "baseUrl": "https://gpu.example.test",
+            "model": "qwen/remote:latest",
+        },
+        "secrets": {"apiKey": "unit-test-provider-token"},
+    }
+
+
 def _patch_state_path(monkeypatch, path):
     from routers import remote_provider_status as rps
 
@@ -187,3 +199,76 @@ def test_remote_provider_status_reports_unreachable_egress(
     assert body["status"] == "degraded"
     assert body["egress"]["reachable"] is False
     assert body["egress"]["reason"] == "egress_unreachable"
+
+
+def test_remote_provider_plan_requires_auth(test_client):
+    resp = test_client.post("/api/remote-provider/plan", json=_lifecycle_payload())
+    assert resp.status_code == 401
+
+
+def test_remote_provider_plan_proxies_to_host_agent(
+    test_client,
+    monkeypatch,
+):
+    from routers import remote_provider_status as rps
+
+    calls = []
+
+    async def fake_request(method, path, *, payload, timeout):
+        calls.append((method, path, payload, timeout))
+        return {
+            "schema": "ods.remote-provider-lifecycle-operation.v1",
+            "action": "test",
+            "ok": True,
+            "route": {
+                "enabled": True,
+                "provider": {
+                    "baseUrl": "https://gpu.example.test/v1",
+                    "model": "qwen/remote:latest",
+                    "transport": "direct",
+                },
+            },
+            "writes": {"routingState": False},
+            "secretRefs": {
+                "REMOTE_LLM_API_KEY": {"present": True, "value": "[REDACTED]"}
+            },
+        }
+
+    monkeypatch.setattr(rps, "async_request_agent_json", fake_request)
+
+    resp = test_client.post(
+        "/api/remote-provider/plan",
+        json=_lifecycle_payload(),
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert body["action"] == "test"
+    assert body["secretRefs"]["REMOTE_LLM_API_KEY"]["value"] == "[REDACTED]"
+    assert "unit-test-provider-token" not in dumped
+    assert calls == [
+        ("POST", "/v1/remote-provider/plan", _lifecycle_payload(), 10)
+    ]
+
+
+def test_remote_provider_plan_preserves_host_agent_validation_errors(
+    test_client,
+    monkeypatch,
+):
+    from routers import remote_provider_status as rps
+
+    async def fake_request(*_args, **_kwargs):
+        raise rps.AgentHTTPError(400, "remote provider base URL is required")
+
+    monkeypatch.setattr(rps, "async_request_agent_json", fake_request)
+
+    resp = test_client.post(
+        "/api/remote-provider/plan",
+        json={"action": "configure"},
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "remote provider base URL is required"


### PR DESCRIPTION
## Summary
- Add authenticated host-agent `POST /v1/remote-provider/plan` for side-effect-free lifecycle request validation.
- Add authenticated Dashboard/API `POST /api/remote-provider/plan` proxy that forwards to the host-agent and preserves validation errors.
- Cover redaction, invalid input, auth, host-agent proxying, and Dashboard error mapping.

## Validation
- `python -m pytest extensions\services\dashboard-api\tests\test_remote_provider_status.py extensions\services\dashboard-api\tests\test_host_agent.py::TestRemoteProviderLifecyclePlan extensions\services\dashboard-api\tests\test_host_agent_client.py`
- `python -m pytest extensions\services\dashboard-api\tests\test_remote_provider_status.py extensions\services\dashboard-api\tests\test_routers.py extensions\services\dashboard-api\tests\test_main.py extensions\services\dashboard-api\tests\test_config.py` → 176 passed, 1 existing async-mock warning
- `python -m ruff check bin\ods-host-agent.py extensions\services\dashboard-api\routers\remote_provider_status.py extensions\services\dashboard-api\tests\test_remote_provider_status.py extensions\services\dashboard-api\tests\test_host_agent.py`
- `python -m py_compile bin\ods-host-agent.py extensions\services\dashboard-api\routers\remote_provider_status.py extensions\services\dashboard-api\tests\test_remote_provider_status.py extensions\services\dashboard-api\tests\test_host_agent.py`
- `python tests\contracts\test-remote-provider-egress-policy.py`
- `python tests\contracts\test-remote-provider-egress-service.py`
- `python tests\test-render-runtime-configs.py`
- `python tests\test-runtime-config-wiring.py`
- `python tests\test-local-image-build-coverage.py`
- `python tests\contracts\test-network-exposure-contracts.py`
- `python scripts\check-dependency-pins.py`
- `python scripts\audit-extensions.py --project-dir .`
- `git diff --check`
- Tower2 immutable SHA validation for `e73f97e31312caf0cec6d559498f91ba8a6d2e8d` passed, including focused/broad dashboard tests, lifecycle/egress contracts, runtime config tests, image build coverage, network exposure contracts, dependency pins, extension audit, and `bash scripts/release-gate.sh`.
  - Log: `/home/michael/ods-pr-remote-provider-plan-e73f97e3.I0v9gh/pr-remote-provider-plan-e73f97e31312caf0cec6d559498f91ba8a6d2e8d.log`