### PR TITLE
Add remote provider lifecycle apply endpoint

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -56,6 +56,9 @@ except Exception:  # pragma: no cover - import environment dependent
     _switchboard_adapters = None
     _switchboard_reconciler = None
 try:
+    from remote_provider.egress import (
+        ROUTING_STATE_SCHEMA as _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA,
+    )
     from remote_provider.lifecycle import (
         LifecycleError as _RemoteProviderLifecycleError,
         plan_lifecycle_operation as _plan_remote_provider_lifecycle_operation,
@@ -64,6 +67,7 @@ try:
 except Exception:  # pragma: no cover - import environment dependent
     _RemoteProviderLifecycleError = ValueError
     _RemoteProviderPolicyError = ValueError
+    _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA = "ods.remote-routing-state.v1"
     _plan_remote_provider_lifecycle_operation = None
 
 VERSION = "1.0.0"
@@ -105,6 +109,26 @@ STARTUP_ODS_MODE: str | None = None
 TIER: str = "1"
 GPU_COUNT: str = "1"
 CORE_SERVICE_IDS: set = set()
+_REMOTE_PROVIDER_EGRESS_UID = 10778
+_REMOTE_PROVIDER_EGRESS_GID = 10778
+_REMOTE_PROVIDER_SECRET_FIELD_TO_REF = {
+    "apiKey": "REMOTE_LLM_API_KEY",
+    "peerToken": "REMOTE_ODS_PEER_TOKEN",
+    "sshPrivateKey": "REMOTE_LLM_SSH_PRIVATE_KEY",
+    "sshKnownHosts": "REMOTE_LLM_SSH_KNOWN_HOSTS",
+    "tlsCaPem": "REMOTE_LLM_TLS_CA_PEM",
+    "tlsClientCert": "REMOTE_LLM_TLS_CLIENT_CERT",
+    "tlsClientKey": "REMOTE_LLM_TLS_CLIENT_KEY",
+}
+_REMOTE_PROVIDER_SECRET_REF_TO_FILENAME = {
+    "REMOTE_LLM_API_KEY": "provider-api-key",
+    "REMOTE_ODS_PEER_TOKEN": "peer-token",
+    "REMOTE_LLM_SSH_PRIVATE_KEY": "ssh-identity",
+    "REMOTE_LLM_SSH_KNOWN_HOSTS": "known_hosts",
+    "REMOTE_LLM_TLS_CA_PEM": "tls-ca.pem",
+    "REMOTE_LLM_TLS_CLIENT_CERT": "tls-client-cert.pem",
+    "REMOTE_LLM_TLS_CLIENT_KEY": "tls-client-key.pem",
+}
 _windows_gpu_metrics_cache: tuple[float, dict | None] = (0.0, None)
 _windows_dxgi_adapters_cache: tuple[float, list[dict]] = (0.0, [])
 _windows_llm_status_cache: tuple[float, dict | None] = (0.0, None)
@@ -1390,6 +1414,181 @@ def _restore_text_file(path: Path, snapshot: dict) -> None:
         if path.is_symlink():
             raise RuntimeError(f"Refusing to remove unexpected symlink during rollback: {path}")
         path.unlink(missing_ok=True)
+
+
+class _RemoteProviderApplyError(RuntimeError):
+    """Lifecycle apply failure with support-bundle-safe rollback metadata."""
+
+    def __init__(self, message: str, rollback: dict) -> None:
+        super().__init__(message)
+        self.rollback = rollback
+
+
+def _remote_provider_root() -> Path:
+    return DATA_DIR / "remote-provider"
+
+
+def _remote_provider_route_state_path() -> Path:
+    return _remote_provider_root() / "routing-state.json"
+
+
+def _remote_provider_secret_path(ref: str) -> Path:
+    filename = _REMOTE_PROVIDER_SECRET_REF_TO_FILENAME.get(ref)
+    if not filename:
+        raise RuntimeError(f"Unsupported remote-provider secret reference: {ref}")
+    return _remote_provider_root() / "secrets" / filename
+
+
+def _remote_provider_secret_owner() -> tuple[int | None, int | None]:
+    if os.name == "nt" or not hasattr(os, "geteuid"):
+        return None, None
+    try:
+        if os.geteuid() == 0:
+            return _REMOTE_PROVIDER_EGRESS_UID, _REMOTE_PROVIDER_EGRESS_GID
+    except OSError:
+        pass
+    return None, None
+
+
+def _remote_provider_projection(route: dict) -> dict:
+    egress = route.get("egress") if isinstance(route.get("egress"), dict) else {}
+    return {
+        "publicModel": str(egress.get("publicModel") or "ods/current"),
+        "gateway": "litellm-cloud",
+        "egressBaseUrl": str(
+            egress.get("internalBaseUrl") or "http://remote-provider-egress:8091/v1"
+        ),
+        "consumerRoute": str(egress.get("consumerRoute") or "gateway"),
+    }
+
+
+def _remote_provider_route_state_from_plan(plan: dict) -> dict:
+    route = plan.get("route") if isinstance(plan.get("route"), dict) else {}
+    enabled = route.get("enabled") is True
+    return {
+        "schema": _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA,
+        "enabled": enabled,
+        "mode": str(route.get("mode") or "cloud"),
+        "provider": route.get("provider") if enabled else None,
+        "projection": _remote_provider_projection(route),
+        "status": {
+            "proven": False,
+            "reason": "pending-provider-handshake" if enabled else "disabled",
+        },
+    }
+
+
+def _remote_provider_secret_values(payload: dict, plan: dict) -> dict[str, str]:
+    secrets_payload = payload.get("secrets")
+    secrets_map = secrets_payload if isinstance(secrets_payload, dict) else {}
+    refs = plan.get("secretRefs") if isinstance(plan.get("secretRefs"), dict) else {}
+    values: dict[str, str] = {}
+    for field, ref in _REMOTE_PROVIDER_SECRET_FIELD_TO_REF.items():
+        if ref not in refs or field not in secrets_map:
+            continue
+        values[ref] = str(secrets_map[field]).strip()
+    return values
+
+
+def _write_remote_provider_route_state(plan: dict) -> None:
+    state = _remote_provider_route_state_from_plan(plan)
+    _atomic_write_text(
+        _remote_provider_route_state_path(),
+        json.dumps(state, indent=2, sort_keys=True) + "\n",
+        0o644,
+    )
+
+
+def _write_remote_provider_secret(ref: str, value: str) -> None:
+    uid, gid = _remote_provider_secret_owner()
+    _atomic_write_text(
+        _remote_provider_secret_path(ref),
+        value.rstrip("\r\n") + "\n",
+        0o600,
+        uid,
+        gid,
+    )
+
+
+def _remove_remote_provider_file(path: Path) -> None:
+    if path.is_symlink():
+        raise RuntimeError(f"Refusing to remove symlinked remote-provider file: {path}")
+    path.unlink(missing_ok=True)
+
+
+def _remote_provider_mutation_paths(action: str) -> list[Path]:
+    paths = [_remote_provider_route_state_path()]
+    if action == "remove":
+        paths.extend(
+            _remote_provider_secret_path(ref)
+            for ref in _REMOTE_PROVIDER_SECRET_REF_TO_FILENAME
+        )
+    return list(dict.fromkeys(paths))
+
+
+def _restore_remote_provider_snapshots(snapshots: dict[Path, dict]) -> None:
+    for path, snapshot in reversed(list(snapshots.items())):
+        _restore_text_file(path, snapshot)
+
+
+def _apply_remote_provider_lifecycle_operation(payload: dict, plan: dict) -> dict:
+    action = str(plan.get("action") or "")
+    result = json.loads(json.dumps(plan))
+    result["applied"] = True
+    result["mutated"] = action in {"configure", "disable", "remove"}
+    result["rollback"] = {"attempted": False, "ok": None}
+    if action == "test":
+        return result
+
+    if action not in {"configure", "disable", "remove"}:
+        raise _RemoteProviderApplyError(
+            f"Unsupported remote-provider lifecycle action: {action}",
+            result["rollback"],
+        )
+
+    if action == "configure":
+        secret_values = _remote_provider_secret_values(payload, plan)
+        mutation_paths = [_remote_provider_route_state_path()]
+        mutation_paths.extend(_remote_provider_secret_path(ref) for ref in secret_values)
+        mutation_paths = list(dict.fromkeys(mutation_paths))
+    else:
+        secret_values = {}
+        mutation_paths = _remote_provider_mutation_paths(action)
+
+    snapshots: dict[Path, dict] = {}
+    mutation_started = False
+    try:
+        snapshots = {path: _snapshot_text_file(path) for path in mutation_paths}
+        if action in {"configure", "disable"}:
+            _write_remote_provider_route_state(plan)
+            mutation_started = True
+        if action == "configure":
+            for ref, secret in secret_values.items():
+                _write_remote_provider_secret(ref, secret)
+                mutation_started = True
+        elif action == "remove":
+            for path in mutation_paths:
+                _remove_remote_provider_file(path)
+                mutation_started = True
+    except Exception as exc:
+        rollback = {"attempted": False, "ok": None}
+        if mutation_started and snapshots:
+            rollback["attempted"] = True
+            try:
+                _restore_remote_provider_snapshots(snapshots)
+            except Exception as rollback_exc:
+                rollback["ok"] = False
+                raise _RemoteProviderApplyError(
+                    f"Remote provider apply failed: {exc}; rollback failed: {rollback_exc}",
+                    rollback,
+                ) from exc
+            rollback["ok"] = True
+        raise _RemoteProviderApplyError(
+            f"Remote provider apply failed: {exc}",
+            rollback,
+        ) from exc
+
+    return result
 
 
 def _assert_text_file_matches_snapshot(path: Path, snapshot: dict) -> None:
@@ -3592,6 +3791,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_model_activate()
         elif self.path == "/v1/remote-provider/plan":
             self._handle_remote_provider_plan()
+        elif self.path == "/v1/remote-provider/apply":
+            self._handle_remote_provider_apply()
         elif self.path == "/v1/runtime/lemonade/ensure":
             self._handle_windows_lemonade_runtime_ensure()
         elif self.path == "/v1/model/delete":
@@ -3633,6 +3834,36 @@ class AgentHandler(BaseHTTPRequestHandler):
             json_response(self, 500, {"error": f"Remote provider planning failed: {exc}"})
             return
         json_response(self, 200, plan)
+
+    def _handle_remote_provider_apply(self):
+        """Apply a remote-provider lifecycle request through host-owned state."""
+        if not check_auth(self):
+            return
+        body = read_optional_json_body(self)
+        if body is None:
+            return
+        if _plan_remote_provider_lifecycle_operation is None:
+            json_response(
+                self,
+                501,
+                {"error": "Remote provider lifecycle planner is unavailable"},
+            )
+            return
+        try:
+            plan = _plan_remote_provider_lifecycle_operation(body)
+            result = _apply_remote_provider_lifecycle_operation(body, plan)
+        except (_RemoteProviderLifecycleError, _RemoteProviderPolicyError) as exc:
+            json_response(self, 400, {"error": str(exc)})
+            return
+        except _RemoteProviderApplyError as exc:
+            logger.exception("remote-provider lifecycle apply failed")
+            json_response(self, 500, {"error": str(exc), "rollback": exc.rollback})
+            return
+        except Exception as exc:
+            logger.exception("remote-provider lifecycle apply failed")
+            json_response(self, 500, {"error": f"Remote provider apply failed: {exc}"})
+            return
+        json_response(self, 200, result)
 
     def _handle_invalidate_compose_cache(self):
         """Drop the .compose-flags cache file so the next CLI call re-resolves it."""

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -225,7 +225,7 @@ async def remote_provider_status() -> dict[str, Any]:
             "odsPeerLifecycle": False,
         },
         "availableActions": {
-            "configure": False,
+            "configure": True,
             "test": bool(route_state.get("enabled")),
             "disable": bool(route_state.get("enabled")),
             "remove": bool(route_state.get("exists")),
@@ -240,6 +240,24 @@ async def remote_provider_plan(payload: dict[str, Any]) -> dict[str, Any]:
         return await async_request_agent_json(
             "POST",
             "/v1/remote-provider/plan",
+            payload=payload,
+            timeout=10,
+        )
+    except AgentHTTPError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except AgentUnavailable as exc:
+        raise HTTPException(status_code=503, detail=f"Host agent unreachable: {exc}") from exc
+    except AgentProtocolError as exc:
+        raise HTTPException(status_code=502, detail=f"Invalid host agent response: {exc}") from exc
+
+
+@router.post("/api/remote-provider/apply", dependencies=[Depends(verify_api_key)])
+async def remote_provider_apply(payload: dict[str, Any]) -> dict[str, Any]:
+    """Apply a remote-provider lifecycle request through the host agent."""
+    try:
+        return await async_request_agent_json(
+            "POST",
+            "/v1/remote-provider/apply",
             payload=payload,
             timeout=10,
         )

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1995,12 +1995,23 @@ class _FakeHandler:
         return json.loads(self.wfile.getvalue().decode("utf-8"))
 
 
-class TestRemoteProviderLifecyclePlan:
-    """Direct host-agent tests for remote-provider lifecycle planning."""
+class TestRemoteProviderLifecycle:
+    """Direct host-agent tests for remote-provider lifecycle planning/apply."""
 
     @pytest.fixture(autouse=True)
     def _auth(self, monkeypatch):
         monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+
+    def _configure_payload(self):
+        return {
+            "action": "configure",
+            "provider": {
+                "transport": "direct",
+                "baseUrl": "https://gpu.example.test",
+                "model": "qwen/remote:latest",
+            },
+            "secrets": {"apiKey": "unit-test-provider-token"},
+        }
 
     def test_plans_redacted_lifecycle_operation(self):
         payload = {
@@ -2052,6 +2063,144 @@ class TestRemoteProviderLifecyclePlan:
         _mod.AgentHandler._handle_remote_provider_plan(handler)
 
         assert handler.response_code == 403
+
+    def test_apply_configure_writes_route_state_and_secret(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        payload = self._configure_payload()
+        handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
+        state_path = tmp_path / "remote-provider" / "routing-state.json"
+        secret_path = tmp_path / "remote-provider" / "secrets" / "provider-api-key"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        assert handler.response_code == 200
+        assert body["applied"] is True
+        assert body["mutated"] is True
+        assert body["rollback"] == {"attempted": False, "ok": None}
+        assert state["schema"] == "ods.remote-routing-state.v1"
+        assert state["enabled"] is True
+        assert state["provider"]["baseUrl"] == "https://gpu.example.test/v1"
+        assert state["projection"]["egressBaseUrl"] == "http://remote-provider-egress:8091/v1"
+        assert state["status"] == {
+            "proven": False,
+            "reason": "pending-provider-handshake",
+        }
+        assert secret_path.read_text(encoding="utf-8") == "unit-test-provider-token\n"
+        assert "unit-test-provider-token" not in dumped
+
+    def test_apply_test_does_not_write_state(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        payload = self._configure_payload()
+        payload["action"] = "test"
+        handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        body = handler.parse_response()
+        assert handler.response_code == 200
+        assert body["applied"] is True
+        assert body["mutated"] is False
+        assert not (tmp_path / "remote-provider").exists()
+
+    def test_apply_disable_keeps_existing_secret(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        root = tmp_path / "remote-provider"
+        secret_path = root / "secrets" / "provider-api-key"
+        secret_path.parent.mkdir(parents=True)
+        secret_path.write_text("old-provider-token\n", encoding="utf-8")
+        (root / "routing-state.json").write_text(
+            json.dumps({"schema": "ods.remote-routing-state.v1", "enabled": True}),
+            encoding="utf-8",
+        )
+        handler = _FakeHandler(json.dumps({"action": "disable"}).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        state = json.loads((root / "routing-state.json").read_text(encoding="utf-8"))
+        assert handler.response_code == 200
+        assert state["enabled"] is False
+        assert state["provider"] is None
+        assert secret_path.read_text(encoding="utf-8") == "old-provider-token\n"
+
+    def test_apply_remove_deletes_route_state_and_secrets(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        root = tmp_path / "remote-provider"
+        secret_dir = root / "secrets"
+        secret_dir.mkdir(parents=True)
+        (root / "routing-state.json").write_text(
+            json.dumps({"schema": "ods.remote-routing-state.v1", "enabled": True}),
+            encoding="utf-8",
+        )
+        for filename in ("provider-api-key", "peer-token", "ssh-identity", "known_hosts"):
+            (secret_dir / filename).write_text(f"{filename}\n", encoding="utf-8")
+        handler = _FakeHandler(json.dumps({"action": "remove"}).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        assert handler.response_code == 200
+        assert not (root / "routing-state.json").exists()
+        assert not (secret_dir / "provider-api-key").exists()
+        assert not (secret_dir / "peer-token").exists()
+        assert not (secret_dir / "ssh-identity").exists()
+        assert not (secret_dir / "known_hosts").exists()
+
+    def test_apply_rolls_back_partial_write_failure(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        root = tmp_path / "remote-provider"
+        secret_path = root / "secrets" / "provider-api-key"
+        secret_path.parent.mkdir(parents=True)
+        old_state = {
+            "schema": "ods.remote-routing-state.v1",
+            "enabled": True,
+            "provider": {"baseUrl": "https://old.example.test/v1"},
+        }
+        (root / "routing-state.json").write_text(json.dumps(old_state), encoding="utf-8")
+        secret_path.write_text("old-provider-token\n", encoding="utf-8")
+        real_atomic_write = _mod._atomic_write_text
+        failed_once = {"value": False}
+
+        def flaky_atomic_write(path, text, *args, **kwargs):
+            if path.name == "provider-api-key" and not failed_once["value"]:
+                failed_once["value"] = True
+                raise RuntimeError("simulated secret write failure")
+            return real_atomic_write(path, text, *args, **kwargs)
+
+        monkeypatch.setattr(_mod, "_atomic_write_text", flaky_atomic_write)
+        handler = _FakeHandler(json.dumps(self._configure_payload()).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
+        state = json.loads((root / "routing-state.json").read_text(encoding="utf-8"))
+        assert handler.response_code == 500
+        assert body["rollback"] == {"attempted": True, "ok": True}
+        assert state == old_state
+        assert secret_path.read_text(encoding="utf-8") == "old-provider-token\n"
+        assert "unit-test-provider-token" not in dumped
 
 
 class TestTailscaleStatus:

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -81,6 +81,7 @@ def test_remote_provider_status_missing_state_is_disabled(
     assert body["routeState"]["exists"] is False
     assert body["routeState"]["valid"] is True
     assert body["routeState"]["provider"] is None
+    assert body["availableActions"]["configure"] is True
     assert body["availableActions"]["test"] is False
 
 
@@ -272,3 +273,70 @@ def test_remote_provider_plan_preserves_host_agent_validation_errors(
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "remote provider base URL is required"
+
+
+def test_remote_provider_apply_requires_auth(test_client):
+    resp = test_client.post("/api/remote-provider/apply", json=_lifecycle_payload())
+    assert resp.status_code == 401
+
+
+def test_remote_provider_apply_proxies_to_host_agent(
+    test_client,
+    monkeypatch,
+):
+    from routers import remote_provider_status as rps
+
+    calls = []
+
+    async def fake_request(method, path, *, payload, timeout):
+        calls.append((method, path, payload, timeout))
+        return {
+            "schema": "ods.remote-provider-lifecycle-operation.v1",
+            "action": "configure",
+            "ok": True,
+            "applied": True,
+            "mutated": True,
+            "rollback": {"attempted": False, "ok": None},
+            "secretRefs": {
+                "REMOTE_LLM_API_KEY": {"present": True, "value": "[REDACTED]"}
+            },
+        }
+
+    monkeypatch.setattr(rps, "async_request_agent_json", fake_request)
+    payload = _lifecycle_payload()
+    payload["action"] = "configure"
+
+    resp = test_client.post(
+        "/api/remote-provider/apply",
+        json=payload,
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert resp.status_code == 200
+    assert body["action"] == "configure"
+    assert body["mutated"] is True
+    assert "unit-test-provider-token" not in dumped
+    assert calls == [("POST", "/v1/remote-provider/apply", payload, 10)]
+
+
+def test_remote_provider_apply_preserves_host_agent_validation_errors(
+    test_client,
+    monkeypatch,
+):
+    from routers import remote_provider_status as rps
+
+    async def fake_request(*_args, **_kwargs):
+        raise rps.AgentHTTPError(500, "Remote provider apply failed: disk full")
+
+    monkeypatch.setattr(rps, "async_request_agent_json", fake_request)
+
+    resp = test_client.post(
+        "/api/remote-provider/apply",
+        json=_lifecycle_payload(),
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Remote provider apply failed: disk full"


### PR DESCRIPTION
Adds authenticated host-agent and Dashboard/API apply endpoints for remote-provider lifecycle operations. Configure writes generated routing state plus private provider secret files transactionally; disable updates the route without deleting secrets; remove deletes route state and known lifecycle secret files; test remains side-effect-free. Partial write failures restore pre-transaction bytes and return rollback metadata without echoing secret values.\n\nValidation:\n- Local: python -m py_compile bin\\ods-host-agent.py extensions\\services\\dashboard-api\\routers\\remote_provider_status.py extensions\\services\\dashboard-api\\tests\\test_host_agent.py extensions\\services\\dashboard-api\\tests\\test_remote_provider_status.py\n- Local: python -m ruff check bin\\ods-host-agent.py extensions\\services\\dashboard-api\\routers\\remote_provider_status.py extensions\\services\\dashboard-api\\tests\\test_host_agent.py extensions\\services\\dashboard-api\\tests\\test_remote_provider_status.py\n- Local: python -m pytest extensions\\services\\dashboard-api\\tests\\test_remote_provider_status.py extensions\\services\\dashboard-api\\tests\\test_host_agent.py::TestRemoteProviderLifecycle extensions\\services\\dashboard-api\\tests\\test_host_agent_client.py (32 passed)\n- Local: python -m pytest extensions\\services\\dashboard-api\\tests\\test_host_agent.py (238 passed, 4 skipped)\n- Local: Dashboard router/config/main suite (179 passed, 1 existing async-mock warning)\n- Local: remote-provider contracts, runtime render/wiring, local image coverage, network exposure contracts, dependency pins, extension audit, git diff --check\n- Tower2 exact SHA 3fc130061b52932a11031f1d39efe59682d7e6a1: PASS, log /home/michael/ods-pr-remote-provider-apply-3fc13006.Cu8wFk/pr-remote-provider-apply-3fc130061b52932a11031f1d39efe59682d7e6a1.log