### PR TITLE
Add remote provider lifecycle test probe

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -64,11 +64,17 @@ try:
         plan_lifecycle_operation as _plan_remote_provider_lifecycle_operation,
     )
     from remote_provider.policy import PolicyError as _RemoteProviderPolicyError
+    from remote_provider.probe import (
+        ProbeError as _RemoteProviderProbeError,
+        probe_direct_provider as _probe_remote_provider_direct,
+    )
 except Exception:  # pragma: no cover - import environment dependent
     _RemoteProviderLifecycleError = ValueError
     _RemoteProviderPolicyError = ValueError
+    _RemoteProviderProbeError = RuntimeError
     _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA = "ods.remote-routing-state.v1"
     _plan_remote_provider_lifecycle_operation = None
+    _probe_remote_provider_direct = None
 
 VERSION = "1.0.0"
 ODS_VERSION = VERSION
@@ -1490,6 +1496,17 @@ def _remote_provider_secret_values(payload: dict, plan: dict) -> dict[str, str]:
     return values
 
 
+def _remote_provider_probe_lifecycle_test(payload: dict, plan: dict) -> dict:
+    if _probe_remote_provider_direct is None:
+        raise RuntimeError("Remote provider probe helper is unavailable")
+    route = plan.get("route") if isinstance(plan.get("route"), dict) else {}
+    secret_values = _remote_provider_secret_values(payload, plan)
+    return _probe_remote_provider_direct(
+        route,
+        provider_secret=secret_values.get("REMOTE_LLM_API_KEY", ""),
+    )
+
+
 def _write_remote_provider_route_state(plan: dict) -> None:
     state = _remote_provider_route_state_from_plan(plan)
     _atomic_write_text(
@@ -1538,6 +1555,7 @@ def _apply_remote_provider_lifecycle_operation(payload: dict, plan: dict) -> dic
     result["mutated"] = action in {"configure", "disable", "remove"}
     result["rollback"] = {"attempted": False, "ok": None}
     if action == "test":
+        result["probe"] = _remote_provider_probe_lifecycle_test(payload, plan)
         return result
 
     if action not in {"configure", "disable", "remove"}:
@@ -3854,6 +3872,16 @@ class AgentHandler(BaseHTTPRequestHandler):
             result = _apply_remote_provider_lifecycle_operation(body, plan)
         except (_RemoteProviderLifecycleError, _RemoteProviderPolicyError) as exc:
             json_response(self, 400, {"error": str(exc)})
+            return
+        except _RemoteProviderProbeError as exc:
+            json_response(
+                self,
+                getattr(exc, "status", 502),
+                {
+                    "error": getattr(exc, "message", str(exc)),
+                    "code": getattr(exc, "code", "provider_probe_failed"),
+                },
+            )
             return
         except _RemoteProviderApplyError as exc:
             logger.exception("remote-provider lifecycle apply failed")

--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -55,11 +55,18 @@ from .lifecycle import (  # noqa: F401
     LifecycleError,
     plan_lifecycle_operation,
 )
+from .probe import (  # noqa: F401
+    DEFAULT_PROBE_TIMEOUT_SECONDS,
+    MAX_PROBE_RESPONSE_BYTES,
+    ProbeError,
+    probe_direct_provider,
+)
 
 __all__ = [
     "ACTIVATION_RECEIPT_SCHEMA",
     "DEFAULT_MAX_BODY_BYTES",
     "DEFAULT_POLICY_PATH",
+    "DEFAULT_PROBE_TIMEOUT_SECONDS",
     "DEFAULT_SECRET_PATH",
     "DEFAULT_SSH_CONTROL_LISTEN_PORT",
     "DEFAULT_SSH_IDENTITY_PATH",
@@ -71,6 +78,7 @@ __all__ = [
     "INTERNAL_EGRESS_BASE_URL",
     "LIFECYCLE_ACTIONS",
     "LIFECYCLE_OPERATION_SCHEMA",
+    "MAX_PROBE_RESPONSE_BYTES",
     "PUBLIC_MODEL_ALIAS",
     "REDACTED",
     "REMOTE_ROUTE_SCHEMA",
@@ -79,6 +87,7 @@ __all__ = [
     "EgressError",
     "LifecycleError",
     "PolicyError",
+    "ProbeError",
     "SshTunnelSpec",
     "TransportError",
     "UpstreamRequest",
@@ -89,6 +98,7 @@ __all__ = [
     "normalize_provider_base_url",
     "plan_route",
     "plan_lifecycle_operation",
+    "probe_direct_provider",
     "prepare_upstream_request",
     "provider_secret_status",
     "public_activation_receipt",

--- a/ods/bin/remote_provider/probe.py
+++ b/ods/bin/remote_provider/probe.py
@@ -1,0 +1,150 @@
+"""Remote-provider lifecycle probe helpers.
+
+The host-agent owns lifecycle initiation; this module keeps the direct-provider
+handshake small, stdlib-only, and testable without opening sockets.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from .egress import EgressError, validate_direct_provider_resolution
+
+
+DEFAULT_PROBE_TIMEOUT_SECONDS = 10.0
+MAX_PROBE_RESPONSE_BYTES = 64 * 1024
+UrlOpener = Callable[..., Any]
+
+
+class ProbeError(Exception):
+    """HTTP-friendly remote-provider probe failure."""
+
+    def __init__(self, status: int, code: str, message: str) -> None:
+        super().__init__(message)
+        self.status = int(status)
+        self.code = str(code)
+        self.message = str(message)
+
+
+def _models_url(base_url: str) -> str:
+    base = base_url.rstrip("/")
+    if base.endswith("/v1"):
+        return f"{base}/models"
+    return f"{base}/v1/models"
+
+
+def _provider(route: Mapping[str, Any]) -> Mapping[str, Any]:
+    provider = route.get("provider")
+    if not isinstance(provider, Mapping):
+        raise ProbeError(503, "invalid_route", "provider route is missing")
+    return provider
+
+
+def _read_probe_body(response: Any) -> bytes:
+    body = response.read(MAX_PROBE_RESPONSE_BYTES + 1)
+    if len(body) > MAX_PROBE_RESPONSE_BYTES:
+        raise ProbeError(
+            502,
+            "provider_probe_too_large",
+            "remote provider probe response exceeded the safety limit",
+        )
+    return body
+
+
+def _model_count(body: bytes) -> int | None:
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    models = payload.get("data")
+    if not isinstance(models, list):
+        return None
+    return len(models)
+
+
+def probe_direct_provider(
+    route: Mapping[str, Any],
+    *,
+    provider_secret: str,
+    resolver: Callable[..., list[tuple[Any, ...]]] = socket.getaddrinfo,
+    opener: UrlOpener = urllib_request.urlopen,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Probe an OpenAI-compatible direct provider without leaking credentials."""
+    if route.get("enabled") is not True:
+        raise ProbeError(503, "remote_route_disabled", "remote provider route is disabled")
+    if route.get("transport") != "direct":
+        raise ProbeError(
+            501,
+            "transport_probe_unavailable",
+            "remote provider test probes require direct transport in this release",
+        )
+    secret = str(provider_secret or "").strip()
+    if not secret:
+        raise ProbeError(400, "missing_provider_secret", "provider secret is required")
+
+    try:
+        resolved_addresses = validate_direct_provider_resolution(route, resolver=resolver)
+    except EgressError as exc:
+        raise ProbeError(exc.status, exc.code, exc.message) from exc
+
+    provider = _provider(route)
+    request = urllib_request.Request(
+        _models_url(str(provider.get("baseUrl") or "")),
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {secret}",
+            "User-Agent": "ODS remote-provider-probe",
+        },
+    )
+    try:
+        with opener(request, timeout=timeout) as response:
+            status = int(getattr(response, "status", 200))
+            body = _read_probe_body(response)
+            content_type = str(response.headers.get("content-type", ""))
+    except urllib_error.HTTPError as exc:
+        raise ProbeError(
+            int(exc.code),
+            "provider_http_error",
+            f"remote provider probe returned HTTP {int(exc.code)}",
+        ) from exc
+    except (TimeoutError, urllib_error.URLError, OSError) as exc:
+        raise ProbeError(
+            502,
+            "provider_unreachable",
+            f"remote provider probe failed: {exc}",
+        ) from exc
+
+    if status < 200 or status >= 300:
+        raise ProbeError(
+            status,
+            "provider_http_error",
+            f"remote provider probe returned HTTP {status}",
+        )
+    return {
+        "ok": True,
+        "status": status,
+        "endpoint": "/v1/models",
+        "contentType": content_type,
+        "modelCount": _model_count(body),
+        "resolution": {
+            "ok": True,
+            "addressCount": len(resolved_addresses),
+        },
+    }
+
+
+__all__ = [
+    "DEFAULT_PROBE_TIMEOUT_SECONDS",
+    "MAX_PROBE_RESPONSE_BYTES",
+    "ProbeError",
+    "probe_direct_provider",
+]

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2101,6 +2101,18 @@ class TestRemoteProviderLifecycle:
         tmp_path,
     ):
         monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        probes = []
+
+        def fake_probe(route, *, provider_secret):
+            probes.append((route, provider_secret))
+            return {
+                "ok": True,
+                "status": 200,
+                "endpoint": "/v1/models",
+                "modelCount": 1,
+            }
+
+        monkeypatch.setattr(_mod, "_probe_remote_provider_direct", fake_probe)
         payload = self._configure_payload()
         payload["action"] = "test"
         handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
@@ -2108,9 +2120,46 @@ class TestRemoteProviderLifecycle:
         _mod.AgentHandler._handle_remote_provider_apply(handler)
 
         body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
         assert handler.response_code == 200
         assert body["applied"] is True
         assert body["mutated"] is False
+        assert body["probe"]["ok"] is True
+        assert probes[0][0]["provider"]["baseUrl"] == "https://gpu.example.test/v1"
+        assert probes[0][1] == "unit-test-provider-token"
+        assert "unit-test-provider-token" not in dumped
+        assert not (tmp_path / "remote-provider").exists()
+
+    def test_apply_test_probe_failure_does_not_write_state_or_leak_secret(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+
+        def failing_probe(_route, *, provider_secret):
+            assert provider_secret == "unit-test-provider-token"
+            raise _mod._RemoteProviderProbeError(
+                502,
+                "provider_unreachable",
+                "remote provider probe failed: no route",
+            )
+
+        monkeypatch.setattr(_mod, "_probe_remote_provider_direct", failing_probe)
+        payload = self._configure_payload()
+        payload["action"] = "test"
+        handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
+        assert handler.response_code == 502
+        assert body == {
+            "error": "remote provider probe failed: no route",
+            "code": "provider_unreachable",
+        }
+        assert "unit-test-provider-token" not in dumped
         assert not (tmp_path / "remote-provider").exists()
 
     def test_apply_disable_keeps_existing_secret(

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -45,6 +45,10 @@ from remote_provider.lifecycle import (  # noqa: E402
     LifecycleError,
     plan_lifecycle_operation,
 )
+from remote_provider.probe import (  # noqa: E402
+    ProbeError,
+    probe_direct_provider,
+)
 
 
 POLICY_PATH = ROOT / "config" / "remote-provider-egress-policy.json"
@@ -79,6 +83,14 @@ def assert_raises_lifecycle_error(func, message: str) -> str:
     raise AssertionError(message)
 
 
+def assert_raises_probe_error(func, message: str) -> ProbeError:
+    try:
+        func()
+    except ProbeError as exc:
+        return exc
+    raise AssertionError(message)
+
+
 def cloud_direct_env(**overrides: str) -> dict[str, str]:
     env = {
         "ODS_MODE": "cloud",
@@ -103,6 +115,31 @@ def cloud_ssh_env(**overrides: str) -> dict[str, str]:
     )
     env.update(overrides)
     return env
+
+
+class _ProbeResponse:
+    status = 200
+    headers = {"content-type": "application/json"}
+
+    def __init__(self, body: bytes = b'{"data":[{"id":"qwen"}]}') -> None:
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit: int) -> bytes:
+        return self.body
+
+
+def _public_resolver(*_args, **_kwargs):
+    return [(None, None, None, None, ("93.184.216.34", 443))]
+
+
+def _private_resolver(*_args, **_kwargs):
+    return [(None, None, None, None, ("10.0.0.5", 443))]
 
 
 def test_policy_document_shape() -> None:
@@ -530,6 +567,70 @@ def test_lifecycle_rejects_unsafe_or_secret_public_inputs() -> None:
     )
 
 
+def test_direct_provider_probe_is_bounded_and_redacted() -> None:
+    route = plan_route(cloud_direct_env())
+    calls = []
+
+    def opener(request, *, timeout: float):
+        calls.append((request, timeout))
+        return _ProbeResponse()
+
+    result = probe_direct_provider(
+        route,
+        provider_secret="unit-test-provider-token",
+        resolver=_public_resolver,
+        opener=opener,
+    )
+    dumped = json.dumps(result, sort_keys=True)
+    assert_true(result["ok"] is True, "direct provider probe should pass")
+    assert_true(result["endpoint"] == "/v1/models", "probe endpoint drifted")
+    assert_true(result["modelCount"] == 1, "probe should count model-list payloads")
+    assert_true(result["resolution"]["addressCount"] == 1, "probe should report DNS count")
+    assert_true("unit-test-provider-token" not in dumped, "probe result leaked token")
+    assert_true(len(calls) == 1, "probe should perform one bounded HTTP request")
+    request, timeout = calls[0]
+    assert_true(timeout == 10.0, "probe timeout drifted")
+    assert_true(request.full_url == "https://gpu.example.test/v1/models", "probe URL drifted")
+    assert_true(
+        request.headers.get("Authorization") == "Bearer unit-test-provider-token",
+        "probe must send provider auth at the request boundary",
+    )
+
+
+def test_direct_provider_probe_fails_closed_before_unsafe_dns_request() -> None:
+    route = plan_route(cloud_direct_env())
+
+    def opener(*_args, **_kwargs):
+        raise AssertionError("unsafe DNS result must prevent provider HTTP")
+
+    error = assert_raises_probe_error(
+        lambda: probe_direct_provider(
+            route,
+            provider_secret="unit-test-provider-token",
+            resolver=_private_resolver,
+            opener=opener,
+        ),
+        "unsafe DNS resolution should reject direct provider probe",
+    )
+    assert_true(error.code == "provider_resolution_rejected", "unsafe DNS error code drifted")
+    assert_true("private" in error.message, "unsafe DNS failure should explain address class")
+
+
+def test_ssh_provider_probe_is_deferred_until_tunnel_supervisor() -> None:
+    route = plan_route(cloud_ssh_env())
+    error = assert_raises_probe_error(
+        lambda: probe_direct_provider(
+            route,
+            provider_secret="unit-test-provider-token",
+            resolver=_public_resolver,
+            opener=lambda *_args, **_kwargs: _ProbeResponse(),
+        ),
+        "SSH probe should fail closed before tunnel supervisor lands",
+    )
+    assert_true(error.status == 501, "SSH probe should report unavailable transport")
+    assert_true(error.code == "transport_probe_unavailable", "SSH probe error code drifted")
+
+
 def main() -> int:
     tests = [
         test_policy_document_shape,
@@ -547,6 +648,9 @@ def main() -> int:
         test_lifecycle_test_disable_and_remove_write_intent,
         test_lifecycle_ssh_operation_tracks_secret_custody_without_leaks,
         test_lifecycle_rejects_unsafe_or_secret_public_inputs,
+        test_direct_provider_probe_is_bounded_and_redacted,
+        test_direct_provider_probe_fails_closed_before_unsafe_dns_request,
+        test_ssh_provider_probe_is_deferred_until_tunnel_supervisor,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
Makes remote-provider lifecycle 	est perform a real direct-provider /v1/models handshake through a stdlib probe helper. The probe reuses the route policy and DNS/IP fail-closed checks, sends the provider bearer token only at the request boundary, bounds response size/time, returns sanitized probe metadata, and keeps SSH probes deferred until the tunnel supervisor exists.\n\nValidation:\n- Local: python -m py_compile bin\\remote_provider\\probe.py bin\\remote_provider\\__init__.py bin\\ods-host-agent.py extensions\\services\\dashboard-api\\tests\\test_host_agent.py tests\\contracts\\test-remote-provider-egress-policy.py\n- Local: python -m ruff check bin\\remote_provider\\probe.py bin\\remote_provider\\__init__.py bin\\ods-host-agent.py extensions\\services\\dashboard-api\\tests\\test_host_agent.py tests\\contracts\\test-remote-provider-egress-policy.py\n- Local: python -m ruff check . --select E,F,W --ignore E501,E701,E731,E741,E402\n- Local: python -m pytest extensions\\services\\dashboard-api\\tests\\test_remote_provider_status.py extensions\\services\\dashboard-api\\tests\\test_host_agent.py::TestRemoteProviderLifecycle extensions\\services\\dashboard-api\\tests\\test_host_agent_client.py (33 passed)\n- Local: Dashboard router/config/main suite (179 passed, 1 existing async-mock warning)\n- Local: remote-provider contracts, egress-service contracts, runtime render/wiring, local image coverage, network exposure contracts, dependency pins, extension audit, git diff --check\n- Tower2 exact SHA 52f4b826dd797e3648f7ee23aa432473038d693b: PASS, log /home/michael/ods-pr-remote-provider-probe-52f4b826.bBF7Kj/pr-remote-provider-probe-52f4b826dd797e3648f7ee23aa432473038d693b.log