### PR TITLE
Add remote provider CLI lifecycle command

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3564,6 +3564,388 @@ _agent_probe_host() {
     printf '%s\n' "$bind_addr"
 }
 
+_strip_outer_quotes() {
+    local value="${1:-}"
+    case "$value" in
+        \"*\") value="${value:1:${#value}-2}" ;;
+        \'*\') value="${value:1:${#value}-2}" ;;
+    esac
+    printf '%s' "$value"
+}
+
+_dashboard_api_key() {
+    local api_key=""
+    api_key="$(_env_get_raw DASHBOARD_API_KEY)"
+    if [[ -z "$api_key" && -f "$INSTALL_DIR/data/dashboard-api-key.txt" ]]; then
+        api_key="$(cat "$INSTALL_DIR/data/dashboard-api-key.txt" 2>/dev/null || true)"
+    fi
+    api_key="$(_strip_outer_quotes "$api_key")"
+    api_key="$(printf '%s' "$api_key" | tr -d '\r\n ')"
+    printf '%s' "$api_key"
+}
+
+_dashboard_api_base_url() {
+    local base_url="${ODS_DASHBOARD_API_URL:-}"
+    if [[ -z "$base_url" ]]; then
+        base_url="$(_env_get_raw ODS_DASHBOARD_API_URL)"
+    fi
+    if [[ -z "$base_url" ]]; then
+        local port
+        port="$(_env_get_raw DASHBOARD_API_PORT)"
+        [[ "$port" =~ ^[0-9]+$ ]] || port="3002"
+        base_url="http://127.0.0.1:${port}"
+    fi
+    base_url="$(_strip_outer_quotes "$base_url")"
+    printf '%s' "${base_url%/}"
+}
+
+_remote_provider_usage() {
+    cat <<'EOF'
+Usage: ods remote-provider <command> [options]
+
+Commands:
+  status [--json]
+      Show sanitized remote-provider route, egress, and action status.
+  plan <configure|test|disable|remove> [options]
+      Print the redacted lifecycle plan without mutating state.
+  configure --base-url URL --model MODEL [secret options]
+      Persist a direct OpenAI-compatible provider route and provider API key.
+  test --base-url URL --model MODEL [secret options]
+      Probe a direct provider without writing route state or secrets.
+  disable
+      Disable the remote-provider route while keeping stored secrets.
+  remove
+      Delete remote-provider route state and stored secrets.
+
+Provider options for configure/test/plan configure/plan test:
+  --transport direct      Direct HTTPS provider transport (default)
+  --base-url URL          OpenAI-compatible base URL, for example https://gpu.example/v1
+  --model MODEL           Provider model id
+
+Secret options for configure/test/plan configure/plan test:
+  --api-key-stdin         Read the provider API key from the first stdin line
+  --api-key-file PATH     Read the provider API key from a local file
+  --api-key-env NAME      Read the provider API key from the process environment (default REMOTE_LLM_API_KEY)
+
+Raw --api-key arguments are intentionally unsupported so secrets do not appear
+in process listings or shell history.
+EOF
+}
+
+_remote_provider_require_tools() {
+    command -v curl >/dev/null 2>&1 || error "curl is required for remote-provider lifecycle commands"
+    command -v jq >/dev/null 2>&1 || error "jq is required for remote-provider lifecycle commands"
+}
+
+_remote_provider_request() {
+    local method="$1" path="$2" response_file="$3" payload_file="${4:-}" timeout="${5:-15}"
+    local api_key base_url curl_status
+    api_key="$(_dashboard_api_key)"
+    [[ -n "$api_key" ]] || error "Dashboard API key is missing from .env or data/dashboard-api-key.txt"
+    [[ "$api_key" != *$'\n'* && "$api_key" != *$'\r'* ]] || \
+        error "Dashboard API key contains invalid newline characters"
+    base_url="$(_dashboard_api_base_url)"
+
+    if [[ -n "$payload_file" ]]; then
+        if printf 'Authorization: Bearer %s\n' "$api_key" | \
+            curl --silent --show-error --max-time "$timeout" \
+                --output "$response_file" --write-out '%{http_code}' \
+                --request "$method" --header @- \
+                --header 'Content-Type: application/json' \
+                --data-binary @"$payload_file" "${base_url}${path}"; then
+            curl_status=0
+        else
+            curl_status=$?
+        fi
+    else
+        if printf 'Authorization: Bearer %s\n' "$api_key" | \
+            curl --silent --show-error --max-time "$timeout" \
+                --output "$response_file" --write-out '%{http_code}' \
+                --request "$method" --header @- "${base_url}${path}"; then
+            curl_status=0
+        else
+            curl_status=$?
+        fi
+    fi
+    return "$curl_status"
+}
+
+_remote_provider_response_error() {
+    local response_file="$1"
+    local detail=""
+    detail="$(jq -r '.detail // .error // empty' "$response_file" 2>/dev/null || true)"
+    if [[ -z "$detail" ]]; then
+        detail="$(head -c 500 "$response_file" 2>/dev/null || true)"
+    fi
+    printf '%s' "${detail:-unknown error}"
+}
+
+_remote_provider_read_secret() {
+    local use_stdin="$1" file="$2" env_name="$3" api_key=""
+    if [[ "$use_stdin" == "true" ]]; then
+        IFS= read -r api_key || true
+    elif [[ -n "$file" ]]; then
+        [[ -f "$file" ]] || error "Provider API key file not found: $file"
+        api_key="$(cat "$file")"
+    else
+        [[ "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || \
+            error "--api-key-env must be a valid environment variable name"
+        api_key="${!env_name:-}"
+    fi
+    api_key="$(_strip_outer_quotes "$api_key")"
+    api_key="${api_key%$'\n'}"
+    api_key="${api_key%$'\r'}"
+    [[ -n "$api_key" ]] || error "Provider API key is required; use --api-key-stdin, --api-key-file, or --api-key-env"
+    [[ "$api_key" != *$'\n'* && "$api_key" != *$'\r'* ]] || \
+        error "Provider API key must be a single-line secret"
+    printf '%s' "$api_key"
+}
+
+_remote_provider_write_payload() {
+    local action="$1" payload_file="$2"
+    shift 2
+    local transport="direct" base_url="" model="" json_mode="false"
+    local api_key_env="REMOTE_LLM_API_KEY" api_key_env_explicit="false" api_key_file="" api_key_stdin="false"
+    local provider_option_seen="false" secret_option_seen="false"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --transport)
+                [[ $# -ge 2 ]] || error "--transport requires a value"
+                provider_option_seen="true"
+                transport="${2:-}"; shift 2 ;;
+            --base-url)
+                [[ $# -ge 2 ]] || error "--base-url requires a value"
+                provider_option_seen="true"
+                base_url="${2:-}"; shift 2 ;;
+            --model)
+                [[ $# -ge 2 ]] || error "--model requires a value"
+                provider_option_seen="true"
+                model="${2:-}"; shift 2 ;;
+            --api-key-stdin)
+                secret_option_seen="true"
+                api_key_stdin="true"; shift ;;
+            --api-key-file)
+                [[ $# -ge 2 ]] || error "--api-key-file requires a value"
+                secret_option_seen="true"
+                api_key_file="${2:-}"; shift 2 ;;
+            --api-key-env)
+                [[ $# -ge 2 ]] || error "--api-key-env requires a value"
+                secret_option_seen="true"
+                api_key_env="${2:-}"; api_key_env_explicit="true"; shift 2 ;;
+            --api-key)
+                error "Raw --api-key is not supported; use --api-key-stdin, --api-key-file, or --api-key-env" ;;
+            --json)
+                json_mode="true"; shift ;;
+            --help|-h)
+                _remote_provider_usage; exit 0 ;;
+            *)
+                error "Unknown remote-provider option: $1" ;;
+        esac
+    done
+
+    REMOTE_PROVIDER_JSON_MODE="$json_mode"
+    if [[ "$action" == "disable" || "$action" == "remove" ]]; then
+        [[ "$provider_option_seen" == "false" && "$secret_option_seen" == "false" ]] || \
+            error "remote-provider $action does not accept provider or secret options"
+        jq -nc --arg action "$action" '{action: $action}' > "$payload_file" || \
+            error "Could not build remote-provider lifecycle request"
+        return 0
+    fi
+
+    transport="$(printf '%s' "$transport" | tr '[:upper:]' '[:lower:]')"
+    [[ "$transport" == "direct" ]] || error "Only direct remote-provider CLI transport is available in this release"
+    [[ -n "$base_url" ]] || error "--base-url is required"
+    [[ -n "$model" ]] || error "--model is required"
+
+    local secret_sources=0 api_key
+    [[ "$api_key_stdin" == "true" ]] && secret_sources=$((secret_sources + 1))
+    [[ -n "$api_key_file" ]] && secret_sources=$((secret_sources + 1))
+    [[ "$api_key_env_explicit" == "true" ]] && secret_sources=$((secret_sources + 1))
+    (( secret_sources > 1 )) && error "Choose only one provider API key source"
+
+    api_key="$(_remote_provider_read_secret "$api_key_stdin" "$api_key_file" "$api_key_env")"
+    printf '%s' "$api_key" | jq -Rs \
+        --arg action "$action" \
+        --arg transport "$transport" \
+        --arg base_url "$base_url" \
+        --arg model "$model" \
+        '{
+            action: $action,
+            provider: {
+                transport: $transport,
+                baseUrl: $base_url,
+                model: $model
+            },
+            secrets: {
+                apiKey: .
+            }
+        }' > "$payload_file" || error "Could not build remote-provider lifecycle request"
+}
+
+_remote_provider_print_status() {
+    local response_file="$1"
+    jq -r '
+        "Remote provider: \(.status // "unknown")",
+        "Route: " + (if .routeState.enabled == true then "enabled" else "disabled" end),
+        (if .routeState.enabled == true and .routeState.provider then
+            "Provider: \(.routeState.provider.model // "unknown") via \(.routeState.provider.transport // "unknown") at \(.routeState.provider.baseUrl // "unknown")"
+         else empty end),
+        "Egress: \(.egress.status // "unknown")" +
+            (if (.egress.reason // "") != "" then " (\(.egress.reason))" else "" end),
+        "Secret: " + (if .egress.secret.configured == true then "configured" else "missing" end),
+        "Actions: " + (
+            [.availableActions | to_entries[] | select(.value == true) | .key] | join(", ")
+        )
+    ' "$response_file"
+}
+
+_remote_provider_print_apply_result() {
+    local response_file="$1"
+    jq -r '
+        "Remote provider \(.action // "operation"): " +
+            (if .applied == true then "applied" else "completed" end),
+        "Mutated state: \(.mutated // false)",
+        (if .probe then
+            "Probe: HTTP \(.probe.status // "unknown") at \(.probe.endpoint // "/v1/models")" +
+            (if (.probe.modelCount // null) != null then " (\(.probe.modelCount) models)" else "" end)
+         else empty end),
+        (if .rollback.attempted == true then
+            "Rollback: " + (if .rollback.ok == true then "ok" else "failed" end)
+         else empty end)
+    ' "$response_file"
+}
+
+cmd_remote_provider() {
+    local subcmd="${1:-status}"
+    shift || true
+
+    case "$subcmd" in
+        help|--help|-h)
+            _remote_provider_usage
+            return 0
+            ;;
+    esac
+
+    check_install
+    cd "$INSTALL_DIR"
+    load_env
+    _remote_provider_require_tools
+
+    case "$subcmd" in
+        status)
+            local json_mode="false"
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --json) json_mode="true"; shift ;;
+                    --help|-h) _remote_provider_usage; return 0 ;;
+                    *) error "Unknown remote-provider status option: $1" ;;
+                esac
+            done
+            local response_file http_code curl_status
+            response_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-status.XXXXXX") || \
+                error "Could not create a remote-provider response file"
+            chmod 600 "$response_file"
+            trap 'rm -f "$response_file"' INT TERM HUP
+            if http_code="$(_remote_provider_request GET /api/remote-provider/status "$response_file" "" 15)"; then
+                curl_status=0
+            else
+                curl_status=$?
+            fi
+            if [[ $curl_status -ne 0 ]]; then
+                rm -f "$response_file"; trap - INT TERM HUP
+                error "Remote-provider status request failed before Dashboard API completed"
+            fi
+            if [[ "$http_code" != "200" ]]; then
+                local detail
+                detail="$(_remote_provider_response_error "$response_file")"
+                rm -f "$response_file"; trap - INT TERM HUP
+                error "Remote-provider status failed (HTTP $http_code): $detail"
+            fi
+            if [[ "$json_mode" == "true" ]]; then
+                jq . "$response_file"
+            else
+                _remote_provider_print_status "$response_file"
+            fi
+            rm -f "$response_file"; trap - INT TERM HUP
+            ;;
+        plan)
+            local action="${1:-}"
+            [[ -n "$action" ]] || error "Usage: ods remote-provider plan <configure|test|disable|remove> [options]"
+            shift || true
+            case "$action" in
+                configure|test|disable|remove) ;;
+                *) error "Usage: ods remote-provider plan <configure|test|disable|remove> [options]" ;;
+            esac
+            local payload_file response_file http_code curl_status
+            payload_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-payload.XXXXXX") || \
+                error "Could not create a remote-provider request file"
+            response_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-plan.XXXXXX") || \
+                error "Could not create a remote-provider response file"
+            chmod 600 "$payload_file" "$response_file"
+            trap 'rm -f "$payload_file" "$response_file"' INT TERM HUP
+            _remote_provider_write_payload "$action" "$payload_file" "$@"
+            if http_code="$(_remote_provider_request POST /api/remote-provider/plan "$response_file" "$payload_file" 15)"; then
+                curl_status=0
+            else
+                curl_status=$?
+            fi
+            rm -f "$payload_file"
+            if [[ $curl_status -ne 0 ]]; then
+                rm -f "$response_file"; trap - INT TERM HUP
+                error "Remote-provider plan request failed before Dashboard API completed"
+            fi
+            if [[ "$http_code" != "200" ]]; then
+                local detail
+                detail="$(_remote_provider_response_error "$response_file")"
+                rm -f "$response_file"; trap - INT TERM HUP
+                error "Remote-provider plan failed (HTTP $http_code): $detail"
+            fi
+            jq . "$response_file"
+            rm -f "$response_file"; trap - INT TERM HUP
+            ;;
+        configure|test|disable|remove)
+            local payload_file response_file http_code curl_status
+            payload_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-payload.XXXXXX") || \
+                error "Could not create a remote-provider request file"
+            response_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-apply.XXXXXX") || \
+                error "Could not create a remote-provider response file"
+            chmod 600 "$payload_file" "$response_file"
+            trap 'rm -f "$payload_file" "$response_file"' INT TERM HUP
+            REMOTE_PROVIDER_JSON_MODE="false"
+            _remote_provider_write_payload "$subcmd" "$payload_file" "$@"
+            if http_code="$(_remote_provider_request POST /api/remote-provider/apply "$response_file" "$payload_file" 20)"; then
+                curl_status=0
+            else
+                curl_status=$?
+            fi
+            rm -f "$payload_file"
+            if [[ $curl_status -ne 0 ]]; then
+                rm -f "$response_file"; trap - INT TERM HUP
+                error "Remote-provider $subcmd request failed before Dashboard API completed"
+            fi
+            if [[ "$http_code" != "200" ]]; then
+                local detail
+                detail="$(_remote_provider_response_error "$response_file")"
+                rm -f "$response_file"; trap - INT TERM HUP
+                error "Remote-provider $subcmd failed (HTTP $http_code): $detail"
+            fi
+            if [[ "${REMOTE_PROVIDER_JSON_MODE:-false}" == "true" ]]; then
+                jq . "$response_file"
+            else
+                _remote_provider_print_apply_result "$response_file"
+            fi
+            rm -f "$response_file"; trap - INT TERM HUP
+            ;;
+        help|--help|-h)
+            _remote_provider_usage
+            ;;
+        *)
+            error "Usage: ods remote-provider <status|plan|configure|test|disable|remove>"
+            ;;
+    esac
+}
+
 cmd_stt() {
     check_install; cd "$INSTALL_DIR"
     local subcmd="${1:-status}"
@@ -5009,6 +5391,8 @@ ${CYAN}Commands:${NC}
                       Switch between local/cloud/hybrid modes
   model [current|list|swap]
                       View or change the local LLM model tier
+  remote-provider [status|plan|configure|test|disable|remove]
+                      Configure, test, disable, or inspect remote GPU provider routing
   stt [current|status|download] [MODEL]
                       View Whisper STT model, check cache, or trigger download
   backup [options]    Create a backup of user data and config
@@ -5058,6 +5442,16 @@ ${CYAN}Model Commands:${NC}
   model list          List available tiers
   model swap <tier>   Switch to a different model tier
 
+${CYAN}Remote Provider Commands:${NC}
+  remote-provider status [--json]
+                      Show remote GPU route and egress status
+  remote-provider plan <action>
+                      Preview configure/test/disable/remove as redacted JSON
+  remote-provider configure --base-url URL --model MODEL --api-key-stdin
+                      Persist a direct OpenAI-compatible remote GPU provider
+  remote-provider test --base-url URL --model MODEL --api-key-stdin
+                      Probe a provider without writing state or secrets
+
 ${CYAN}Service aliases:${NC}
 EOF
     # Dynamic alias listing from registry
@@ -5089,6 +5483,8 @@ ${CYAN}Examples:${NC}
   ods enable n8n                # Enable the n8n extension
   ods disable whisper           # Disable Whisper STT
   ods mode local                # Switch to local mode
+  printf '%s\n' "\$REMOTE_LLM_API_KEY" | ods remote-provider test --base-url https://gpu.example/v1 --model qwen/remote:latest --api-key-stdin
+                                  # Test a remote provider without persisting secrets
   ods preset save my-setup      # Snapshot your config
   ods preset load my-setup      # Restore it later
   ods preset export my-setup my-setup.tar.gz
@@ -5139,6 +5535,7 @@ case "${1:-help}" in
     preset|p)    shift; cmd_preset "$@" ;;
     mode|m)      shift; cmd_mode "$@" ;;
     model)       shift; cmd_model "$@" ;;
+    remote-provider) shift; cmd_remote_provider "$@" ;;
     stt)         shift; cmd_stt "$@" ;;
     backup)      shift; cmd_backup "$@" ;;
     restore)     shift; cmd_restore "$@" ;;

--- a/ods/tests/contracts/test-ods-cli-contracts.py
+++ b/ods/tests/contracts/test-ods-cli-contracts.py
@@ -27,6 +27,10 @@ COMMANDS = {
     "preset": ("cmd_preset", "preset <action>"),
     "mode": ("cmd_mode", "mode [local|cloud|hybrid]"),
     "model": ("cmd_model", "model [current|list|swap]"),
+    "remote-provider": (
+        "cmd_remote_provider",
+        "remote-provider [status|plan|configure|test|disable|remove]",
+    ),
     "stt": ("cmd_stt", "stt [current|status|download]"),
     "backup": ("cmd_backup", "backup [options]"),
     "restore": ("cmd_restore", "restore [backup_id]"),

--- a/ods/tests/contracts/test-remote-provider-cli.py
+++ b/ods/tests/contracts/test-remote-provider-cli.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Static contracts for the remote-provider ods CLI lifecycle surface."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+ODS_CLI = ROOT_DIR / "ods-cli"
+
+
+def fail(message: str) -> None:
+    print(f"[FAIL] {message}")
+    raise SystemExit(1)
+
+
+def require(pattern: str, text: str, message: str) -> None:
+    if not re.search(pattern, text, flags=re.MULTILINE):
+        fail(message)
+
+
+def main() -> int:
+    text = ODS_CLI.read_text(encoding="utf-8")
+
+    require(
+        r"^cmd_remote_provider\(\) \{",
+        text,
+        "ods-cli must implement remote-provider lifecycle command",
+    )
+    require(
+        r"remote-provider \[status\|plan\|configure\|test\|disable\|remove\]",
+        text,
+        "remote-provider command must be visible in top-level help",
+    )
+    require(
+        r"remote-provider\)\s+shift; cmd_remote_provider \"\$@\" ;;",
+        text,
+        "remote-provider command must be dispatched by the main CLI",
+    )
+    for endpoint in (
+        "/api/remote-provider/status",
+        "/api/remote-provider/plan",
+        "/api/remote-provider/apply",
+    ):
+        require(re.escape(endpoint), text, f"CLI must call {endpoint}")
+
+    require(
+        r"printf 'Authorization: Bearer %s\\n' \"\$api_key\" \|[\s\S]*--header @-",
+        text,
+        "Dashboard API bearer token must be streamed through stdin, not argv",
+    )
+    require(
+        r"--data-binary @\"\$payload_file\"",
+        text,
+        "remote-provider lifecycle payload must be sent from a private file",
+    )
+    require(
+        r"chmod 600 \"\$payload_file\" \"\$response_file\"",
+        text,
+        "remote-provider request and response files must be owner-only",
+    )
+    require(
+        r"Raw --api-key is not supported",
+        text,
+        "CLI must reject raw provider API keys in command arguments",
+    )
+    require(
+        r"remote-provider \$action does not accept provider or secret options",
+        text,
+        "disable/remove must reject irrelevant provider or secret options",
+    )
+    if "--api-key VALUE" in text or "--api-key <" in text:
+        fail("remote-provider help must not advertise raw --api-key values")
+    if '"$REMOTE_LLM_API_KEY"' in text:
+        fail("top-level help must escape REMOTE_LLM_API_KEY under set -u")
+
+    secret_reader = re.search(
+        r"^_remote_provider_read_secret\(\) \{(?P<body>[\s\S]*?)^\}\s*$",
+        text,
+        flags=re.MULTILINE,
+    )
+    if secret_reader is None:
+        fail("remote-provider secret reader could not be parsed")
+    if "_env_get_raw" in secret_reader.group("body"):
+        fail("provider API keys must not be read from public .env keys")
+
+    remote_provider_function = re.search(
+        r"^cmd_remote_provider\(\) \{(?P<body>[\s\S]*?)^\}\s*$",
+        text,
+        flags=re.MULTILINE,
+    )
+    if remote_provider_function is None:
+        fail("remote-provider function could not be parsed")
+    body = remote_provider_function.group("body")
+    for subcommand in ("status", "plan", "configure", "test", "disable", "remove"):
+        if subcommand not in body:
+            fail(f"remote-provider CLI missing subcommand: {subcommand}")
+
+    print("[PASS] remote-provider CLI static contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- Adds `ods remote-provider` CLI lifecycle commands for status, redacted planning, configure, test, disable, and remove.
- Routes CLI lifecycle calls through the authenticated Dashboard API remote-provider endpoints already backed by host-agent planning/apply.
- Reads provider API keys only from stdin, a private file, or the current process environment; raw `--api-key` arguments are rejected, requests use private temp payload files, and responses stay redacted.
- Adds static CLI contracts for help/dispatch/API endpoint wiring and secret-handling invariants, including a guard for set-u-safe help examples.

## Validation
- Local: Git Bash `bash -n ods-cli`; `ods-cli help`; remote-provider help smoke; parser/redaction smoke with throwaway `ODS_HOME`.
- Local: `python tests/contracts/test-ods-cli-contracts.py`; `python tests/contracts/test-remote-provider-cli.py`; `python -m ruff check . --select E,F,W --ignore E501,E701,E731,E741,E402`.
- Local: `python -m pytest extensions/services/dashboard-api/tests/test_remote_provider_status.py extensions/services/dashboard-api/tests/test_host_agent.py::TestRemoteProviderLifecycle extensions/services/dashboard-api/tests/test_host_agent_client.py` (33 passed).
- Local: remote-provider policy/egress/network contracts, runtime config rendering/wiring/local-image coverage, dependency pins, extension audit.
- Local release gate progressed to update rollback, then stopped only because this Windows Git Bash environment lacks `rsync`.
- Tower2 exact SHA `8b5c98a878223271fdb57d5ba649db15dcbd4a7c`: clean clone, Bash syntax, CLI contracts, runtime redaction smoke, Ruff, focused Dashboard/API pytest, remote-provider/network contracts, runtime/config audits, `bash scripts/release-gate.sh`, `git diff --check` all passed.

Tower2 log: `/home/michael/ods-pr-remote-provider-cli-8b5c98a8.E7vWN3/pr-remote-provider-cli-8b5c98a878223271fdb57d5ba649db15dcbd4a7c.log`
