### PR TITLE
Persist remote provider probe proof status

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -67,6 +67,7 @@ try:
     from remote_provider.probe import (
         ProbeError as _RemoteProviderProbeError,
         probe_direct_provider as _probe_remote_provider_direct,
+        public_probe_receipt as _remote_provider_public_probe_receipt,
     )
 except Exception:  # pragma: no cover - import environment dependent
     _RemoteProviderLifecycleError = ValueError
@@ -75,6 +76,7 @@ except Exception:  # pragma: no cover - import environment dependent
     _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA = "ods.remote-routing-state.v1"
     _plan_remote_provider_lifecycle_operation = None
     _probe_remote_provider_direct = None
+    _remote_provider_public_probe_receipt = None
 
 VERSION = "1.0.0"
 ODS_VERSION = VERSION
@@ -1468,7 +1470,27 @@ def _remote_provider_projection(route: dict) -> dict:
     }
 
 
-def _remote_provider_route_state_from_plan(plan: dict) -> dict:
+def _remote_provider_route_status(
+    *,
+    enabled: bool,
+    probe_receipt: dict | None = None,
+) -> dict:
+    if not enabled:
+        return {"proven": False, "reason": "disabled"}
+    if isinstance(probe_receipt, dict) and probe_receipt.get("ok") is True:
+        return {
+            "proven": True,
+            "reason": "provider-handshake-ok",
+            "lastProbe": probe_receipt,
+        }
+    return {"proven": False, "reason": "pending-provider-handshake"}
+
+
+def _remote_provider_route_state_from_plan(
+    plan: dict,
+    *,
+    probe_receipt: dict | None = None,
+) -> dict:
     route = plan.get("route") if isinstance(plan.get("route"), dict) else {}
     enabled = route.get("enabled") is True
     return {
@@ -1477,10 +1499,10 @@ def _remote_provider_route_state_from_plan(plan: dict) -> dict:
         "mode": str(route.get("mode") or "cloud"),
         "provider": route.get("provider") if enabled else None,
         "projection": _remote_provider_projection(route),
-        "status": {
-            "proven": False,
-            "reason": "pending-provider-handshake" if enabled else "disabled",
-        },
+        "status": _remote_provider_route_status(
+            enabled=enabled,
+            probe_receipt=probe_receipt,
+        ),
     }
 
 
@@ -1499,16 +1521,29 @@ def _remote_provider_secret_values(payload: dict, plan: dict) -> dict[str, str]:
 def _remote_provider_probe_lifecycle_test(payload: dict, plan: dict) -> dict:
     if _probe_remote_provider_direct is None:
         raise RuntimeError("Remote provider probe helper is unavailable")
+    if _remote_provider_public_probe_receipt is None:
+        raise RuntimeError("Remote provider probe receipt helper is unavailable")
     route = plan.get("route") if isinstance(plan.get("route"), dict) else {}
     secret_values = _remote_provider_secret_values(payload, plan)
-    return _probe_remote_provider_direct(
+    probe_result = _probe_remote_provider_direct(
         route,
         provider_secret=secret_values.get("REMOTE_LLM_API_KEY", ""),
     )
+    return _remote_provider_public_probe_receipt(
+        probe_result,
+        verified_at=_iso_now(),
+    )
 
 
-def _write_remote_provider_route_state(plan: dict) -> None:
-    state = _remote_provider_route_state_from_plan(plan)
+def _write_remote_provider_route_state(
+    plan: dict,
+    *,
+    probe_receipt: dict | None = None,
+) -> None:
+    state = _remote_provider_route_state_from_plan(
+        plan,
+        probe_receipt=probe_receipt,
+    )
     _atomic_write_text(
         _remote_provider_route_state_path(),
         json.dumps(state, indent=2, sort_keys=True) + "\n",
@@ -1554,8 +1589,11 @@ def _apply_remote_provider_lifecycle_operation(payload: dict, plan: dict) -> dic
     result["applied"] = True
     result["mutated"] = action in {"configure", "disable", "remove"}
     result["rollback"] = {"attempted": False, "ok": None}
+    probe_receipt = None
+    if action in {"configure", "test"}:
+        probe_receipt = _remote_provider_probe_lifecycle_test(payload, plan)
+        result["probe"] = probe_receipt
     if action == "test":
-        result["probe"] = _remote_provider_probe_lifecycle_test(payload, plan)
         return result
 
     if action not in {"configure", "disable", "remove"}:
@@ -1577,13 +1615,15 @@ def _apply_remote_provider_lifecycle_operation(payload: dict, plan: dict) -> dic
     mutation_started = False
     try:
         snapshots = {path: _snapshot_text_file(path) for path in mutation_paths}
-        if action in {"configure", "disable"}:
-            _write_remote_provider_route_state(plan)
-            mutation_started = True
         if action == "configure":
             for ref, secret in secret_values.items():
                 _write_remote_provider_secret(ref, secret)
                 mutation_started = True
+            _write_remote_provider_route_state(plan, probe_receipt=probe_receipt)
+            mutation_started = True
+        elif action == "disable":
+            _write_remote_provider_route_state(plan)
+            mutation_started = True
         elif action == "remove":
             for path in mutation_paths:
                 _remove_remote_provider_file(path)

--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -58,8 +58,10 @@ from .lifecycle import (  # noqa: F401
 from .probe import (  # noqa: F401
     DEFAULT_PROBE_TIMEOUT_SECONDS,
     MAX_PROBE_RESPONSE_BYTES,
+    PROBE_RECEIPT_SCHEMA,
     ProbeError,
     probe_direct_provider,
+    public_probe_receipt,
 )
 
 __all__ = [
@@ -80,6 +82,7 @@ __all__ = [
     "LIFECYCLE_OPERATION_SCHEMA",
     "MAX_PROBE_RESPONSE_BYTES",
     "PUBLIC_MODEL_ALIAS",
+    "PROBE_RECEIPT_SCHEMA",
     "REDACTED",
     "REMOTE_ROUTE_SCHEMA",
     "ROUTING_STATE_SCHEMA",
@@ -102,6 +105,7 @@ __all__ = [
     "prepare_upstream_request",
     "provider_secret_status",
     "public_activation_receipt",
+    "public_probe_receipt",
     "read_provider_secret",
     "redacted_secret_refs",
     "resolve_direct_provider_addresses",

--- a/ods/bin/remote_provider/probe.py
+++ b/ods/bin/remote_provider/probe.py
@@ -18,6 +18,7 @@ from .egress import EgressError, validate_direct_provider_resolution
 
 DEFAULT_PROBE_TIMEOUT_SECONDS = 10.0
 MAX_PROBE_RESPONSE_BYTES = 64 * 1024
+PROBE_RECEIPT_SCHEMA = "ods.remote-provider-probe-receipt.v1"
 UrlOpener = Callable[..., Any]
 
 
@@ -67,6 +68,49 @@ def _model_count(body: bytes) -> int | None:
     if not isinstance(models, list):
         return None
     return len(models)
+
+
+def _safe_int(value: Any) -> int | None:
+    return value if type(value) is int else None
+
+
+def _safe_text(value: Any, *, max_length: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if any(ord(char) < 32 or ord(char) == 127 for char in text):
+        return ""
+    return text[:max_length]
+
+
+def public_probe_receipt(
+    probe_result: Mapping[str, Any],
+    *,
+    verified_at: str,
+) -> dict[str, Any]:
+    """Return a support-bundle-safe provider probe receipt."""
+    result = probe_result if isinstance(probe_result, Mapping) else {}
+    resolution = result.get("resolution")
+    clean_resolution = None
+    if isinstance(resolution, Mapping):
+        clean_resolution = {
+            "ok": bool(resolution.get("ok")),
+            "addressCount": _safe_int(resolution.get("addressCount")),
+        }
+
+    receipt: dict[str, Any] = {
+        "schema": PROBE_RECEIPT_SCHEMA,
+        "ok": bool(result.get("ok")),
+        "verifiedAt": _safe_text(verified_at, max_length=64),
+        "endpoint": _safe_text(result.get("endpoint"), max_length=32),
+        "httpStatus": _safe_int(result.get("status")),
+        "modelCount": _safe_int(result.get("modelCount")),
+        "resolution": clean_resolution,
+    }
+    content_type = _safe_text(result.get("contentType"), max_length=128)
+    if content_type:
+        receipt["contentType"] = content_type
+    return receipt
 
 
 def probe_direct_provider(
@@ -145,6 +189,8 @@ def probe_direct_provider(
 __all__ = [
     "DEFAULT_PROBE_TIMEOUT_SECONDS",
     "MAX_PROBE_RESPONSE_BYTES",
+    "PROBE_RECEIPT_SCHEMA",
     "ProbeError",
     "probe_direct_provider",
+    "public_probe_receipt",
 ]

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -50,6 +50,56 @@ def _safe_string_map(value: Any, keys: set[str]) -> dict[str, str]:
     return clean
 
 
+def _safe_text(value: Any, *, max_length: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if any(ord(char) < 32 or ord(char) == 127 for char in text):
+        return ""
+    return text[:max_length]
+
+
+def _safe_int(value: Any) -> int | None:
+    return value if type(value) is int else None
+
+
+def _safe_probe_receipt(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    resolution = value.get("resolution")
+    clean_resolution = None
+    if isinstance(resolution, Mapping):
+        clean_resolution = {
+            "ok": bool(resolution.get("ok")),
+            "addressCount": _safe_int(resolution.get("addressCount")),
+        }
+    receipt: dict[str, Any] = {
+        "schema": _safe_text(value.get("schema"), max_length=64),
+        "ok": bool(value.get("ok")),
+        "verifiedAt": _safe_text(value.get("verifiedAt"), max_length=64),
+        "endpoint": _safe_text(value.get("endpoint"), max_length=32),
+        "httpStatus": _safe_int(value.get("httpStatus")),
+        "modelCount": _safe_int(value.get("modelCount")),
+        "resolution": clean_resolution,
+    }
+    content_type = _safe_text(value.get("contentType"), max_length=128)
+    if content_type:
+        receipt["contentType"] = content_type
+    return receipt
+
+
+def _safe_route_status(value: Any) -> dict[str, Any]:
+    status = value if isinstance(value, Mapping) else {}
+    clean: dict[str, Any] = {
+        "proven": bool(status.get("proven")),
+        "reason": _safe_text(status.get("reason"), max_length=128) or "disabled",
+    }
+    last_probe = _safe_probe_receipt(status.get("lastProbe"))
+    if last_probe is not None:
+        clean["lastProbe"] = last_probe
+    return clean
+
+
 def _state_response(
     *,
     exists: bool,
@@ -68,10 +118,7 @@ def _state_response(
         "mode": mode,
         "provider": _safe_string_map(provider, _SAFE_PROVIDER_KEYS) if enabled else None,
         "projection": _safe_string_map(projection, _SAFE_PROJECTION_KEYS),
-        "status": {
-            "proven": bool((status or {}).get("proven")),
-            "reason": str((status or {}).get("reason") or "disabled"),
-        },
+        "status": _safe_route_status(status),
         "errors": errors or [],
     }
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2013,6 +2013,28 @@ class TestRemoteProviderLifecycle:
             "secrets": {"apiKey": "unit-test-provider-token"},
         }
 
+    def _patch_successful_probe(self, monkeypatch):
+        probes = []
+
+        def fake_probe(route, *, provider_secret):
+            probes.append((route, provider_secret))
+            return {
+                "ok": True,
+                "status": 200,
+                "endpoint": "/v1/models",
+                "contentType": "application/json",
+                "modelCount": 1,
+                "resolution": {"ok": True, "addressCount": 1},
+            }
+
+        monkeypatch.setattr(_mod, "_probe_remote_provider_direct", fake_probe)
+        monkeypatch.setattr(
+            _mod,
+            "_iso_now",
+            lambda: "2026-07-26T00:00:00+00:00",
+        )
+        return probes
+
     def test_plans_redacted_lifecycle_operation(self):
         payload = {
             "action": "test",
@@ -2070,6 +2092,7 @@ class TestRemoteProviderLifecycle:
         tmp_path,
     ):
         monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        probes = self._patch_successful_probe(monkeypatch)
         payload = self._configure_payload()
         handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
 
@@ -2084,14 +2107,19 @@ class TestRemoteProviderLifecycle:
         assert body["applied"] is True
         assert body["mutated"] is True
         assert body["rollback"] == {"attempted": False, "ok": None}
+        assert body["probe"]["schema"] == "ods.remote-provider-probe-receipt.v1"
+        assert body["probe"]["verifiedAt"] == "2026-07-26T00:00:00+00:00"
         assert state["schema"] == "ods.remote-routing-state.v1"
         assert state["enabled"] is True
         assert state["provider"]["baseUrl"] == "https://gpu.example.test/v1"
         assert state["projection"]["egressBaseUrl"] == "http://remote-provider-egress:8091/v1"
         assert state["status"] == {
-            "proven": False,
-            "reason": "pending-provider-handshake",
+            "proven": True,
+            "reason": "provider-handshake-ok",
+            "lastProbe": body["probe"],
         }
+        assert probes[0][0]["provider"]["baseUrl"] == "https://gpu.example.test/v1"
+        assert probes[0][1] == "unit-test-provider-token"
         assert secret_path.read_text(encoding="utf-8") == "unit-test-provider-token\n"
         assert "unit-test-provider-token" not in dumped
 
@@ -2101,18 +2129,7 @@ class TestRemoteProviderLifecycle:
         tmp_path,
     ):
         monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
-        probes = []
-
-        def fake_probe(route, *, provider_secret):
-            probes.append((route, provider_secret))
-            return {
-                "ok": True,
-                "status": 200,
-                "endpoint": "/v1/models",
-                "modelCount": 1,
-            }
-
-        monkeypatch.setattr(_mod, "_probe_remote_provider_direct", fake_probe)
+        probes = self._patch_successful_probe(monkeypatch)
         payload = self._configure_payload()
         payload["action"] = "test"
         handler = _FakeHandler(json.dumps(payload).encode("utf-8"))
@@ -2125,8 +2142,39 @@ class TestRemoteProviderLifecycle:
         assert body["applied"] is True
         assert body["mutated"] is False
         assert body["probe"]["ok"] is True
+        assert body["probe"]["verifiedAt"] == "2026-07-26T00:00:00+00:00"
         assert probes[0][0]["provider"]["baseUrl"] == "https://gpu.example.test/v1"
         assert probes[0][1] == "unit-test-provider-token"
+        assert "unit-test-provider-token" not in dumped
+        assert not (tmp_path / "remote-provider").exists()
+
+    def test_apply_configure_probe_failure_does_not_write_state_or_secret(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+
+        def failing_probe(_route, *, provider_secret):
+            assert provider_secret == "unit-test-provider-token"
+            raise _mod._RemoteProviderProbeError(
+                502,
+                "provider_unreachable",
+                "remote provider probe failed: no route",
+            )
+
+        monkeypatch.setattr(_mod, "_probe_remote_provider_direct", failing_probe)
+        handler = _FakeHandler(json.dumps(self._configure_payload()).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
+        assert handler.response_code == 502
+        assert body == {
+            "error": "remote provider probe failed: no route",
+            "code": "provider_unreachable",
+        }
         assert "unit-test-provider-token" not in dumped
         assert not (tmp_path / "remote-provider").exists()
 
@@ -2218,6 +2266,7 @@ class TestRemoteProviderLifecycle:
         tmp_path,
     ):
         monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        self._patch_successful_probe(monkeypatch)
         root = tmp_path / "remote-provider"
         secret_path = root / "secrets" / "provider-api-key"
         secret_path.parent.mkdir(parents=True)
@@ -2232,9 +2281,9 @@ class TestRemoteProviderLifecycle:
         failed_once = {"value": False}
 
         def flaky_atomic_write(path, text, *args, **kwargs):
-            if path.name == "provider-api-key" and not failed_once["value"]:
+            if path.name == "routing-state.json" and not failed_once["value"]:
                 failed_once["value"] = True
-                raise RuntimeError("simulated secret write failure")
+                raise RuntimeError("simulated route-state write failure")
             return real_atomic_write(path, text, *args, **kwargs)
 
         monkeypatch.setattr(_mod, "_atomic_write_text", flaky_atomic_write)
@@ -3289,6 +3338,12 @@ class TestModelActivationLemonadePersistence:
             _mod,
             "_capture_container_state",
             lambda _name: {"exists": False, "running": False},
+        )
+        monkeypatch.setattr(_mod, "_opencode_installed", lambda: False)
+        monkeypatch.setattr(
+            _mod,
+            "_capture_managed_opencode_state",
+            lambda: {"system": "Linux", "active": False},
         )
         handler = _FakeHandler(b"")
 

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 
 
-def _route_state(model: str = "qwen/remote:latest") -> dict[str, object]:
+def _route_state(
+    model: str = "qwen/remote:latest",
+    *,
+    status: dict[str, object] | None = None,
+) -> dict[str, object]:
     return {
         "schema": "ods.remote-routing-state.v1",
         "enabled": True,
@@ -22,7 +26,7 @@ def _route_state(model: str = "qwen/remote:latest") -> dict[str, object]:
             "egressBaseUrl": "http://remote-provider-egress:8091/v1",
             "consumerRoute": "gateway",
         },
-        "status": {"proven": False, "reason": "pending-provider-handshake"},
+        "status": status or {"proven": False, "reason": "pending-provider-handshake"},
     }
 
 
@@ -132,6 +136,70 @@ def test_remote_provider_status_sanitizes_egress_secret_health(
     assert "unit-test-provider-token" not in dumped
     assert "provider-api-key" not in dumped
     assert body["capabilities"]["odsPeerLifecycle"] is False
+
+
+def test_remote_provider_status_exposes_sanitized_probe_receipt(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    status = {
+        "proven": True,
+        "reason": "provider-handshake-ok",
+        "lastProbe": {
+            "schema": "ods.remote-provider-probe-receipt.v1",
+            "ok": True,
+            "verifiedAt": "2026-07-26T00:00:00+00:00",
+            "endpoint": "/v1/models",
+            "httpStatus": 200,
+            "contentType": "application/json",
+            "modelCount": 1,
+            "resolution": {"ok": True, "addressCount": 1, "raw": "93.184.216.34"},
+            "value": "unit-test-provider-token",
+        },
+    }
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text(json.dumps(_route_state(status=status)), encoding="utf-8")
+    rps = _patch_state_path(monkeypatch, state_path)
+
+    async def fake_fetch():
+        return {
+            "reachable": True,
+            "valid": True,
+            "ready": True,
+            "status": "ok",
+            "reason": "ready",
+            "secret": {"configured": True, "bytes": 24},
+            "resolution": {"ok": True, "addressCount": 1},
+        }
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert resp.status_code == 200
+    assert body["status"] == "ready"
+    assert body["routeState"]["status"] == {
+        "proven": True,
+        "reason": "provider-handshake-ok",
+        "lastProbe": {
+            "schema": "ods.remote-provider-probe-receipt.v1",
+            "ok": True,
+            "verifiedAt": "2026-07-26T00:00:00+00:00",
+            "endpoint": "/v1/models",
+            "httpStatus": 200,
+            "contentType": "application/json",
+            "modelCount": 1,
+            "resolution": {"ok": True, "addressCount": 1},
+        },
+    }
+    assert "unit-test-provider-token" not in dumped
+    assert "93.184.216.34" not in dumped
 
 
 def test_remote_provider_status_invalid_state_is_diagnostic(

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -46,8 +46,10 @@ from remote_provider.lifecycle import (  # noqa: E402
     plan_lifecycle_operation,
 )
 from remote_provider.probe import (  # noqa: E402
+    PROBE_RECEIPT_SCHEMA,
     ProbeError,
     probe_direct_provider,
+    public_probe_receipt,
 )
 
 
@@ -597,6 +599,31 @@ def test_direct_provider_probe_is_bounded_and_redacted() -> None:
     )
 
 
+def test_public_probe_receipt_is_redacted_and_typed() -> None:
+    receipt = public_probe_receipt(
+        {
+            "ok": True,
+            "status": 200,
+            "endpoint": "/v1/models",
+            "contentType": "application/json",
+            "modelCount": 1,
+            "resolution": {"ok": True, "addressCount": 1, "raw": "93.184.216.34"},
+            "authorization": "Bearer unit-test-provider-token",
+        },
+        verified_at="2026-07-26T00:00:00+00:00",
+    )
+    dumped = json.dumps(receipt, sort_keys=True)
+    assert_true(receipt["schema"] == PROBE_RECEIPT_SCHEMA, "probe receipt schema drifted")
+    assert_true(receipt["ok"] is True, "probe receipt should keep success status")
+    assert_true(receipt["httpStatus"] == 200, "probe HTTP status not retained")
+    assert_true(
+        receipt["resolution"] == {"ok": True, "addressCount": 1},
+        "probe DNS receipt not sanitized",
+    )
+    assert_true("unit-test-provider-token" not in dumped, "probe receipt leaked provider auth")
+    assert_true("93.184.216.34" not in dumped, "probe receipt should not expose raw DNS answers")
+
+
 def test_direct_provider_probe_fails_closed_before_unsafe_dns_request() -> None:
     route = plan_route(cloud_direct_env())
 
@@ -649,6 +676,7 @@ def main() -> int:
         test_lifecycle_ssh_operation_tracks_secret_custody_without_leaks,
         test_lifecycle_rejects_unsafe_or_secret_public_inputs,
         test_direct_provider_probe_is_bounded_and_redacted,
+        test_public_probe_receipt_is_redacted_and_typed,
         test_direct_provider_probe_fails_closed_before_unsafe_dns_request,
         test_ssh_provider_probe_is_deferred_until_tunnel_supervisor,
     ]


### PR DESCRIPTION
## Summary
- require remote-provider configure to complete the bounded provider `/v1/models` probe before persisting an enabled route
- persist a redacted probe receipt in routing-state status and expose the sanitized proof through `/api/remote-provider/status`
- keep test actions non-mutating while returning the same support-safe probe receipt
- keep the Lemonade activation unit test hermetic from a real user `opencode-web.service`

## Evidence
- SHA: e0511dff5db2b96b3907f433aac1842e4d7e3658
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py` -> 240 passed, 4 skipped
- `python -m pytest extensions/services/dashboard-api/tests/test_remote_provider_status.py extensions/services/dashboard-api/tests/test_host_agent.py::TestRemoteProviderLifecycle extensions/services/dashboard-api/tests/test_host_agent_client.py` -> 35 passed
- `python tests/contracts/test-remote-provider-egress-policy.py` -> pass
- `python tests/contracts/test-remote-provider-egress-service.py` -> pass
- `python tests/contracts/test-remote-provider-cli.py` -> pass
- `python -m py_compile ...` -> pass
- `python -m ruff check ... --select E,F,W --ignore E501,E701,E731,E741,E402` -> pass
- `git diff --check` -> pass (Windows LF-to-CRLF warnings only)

## Tower2
- PASS exact SHA `e0511dff5db2b96b3907f433aac1842e4d7e3658`
- Log: `/home/michael/ods-pr-remote-provider-proof-e0511dff.YKHa3K/pr-remote-provider-proof-e0511dff5db2b96b3907f433aac1842e4d7e3658.log`
- Covered: clean clone checkout, py_compile, focused Dashboard/host-agent pytest (35 passed), full host-agent pytest (244 passed), remote-provider contracts, Ruff, dependency pins, extension audit, `bash scripts/release-gate.sh`, `git diff --check`.