### PR TITLE
Add remote provider SSH supervisor plan

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -1498,6 +1498,7 @@ def _remote_provider_route_state_from_plan(
         "enabled": enabled,
         "mode": str(route.get("mode") or "cloud"),
         "provider": route.get("provider") if enabled else None,
+        "ssh": route.get("ssh") if enabled and route.get("transport") == "ssh" else None,
         "projection": _remote_provider_projection(route),
         "status": _remote_provider_route_status(
             enabled=enabled,

--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -33,6 +33,13 @@ from .transport import (  # noqa: F401
     TransportError,
     build_ssh_tunnel_specs,
 )
+from .ssh_supervisor import (  # noqa: F401
+    DEFAULT_SSH_SECRET_DIR,
+    DEFAULT_SSH_TUNNEL_SERVICE_HOST,
+    SSH_SUPERVISOR_PLAN_SCHEMA,
+    ssh_secret_status,
+    ssh_supervisor_plan,
+)
 from .egress import (  # noqa: F401
     DEFAULT_MAX_BODY_BYTES,
     DEFAULT_SECRET_PATH,
@@ -75,6 +82,8 @@ __all__ = [
     "DEFAULT_SSH_INFERENCE_LISTEN_PORT",
     "DEFAULT_SSH_KNOWN_HOSTS_PATH",
     "DEFAULT_SSH_LOCAL_BIND_HOST",
+    "DEFAULT_SSH_SECRET_DIR",
+    "DEFAULT_SSH_TUNNEL_SERVICE_HOST",
     "FORBIDDEN_PUBLIC_SECRET_ENV",
     "FORWARD_PATHS",
     "INTERNAL_EGRESS_BASE_URL",
@@ -87,6 +96,7 @@ __all__ = [
     "REMOTE_ROUTE_SCHEMA",
     "ROUTING_STATE_SCHEMA",
     "SCHEMA",
+    "SSH_SUPERVISOR_PLAN_SCHEMA",
     "EgressError",
     "LifecycleError",
     "PolicyError",
@@ -111,6 +121,8 @@ __all__ = [
     "resolve_direct_provider_addresses",
     "route_from_state",
     "sanitize_forward_headers",
+    "ssh_secret_status",
+    "ssh_supervisor_plan",
     "validate_direct_provider_resolution",
     "validate_public_env_keys",
     "validate_remote_model_id",

--- a/ods/bin/remote_provider/ssh_supervisor.py
+++ b/ods/bin/remote_provider/ssh_supervisor.py
@@ -1,0 +1,116 @@
+"""Support-bundle-safe planning for the remote-provider SSH tunnel supervisor.
+
+The functions here are intentionally inert.  They validate route metadata,
+summarize secret custody, and build the exact SSH argv plan, but they never
+spawn ssh or open sockets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .transport import (
+    DEFAULT_SSH_INFERENCE_LISTEN_PORT,
+    SshTunnelSpec,
+    build_ssh_tunnel_specs,
+)
+
+
+SSH_SUPERVISOR_PLAN_SCHEMA = "ods.remote-provider-ssh-supervisor-plan.v1"
+DEFAULT_SSH_TUNNEL_SERVICE_HOST = "remote-provider-ssh-tunnel"
+DEFAULT_SSH_SECRET_DIR = Path("/state/remote-provider/secrets")
+
+
+def _file_status(path: Path) -> dict[str, Any]:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return {"configured": False, "bytes": 0}
+    except OSError:
+        return {"configured": False, "bytes": None}
+    return {"configured": stat.st_size > 0, "bytes": stat.st_size}
+
+
+def ssh_secret_status(secret_dir: str | Path = DEFAULT_SSH_SECRET_DIR) -> dict[str, Any]:
+    """Return support-bundle-safe SSH secret custody status."""
+    root = Path(secret_dir)
+    return {
+        "sshIdentity": _file_status(root / "ssh-identity"),
+        "sshKnownHosts": _file_status(root / "known_hosts"),
+    }
+
+
+def _secret_ready(secret_status: Mapping[str, Any], key: str) -> bool:
+    value = secret_status.get(key)
+    return isinstance(value, Mapping) and value.get("configured") is True
+
+
+def _public_tunnel(spec: SshTunnelSpec) -> dict[str, Any]:
+    return {
+        "name": spec.name,
+        "listenHost": spec.listen_host,
+        "listenPort": spec.listen_port,
+        "targetHost": spec.target_host,
+        "targetPort": spec.target_port,
+        "argv": list(spec.args),
+    }
+
+
+def _tunnel_base_url(specs: tuple[SshTunnelSpec, ...]) -> str:
+    inference = next((spec for spec in specs if spec.name == "inference"), None)
+    port = inference.listen_port if inference is not None else DEFAULT_SSH_INFERENCE_LISTEN_PORT
+    return f"http://{DEFAULT_SSH_TUNNEL_SERVICE_HOST}:{port}/v1"
+
+
+def ssh_supervisor_plan(
+    route: Mapping[str, Any],
+    *,
+    secrets: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a redacted supervisor plan for an SSH route."""
+    secret_status = dict(secrets or ssh_secret_status())
+    base: dict[str, Any] = {
+        "schema": SSH_SUPERVISOR_PLAN_SCHEMA,
+        "status": "disabled",
+        "ready": False,
+        "readyToStart": False,
+        "reason": "remote_route_disabled",
+        "tunnelBaseUrl": None,
+        "tunnels": [],
+        "secrets": secret_status,
+    }
+    if route.get("enabled") is not True:
+        return base
+    if route.get("transport") != "ssh":
+        base["status"] = "inactive"
+        base["reason"] = "not_ssh_transport"
+        return base
+
+    specs = build_ssh_tunnel_specs(route)
+    missing = [
+        key
+        for key in ("sshIdentity", "sshKnownHosts")
+        if not _secret_ready(secret_status, key)
+    ]
+    base.update(
+        {
+            "status": "blocked" if missing else "planned",
+            "reason": "missing_ssh_secrets" if missing else "tunnel_process_not_started",
+            "readyToStart": not missing,
+            "tunnelBaseUrl": _tunnel_base_url(specs),
+            "tunnels": [_public_tunnel(spec) for spec in specs],
+            "missingSecrets": missing,
+        }
+    )
+    return base
+
+
+__all__ = [
+    "DEFAULT_SSH_SECRET_DIR",
+    "DEFAULT_SSH_TUNNEL_SERVICE_HOST",
+    "SSH_SUPERVISOR_PLAN_SCHEMA",
+    "ssh_secret_status",
+    "ssh_supervisor_plan",
+]

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2123,6 +2123,40 @@ class TestRemoteProviderLifecycle:
         assert secret_path.read_text(encoding="utf-8") == "unit-test-provider-token\n"
         assert "unit-test-provider-token" not in dumped
 
+    def test_route_state_preserves_ssh_metadata_without_secret_values(self):
+        payload = {
+            "action": "configure",
+            "provider": {
+                "transport": "ssh",
+                "baseUrl": "http://127.0.0.1:8000/v1",
+                "model": "qwen/remote:latest",
+            },
+            "ssh": {
+                "host": "gpu.example.test",
+                "user": "ods",
+                "port": "22",
+                "inferenceHost": "127.0.0.1",
+                "inferencePort": "8000",
+            },
+            "secrets": {
+                "apiKey": "unit-test-provider-token",
+                "sshPrivateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nunit-test-key\n-----END OPENSSH PRIVATE KEY-----",
+                "sshKnownHosts": "gpu.example.test ssh-ed25519 AAAATEST",
+            },
+        }
+
+        plan = _mod._plan_remote_provider_lifecycle_operation(payload)
+        state = _mod._remote_provider_route_state_from_plan(plan)
+
+        dumped = json.dumps(state, sort_keys=True)
+        assert state["enabled"] is True
+        assert state["provider"]["transport"] == "ssh"
+        assert state["ssh"]["host"] == "gpu.example.test"
+        assert state["ssh"]["inferencePort"] == 8000
+        assert "unit-test-provider-token" not in dumped
+        assert "unit-test-key" not in dumped
+        assert "AAAATEST" not in dumped
+
     def test_apply_test_does_not_write_state(
         self,
         monkeypatch,

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -33,6 +34,11 @@ from remote_provider.transport import (  # noqa: E402
     DEFAULT_SSH_LOCAL_BIND_HOST,
     TransportError,
     build_ssh_tunnel_specs,
+)
+from remote_provider.ssh_supervisor import (  # noqa: E402
+    SSH_SUPERVISOR_PLAN_SCHEMA,
+    ssh_secret_status,
+    ssh_supervisor_plan,
 )
 from remote_provider.reconciler import (  # noqa: E402
     PHASES,
@@ -332,6 +338,71 @@ def test_ssh_transport_specs_reject_unsafe_tokens() -> None:
         lambda: build_ssh_tunnel_specs(unsafe_host),
         "unsafe SSH host was accepted",
     )
+
+
+def test_ssh_supervisor_plan_is_redacted_and_start_gated() -> None:
+    route = plan_route(
+        cloud_ssh_env(
+            REMOTE_LLM_SSH_CONTROL_HOST="127.0.0.1",
+            REMOTE_LLM_SSH_CONTROL_PORT="8091",
+        )
+    )
+    plan = ssh_supervisor_plan(
+        route,
+        secrets={
+            "sshIdentity": {"configured": True, "bytes": 123},
+            "sshKnownHosts": {"configured": True, "bytes": 45},
+        },
+    )
+    dumped = json.dumps(plan, sort_keys=True)
+    assert_true(plan["schema"] == SSH_SUPERVISOR_PLAN_SCHEMA, "supervisor plan schema drifted")
+    assert_true(plan["status"] == "planned", "ready SSH custody should produce a planned tunnel")
+    assert_true(plan["ready"] is False, "inert supervisor plan must not report a live tunnel")
+    assert_true(plan["readyToStart"] is True, "ready SSH custody should allow process start")
+    assert_true(plan["reason"] == "tunnel_process_not_started", "planned SSH tunnel reason drifted")
+    assert_true(
+        plan["tunnelBaseUrl"] == "http://remote-provider-ssh-tunnel:18091/v1",
+        "SSH tunnel base URL drifted",
+    )
+    assert_true(len(plan["tunnels"]) == 2, "SSH plan should expose inference and control tunnels")
+    for tunnel in plan["tunnels"]:
+        argv = tunnel["argv"]
+        assert_true(argv[0] == "ssh", "SSH tunnel must be an argv list starting with ssh")
+        assert_true("-F" in argv and "/dev/null" in argv, "SSH tunnel must ignore user config")
+    assert_true("unit-test-key" not in dumped, "SSH identity contents leaked into supervisor plan")
+    assert_true("AAAATEST" not in dumped, "known_hosts contents leaked into supervisor plan")
+    assert_true("REMOTE_LLM_SSH_PRIVATE_KEY" not in dumped, "secret env name leaked into supervisor plan")
+
+
+def test_ssh_supervisor_plan_blocks_missing_secret_custody() -> None:
+    route = plan_route(cloud_ssh_env())
+    plan = ssh_supervisor_plan(
+        route,
+        secrets={
+            "sshIdentity": {"configured": False, "bytes": 0},
+            "sshKnownHosts": {"configured": False, "bytes": 0},
+        },
+    )
+    assert_true(plan["status"] == "blocked", "missing SSH custody must block startup")
+    assert_true(plan["readyToStart"] is False, "missing SSH custody must not be startable")
+    assert_true(
+        set(plan["missingSecrets"]) == {"sshIdentity", "sshKnownHosts"},
+        "missing SSH custody should name both required secret files",
+    )
+
+
+def test_ssh_secret_status_is_support_bundle_safe() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        secret_dir = Path(tmp)
+        (secret_dir / "ssh-identity").write_text("unit-test-key\n", encoding="utf-8")
+        (secret_dir / "known_hosts").write_text("gpu.example.test ssh-ed25519 AAAATEST\n", encoding="utf-8")
+        status = ssh_secret_status(secret_dir)
+    dumped = json.dumps(status, sort_keys=True)
+    assert_true(status["sshIdentity"]["configured"] is True, "identity status drifted")
+    assert_true(status["sshIdentity"]["bytes"] >= 14, "identity byte status drifted")
+    assert_true(status["sshKnownHosts"]["configured"] is True, "known_hosts status drifted")
+    assert_true("unit-test-key" not in dumped, "identity contents leaked into secret status")
+    assert_true("AAAATEST" not in dumped, "known_hosts contents leaked into secret status")
 
 
 def test_public_env_forbids_remote_secrets() -> None:
@@ -667,6 +738,9 @@ def main() -> int:
         test_ssh_requires_transport_metadata,
         test_ssh_transport_specs_are_structured_and_hardened,
         test_ssh_transport_specs_reject_unsafe_tokens,
+        test_ssh_supervisor_plan_is_redacted_and_start_gated,
+        test_ssh_supervisor_plan_blocks_missing_secret_custody,
+        test_ssh_secret_status_is_support_bundle_safe,
         test_public_env_forbids_remote_secrets,
         test_activation_receipt_redacts_secret_references,
         test_activation_transaction_orders_phases,


### PR DESCRIPTION
﻿## Summary
- add an inert, support-bundle-safe SSH supervisor plan helper for remote-provider routes
- expose redacted SSH secret custody status and exact hardened tunnel argv planning
- preserve non-secret SSH route metadata in host-agent routing state for future supervisor startup

## Validation
- `python -m py_compile bin/remote_provider/ssh_supervisor.py bin/remote_provider/__init__.py bin/ods-host-agent.py extensions/services/dashboard-api/tests/test_host_agent.py tests/contracts/test-remote-provider-egress-policy.py`
- `python tests/contracts/test-remote-provider-egress-policy.py`
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py::TestRemoteProviderLifecycle`
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py`
- `python -m ruff check bin/remote_provider/ssh_supervisor.py bin/remote_provider/__init__.py bin/ods-host-agent.py extensions/services/dashboard-api/tests/test_host_agent.py tests/contracts/test-remote-provider-egress-policy.py --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check`
- Tower2 exact-SHA validation for `6b095915fcfdbed3ab4360d39802c0489dd5ef22`
  - clean clone checkout of exact SHA
  - `python -m py_compile ...`
  - `python tests/contracts/test-remote-provider-egress-policy.py`
  - `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py::TestRemoteProviderLifecycle`
  - `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py` (`245 passed`)
  - `python -m ruff check ...`
  - `python scripts/check-dependency-pins.py`
  - `python scripts/audit-extensions.py --project-dir . --json` (`26 services, 0 errors`)
  - `bash scripts/release-gate.sh`
  - `git diff --check`

Tower2 log: `/home/michael/ods-pr-ssh-supervisor-6b095915fcfd.gtJHxe/pr-remote-provider-ssh-supervisor-6b095915fcfdbed3ab4360d39802c0489dd5ef22.log`