### PR TITLE
Expose remote provider SSH supervisor status

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -69,14 +69,20 @@ try:
         probe_direct_provider as _probe_remote_provider_direct,
         public_probe_receipt as _remote_provider_public_probe_receipt,
     )
+    from remote_provider.ssh_supervisor import (
+        SSH_SUPERVISOR_PLAN_SCHEMA as _REMOTE_PROVIDER_SSH_SUPERVISOR_PLAN_SCHEMA,
+        ssh_supervisor_plan as _remote_provider_ssh_supervisor_plan,
+    )
 except Exception:  # pragma: no cover - import environment dependent
     _RemoteProviderLifecycleError = ValueError
     _RemoteProviderPolicyError = ValueError
     _RemoteProviderProbeError = RuntimeError
     _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA = "ods.remote-routing-state.v1"
+    _REMOTE_PROVIDER_SSH_SUPERVISOR_PLAN_SCHEMA = "ods.remote-provider-ssh-supervisor-plan.v1"
     _plan_remote_provider_lifecycle_operation = None
     _probe_remote_provider_direct = None
     _remote_provider_public_probe_receipt = None
+    _remote_provider_ssh_supervisor_plan = None
 
 VERSION = "1.0.0"
 ODS_VERSION = VERSION
@@ -1458,6 +1464,29 @@ def _remote_provider_secret_owner() -> tuple[int | None, int | None]:
     return None, None
 
 
+def _remote_provider_secret_file_status(path: Path) -> dict:
+    try:
+        if path.is_symlink():
+            return {"configured": False, "bytes": None}
+        metadata = path.stat()
+    except FileNotFoundError:
+        return {"configured": False, "bytes": 0}
+    except OSError:
+        return {"configured": False, "bytes": None}
+    return {"configured": metadata.st_size > 0, "bytes": metadata.st_size}
+
+
+def _remote_provider_ssh_secret_status() -> dict:
+    return {
+        "sshIdentity": _remote_provider_secret_file_status(
+            _remote_provider_secret_path("REMOTE_LLM_SSH_PRIVATE_KEY")
+        ),
+        "sshKnownHosts": _remote_provider_secret_file_status(
+            _remote_provider_secret_path("REMOTE_LLM_SSH_KNOWN_HOSTS")
+        ),
+    }
+
+
 def _remote_provider_projection(route: dict) -> dict:
     egress = route.get("egress") if isinstance(route.get("egress"), dict) else {}
     return {
@@ -1505,6 +1534,71 @@ def _remote_provider_route_state_from_plan(
             probe_receipt=probe_receipt,
         ),
     }
+
+
+def _remote_provider_ssh_supervisor_error(reason: str, *, status: str = "invalid") -> dict:
+    return {
+        "schema": _REMOTE_PROVIDER_SSH_SUPERVISOR_PLAN_SCHEMA,
+        "status": status,
+        "ready": False,
+        "readyToStart": False,
+        "reason": reason,
+        "tunnelBaseUrl": None,
+        "tunnels": [],
+        "secrets": _remote_provider_ssh_secret_status(),
+        "missingSecrets": [],
+    }
+
+
+def _remote_provider_route_for_ssh_supervisor() -> tuple[dict, str | None]:
+    path = _remote_provider_route_state_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {"enabled": False}, None
+    except OSError:
+        return {}, "route_state_unreadable"
+
+    try:
+        doc = json.loads(raw)
+    except ValueError:
+        return {}, "route_state_not_json"
+    if not isinstance(doc, dict):
+        return {}, "route_state_not_object"
+    if doc.get("schema") != _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA:
+        return {}, "route_state_unknown_schema"
+
+    enabled = doc.get("enabled") is True
+    provider = doc.get("provider") if isinstance(doc.get("provider"), dict) else {}
+    if enabled and not provider:
+        return {}, "route_state_missing_provider"
+    ssh = doc.get("ssh") if isinstance(doc.get("ssh"), dict) else None
+    return {
+        "enabled": enabled,
+        "mode": str(doc.get("mode") or "cloud"),
+        "transport": str(provider.get("transport") or "direct") if enabled else "direct",
+        "provider": provider if enabled else None,
+        "ssh": ssh,
+    }, None
+
+
+def _remote_provider_ssh_supervisor_status() -> dict:
+    if _remote_provider_ssh_supervisor_plan is None:
+        return _remote_provider_ssh_supervisor_error(
+            "ssh_supervisor_unavailable",
+            status="unavailable",
+        )
+    route, error = _remote_provider_route_for_ssh_supervisor()
+    if error:
+        return _remote_provider_ssh_supervisor_error(error)
+    try:
+        return _remote_provider_ssh_supervisor_plan(
+            route,
+            secrets=_remote_provider_ssh_secret_status(),
+        )
+    except Exception as exc:
+        logger.warning("remote-provider SSH supervisor planning failed: %s", exc)
+        return _remote_provider_ssh_supervisor_error("ssh_supervisor_plan_failed")
 
 
 def _remote_provider_secret_values(payload: dict, plan: dict) -> dict[str, str]:
@@ -3497,6 +3591,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_ap_mode_status()
         elif path == "/v1/update/status":
             self._handle_update_status()
+        elif path == "/v1/remote-provider/ssh-supervisor":
+            self._handle_remote_provider_ssh_supervisor_status()
         elif path == "/v1/host/port":
             self._handle_host_port_status(parse_qs(parsed.query))
         else:
@@ -3933,6 +4029,12 @@ class AgentHandler(BaseHTTPRequestHandler):
             json_response(self, 500, {"error": f"Remote provider apply failed: {exc}"})
             return
         json_response(self, 200, result)
+
+    def _handle_remote_provider_ssh_supervisor_status(self):
+        """Return redacted remote-provider SSH tunnel supervisor readiness."""
+        if not check_auth(self):
+            return
+        json_response(self, 200, _remote_provider_ssh_supervisor_status())
 
     def _handle_invalidate_compose_cache(self):
         """Drop the .compose-flags cache file so the next CLI call re-resolves it."""

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -30,6 +30,7 @@ EGRESS_TIMEOUT_SECONDS = 3.0
 
 _SAFE_PROVIDER_KEYS = {"capability", "baseUrl", "model", "transport"}
 _SAFE_PROJECTION_KEYS = {"publicModel", "gateway", "egressBaseUrl", "consumerRoute"}
+_SSH_SUPERVISOR_SCHEMA = "ods.remote-provider-ssh-supervisor-plan.v1"
 
 
 def _state_path() -> Path:
@@ -169,6 +170,127 @@ def _safe_secret_status(value: Any) -> dict[str, Any]:
     }
 
 
+def _safe_ssh_tunnel(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    argv = value.get("argv")
+    clean_argv: list[str] = []
+    if isinstance(argv, list):
+        for item in argv[:64]:
+            text = _safe_text(item, max_length=256)
+            if text:
+                clean_argv.append(text)
+    return {
+        "name": _safe_text(value.get("name"), max_length=32),
+        "listenHost": _safe_text(value.get("listenHost"), max_length=128),
+        "listenPort": _safe_int(value.get("listenPort")),
+        "targetHost": _safe_text(value.get("targetHost"), max_length=128),
+        "targetPort": _safe_int(value.get("targetPort")),
+        "argv": clean_argv,
+    }
+
+
+def _safe_ssh_supervisor_status(
+    payload: Any,
+    *,
+    reachable: bool = True,
+) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        return {
+            "reachable": reachable,
+            "valid": False,
+            "schema": "",
+            "status": "invalid",
+            "ready": False,
+            "readyToStart": False,
+            "reason": "invalid_ssh_supervisor_status",
+            "tunnelBaseUrl": None,
+            "tunnels": [],
+            "secrets": {
+                "sshIdentity": {"configured": False, "bytes": None},
+                "sshKnownHosts": {"configured": False, "bytes": None},
+            },
+            "missingSecrets": [],
+        }
+    tunnels: list[dict[str, Any]] = []
+    raw_tunnels = payload.get("tunnels")
+    if isinstance(raw_tunnels, list):
+        tunnels = [
+            tunnel
+            for tunnel in (_safe_ssh_tunnel(item) for item in raw_tunnels[:8])
+            if tunnel is not None
+        ]
+    missing = payload.get("missingSecrets")
+    missing_secrets = [
+        text
+        for text in (
+            _safe_text(item, max_length=64)
+            for item in (missing[:8] if isinstance(missing, list) else [])
+        )
+        if text
+    ]
+    secrets = payload.get("secrets") if isinstance(payload.get("secrets"), Mapping) else {}
+    schema = _safe_text(payload.get("schema"), max_length=80)
+    return {
+        "reachable": reachable,
+        "valid": schema == _SSH_SUPERVISOR_SCHEMA,
+        "schema": schema,
+        "status": _safe_text(payload.get("status"), max_length=64) or "unknown",
+        "ready": bool(payload.get("ready")),
+        "readyToStart": bool(payload.get("readyToStart")),
+        "reason": _safe_text(payload.get("reason"), max_length=128) or "unknown",
+        "tunnelBaseUrl": _safe_text(payload.get("tunnelBaseUrl"), max_length=256) or None,
+        "tunnels": tunnels,
+        "secrets": {
+            "sshIdentity": _safe_secret_status(secrets.get("sshIdentity")),
+            "sshKnownHosts": _safe_secret_status(secrets.get("sshKnownHosts")),
+        },
+        "missingSecrets": missing_secrets,
+    }
+
+
+async def _fetch_ssh_supervisor_status() -> dict[str, Any]:
+    try:
+        payload = await async_request_agent_json(
+            "GET",
+            "/v1/remote-provider/ssh-supervisor",
+            timeout=5,
+        )
+    except AgentHTTPError as exc:
+        logger.debug("remote-provider SSH supervisor status returned HTTP error: %s", exc)
+        return _safe_ssh_supervisor_status(
+            {
+                "schema": _SSH_SUPERVISOR_SCHEMA,
+                "status": "unavailable",
+                "ready": False,
+                "readyToStart": False,
+                "reason": f"host_agent_http_{exc.status_code}",
+                "tunnelBaseUrl": None,
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            },
+            reachable=True,
+        )
+    except (AgentUnavailable, AgentProtocolError) as exc:
+        logger.debug("remote-provider SSH supervisor status unavailable: %s", exc)
+        return _safe_ssh_supervisor_status(
+            {
+                "schema": _SSH_SUPERVISOR_SCHEMA,
+                "status": "unavailable",
+                "ready": False,
+                "readyToStart": False,
+                "reason": "host_agent_unavailable",
+                "tunnelBaseUrl": None,
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            },
+            reachable=False,
+        )
+    return _safe_ssh_supervisor_status(payload)
+
+
 def _sanitize_egress_health(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, Mapping):
         return {
@@ -263,9 +385,11 @@ async def remote_provider_status() -> dict[str, Any]:
     """Return sanitized remote-provider status without mutating configuration."""
     route_state = _read_route_state()
     egress = await _fetch_egress_health()
+    ssh_supervisor = await _fetch_ssh_supervisor_status()
     return {
         "status": _overall_status(route_state, egress),
         "routeState": route_state,
+        "sshSupervisor": ssh_supervisor,
         "egress": egress,
         "capabilities": {
             "inference": bool(route_state.get("enabled")),

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2157,6 +2157,62 @@ class TestRemoteProviderLifecycle:
         assert "unit-test-key" not in dumped
         assert "AAAATEST" not in dumped
 
+    def test_ssh_supervisor_status_uses_route_state_and_secret_custody(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        root = tmp_path / "remote-provider"
+        secret_dir = root / "secrets"
+        secret_dir.mkdir(parents=True)
+        (secret_dir / "ssh-identity").write_text("unit-test-key\n", encoding="utf-8")
+        (secret_dir / "known_hosts").write_text(
+            "gpu.example.test ssh-ed25519 AAAATEST\n",
+            encoding="utf-8",
+        )
+        payload = {
+            "action": "configure",
+            "provider": {
+                "transport": "ssh",
+                "baseUrl": "http://127.0.0.1:8000/v1",
+                "model": "qwen/remote:latest",
+            },
+            "ssh": {
+                "host": "gpu.example.test",
+                "user": "ods",
+                "port": "22",
+                "inferenceHost": "127.0.0.1",
+                "inferencePort": "8000",
+            },
+            "secrets": {
+                "apiKey": "unit-test-provider-token",
+                "sshPrivateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nunit-test-key\n-----END OPENSSH PRIVATE KEY-----",
+                "sshKnownHosts": "gpu.example.test ssh-ed25519 AAAATEST",
+            },
+        }
+        plan = _mod._plan_remote_provider_lifecycle_operation(payload)
+        state = _mod._remote_provider_route_state_from_plan(plan)
+        (root / "routing-state.json").write_text(json.dumps(state), encoding="utf-8")
+        handler = _FakeHandler(b"")
+
+        _mod.AgentHandler._handle_remote_provider_ssh_supervisor_status(handler)
+
+        body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
+        assert handler.response_code == 200
+        assert body["schema"] == "ods.remote-provider-ssh-supervisor-plan.v1"
+        assert body["status"] == "planned"
+        assert body["ready"] is False
+        assert body["readyToStart"] is True
+        assert body["tunnelBaseUrl"] == "http://remote-provider-ssh-tunnel:18091/v1"
+        assert body["secrets"]["sshIdentity"]["configured"] is True
+        assert body["secrets"]["sshKnownHosts"]["configured"] is True
+        assert body["tunnels"][0]["argv"][0] == "ssh"
+        assert "unit-test-provider-token" not in dumped
+        assert "unit-test-key" not in dumped
+        assert "AAAATEST" not in dumped
+
     def test_apply_test_does_not_write_state(
         self,
         monkeypatch,

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -9,6 +9,7 @@ def _route_state(
     model: str = "qwen/remote:latest",
     *,
     status: dict[str, object] | None = None,
+    transport: str = "direct",
 ) -> dict[str, object]:
     return {
         "schema": "ods.remote-routing-state.v1",
@@ -18,7 +19,7 @@ def _route_state(
             "capability": "openai-compatible",
             "baseUrl": "https://gpu.example.test/v1",
             "model": model,
-            "transport": "direct",
+            "transport": transport,
         },
         "projection": {
             "publicModel": "ods/current",
@@ -73,6 +74,22 @@ def test_remote_provider_status_missing_state_is_disabled(
         }
 
     monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+    async def fake_ssh_supervisor():
+        return rps._safe_ssh_supervisor_status(
+            {
+                "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+                "status": "disabled",
+                "ready": False,
+                "readyToStart": False,
+                "reason": "remote_route_disabled",
+                "tunnelBaseUrl": None,
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            }
+        )
+
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", fake_ssh_supervisor)
 
     resp = test_client.get(
         "/api/remote-provider/status",
@@ -87,6 +104,7 @@ def test_remote_provider_status_missing_state_is_disabled(
     assert body["routeState"]["provider"] is None
     assert body["availableActions"]["configure"] is True
     assert body["availableActions"]["test"] is False
+    assert body["sshSupervisor"]["status"] == "disabled"
 
 
 def test_remote_provider_status_sanitizes_egress_secret_health(
@@ -115,6 +133,22 @@ def test_remote_provider_status_sanitizes_egress_secret_health(
         )
 
     monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+    async def fake_ssh_supervisor():
+        return rps._safe_ssh_supervisor_status(
+            {
+                "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+                "status": "inactive",
+                "ready": False,
+                "readyToStart": False,
+                "reason": "not_ssh_transport",
+                "tunnelBaseUrl": None,
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            }
+        )
+
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", fake_ssh_supervisor)
 
     resp = test_client.get(
         "/api/remote-provider/status",
@@ -135,7 +169,129 @@ def test_remote_provider_status_sanitizes_egress_secret_health(
     }
     assert "unit-test-provider-token" not in dumped
     assert "provider-api-key" not in dumped
+    assert body["sshSupervisor"]["status"] == "inactive"
     assert body["capabilities"]["odsPeerLifecycle"] is False
+
+
+def test_remote_provider_status_exposes_sanitized_ssh_supervisor_plan(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text(json.dumps(_route_state(transport="ssh")), encoding="utf-8")
+    rps = _patch_state_path(monkeypatch, state_path)
+
+    async def fake_fetch():
+        return {
+            "reachable": True,
+            "valid": True,
+            "ready": False,
+            "status": "deferred",
+            "reason": "ssh_transport_deferred",
+            "secret": {"configured": True, "bytes": 24},
+            "resolution": None,
+        }
+
+    async def fake_ssh_supervisor():
+        return rps._safe_ssh_supervisor_status(
+            {
+                "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+                "status": "planned",
+                "ready": False,
+                "readyToStart": True,
+                "reason": "tunnel_process_not_started",
+                "tunnelBaseUrl": "http://remote-provider-ssh-tunnel:18091/v1",
+                "tunnels": [
+                    {
+                        "name": "inference",
+                        "listenHost": "0.0.0.0",
+                        "listenPort": 18091,
+                        "targetHost": "127.0.0.1",
+                        "targetPort": 8000,
+                        "argv": ["ssh", "-F", "/dev/null", "ods@gpu.example.test"],
+                        "value": "unit-test-key",
+                    }
+                ],
+                "secrets": {
+                    "sshIdentity": {
+                        "configured": True,
+                        "bytes": 14,
+                        "path": "/state/remote-provider/secrets/ssh-identity",
+                        "value": "unit-test-key",
+                    },
+                    "sshKnownHosts": {
+                        "configured": True,
+                        "bytes": 40,
+                        "value": "AAAATEST",
+                    },
+                },
+                "missingSecrets": [],
+            }
+        )
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", fake_ssh_supervisor)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert resp.status_code == 200
+    assert body["sshSupervisor"]["valid"] is True
+    assert body["sshSupervisor"]["status"] == "planned"
+    assert body["sshSupervisor"]["readyToStart"] is True
+    assert body["sshSupervisor"]["tunnelBaseUrl"] == "http://remote-provider-ssh-tunnel:18091/v1"
+    assert body["sshSupervisor"]["tunnels"][0]["argv"][:3] == ["ssh", "-F", "/dev/null"]
+    assert body["sshSupervisor"]["secrets"]["sshIdentity"] == {
+        "configured": True,
+        "bytes": 14,
+    }
+    assert "unit-test-key" not in dumped
+    assert "AAAATEST" not in dumped
+    assert "ssh-identity" not in dumped
+
+
+def test_remote_provider_status_tolerates_unreachable_ssh_supervisor(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text(json.dumps(_route_state()), encoding="utf-8")
+    rps = _patch_state_path(monkeypatch, state_path)
+
+    async def fake_fetch():
+        return {
+            "reachable": True,
+            "valid": True,
+            "ready": True,
+            "status": "ok",
+            "reason": "ready",
+            "secret": {"configured": True, "bytes": 24},
+            "resolution": {"ok": True, "addressCount": 1},
+        }
+
+    async def fake_agent_request(*_args, **_kwargs):
+        raise rps.AgentUnavailable("host agent route is down")
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+    monkeypatch.setattr(rps, "async_request_agent_json", fake_agent_request)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["status"] == "ready"
+    assert body["sshSupervisor"]["reachable"] is False
+    assert body["sshSupervisor"]["status"] == "unavailable"
+    assert body["sshSupervisor"]["reason"] == "host_agent_unavailable"
 
 
 def test_remote_provider_status_exposes_sanitized_probe_receipt(


### PR DESCRIPTION
﻿## Summary
- add a read-only host-agent SSH supervisor status endpoint for remote-provider routing state
- have dashboard-api include a sanitized `sshSupervisor` block in `/api/remote-provider/status`
- report local SSH secret custody readiness without exposing secret values or raw secret status paths

## Validation
- `python -m py_compile bin/ods-host-agent.py extensions/services/dashboard-api/routers/remote_provider_status.py extensions/services/dashboard-api/tests/test_host_agent.py extensions/services/dashboard-api/tests/test_remote_provider_status.py`
- `python -m pytest extensions/services/dashboard-api/tests/test_remote_provider_status.py extensions/services/dashboard-api/tests/test_host_agent.py::TestRemoteProviderLifecycle`
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py extensions/services/dashboard-api/tests/test_remote_provider_status.py` (`256 passed, 4 skipped` locally; `260 passed` on Tower2/Linux)
- `python -m ruff check bin/ods-host-agent.py extensions/services/dashboard-api/routers/remote_provider_status.py extensions/services/dashboard-api/tests/test_host_agent.py extensions/services/dashboard-api/tests/test_remote_provider_status.py --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check`
- Tower2 exact-SHA validation for `aa66563bc4041d6c3e0d1210c0e182a2ec142d47`
  - clean clone checkout of exact SHA
  - `python -m py_compile ...`
  - focused status tests (`26 passed`)
  - full host-agent + remote-provider status tests (`260 passed`)
  - `python tests/contracts/test-remote-provider-egress-policy.py`
  - `python -m ruff check ...`
  - `python scripts/check-dependency-pins.py`
  - `python scripts/audit-extensions.py --project-dir . --json` (`26 services, 0 errors`)
  - `bash scripts/release-gate.sh`
  - `git diff --check`

Tower2 log: `/home/michael/ods-pr-ssh-status-aa66563bc404.6NVBvv/pr-remote-provider-ssh-status-aa66563bc4041d6c3e0d1210c0e182a2ec142d47.log`