### PR TITLE
Add remote provider SSH tunnel service scaffold

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -111,7 +111,8 @@ _MACOS_HOST_AGENT_BRIDGE_LABEL = "com.ods.host-agent-bridge"
 _FALLBACK_CORE_IDS = frozenset({
     "dashboard-api", "dashboard", "llama-server", "model-router", "open-webui",
     "litellm", "langfuse", "hermes", "hermes-proxy", "n8n", "openclaw", "opencode",
-    "perplexica", "searxng", "qdrant", "tts", "whisper",
+    "perplexica", "searxng", "qdrant", "remote-provider-egress",
+    "remote-provider-ssh-tunnel", "tts", "whisper",
     "embeddings", "token-spy", "comfyui", "ape", "privacy-shield",
 })
 
@@ -154,7 +155,8 @@ WINDOWS_WHISPER_CUDA_MIN_DRIVER_MAJOR = 575
 # Always-on services defined in docker-compose.base.yml — never stoppable via API.
 # Distinct from CORE_SERVICE_IDS (which is the allowlist of known service IDs).
 ALWAYS_ON_SERVICES: frozenset = frozenset({
-    "llama-server", "model-router", "open-webui", "dashboard", "dashboard-api",
+    "llama-server", "model-router", "remote-provider-egress", "remote-provider-ssh-tunnel",
+    "open-webui", "dashboard", "dashboard-api",
 })
 USER_EXTENSIONS_DIR: Path = Path()
 EXTENSIONS_DIR: Path = Path()

--- a/ods/config/core-service-ids.json
+++ b/ods/config/core-service-ids.json
@@ -18,6 +18,7 @@
   "privacy-shield",
   "qdrant",
   "remote-provider-egress",
+  "remote-provider-ssh-tunnel",
   "searxng",
   "token-spy",
   "tts",

--- a/ods/config/dependency-lock.json
+++ b/ods/config/dependency-lock.json
@@ -98,6 +98,12 @@
       "value": "python:3.11-slim"
     },
     {
+      "id": "remote-provider-ssh-tunnel.python",
+      "type": "image",
+      "path": "extensions/services/remote-provider-ssh-tunnel/Dockerfile",
+      "value": "python:3.11-slim"
+    },
+    {
       "id": "ods-proxy.caddy",
       "type": "image",
       "path": "extensions/services/ods-proxy/compose.yaml",
@@ -291,6 +297,11 @@
       "path": "docker-compose.base.yml",
       "value": "ods-remote-provider-egress:local",
       "reason": "Core internal egress service image is built from extensions/services/remote-provider-egress/Dockerfile."
+    },
+    {
+      "path": "docker-compose.base.yml",
+      "value": "ods-remote-provider-ssh-tunnel:local",
+      "reason": "Core internal SSH tunnel service image is built from extensions/services/remote-provider-ssh-tunnel/Dockerfile."
     }
   ],
   "allow_variable_refs": [

--- a/ods/config/network-exposure-policy.json
+++ b/ods/config/network-exposure-policy.json
@@ -122,6 +122,12 @@
       "auth_required": true,
       "notes": "Internal-only boundary that injects private provider credentials and forwards remote LLM traffic."
     },
+    "remote-provider-ssh-tunnel": {
+      "risk": "remote-llm-ssh-transport",
+      "lan_exposure": "none",
+      "auth_required": true,
+      "notes": "Internal-only SSH tunnel sidecar for remote LLM transport; binds no host ports and reads SSH custody files from private state."
+    },
     "searxng": {
       "risk": "search-ui",
       "lan_exposure": "operator-controlled",

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -386,6 +386,49 @@ services:
       start_period: 10s
 
   # ============================================
+  # Remote Provider SSH Tunnel (remote LLM SSH transport)
+  # ============================================
+  remote-provider-ssh-tunnel:
+    build:
+      context: .
+      dockerfile: extensions/services/remote-provider-ssh-tunnel/Dockerfile
+    image: ods-remote-provider-ssh-tunnel:local
+    container_name: ods-remote-provider-ssh-tunnel
+    restart: unless-stopped
+    expose:
+      - "18090"
+      - "18091"
+      - "18092"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    logging: *default-logging
+    environment:
+      - ODS_REMOTE_PROVIDER_ROUTE_PATH=/state/remote-provider/routing-state.json
+      - ODS_REMOTE_PROVIDER_SECRET_DIR=/state/remote-provider/secrets
+      - ODS_REMOTE_PROVIDER_SSH_STATUS_PORT=18090
+    volumes:
+      - ${ODS_DATA_DIR:-./data}:/state:ro
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128M
+        reservations:
+          cpus: '0.05'
+          memory: 32M
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:18090/health',timeout=4).status==200 else 1)"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # ============================================
   # Dashboard UI (Control Center)
   # ============================================
   dashboard:

--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -403,7 +403,8 @@ def _load_core_service_ids() -> frozenset:
     return frozenset({
         "dashboard-api", "dashboard", "llama-server", "model-router", "open-webui",
         "litellm", "langfuse", "hermes", "hermes-proxy", "n8n", "openclaw", "opencode",
-        "perplexica", "searxng", "qdrant", "remote-provider-egress", "tts", "whisper",
+        "perplexica", "searxng", "qdrant", "remote-provider-egress",
+        "remote-provider-ssh-tunnel", "tts", "whisper",
         "embeddings", "token-spy", "comfyui", "ape", "privacy-shield",
     })
 
@@ -413,7 +414,8 @@ CORE_SERVICE_IDS = _load_core_service_ids()
 # Always-on services defined in docker-compose.base.yml — never manageable via API.
 # Distinct from CORE_SERVICE_IDS (the full built-in service allowlist).
 ALWAYS_ON_SERVICES: frozenset = frozenset({
-    "llama-server", "model-router", "remote-provider-egress", "open-webui", "dashboard", "dashboard-api",
+    "llama-server", "model-router", "remote-provider-egress",
+    "remote-provider-ssh-tunnel", "open-webui", "dashboard", "dashboard-api",
 })
 
 

--- a/ods/extensions/services/remote-provider-ssh-tunnel/Dockerfile
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+RUN addgroup --gid 10778 odsremote \
+    && adduser --uid 10778 --gid 10778 --disabled-password --gecos "" odsremote
+
+WORKDIR /srv/remote-provider-ssh-tunnel
+COPY extensions/services/remote-provider-ssh-tunnel/app ./app
+COPY bin/remote_provider ./remote_provider
+
+USER odsremote
+EXPOSE 18090 18091 18092
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 --start-period=10s \
+    CMD python -c "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:18090/health',timeout=4).status==200 else 1)"
+CMD ["python", "-m", "app.main"]

--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/__init__.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/__init__.py
@@ -1,0 +1,1 @@
+"""Remote-provider SSH tunnel service package."""

--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
@@ -1,0 +1,162 @@
+"""Internal-only remote-provider SSH tunnel status service.
+
+This scaffold is intentionally inert: it loads generated route state, reports
+a redacted supervisor plan, and never starts ssh or opens provider tunnels.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Mapping
+
+from remote_provider.ssh_supervisor import (
+    SSH_SUPERVISOR_PLAN_SCHEMA,
+    ssh_secret_status,
+    ssh_supervisor_plan,
+)
+
+
+HEALTH_SCHEMA = "ods.remote-provider-ssh-tunnel-health.v1"
+ROUTE_STATE_SCHEMA = "ods.remote-routing-state.v1"
+DEFAULT_ROUTE_PATH = Path("/state/remote-provider/routing-state.json")
+DEFAULT_SECRET_DIR = Path("/state/remote-provider/secrets")
+DEFAULT_STATUS_PORT = 18090
+
+LOGGER = logging.getLogger("remote-provider-ssh-tunnel")
+
+
+def _env_path(name: str, default: Path) -> Path:
+    return Path(os.environ.get(name, str(default)))
+
+
+def _status_port() -> int:
+    raw = os.environ.get("ODS_REMOTE_PROVIDER_SSH_STATUS_PORT", str(DEFAULT_STATUS_PORT))
+    try:
+        port = int(raw)
+    except ValueError:
+        LOGGER.warning("invalid ODS_REMOTE_PROVIDER_SSH_STATUS_PORT=%r; using default", raw)
+        return DEFAULT_STATUS_PORT
+    if port < 1 or port > 65535:
+        LOGGER.warning("out-of-range ODS_REMOTE_PROVIDER_SSH_STATUS_PORT=%r; using default", raw)
+        return DEFAULT_STATUS_PORT
+    return port
+
+
+def _disabled_route() -> dict[str, Any]:
+    return {
+        "enabled": False,
+        "mode": None,
+        "transport": "direct",
+        "provider": None,
+        "ssh": None,
+    }
+
+
+def _error_plan(reason: str, *, status: str = "invalid") -> dict[str, Any]:
+    return {
+        "schema": SSH_SUPERVISOR_PLAN_SCHEMA,
+        "status": status,
+        "ready": False,
+        "readyToStart": False,
+        "reason": reason,
+        "tunnelBaseUrl": None,
+        "tunnels": [],
+        "secrets": ssh_secret_status(_env_path("ODS_REMOTE_PROVIDER_SECRET_DIR", DEFAULT_SECRET_DIR)),
+    }
+
+
+def _route_from_state_doc(doc: Mapping[str, Any]) -> dict[str, Any]:
+    if doc.get("schema") != ROUTE_STATE_SCHEMA:
+        raise ValueError("unknown route-state schema")
+    enabled = doc.get("enabled") is True
+    provider = doc.get("provider")
+    if enabled and not isinstance(provider, Mapping):
+        raise ValueError("enabled route state is missing provider metadata")
+    provider_dict = dict(provider) if isinstance(provider, Mapping) else {}
+    ssh = doc.get("ssh")
+    return {
+        "enabled": enabled,
+        "mode": doc.get("mode"),
+        "transport": str(provider_dict.get("transport") or "direct") if enabled else "direct",
+        "provider": provider_dict if enabled else None,
+        "ssh": dict(ssh) if isinstance(ssh, Mapping) else None,
+    }
+
+
+def _load_route(route_path: Path) -> dict[str, Any]:
+    try:
+        raw = route_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _disabled_route()
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("route state is not valid JSON") from exc
+    if not isinstance(doc, Mapping):
+        raise ValueError("route state must be a JSON object")
+    return _route_from_state_doc(doc)
+
+
+def _supervisor_plan() -> dict[str, Any]:
+    route_path = _env_path("ODS_REMOTE_PROVIDER_ROUTE_PATH", DEFAULT_ROUTE_PATH)
+    secret_dir = _env_path("ODS_REMOTE_PROVIDER_SECRET_DIR", DEFAULT_SECRET_DIR)
+    try:
+        route = _load_route(route_path)
+    except (OSError, ValueError) as exc:
+        LOGGER.info("remote route state unavailable: %s", exc)
+        return _error_plan("route_state_unavailable")
+    try:
+        return ssh_supervisor_plan(route, secrets=ssh_secret_status(secret_dir))
+    except (TypeError, ValueError) as exc:
+        LOGGER.info("remote SSH supervisor plan unavailable: %s", exc)
+        return _error_plan("ssh_plan_unavailable")
+
+
+def health_payload() -> dict[str, Any]:
+    plan = _supervisor_plan()
+    return {
+        "schema": HEALTH_SCHEMA,
+        "ready": bool(plan.get("ready")),
+        "status": plan.get("status"),
+        "reason": plan.get("reason"),
+        "plan": plan,
+    }
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    server_version = "ODSRemoteProviderSSHTunnel/1"
+    sys_version = ""
+
+    def do_GET(self) -> None:
+        if self.path != "/health":
+            self._write_json({"error": "not_found"}, status=404)
+            return
+        self._write_json(health_payload())
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        LOGGER.info("%s - %s", self.address_string(), fmt % args)
+
+    def _write_json(self, payload: Mapping[str, Any], *, status: int = 200) -> None:
+        body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+
+def main() -> int:
+    logging.basicConfig(level=os.environ.get("ODS_LOG_LEVEL", "INFO"))
+    server = ThreadingHTTPServer(("0.0.0.0", _status_port()), HealthHandler)
+    LOGGER.info("remote-provider SSH tunnel status service listening on %s", server.server_address)
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/extensions/services/remote-provider-ssh-tunnel/manifest.yaml
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/manifest.yaml
@@ -1,0 +1,35 @@
+schema_version: ods.services.v1
+
+compatibility:
+  ods_min: "2.0.0"
+
+service:
+  id: remote-provider-ssh-tunnel
+  name: Remote Provider SSH Tunnel
+  aliases: []
+  container_name: ods-remote-provider-ssh-tunnel
+  default_host: remote-provider-ssh-tunnel
+  port: 18090
+  external_port_default: 0
+  health: /health
+  ui_path: /health
+  external_link: false
+  type: docker
+  gpu_backends: [all]
+  category: core
+  depends_on: []
+  startup_check: true
+  description: >
+    Internal-only SSH transport supervisor scaffold for optional remote LLM
+    providers. It reads generated remote routing state and private SSH custody
+    files, reports a redacted fail-closed plan, and exposes no host port.
+  env_vars:
+    - key: ODS_REMOTE_PROVIDER_ROUTE_PATH
+      default: /state/remote-provider/routing-state.json
+      description: Generated remote routing-state path mounted read-only into the SSH tunnel service.
+    - key: ODS_REMOTE_PROVIDER_SECRET_DIR
+      default: /state/remote-provider/secrets
+      description: Private SSH identity and known_hosts custody directory mounted read-only into the SSH tunnel service.
+    - key: ODS_REMOTE_PROVIDER_SSH_STATUS_PORT
+      default: "18090"
+      description: Internal-only health/status port for the SSH tunnel supervisor scaffold.

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2429,7 +2429,7 @@ for service in (data.get("services") or {}).values():
     # surface unrelated Dockerfile failures and make a healthy selected stack
     # look broken.
     ai "Rebuilding local-built images..."
-    _macos_candidate_build_services=(dashboard dashboard-api model-router remote-provider-egress ape token-spy privacy-shield brave-search)
+    _macos_candidate_build_services=(dashboard dashboard-api model-router remote-provider-egress remote-provider-ssh-tunnel ape token-spy privacy-shield brave-search)
     if ! _macos_enabled_services="$(docker compose "${COMPOSE_FLAGS[@]}" config --services 2>>"$ODS_LOG_FILE")"; then
         ai_err "Could not resolve macOS compose services for local image rebuilds."
         ai "Inspect compose config with: cd '$INSTALL_DIR' && docker compose ${COMPOSE_FLAGS[*]} config --services"

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -1047,7 +1047,7 @@ MODELS_INI_EOF
     compose_ok=false
     # Build local images individually so every failure is reported before the
     # installer refuses to launch any potentially stale image.
-    _candidate_build_services=(dashboard dashboard-api model-router remote-provider-egress ape token-spy privacy-shield brave-search)
+    _candidate_build_services=(dashboard dashboard-api model-router remote-provider-egress remote-provider-ssh-tunnel ape token-spy privacy-shield brave-search)
     [[ "$ENABLE_COMFYUI" == "true" ]] && _candidate_build_services+=(comfyui)
     [[ "$GPU_BACKEND" == "amd" ]] && _candidate_build_services+=(llama-server)
     if ! _enabled_compose_services="$($DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" config --services 2>>"$LOG_FILE")"; then

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -1708,7 +1708,7 @@ litellm_settings:
         # `up -d`. llama-server runs natively on Windows (Lemonade or Vulkan
         # binary) so it is not built here. ComfyUI is only locally built on
         # NVIDIA; the Windows AMD stack uses a prebuilt image overlay.
-        $_buildServices = @("dashboard", "dashboard-api", "model-router", "remote-provider-egress")
+        $_buildServices = @("dashboard", "dashboard-api", "model-router", "remote-provider-egress", "remote-provider-ssh-tunnel")
         if (Test-ODSWindowsServiceEnabled -ServiceId "ape" -Plan $servicePlan) {
             $_buildServices += "ape"
         }

--- a/ods/scripts/release-gate.sh
+++ b/ods/scripts/release-gate.sh
@@ -36,6 +36,7 @@ bash tests/test-windows-missing-service-hints.sh
 "$PYTHON_CMD" tests/contracts/test-network-exposure-contracts.py
 "$PYTHON_CMD" tests/contracts/test-remote-provider-egress-policy.py
 "$PYTHON_CMD" tests/contracts/test-remote-provider-egress-service.py
+"$PYTHON_CMD" tests/contracts/test-remote-provider-ssh-tunnel-service.py
 
 echo "[gate] smoke"
 bash tests/smoke/linux-amd.sh

--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -240,7 +240,7 @@ except (OSError, ValueError):
         "ape", "comfyui", "dashboard", "dashboard-api",
         "embeddings", "langfuse", "litellm", "llama-server", "n8n",
         "open-webui", "openclaw", "perplexica", "privacy-shield", "qdrant",
-        "remote-provider-egress",
+        "remote-provider-egress", "remote-provider-ssh-tunnel",
         "searxng", "token-spy", "tts", "whisper",
     }
 

--- a/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
+++ b/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Remote-provider SSH tunnel service contracts."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "bin"))
+sys.path.insert(0, str(ROOT / "extensions" / "services" / "remote-provider-ssh-tunnel"))
+
+from remote_provider.ssh_supervisor import SSH_SUPERVISOR_PLAN_SCHEMA  # noqa: E402
+
+
+BASE_COMPOSE = ROOT / "docker-compose.base.yml"
+MANIFEST = ROOT / "extensions" / "services" / "remote-provider-ssh-tunnel" / "manifest.yaml"
+DOCKERFILE = ROOT / "extensions" / "services" / "remote-provider-ssh-tunnel" / "Dockerfile"
+APP_MAIN = ROOT / "extensions" / "services" / "remote-provider-ssh-tunnel" / "app" / "main.py"
+EXPOSURE_POLICY = ROOT / "config" / "network-exposure-policy.json"
+
+PUBLIC_SSH_SECRET_ENV = (
+    "REMOTE_LLM_SSH_PRIVATE_KEY",
+    "REMOTE_LLM_SSH_KNOWN_HOSTS",
+)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+class patched_env:
+    def __init__(self, **values: str) -> None:
+        self.values = values
+        self.previous: dict[str, str | None] = {}
+
+    def __enter__(self) -> None:
+        for key, value in self.values.items():
+            self.previous[key] = os.environ.get(key)
+            os.environ[key] = value
+
+    def __exit__(self, *_args: object) -> None:
+        for key, value in self.previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def ssh_route_state() -> dict[str, object]:
+    return {
+        "schema": "ods.remote-routing-state.v1",
+        "enabled": True,
+        "mode": "cloud",
+        "provider": {
+            "capability": "openai-compatible",
+            "baseUrl": "http://127.0.0.1:8000/v1",
+            "model": "qwen/remote:latest",
+            "transport": "ssh",
+        },
+        "ssh": {
+            "host": "gpu.example.test",
+            "user": "ods",
+            "port": 22,
+            "inferenceHost": "127.0.0.1",
+            "inferencePort": 8000,
+            "controlHost": "127.0.0.1",
+            "controlPort": 8091,
+        },
+        "projection": {
+            "publicModel": "ods/current",
+            "gateway": "litellm-cloud",
+            "egressBaseUrl": "http://remote-provider-egress:8091/v1",
+            "consumerRoute": "gateway",
+        },
+        "status": {"proven": False, "reason": "pending-provider-handshake"},
+    }
+
+
+def _compose_block() -> str:
+    compose = read(BASE_COMPOSE)
+    assert_true("  remote-provider-ssh-tunnel:" in compose, "base compose must define remote-provider-ssh-tunnel")
+    return compose.split("  remote-provider-ssh-tunnel:", 1)[1].split("\n  # ", 1)[0]
+
+
+def _health_app():
+    return importlib.import_module("app.main")
+
+
+def _payload_with_env(route_path: Path, secret_dir: Path) -> dict[str, object]:
+    with patched_env(
+        ODS_REMOTE_PROVIDER_ROUTE_PATH=str(route_path),
+        ODS_REMOTE_PROVIDER_SECRET_DIR=str(secret_dir),
+    ):
+        return _health_app().health_payload()
+
+
+def _walk_service_source() -> Iterator[tuple[Path, str]]:
+    for path in (MANIFEST, DOCKERFILE, APP_MAIN, BASE_COMPOSE):
+        yield path, read(path)
+
+
+def test_compose_service_is_internal_only_and_hardened() -> None:
+    block = _compose_block()
+    assert_true("dockerfile: extensions/services/remote-provider-ssh-tunnel/Dockerfile" in block, "service must use its Dockerfile")
+    assert_true("image: ods-remote-provider-ssh-tunnel:local" in block, "service image must be local-only")
+    assert_true("expose:" in block, "service must expose only internal ports")
+    for port in ('"18090"', '"18091"', '"18092"'):
+        assert_true(port in block, f"service must expose internal port {port}")
+    assert_true("ports:" not in block, "service must not bind a host port")
+    assert_true("cap_drop:" in block and "- ALL" in block, "service must drop capabilities")
+    assert_true("read_only: true" in block, "service filesystem must be read-only")
+    assert_true("/state:ro" in block, "service must mount ODS state read-only")
+    assert_true("ODS_REMOTE_PROVIDER_SECRET_DIR=/state/remote-provider/secrets" in block, "service must use secret custody directory")
+    for key in PUBLIC_SSH_SECRET_ENV:
+        assert_true(key not in block, f"service must not source public SSH secret env {key}")
+
+
+def test_manifest_and_network_policy_mark_no_lan_exposure() -> None:
+    manifest = read(MANIFEST)
+    exposure = json.loads(read(EXPOSURE_POLICY))
+    assert_true("id: remote-provider-ssh-tunnel" in manifest, "manifest must declare service id")
+    assert_true("external_port_default: 0" in manifest, "manifest must prevent host URL fallback")
+    assert_true("category: core" in manifest, "SSH tunnel service should be a core internal service")
+    assert_true("compose_file:" not in manifest, "base-stack service manifest must not add an extension overlay")
+    entry = exposure["services"]["remote-provider-ssh-tunnel"]
+    assert_true(entry["lan_exposure"] == "none", "SSH tunnel service must have no LAN exposure")
+    assert_true(entry["auth_required"] is True, "SSH tunnel service must require private SSH custody")
+
+
+def test_image_contains_ssh_client_and_shared_helpers() -> None:
+    dockerfile = read(DOCKERFILE)
+    assert_true("openssh-client" in dockerfile, "image must include the SSH client")
+    assert_true("COPY bin/remote_provider ./remote_provider" in dockerfile, "image must copy shared transport helpers")
+    assert_true("USER odsremote" in dockerfile, "image must run as non-root service user")
+    assert_true("EXPOSE 18090 18091 18092" in dockerfile, "image must document internal status and tunnel ports")
+
+
+def test_health_app_reports_disabled_without_route_and_no_secrets() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        payload = _payload_with_env(root / "missing-routing-state.json", root / "secrets")
+    dumped = json.dumps(payload, sort_keys=True)
+    assert_true(payload["schema"] == "ods.remote-provider-ssh-tunnel-health.v1", "health schema drifted")
+    assert_true(payload["ready"] is False, "missing route must not report ready")
+    assert_true(payload["status"] == "disabled", "missing route should be a disabled supervisor")
+    assert_true(payload["reason"] == "remote_route_disabled", "missing route reason drifted")
+    assert_true(payload["plan"]["schema"] == SSH_SUPERVISOR_PLAN_SCHEMA, "plan schema drifted")
+    assert_true("unit-test-key" not in dumped, "identity contents leaked into disabled health payload")
+    assert_true("AAAATEST" not in dumped, "known_hosts contents leaked into disabled health payload")
+
+
+def test_health_app_reports_invalid_state_without_starting() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        route_path = root / "routing-state.json"
+        route_path.write_text(json.dumps({"schema": "ods.unknown", "enabled": True}), encoding="utf-8")
+        payload = _payload_with_env(route_path, root / "secrets")
+    assert_true(payload["ready"] is False, "invalid route state must not report ready")
+    assert_true(payload["status"] == "invalid", "invalid route state should report a diagnostic status")
+    assert_true(payload["reason"] == "route_state_unavailable", "invalid route state reason drifted")
+    assert_true(payload["plan"]["readyToStart"] is False, "invalid route state must not be startable")
+
+
+def test_health_app_reports_planned_when_route_and_secret_custody_exist() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        route_path = root / "routing-state.json"
+        secret_dir = root / "secrets"
+        secret_dir.mkdir()
+        route_path.write_text(json.dumps(ssh_route_state()), encoding="utf-8")
+        (secret_dir / "ssh-identity").write_text("unit-test-key\n", encoding="utf-8")
+        (secret_dir / "known_hosts").write_text("gpu.example.test ssh-ed25519 AAAATEST\n", encoding="utf-8")
+        payload = _payload_with_env(route_path, secret_dir)
+    plan = payload["plan"]
+    dumped = json.dumps(payload, sort_keys=True)
+    assert_true(payload["status"] == "planned", "ready SSH custody should produce a planned status")
+    assert_true(payload["ready"] is False, "service scaffold must not report a live tunnel")
+    assert_true(plan["readyToStart"] is True, "ready SSH custody should allow a later process start")
+    assert_true(plan["reason"] == "tunnel_process_not_started", "planned status reason drifted")
+    assert_true(plan["tunnelBaseUrl"] == "http://remote-provider-ssh-tunnel:18091/v1", "tunnel base URL drifted")
+    assert_true(len(plan["tunnels"]) == 2, "SSH route should plan inference and control tunnels")
+    assert_true("unit-test-key" not in dumped, "identity contents leaked into planned health payload")
+    assert_true("AAAATEST" not in dumped, "known_hosts contents leaked into planned health payload")
+
+
+def test_service_source_avoids_public_secret_names() -> None:
+    for path, text in _walk_service_source():
+        for key in PUBLIC_SSH_SECRET_ENV:
+            assert_true(key not in text, f"{key} must not appear in {path}")
+    assert_true("ODS_REMOTE_PROVIDER_SECRET_DIR" in read(APP_MAIN), "app must read only the SSH secret custody directory")
+    assert_true("ssh_secret_status" in read(APP_MAIN), "app must use shared support-bundle-safe secret status")
+    assert_true("ssh_supervisor_plan" in read(APP_MAIN), "app must use shared supervisor planner")
+
+
+def main() -> int:
+    tests = [
+        test_compose_service_is_internal_only_and_hardened,
+        test_manifest_and_network_policy_mark_no_lan_exposure,
+        test_image_contains_ssh_client_and_shared_helpers,
+        test_health_app_reports_disabled_without_route_and_no_secrets,
+        test_health_app_reports_invalid_state_without_starting,
+        test_health_app_reports_planned_when_route_and_secret_custody_exist,
+        test_service_source_avoids_public_secret_names,
+    ]
+    for test in tests:
+        test()
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/ods/tests/test-macos-cloud-resolver.sh
+++ b/ods/tests/test-macos-cloud-resolver.sh
@@ -296,7 +296,7 @@ PYTHON_CMD="$(ods_detect_python_cmd_with_module yaml)"
 
 if $DOCKER_COMPOSE_AVAILABLE; then
     render_state disabled \
-        'dashboard,dashboard-api,litellm,open-webui,qdrant,remote-provider-egress' false
+        'dashboard,dashboard-api,litellm,open-webui,qdrant,remote-provider-egress,remote-provider-ssh-tunnel' false
     pass "Hermes-disabled Apple cloud stack renders with exact selected services and auth"
 fi
 
@@ -308,7 +308,7 @@ assert_selected_bases "$enabled_files" \
     'extensions/services/hermes/compose.yaml,extensions/services/litellm/compose.yaml,extensions/services/qdrant/compose.yaml'
 if $DOCKER_COMPOSE_AVAILABLE; then
     render_state enabled \
-        'dashboard,dashboard-api,hermes,litellm,open-webui,qdrant,remote-provider-egress' true
+        'dashboard,dashboard-api,hermes,litellm,open-webui,qdrant,remote-provider-egress,remote-provider-ssh-tunnel' true
     pass "Hermes-enabled Apple cloud stack renders without missing client auth"
 fi
 
@@ -319,7 +319,7 @@ assert_selected_bases "$reenabled_files" \
     'extensions/services/litellm/compose.yaml,extensions/services/qdrant/compose.yaml'
 if $DOCKER_COMPOSE_AVAILABLE; then
     render_state redisabled \
-        'dashboard,dashboard-api,litellm,open-webui,qdrant,remote-provider-egress' false
+        'dashboard,dashboard-api,litellm,open-webui,qdrant,remote-provider-egress,remote-provider-ssh-tunnel' false
     pass "Hermes re-disable renders cleanly without a partial service"
 else
     echo "[SKIP] docker compose unavailable; resolver selection checks still passed"


### PR DESCRIPTION
## Summary
- add an internal-only `remote-provider-ssh-tunnel` base-stack service with no host `ports:` binding, read-only ODS state access, non-root runtime, and a small stdlib `/health` app
- report redacted SSH supervisor health from persisted routing state and file-based SSH custody, staying non-ready/fail-closed when route state or custody is absent or invalid
- wire the new service through core-service anti-shadowing, always-on guards, installer local-image rebuild lists, dependency pins, network-exposure policy, release gate, and macOS resolver expectations

## Safety boundary
- This PR does not start `ssh`, open provider tunnels, or make SSH routes live in egress/probe paths.
- The service is safe to run by default: missing route state reports disabled, invalid route state reports non-ready diagnostics, and secret file contents are never projected into health output.

## Validation
- `python -m py_compile bin\ods-host-agent.py extensions\services\dashboard-api\config.py extensions\services\remote-provider-ssh-tunnel\app\main.py tests\contracts\test-remote-provider-ssh-tunnel-service.py`
- `python tests\contracts\test-remote-provider-ssh-tunnel-service.py`
- `python tests\contracts\test-network-exposure-contracts.py`
- `python tests\contracts\test-remote-provider-egress-service.py`
- `python tests\contracts\test-remote-provider-egress-policy.py`
- `python scripts\audit-extensions.py --project-dir . --json`
- `python scripts\check-dependency-pins.py`
- `python -m pytest extensions\services\dashboard-api\tests\test_extensions.py::TestAssertNotCoreAllowsBuiltins extensions\services\dashboard-api\tests\test_host_agent.py::TestRemoteProviderLifecycle extensions\services\dashboard-api\tests\test_remote_provider_status.py`
- `python -m ruff check bin\ods-host-agent.py extensions\services\dashboard-api\config.py extensions\services\remote-provider-ssh-tunnel\app\main.py tests\contracts\test-remote-provider-ssh-tunnel-service.py --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check`
- `$env:WEBUI_SECRET='compose-config-test'; docker compose -f docker-compose.base.yml config --services`

Local note: `bash tests\test-macos-cloud-resolver.sh` could not run in this Windows shell because `/bin/bash` is unavailable; Tower2 validation will cover the Linux shell contracts at the exact PR SHA.
