### PR TITLE
Route remote provider SSH egress through tunnel

### DIFF
--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -39,6 +39,7 @@ from .ssh_supervisor import (  # noqa: F401
     SSH_SUPERVISOR_PLAN_SCHEMA,
     ssh_secret_status,
     ssh_supervisor_plan,
+    ssh_tunnel_base_url,
 )
 from .egress import (  # noqa: F401
     DEFAULT_MAX_BODY_BYTES,
@@ -54,6 +55,7 @@ from .egress import (  # noqa: F401
     resolve_direct_provider_addresses,
     route_from_state,
     sanitize_forward_headers,
+    upstream_base_url_for_route,
     validate_direct_provider_resolution,
 )
 from .lifecycle import (  # noqa: F401
@@ -123,6 +125,8 @@ __all__ = [
     "sanitize_forward_headers",
     "ssh_secret_status",
     "ssh_supervisor_plan",
+    "ssh_tunnel_base_url",
+    "upstream_base_url_for_route",
     "validate_direct_provider_resolution",
     "validate_public_env_keys",
     "validate_remote_model_id",

--- a/ods/bin/remote_provider/egress.py
+++ b/ods/bin/remote_provider/egress.py
@@ -23,6 +23,7 @@ from .policy import (
     load_policy,
     plan_route,
 )
+from .ssh_supervisor import ssh_tunnel_base_url
 
 
 ROUTING_STATE_SCHEMA = "ods.remote-routing-state.v1"
@@ -30,6 +31,15 @@ FORWARD_PATHS = {
     "/v1/chat/completions": "POST",
     "/v1/completions": "POST",
     "/v1/responses": "POST",
+}
+SSH_STATE_ENV_KEYS = {
+    "host": "REMOTE_LLM_SSH_HOST",
+    "user": "REMOTE_LLM_SSH_USER",
+    "port": "REMOTE_LLM_SSH_PORT",
+    "inferenceHost": "REMOTE_LLM_SSH_INFERENCE_HOST",
+    "inferencePort": "REMOTE_LLM_SSH_INFERENCE_PORT",
+    "controlHost": "REMOTE_LLM_SSH_CONTROL_HOST",
+    "controlPort": "REMOTE_LLM_SSH_CONTROL_PORT",
 }
 DEFAULT_MAX_BODY_BYTES = 4 * 1024 * 1024
 DEFAULT_SECRET_PATH = Path("/state/remote-provider/secrets/provider-api-key")
@@ -102,6 +112,27 @@ def load_route_state(path: str | Path) -> dict[str, Any]:
         raise EgressError(503, "invalid_route_state", str(exc)) from exc
 
 
+def _route_env_from_state(state: Mapping[str, Any], provider: Mapping[str, Any]) -> dict[str, str]:
+    transport = str(provider.get("transport") or "")
+    env = {
+        "ODS_MODE": str(state.get("mode") or "cloud"),
+        "REMOTE_LLM_ENABLED": "true",
+        "REMOTE_LLM_TRANSPORT": transport,
+        "REMOTE_LLM_BASE_URL": str(provider.get("baseUrl") or ""),
+        "REMOTE_LLM_MODEL": str(provider.get("model") or ""),
+    }
+    if transport != "ssh":
+        return env
+    ssh = state.get("ssh")
+    if not isinstance(ssh, Mapping):
+        raise EgressError(503, "invalid_route_state", "ssh metadata is missing")
+    for state_key, env_key in SSH_STATE_ENV_KEYS.items():
+        value = ssh.get(state_key)
+        if value not in (None, ""):
+            env[env_key] = str(value)
+    return env
+
+
 def route_from_state(
     state: Mapping[str, Any],
     *,
@@ -116,22 +147,11 @@ def route_from_state(
     provider = state.get("provider")
     if not isinstance(provider, Mapping):
         raise EgressError(503, "invalid_route_state", "provider metadata is missing")
-    transport = str(provider.get("transport") or "")
-    if transport == "ssh":
-        raise EgressError(
-            503,
-            "ssh_transport_deferred",
-            "SSH transport requires the tunnel supervisor before egress can forward",
-        )
-    env = {
-        "ODS_MODE": mode,
-        "REMOTE_LLM_ENABLED": "true",
-        "REMOTE_LLM_TRANSPORT": transport,
-        "REMOTE_LLM_BASE_URL": str(provider.get("baseUrl") or ""),
-        "REMOTE_LLM_MODEL": str(provider.get("model") or ""),
-    }
     try:
-        return plan_route(env, policy=policy or load_policy(DEFAULT_POLICY_PATH))
+        return plan_route(
+            _route_env_from_state({**state, "mode": mode}, provider),
+            policy=policy or load_policy(DEFAULT_POLICY_PATH),
+        )
     except PolicyError as exc:
         raise EgressError(503, "route_policy_rejected", str(exc)) from exc
 
@@ -276,6 +296,26 @@ def validate_direct_provider_resolution(
     return addresses
 
 
+def upstream_base_url_for_route(route: Mapping[str, Any]) -> str:
+    """Return the service-internal upstream URL used at the egress boundary."""
+    provider = route.get("provider")
+    if not isinstance(provider, Mapping):
+        raise EgressError(503, "invalid_route", "provider route is missing")
+    transport = route.get("transport")
+    if transport == "direct":
+        return str(provider.get("baseUrl") or "")
+    if transport == "ssh":
+        try:
+            return ssh_tunnel_base_url(route)
+        except (TypeError, ValueError) as exc:
+            raise EgressError(503, "invalid_route", str(exc)) from exc
+    raise EgressError(
+        503,
+        "transport_unavailable",
+        "remote provider transport is not available in this egress service",
+    )
+
+
 def prepare_upstream_request(
     *,
     method: str,
@@ -298,12 +338,6 @@ def prepare_upstream_request(
         raise EgressError(413, "payload_too_large", "request body exceeds limit")
     if route.get("enabled") is not True:
         raise EgressError(503, "remote_route_disabled", "remote provider route is disabled")
-    if route.get("transport") != "direct":
-        raise EgressError(
-            503,
-            "transport_unavailable",
-            "remote provider transport is not available in this egress service",
-        )
     if not provider_secret:
         raise EgressError(
             503,
@@ -313,6 +347,7 @@ def prepare_upstream_request(
     provider = route.get("provider")
     if not isinstance(provider, Mapping):
         raise EgressError(503, "invalid_route", "provider route is missing")
+    upstream_base_url = upstream_base_url_for_route(route)
     try:
         payload = json.loads(body.decode("utf-8"))
     except (UnicodeDecodeError, ValueError) as exc:
@@ -325,7 +360,7 @@ def prepare_upstream_request(
     content = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     return UpstreamRequest(
         method=required_method,
-        url=_join_openai_path(str(provider.get("baseUrl") or ""), path),
+        url=_join_openai_path(upstream_base_url, path),
         headers=sanitize_forward_headers(headers, provider_secret=provider_secret),
         content=content,
         requested_model=requested_model,
@@ -348,5 +383,6 @@ __all__ = [
     "route_from_state",
     "sanitize_forward_headers",
     "resolve_direct_provider_addresses",
+    "upstream_base_url_for_route",
     "validate_direct_provider_resolution",
 ]

--- a/ods/bin/remote_provider/ssh_supervisor.py
+++ b/ods/bin/remote_provider/ssh_supervisor.py
@@ -64,6 +64,11 @@ def _tunnel_base_url(specs: tuple[SshTunnelSpec, ...]) -> str:
     return f"http://{DEFAULT_SSH_TUNNEL_SERVICE_HOST}:{port}/v1"
 
 
+def ssh_tunnel_base_url(route: Mapping[str, Any]) -> str:
+    """Return the internal OpenAI-compatible base URL exposed by the SSH tunnel."""
+    return _tunnel_base_url(build_ssh_tunnel_specs(route))
+
+
 def ssh_supervisor_plan(
     route: Mapping[str, Any],
     *,
@@ -113,4 +118,5 @@ __all__ = [
     "SSH_SUPERVISOR_PLAN_SCHEMA",
     "ssh_secret_status",
     "ssh_supervisor_plan",
+    "ssh_tunnel_base_url",
 ]

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -367,6 +367,8 @@ services:
       - ODS_REMOTE_PROVIDER_API_KEY_FILE=/state/remote-provider/secrets/provider-api-key
       - ODS_REMOTE_PROVIDER_MAX_BODY_BYTES=${ODS_REMOTE_PROVIDER_MAX_BODY_BYTES:-4194304}
       - ODS_REMOTE_PROVIDER_UPSTREAM_TIMEOUT=${ODS_REMOTE_PROVIDER_UPSTREAM_TIMEOUT:-600}
+      - ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL=${ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL:-http://remote-provider-ssh-tunnel:18090/health}
+      - ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_TIMEOUT=${ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_TIMEOUT:-2}
     volumes:
       - ${ODS_DATA_DIR:-./data}:/state:ro
       - ${ODS_CONFIG_DIR:-./config}/remote-provider-egress-policy.json:/config/remote-provider-egress-policy.json:ro

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -47,6 +47,13 @@ MAX_BODY_BYTES = int(
 UPSTREAM_TIMEOUT_SECONDS = float(
     os.environ.get("ODS_REMOTE_PROVIDER_UPSTREAM_TIMEOUT", "600")
 )
+SSH_TUNNEL_HEALTH_URL = os.environ.get(
+    "ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL",
+    "http://remote-provider-ssh-tunnel:18090/health",
+)
+SSH_TUNNEL_HEALTH_TIMEOUT_SECONDS = float(
+    os.environ.get("ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_TIMEOUT", "2")
+)
 
 app = FastAPI(title="ODS Remote Provider Egress", docs_url=None, redoc_url=None, openapi_url=None)
 
@@ -79,6 +86,14 @@ def _load_route() -> dict[str, Any]:
     return route_from_state(load_route_state(ROUTE_PATH), policy=policy)
 
 
+def _http_client() -> httpx.AsyncClient:
+    client = getattr(app.state, "http", None)
+    if client is None or client.is_closed:
+        client = httpx.AsyncClient(follow_redirects=False)
+        app.state.http = client
+    return client
+
+
 def _error_response(exc: EgressError) -> JSONResponse:
     return JSONResponse(
         {
@@ -98,6 +113,72 @@ def _response_headers(headers: Mapping[str, str]) -> dict[str, str]:
         for name, value in headers.items()
         if name.lower() not in _HOP_BY_HOP_RESPONSE_HEADERS
     }
+
+
+def _safe_tunnel_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    process = payload.get("process")
+    if not isinstance(process, Mapping):
+        process = {}
+    ready = payload.get("ready") is True
+    return {
+        "ok": ready,
+        "ready": ready,
+        "status": payload.get("status"),
+        "reason": payload.get("reason") or ("ready" if ready else "ssh_tunnel_not_ready"),
+        "process": {
+            "status": process.get("status"),
+            "pid": process.get("pid"),
+        },
+    }
+
+
+async def _ssh_tunnel_status() -> dict[str, Any]:
+    client = _http_client()
+    try:
+        response = await client.get(
+            SSH_TUNNEL_HEALTH_URL,
+            timeout=SSH_TUNNEL_HEALTH_TIMEOUT_SECONDS,
+        )
+    except httpx.TimeoutException:
+        return {
+            "ok": False,
+            "ready": False,
+            "status": "unavailable",
+            "reason": "ssh_tunnel_timeout",
+        }
+    except httpx.HTTPError as exc:
+        return {
+            "ok": False,
+            "ready": False,
+            "status": "unavailable",
+            "reason": "ssh_tunnel_unavailable",
+            "errorType": exc.__class__.__name__,
+        }
+    if response.status_code != 200:
+        return {
+            "ok": False,
+            "ready": False,
+            "status": "unavailable",
+            "reason": "ssh_tunnel_unavailable",
+            "httpStatus": response.status_code,
+        }
+    try:
+        payload = response.json()
+    except ValueError:
+        return {
+            "ok": False,
+            "ready": False,
+            "status": "invalid",
+            "reason": "ssh_tunnel_health_invalid",
+        }
+    if not isinstance(payload, Mapping):
+        return {
+            "ok": False,
+            "ready": False,
+            "status": "invalid",
+            "reason": "ssh_tunnel_health_invalid",
+        }
+    return _safe_tunnel_summary(payload)
 
 
 @app.get("/health")
@@ -132,22 +213,37 @@ async def health() -> dict[str, Any]:
             "resolution": {"ok": False, "reason": exc.code},
             "secret": secret,
         }
-    if route.get("transport") == "direct" and not secret["configured"]:
+    resolution = {"ok": True, "addressCount": len(resolved_addresses)}
+    if not secret["configured"]:
         return {
             "status": "degraded",
             "ready": False,
             "reason": "missing_provider_secret",
             "route": _safe_route_summary(route),
-            "resolution": {"ok": True, "addressCount": len(resolved_addresses)},
+            "resolution": resolution,
             "secret": secret,
         }
+    tunnel = None
+    if route.get("transport") == "ssh":
+        tunnel = await _ssh_tunnel_status()
+        if tunnel["ready"] is not True:
+            return {
+                "status": "degraded",
+                "ready": False,
+                "reason": "ssh_tunnel_not_ready",
+                "route": _safe_route_summary(route),
+                "resolution": resolution,
+                "secret": secret,
+                "tunnel": tunnel,
+            }
     return {
         "status": "ok",
         "ready": True,
         "reason": "ready",
         "route": _safe_route_summary(route),
-        "resolution": {"ok": True, "addressCount": len(resolved_addresses)},
+        "resolution": resolution,
         "secret": secret,
+        "tunnel": tunnel,
     }
 
 
@@ -180,6 +276,12 @@ async def forward(full_path: str, request: Request) -> Response:
         route = _load_route()
         validate_direct_provider_resolution(route)
         secret = read_provider_secret(SECRET_PATH)
+        if route.get("transport") == "ssh":
+            tunnel = await _ssh_tunnel_status()
+            if tunnel["ready"] is not True:
+                return _error_response(
+                    EgressError(503, "ssh_tunnel_not_ready", "SSH tunnel is not ready")
+                )
         upstream_request = prepare_upstream_request(
             method=request.method,
             path=path,
@@ -192,7 +294,7 @@ async def forward(full_path: str, request: Request) -> Response:
     except EgressError as exc:
         return _error_response(exc)
 
-    client: httpx.AsyncClient = app.state.http
+    client = _http_client()
     ods_headers = {
         "X-ODS-Remote-Transport": str(route.get("transport") or ""),
         "X-ODS-Requested-Model": upstream_request.requested_model,

--- a/ods/extensions/services/remote-provider-egress/manifest.yaml
+++ b/ods/extensions/services/remote-provider-egress/manifest.yaml
@@ -34,3 +34,9 @@ service:
     - key: ODS_REMOTE_PROVIDER_API_KEY_FILE
       default: /state/remote-provider/secrets/provider-api-key
       description: Private provider bearer token file. The value is never projected into public env/config.
+    - key: ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL
+      default: http://remote-provider-ssh-tunnel:18090/health
+      description: Internal SSH tunnel readiness endpoint used only for SSH transport health gating.
+    - key: ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_TIMEOUT
+      default: "2"
+      description: Seconds the egress service waits for the internal SSH tunnel health endpoint.

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -18,6 +18,7 @@ from remote_provider.egress import (  # noqa: E402
     prepare_upstream_request,
     provider_secret_status,
     route_from_state,
+    upstream_base_url_for_route,
     validate_direct_provider_resolution,
 )
 
@@ -47,6 +48,18 @@ def assert_egress_error(func, code: str) -> EgressError:
     raise AssertionError(f"expected EgressError {code}")
 
 
+def ssh_metadata(**overrides: object) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "host": "gpu.example.test",
+        "user": "ods",
+        "port": 22,
+        "inferenceHost": "127.0.0.1",
+        "inferencePort": 8000,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
 def route_state(**provider_overrides: str) -> dict[str, object]:
     provider = {
         "capability": "openai-compatible",
@@ -55,11 +68,13 @@ def route_state(**provider_overrides: str) -> dict[str, object]:
         "transport": "direct",
     }
     provider.update(provider_overrides)
+    ssh = ssh_metadata() if provider["transport"] == "ssh" else None
     return {
         "schema": "ods.remote-routing-state.v1",
         "enabled": True,
         "mode": "cloud",
         "provider": provider,
+        "ssh": ssh,
         "projection": {
             "publicModel": "ods/current",
             "gateway": "litellm-cloud",
@@ -104,6 +119,7 @@ def test_compose_service_is_internal_only_and_hardened() -> None:
     assert_true("cap_drop:" in block and "- ALL" in block, "service must drop capabilities")
     assert_true("read_only: true" in block, "service filesystem must be read-only")
     assert_true("/remote-provider/secrets/provider-api-key" in block, "service must use a secret file path")
+    assert_true("http://remote-provider-ssh-tunnel:18090/health" in block, "service must check internal SSH tunnel health")
     assert_true("REMOTE_LLM_API_KEY" not in block, "service must not source provider API keys from public env")
 
 
@@ -176,6 +192,41 @@ def test_direct_resolution_rejects_unsafe_dns_answers() -> None:
     )
 
 
+def test_ssh_route_uses_internal_tunnel_without_direct_dns() -> None:
+    route = route_from_state(
+        route_state(transport="ssh", baseUrl="http://127.0.0.1:8000/v1")
+    )
+    assert_true(route["transport"] == "ssh", "SSH route should now be accepted")
+    assert_true(
+        route["provider"]["baseUrl"] == "http://127.0.0.1:8000/v1",
+        "public route should preserve remote-side provider metadata",
+    )
+    assert_true(
+        upstream_base_url_for_route(route) == "http://remote-provider-ssh-tunnel:18091/v1",
+        "SSH egress must target the internal tunnel service",
+    )
+    addresses = validate_direct_provider_resolution(
+        route,
+        resolver=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("SSH routes must not run direct DNS validation")
+        ),
+    )
+    assert_true(addresses == [], "SSH routes should skip direct DNS checks")
+    upstream = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={"authorization": "Bearer client-token"},
+        body=b'{"model":"ods/current","messages":[]}',
+        route=route,
+        provider_secret="unit-test-provider-token",
+    )
+    assert_true(
+        upstream.url == "http://remote-provider-ssh-tunnel:18091/v1/chat/completions",
+        "SSH forward must use the tunnel service URL",
+    )
+    assert_true(upstream.headers["authorization"] == "Bearer unit-test-provider-token", "provider auth must still be injected")
+
+
 def test_egress_fails_closed_without_secret_or_supported_transport() -> None:
     route = route_from_state(route_state())
     assert_egress_error(
@@ -189,9 +240,16 @@ def test_egress_fails_closed_without_secret_or_supported_transport() -> None:
         ),
         "missing_provider_secret",
     )
+    unsupported = route_state(transport="unix", baseUrl="http://127.0.0.1:8000/v1")
     assert_egress_error(
-        lambda: route_from_state(route_state(transport="ssh", baseUrl="http://127.0.0.1:8000/v1")),
-        "ssh_transport_deferred",
+        lambda: route_from_state(unsupported),
+        "route_policy_rejected",
+    )
+    missing_ssh = route_state(transport="ssh", baseUrl="http://127.0.0.1:8000/v1")
+    missing_ssh["ssh"] = None
+    assert_egress_error(
+        lambda: route_from_state(missing_ssh),
+        "invalid_route_state",
     )
 
 
@@ -212,6 +270,8 @@ def test_service_source_avoids_public_env_secret_names() -> None:
     assert_true("ODS_REMOTE_PROVIDER_API_KEY_FILE" in text, "app must read only the provider key file path")
     assert_true("read_provider_secret" in text, "app must use shared secret-file helper")
     assert_true("validate_direct_provider_resolution" in text, "app must enforce runtime DNS/address policy")
+    assert_true("ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL" in text, "app must check SSH tunnel readiness")
+    assert_true("ssh_tunnel_not_ready" in text, "app must fail closed when the SSH tunnel is down")
     assert_true(POLICY.exists(), "policy document must exist for mounted service config")
 
 
@@ -223,6 +283,7 @@ def main() -> int:
         test_route_state_prepares_direct_provider_request_without_client_auth,
         test_direct_resolution_allows_only_global_provider_addresses,
         test_direct_resolution_rejects_unsafe_dns_answers,
+        test_ssh_route_uses_internal_tunnel_without_direct_dns,
         test_egress_fails_closed_without_secret_or_supported_transport,
         test_secret_file_status_is_support_bundle_safe,
         test_service_source_avoids_public_env_secret_names,


### PR DESCRIPTION
## Summary
- accept SSH remote-provider route state in the egress helper instead of returning `ssh_transport_deferred`
- route SSH upstream requests to `http://remote-provider-ssh-tunnel:18091/v1` only at the private egress boundary while preserving public provider metadata
- gate egress health and forwarding on the internal SSH tunnel health endpoint, with provider API key custody still file-only

## Validation
Local:
- `python -m py_compile ods\bin\remote_provider\egress.py ods\bin\remote_provider\ssh_supervisor.py ods\bin\remote_provider\__init__.py ods\extensions\services\remote-provider-egress\app\main.py ods\tests\contracts\test-remote-provider-egress-service.py`
- `python ods\tests\contracts\test-remote-provider-egress-service.py`
- `python ods\tests\contracts\test-remote-provider-egress-policy.py`
- `python ods\tests\contracts\test-remote-provider-ssh-tunnel-service.py`
- `python ods\tests\contracts\test-network-exposure-contracts.py`
- `python ods\scripts\audit-extensions.py --project-dir ods --json`
- `python ods\scripts\check-dependency-pins.py`
- `python -m ruff check ods\ --select E,F,W --ignore E501,E701,E731,E741,E402`
- `$env:WEBUI_SECRET='compose-config-test'; docker compose -f ods\docker-compose.base.yml config --services`
- `python -m pytest ods\extensions\services\dashboard-api\tests\test_remote_provider_status.py -q`
- `python -m pytest ods\extensions\services\dashboard-api\tests\test_host_agent.py -q`
- `git diff --check` (only Windows line-ending warnings)

Tower2 exact-SHA validation:
- SHA: `f8bcfef5da36a490f24846f55e8c7c2a096bdc05`
- Log: `/home/michael/ods-pr-egress-ssh-tunnel-f8bcfef5da36.tSj711/pr-remote-provider-egress-ssh-tunnel-f8bcfef5da36a490f24846f55e8c7c2a096bdc05.log`
- Verified: focused contracts, network exposure, extension audit, dependency pins, Ruff, compose render, `git diff --check`, and full `bash ods/scripts/release-gate.sh`