### PR TITLE
Add SSH-aware remote provider probe helper

### DIFF
--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -70,6 +70,7 @@ from .probe import (  # noqa: F401
     PROBE_RECEIPT_SCHEMA,
     ProbeError,
     probe_direct_provider,
+    probe_provider_route,
     public_probe_receipt,
 )
 
@@ -114,6 +115,7 @@ __all__ = [
     "plan_route",
     "plan_lifecycle_operation",
     "probe_direct_provider",
+    "probe_provider_route",
     "prepare_upstream_request",
     "provider_secret_status",
     "public_activation_receipt",

--- a/ods/bin/remote_provider/probe.py
+++ b/ods/bin/remote_provider/probe.py
@@ -13,7 +13,11 @@ from typing import Any
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
-from .egress import EgressError, validate_direct_provider_resolution
+from .egress import (
+    EgressError,
+    upstream_base_url_for_route,
+    validate_direct_provider_resolution,
+)
 
 
 DEFAULT_PROBE_TIMEOUT_SECONDS = 10.0
@@ -44,6 +48,10 @@ def _provider(route: Mapping[str, Any]) -> Mapping[str, Any]:
     if not isinstance(provider, Mapping):
         raise ProbeError(503, "invalid_route", "provider route is missing")
     return provider
+
+
+def _transport(route: Mapping[str, Any]) -> str:
+    return str(route.get("transport") or "")
 
 
 def _read_probe_body(response: Any) -> bytes:
@@ -113,35 +121,21 @@ def public_probe_receipt(
     return receipt
 
 
-def probe_direct_provider(
-    route: Mapping[str, Any],
+def _probe_models_endpoint(
     *,
+    base_url: str,
     provider_secret: str,
-    resolver: Callable[..., list[tuple[Any, ...]]] = socket.getaddrinfo,
-    opener: UrlOpener = urllib_request.urlopen,
+    resolution: Mapping[str, Any],
+    transport: str,
+    opener: UrlOpener,
     timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
-    """Probe an OpenAI-compatible direct provider without leaking credentials."""
-    if route.get("enabled") is not True:
-        raise ProbeError(503, "remote_route_disabled", "remote provider route is disabled")
-    if route.get("transport") != "direct":
-        raise ProbeError(
-            501,
-            "transport_probe_unavailable",
-            "remote provider test probes require direct transport in this release",
-        )
     secret = str(provider_secret or "").strip()
     if not secret:
         raise ProbeError(400, "missing_provider_secret", "provider secret is required")
 
-    try:
-        resolved_addresses = validate_direct_provider_resolution(route, resolver=resolver)
-    except EgressError as exc:
-        raise ProbeError(exc.status, exc.code, exc.message) from exc
-
-    provider = _provider(route)
     request = urllib_request.Request(
-        _models_url(str(provider.get("baseUrl") or "")),
+        _models_url(base_url),
         method="GET",
         headers={
             "Accept": "application/json",
@@ -177,13 +171,78 @@ def probe_direct_provider(
         "ok": True,
         "status": status,
         "endpoint": "/v1/models",
+        "transport": transport,
         "contentType": content_type,
         "modelCount": _model_count(body),
-        "resolution": {
-            "ok": True,
-            "addressCount": len(resolved_addresses),
-        },
+        "resolution": dict(resolution),
     }
+
+
+def probe_provider_route(
+    route: Mapping[str, Any],
+    *,
+    provider_secret: str,
+    resolver: Callable[..., list[tuple[Any, ...]]] = socket.getaddrinfo,
+    opener: UrlOpener = urllib_request.urlopen,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Probe an OpenAI-compatible provider through the route's transport boundary."""
+    if route.get("enabled") is not True:
+        raise ProbeError(503, "remote_route_disabled", "remote provider route is disabled")
+    transport = _transport(route)
+    if transport == "direct":
+        try:
+            resolved_addresses = validate_direct_provider_resolution(route, resolver=resolver)
+        except EgressError as exc:
+            raise ProbeError(exc.status, exc.code, exc.message) from exc
+        base_url = str(_provider(route).get("baseUrl") or "")
+        resolution = {"ok": True, "addressCount": len(resolved_addresses)}
+    elif transport == "ssh":
+        try:
+            base_url = upstream_base_url_for_route(route)
+        except EgressError as exc:
+            raise ProbeError(exc.status, exc.code, exc.message) from exc
+        resolution = {"ok": True, "addressCount": 0}
+    else:
+        raise ProbeError(
+            501,
+            "transport_probe_unavailable",
+            "remote provider test probes require direct or ssh transport",
+        )
+    return _probe_models_endpoint(
+        base_url=base_url,
+        provider_secret=provider_secret,
+        resolution=resolution,
+        transport=transport,
+        opener=opener,
+        timeout=timeout,
+    )
+
+
+def probe_direct_provider(
+    route: Mapping[str, Any],
+    *,
+    provider_secret: str,
+    resolver: Callable[..., list[tuple[Any, ...]]] = socket.getaddrinfo,
+    opener: UrlOpener = urllib_request.urlopen,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Probe an OpenAI-compatible direct provider without leaking credentials."""
+    if route.get("enabled") is not True:
+        raise ProbeError(503, "remote_route_disabled", "remote provider route is disabled")
+    if _transport(route) != "direct":
+        raise ProbeError(
+            501,
+            "transport_probe_unavailable",
+            "remote provider direct probes require direct transport",
+        )
+    return probe_provider_route(
+        route,
+        provider_secret=provider_secret,
+        resolver=resolver,
+        opener=opener,
+        timeout=timeout,
+    )
 
 
 __all__ = [
@@ -192,5 +251,6 @@ __all__ = [
     "PROBE_RECEIPT_SCHEMA",
     "ProbeError",
     "probe_direct_provider",
+    "probe_provider_route",
     "public_probe_receipt",
 ]

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -55,6 +55,7 @@ from remote_provider.probe import (  # noqa: E402
     PROBE_RECEIPT_SCHEMA,
     ProbeError,
     probe_direct_provider,
+    probe_provider_route,
     public_probe_receipt,
 )
 
@@ -714,7 +715,41 @@ def test_direct_provider_probe_fails_closed_before_unsafe_dns_request() -> None:
     assert_true("private" in error.message, "unsafe DNS failure should explain address class")
 
 
-def test_ssh_provider_probe_is_deferred_until_tunnel_supervisor() -> None:
+def test_generic_ssh_provider_probe_uses_tunnel_boundary() -> None:
+    route = plan_route(cloud_ssh_env())
+    calls = []
+
+    def opener(request, *, timeout: float):
+        calls.append((request, timeout))
+        return _ProbeResponse()
+
+    result = probe_provider_route(
+        route,
+        provider_secret="unit-test-provider-token",
+        resolver=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("SSH tunnel probes must not run direct DNS validation")
+        ),
+        opener=opener,
+    )
+    dumped = json.dumps(result, sort_keys=True)
+    assert_true(result["ok"] is True, "SSH provider probe should pass through generic helper")
+    assert_true(result["transport"] == "ssh", "SSH probe transport metadata drifted")
+    assert_true(result["resolution"] == {"ok": True, "addressCount": 0}, "SSH probe should not expose direct DNS")
+    assert_true(len(calls) == 1, "SSH probe should perform one bounded HTTP request")
+    request, timeout = calls[0]
+    assert_true(timeout == 10.0, "SSH probe timeout drifted")
+    assert_true(
+        request.full_url == "http://remote-provider-ssh-tunnel:18091/v1/models",
+        "SSH probe must target the internal tunnel service",
+    )
+    assert_true(
+        request.headers.get("Authorization") == "Bearer unit-test-provider-token",
+        "SSH probe must inject provider auth at the request boundary",
+    )
+    assert_true("unit-test-provider-token" not in dumped, "SSH probe result leaked provider auth")
+
+
+def test_direct_probe_api_still_defers_ssh_transport() -> None:
     route = plan_route(cloud_ssh_env())
     error = assert_raises_probe_error(
         lambda: probe_direct_provider(
@@ -723,7 +758,7 @@ def test_ssh_provider_probe_is_deferred_until_tunnel_supervisor() -> None:
             resolver=_public_resolver,
             opener=lambda *_args, **_kwargs: _ProbeResponse(),
         ),
-        "SSH probe should fail closed before tunnel supervisor lands",
+        "direct probe API should reject SSH transport",
     )
     assert_true(error.status == 501, "SSH probe should report unavailable transport")
     assert_true(error.code == "transport_probe_unavailable", "SSH probe error code drifted")
@@ -752,7 +787,8 @@ def main() -> int:
         test_direct_provider_probe_is_bounded_and_redacted,
         test_public_probe_receipt_is_redacted_and_typed,
         test_direct_provider_probe_fails_closed_before_unsafe_dns_request,
-        test_ssh_provider_probe_is_deferred_until_tunnel_supervisor,
+        test_generic_ssh_provider_probe_uses_tunnel_boundary,
+        test_direct_probe_api_still_defers_ssh_transport,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary
- Add a generic remote provider probe helper that supports SSH-routed provider routes through the SSH tunnel boundary.
- Keep the existing direct probe API direct-only so current host-agent behavior stays unchanged.
- Extend the remote provider egress policy contract to cover SSH probe tunneling and direct API SSH deferral.

## Validation
- `python -m py_compile ods\bin\remote_provider\probe.py ods\bin\remote_provider\__init__.py ods\tests\contracts\test-remote-provider-egress-policy.py`
- `python ods\tests\contracts\test-remote-provider-egress-policy.py`
- `python ods\tests\contracts\test-remote-provider-egress-service.py`
- `python ods\tests\contracts\test-remote-provider-ssh-tunnel-service.py`
- `python ods\tests\contracts\test-network-exposure-contracts.py`
- `python ods\scripts\check-dependency-pins.py`
- `python -m ruff check ods\ --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check` (line-ending warnings only)
- Tower2 exact-SHA release gate for `f131a3ad5149edc265449efeabdb52428ecc458f`: `/home/michael/ods-pr-ssh-probe-f131a3ad5149.kUhdnD/pr-remote-provider-ssh-probe-f131a3ad5149edc265449efeabdb52428ecc458f.log` with `[PASS] release gate` and `[tower2] PASS sha=f131a3ad5149edc265449efeabdb52428ecc458f`.