### PR TITLE
Expose SSH tunnel health in remote provider status

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -249,6 +249,32 @@ def _safe_ssh_supervisor_status(
     }
 
 
+def _safe_egress_tunnel(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    process = value.get("process")
+    clean_process = None
+    if isinstance(process, Mapping):
+        clean_process = {
+            "status": _safe_text(process.get("status"), max_length=64) or "unknown",
+            "pid": _safe_int(process.get("pid")),
+        }
+    tunnel: dict[str, Any] = {
+        "ok": bool(value.get("ok")),
+        "ready": bool(value.get("ready")),
+        "status": _safe_text(value.get("status"), max_length=64) or "unknown",
+        "reason": _safe_text(value.get("reason"), max_length=128) or "unknown",
+        "process": clean_process,
+    }
+    http_status = _safe_int(value.get("httpStatus"))
+    if http_status is not None:
+        tunnel["httpStatus"] = http_status
+    error_type = _safe_text(value.get("errorType"), max_length=128)
+    if error_type:
+        tunnel["errorType"] = error_type
+    return tunnel
+
+
 async def _fetch_ssh_supervisor_status() -> dict[str, Any]:
     try:
         payload = await async_request_agent_json(
@@ -301,13 +327,14 @@ def _sanitize_egress_health(payload: Any) -> dict[str, Any]:
             "reason": "invalid_egress_health",
             "secret": {"configured": False, "bytes": None},
             "resolution": None,
+            "tunnel": None,
         }
     resolution = payload.get("resolution")
     clean_resolution = None
     if isinstance(resolution, Mapping):
         clean_resolution = {
             "ok": bool(resolution.get("ok")),
-            "reason": str(resolution.get("reason") or ""),
+            "reason": _safe_text(resolution.get("reason"), max_length=128),
             "addressCount": (
                 resolution.get("addressCount")
                 if type(resolution.get("addressCount")) is int
@@ -318,10 +345,11 @@ def _sanitize_egress_health(payload: Any) -> dict[str, Any]:
         "reachable": True,
         "valid": True,
         "ready": bool(payload.get("ready")),
-        "status": str(payload.get("status") or "unknown"),
-        "reason": str(payload.get("reason") or ""),
+        "status": _safe_text(payload.get("status"), max_length=64) or "unknown",
+        "reason": _safe_text(payload.get("reason"), max_length=128),
         "secret": _safe_secret_status(payload.get("secret")),
         "resolution": clean_resolution,
+        "tunnel": _safe_egress_tunnel(payload.get("tunnel")),
     }
 
 
@@ -340,6 +368,7 @@ async def _fetch_egress_health() -> dict[str, Any]:
             "reason": "egress_unreachable",
             "secret": {"configured": False, "bytes": None},
             "resolution": None,
+            "tunnel": None,
         }
     except httpx.HTTPError as exc:
         logger.debug("remote-provider-egress health request failed: %s", exc)
@@ -351,6 +380,7 @@ async def _fetch_egress_health() -> dict[str, Any]:
             "reason": "egress_request_failed",
             "secret": {"configured": False, "bytes": None},
             "resolution": None,
+            "tunnel": None,
         }
 
     if response.status_code >= 400:
@@ -362,6 +392,7 @@ async def _fetch_egress_health() -> dict[str, Any]:
             "reason": f"egress_http_{response.status_code}",
             "secret": {"configured": False, "bytes": None},
             "resolution": None,
+            "tunnel": None,
         }
     try:
         payload = response.json()

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -173,6 +173,88 @@ def test_remote_provider_status_sanitizes_egress_secret_health(
     assert body["capabilities"]["odsPeerLifecycle"] is False
 
 
+def test_remote_provider_status_exposes_sanitized_egress_tunnel_health(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text(json.dumps(_route_state(transport="ssh")), encoding="utf-8")
+    rps = _patch_state_path(monkeypatch, state_path)
+
+    async def fake_fetch():
+        return rps._sanitize_egress_health(
+            {
+                "status": "ok",
+                "ready": True,
+                "reason": "ready",
+                "secret": {
+                    "configured": True,
+                    "bytes": 24,
+                    "path": "/state/remote-provider/secrets/provider-api-key",
+                    "value": "unit-test-provider-token",
+                },
+                "resolution": {"ok": True, "addressCount": 0, "raw": "127.0.0.1"},
+                "tunnel": {
+                    "ok": True,
+                    "ready": True,
+                    "status": "running",
+                    "reason": "ready",
+                    "process": {
+                        "status": "running",
+                        "pid": 1234,
+                        "argv": ["ssh", "-i", "/state/remote-provider/secrets/ssh-identity"],
+                    },
+                    "secretValue": "unit-test-ssh-key",
+                },
+            }
+        )
+
+    async def fake_ssh_supervisor():
+        return rps._safe_ssh_supervisor_status(
+            {
+                "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+                "status": "running",
+                "ready": True,
+                "readyToStart": True,
+                "reason": "ready",
+                "tunnelBaseUrl": "http://remote-provider-ssh-tunnel:18091/v1",
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            }
+        )
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", fake_ssh_supervisor)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert resp.status_code == 200
+    assert body["status"] == "ready"
+    assert body["egress"]["tunnel"] == {
+        "ok": True,
+        "ready": True,
+        "status": "running",
+        "reason": "ready",
+        "process": {"status": "running", "pid": 1234},
+    }
+    assert body["egress"]["resolution"] == {
+        "ok": True,
+        "reason": "",
+        "addressCount": 0,
+    }
+    assert "unit-test-provider-token" not in dumped
+    assert "provider-api-key" not in dumped
+    assert "unit-test-ssh-key" not in dumped
+    assert "ssh-identity" not in dumped
+
+
 def test_remote_provider_status_exposes_sanitized_ssh_supervisor_plan(
     test_client,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Surface the SSH tunnel readiness summary already produced by remote-provider-egress through the Dashboard API status payload.
- Sanitize tunnel health to safe booleans, status/reason text, HTTP error type/status, and process status/pid only.
- Add a regression test proving provider and SSH custody details do not leak through the Dashboard status response.

## Validation
- `python -m py_compile ods\extensions\services\dashboard-api\routers\remote_provider_status.py ods\extensions\services\dashboard-api\tests\test_remote_provider_status.py`
- `python -m ruff check ods\extensions\services\dashboard-api\routers\remote_provider_status.py ods\extensions\services\dashboard-api\tests\test_remote_provider_status.py --select E,F,W --ignore E501,E701,E731,E741,E402`
- `pytest ods\extensions\services\dashboard-api\tests\test_remote_provider_status.py -q`
- `pytest ods\extensions\services\dashboard-api\tests\test_host_agent.py -q`
- `python ods\tests\contracts\test-remote-provider-egress-policy.py`
- `python ods\tests\contracts\test-remote-provider-egress-service.py`
- `python ods\tests\contracts\test-remote-provider-ssh-tunnel-service.py`
- `python ods\tests\contracts\test-network-exposure-contracts.py`
- `python ods\scripts\check-dependency-pins.py`
- `python -m ruff check ods\ --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check` (line-ending warnings only)
- Tower2 exact-SHA release gate for `90c856b40d8fb9342534d5398bef1a95450b9700`: `/home/michael/ods-pr-egress-tunnel-status-90c856b40d8f.4gbXbf/pr-remote-provider-egress-tunnel-status-90c856b40d8fb9342534d5398bef1a95450b9700.log` with `[PASS] release gate` and `[tower2] PASS sha=90c856b40d8fb9342534d5398bef1a95450b9700`.