### PR TITLE
Stage SSH remote provider configuration without host probe

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -1504,6 +1504,7 @@ def _remote_provider_projection(route: dict) -> dict:
 def _remote_provider_route_status(
     *,
     enabled: bool,
+    pending_reason: str = "pending-provider-handshake",
     probe_receipt: dict | None = None,
 ) -> dict:
     if not enabled:
@@ -1514,7 +1515,7 @@ def _remote_provider_route_status(
             "reason": "provider-handshake-ok",
             "lastProbe": probe_receipt,
         }
-    return {"proven": False, "reason": "pending-provider-handshake"}
+    return {"proven": False, "reason": pending_reason}
 
 
 def _remote_provider_route_state_from_plan(
@@ -1524,6 +1525,11 @@ def _remote_provider_route_state_from_plan(
 ) -> dict:
     route = plan.get("route") if isinstance(plan.get("route"), dict) else {}
     enabled = route.get("enabled") is True
+    pending_reason = (
+        "pending-ssh-tunnel-proof"
+        if enabled and route.get("transport") == "ssh"
+        else "pending-provider-handshake"
+    )
     return {
         "schema": _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA,
         "enabled": enabled,
@@ -1533,6 +1539,7 @@ def _remote_provider_route_state_from_plan(
         "projection": _remote_provider_projection(route),
         "status": _remote_provider_route_status(
             enabled=enabled,
+            pending_reason=pending_reason,
             probe_receipt=probe_receipt,
         ),
     }
@@ -1687,9 +1694,18 @@ def _apply_remote_provider_lifecycle_operation(payload: dict, plan: dict) -> dic
     result["mutated"] = action in {"configure", "disable", "remove"}
     result["rollback"] = {"attempted": False, "ok": None}
     probe_receipt = None
-    if action in {"configure", "test"}:
+    route = plan.get("route") if isinstance(plan.get("route"), dict) else {}
+    ssh_configure = action == "configure" and route.get("transport") == "ssh"
+    if action in {"configure", "test"} and not ssh_configure:
         probe_receipt = _remote_provider_probe_lifecycle_test(payload, plan)
         result["probe"] = probe_receipt
+    if ssh_configure:
+        result["proof"] = {
+            "required": True,
+            "status": "pending",
+            "reason": "pending-ssh-tunnel-proof",
+            "boundary": "remote-provider-egress",
+        }
     if action == "test":
         return result
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2013,6 +2013,28 @@ class TestRemoteProviderLifecycle:
             "secrets": {"apiKey": "unit-test-provider-token"},
         }
 
+    def _ssh_configure_payload(self):
+        return {
+            "action": "configure",
+            "provider": {
+                "transport": "ssh",
+                "baseUrl": "http://127.0.0.1:8000/v1",
+                "model": "qwen/remote:latest",
+            },
+            "ssh": {
+                "host": "gpu.example.test",
+                "user": "ods",
+                "port": "22",
+                "inferenceHost": "127.0.0.1",
+                "inferencePort": "8000",
+            },
+            "secrets": {
+                "apiKey": "unit-test-provider-token",
+                "sshPrivateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nunit-test-key\n-----END OPENSSH PRIVATE KEY-----",
+                "sshKnownHosts": "gpu.example.test ssh-ed25519 AAAATEST",
+            },
+        }
+
     def _patch_successful_probe(self, monkeypatch):
         probes = []
 
@@ -2124,26 +2146,7 @@ class TestRemoteProviderLifecycle:
         assert "unit-test-provider-token" not in dumped
 
     def test_route_state_preserves_ssh_metadata_without_secret_values(self):
-        payload = {
-            "action": "configure",
-            "provider": {
-                "transport": "ssh",
-                "baseUrl": "http://127.0.0.1:8000/v1",
-                "model": "qwen/remote:latest",
-            },
-            "ssh": {
-                "host": "gpu.example.test",
-                "user": "ods",
-                "port": "22",
-                "inferenceHost": "127.0.0.1",
-                "inferencePort": "8000",
-            },
-            "secrets": {
-                "apiKey": "unit-test-provider-token",
-                "sshPrivateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nunit-test-key\n-----END OPENSSH PRIVATE KEY-----",
-                "sshKnownHosts": "gpu.example.test ssh-ed25519 AAAATEST",
-            },
-        }
+        payload = self._ssh_configure_payload()
 
         plan = _mod._plan_remote_provider_lifecycle_operation(payload)
         state = _mod._remote_provider_route_state_from_plan(plan)
@@ -2153,6 +2156,61 @@ class TestRemoteProviderLifecycle:
         assert state["provider"]["transport"] == "ssh"
         assert state["ssh"]["host"] == "gpu.example.test"
         assert state["ssh"]["inferencePort"] == 8000
+        assert state["status"] == {
+            "proven": False,
+            "reason": "pending-ssh-tunnel-proof",
+        }
+        assert "unit-test-provider-token" not in dumped
+        assert "unit-test-key" not in dumped
+        assert "AAAATEST" not in dumped
+
+    def test_apply_ssh_configure_stages_route_and_secret_custody_without_host_probe(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+
+        def fail_if_called(_route, *, provider_secret):
+            raise AssertionError("SSH configure must not use the host-side direct probe")
+
+        monkeypatch.setattr(_mod, "_probe_remote_provider_direct", fail_if_called)
+        handler = _FakeHandler(json.dumps(self._ssh_configure_payload()).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_apply(handler)
+
+        body = handler.parse_response()
+        dumped = json.dumps(body, sort_keys=True)
+        root = tmp_path / "remote-provider"
+        state_path = root / "routing-state.json"
+        secret_dir = root / "secrets"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        assert handler.response_code == 200
+        assert body["applied"] is True
+        assert body["mutated"] is True
+        assert body["proof"] == {
+            "required": True,
+            "status": "pending",
+            "reason": "pending-ssh-tunnel-proof",
+            "boundary": "remote-provider-egress",
+        }
+        assert "probe" not in body
+        assert state["enabled"] is True
+        assert state["provider"]["transport"] == "ssh"
+        assert state["ssh"]["host"] == "gpu.example.test"
+        assert state["status"] == {
+            "proven": False,
+            "reason": "pending-ssh-tunnel-proof",
+        }
+        assert (secret_dir / "provider-api-key").read_text(encoding="utf-8") == (
+            "unit-test-provider-token\n"
+        )
+        assert (secret_dir / "ssh-identity").read_text(encoding="utf-8") == (
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nunit-test-key\n-----END OPENSSH PRIVATE KEY-----\n"
+        )
+        assert (secret_dir / "known_hosts").read_text(encoding="utf-8") == (
+            "gpu.example.test ssh-ed25519 AAAATEST\n"
+        )
         assert "unit-test-provider-token" not in dumped
         assert "unit-test-key" not in dumped
         assert "AAAATEST" not in dumped
@@ -2171,26 +2229,7 @@ class TestRemoteProviderLifecycle:
             "gpu.example.test ssh-ed25519 AAAATEST\n",
             encoding="utf-8",
         )
-        payload = {
-            "action": "configure",
-            "provider": {
-                "transport": "ssh",
-                "baseUrl": "http://127.0.0.1:8000/v1",
-                "model": "qwen/remote:latest",
-            },
-            "ssh": {
-                "host": "gpu.example.test",
-                "user": "ods",
-                "port": "22",
-                "inferenceHost": "127.0.0.1",
-                "inferencePort": "8000",
-            },
-            "secrets": {
-                "apiKey": "unit-test-provider-token",
-                "sshPrivateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nunit-test-key\n-----END OPENSSH PRIVATE KEY-----",
-                "sshKnownHosts": "gpu.example.test ssh-ed25519 AAAATEST",
-            },
-        }
+        payload = self._ssh_configure_payload()
         plan = _mod._plan_remote_provider_lifecycle_operation(payload)
         state = _mod._remote_provider_route_state_from_plan(plan)
         (root / "routing-state.json").write_text(json.dumps(state), encoding="utf-8")


### PR DESCRIPTION
## Summary
- Let SSH remote-provider `configure` stage route state plus provider/SSH secret custody without using the host-side direct provider probe.
- Mark staged SSH routes as unproven with `pending-ssh-tunnel-proof`, and return a pending proof descriptor pointing at the egress boundary.
- Keep direct configure/test probe behavior unchanged, so direct providers still fail before writing state or secrets when the probe fails.

## Validation
- `python -m py_compile ods\bin\ods-host-agent.py ods\extensions\services\dashboard-api\tests\test_host_agent.py`
- `python -m ruff check ods\bin\ods-host-agent.py ods\extensions\services\dashboard-api\tests\test_host_agent.py --select E,F,W --ignore E501,E701,E731,E741,E402`
- `pytest ods\extensions\services\dashboard-api\tests\test_host_agent.py::TestRemoteProviderLifecycle -q`
- `pytest ods\extensions\services\dashboard-api\tests\test_host_agent.py -q`
- `pytest ods\extensions\services\dashboard-api\tests\test_remote_provider_status.py -q`
- `python ods\tests\contracts\test-remote-provider-egress-policy.py`
- `python ods\tests\contracts\test-remote-provider-egress-service.py`
- `python ods\tests\contracts\test-remote-provider-ssh-tunnel-service.py`
- `python ods\tests\contracts\test-network-exposure-contracts.py`
- `python ods\scripts\check-dependency-pins.py`
- `python -m ruff check ods\ --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check` (line-ending warnings only)
- Tower2 exact-SHA release gate for `f2fdb1e4e04c26dc5d873986be5c7de5238f2eae`: `/home/michael/ods-pr-ssh-configure-stage-f2fdb1e4e04c.IuLlx5/pr-remote-provider-ssh-configure-stage-f2fdb1e4e04c26dc5d873986be5c7de5238f2eae.log` with `[PASS] release gate` and `[tower2] PASS sha=f2fdb1e4e04c26dc5d873986be5c7de5238f2eae`.