### PR TITLE
Add remote provider egress probe endpoint

### DIFF
--- a/ods/bin/remote_provider/__init__.py
+++ b/ods/bin/remote_provider/__init__.py
@@ -58,6 +58,10 @@ from .egress import (  # noqa: F401
     upstream_base_url_for_route,
     validate_direct_provider_resolution,
 )
+from .egress_probe import (  # noqa: F401
+    PROBE_RESPONSE_SCHEMA,
+    probe_route_response,
+)
 from .lifecycle import (  # noqa: F401
     LIFECYCLE_ACTIONS,
     LIFECYCLE_OPERATION_SCHEMA,
@@ -95,6 +99,7 @@ __all__ = [
     "MAX_PROBE_RESPONSE_BYTES",
     "PUBLIC_MODEL_ALIAS",
     "PROBE_RECEIPT_SCHEMA",
+    "PROBE_RESPONSE_SCHEMA",
     "REDACTED",
     "REMOTE_ROUTE_SCHEMA",
     "ROUTING_STATE_SCHEMA",
@@ -116,6 +121,7 @@ __all__ = [
     "plan_lifecycle_operation",
     "probe_direct_provider",
     "probe_provider_route",
+    "probe_route_response",
     "prepare_upstream_request",
     "provider_secret_status",
     "public_activation_receipt",

--- a/ods/bin/remote_provider/egress_probe.py
+++ b/ods/bin/remote_provider/egress_probe.py
@@ -1,0 +1,52 @@
+"""Pure egress probe response helpers for remote-provider services."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from .egress import EgressError
+from .probe import (
+    DEFAULT_PROBE_TIMEOUT_SECONDS,
+    ProbeError,
+    probe_provider_route,
+    public_probe_receipt,
+)
+
+
+PROBE_RESPONSE_SCHEMA = "ods.remote-provider-egress-probe.v1"
+RouteProbe = Callable[..., Mapping[str, Any]]
+
+
+def probe_route_response(
+    route: Mapping[str, Any],
+    *,
+    provider_secret: str,
+    verified_at: str,
+    tunnel: Mapping[str, Any] | None = None,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+    probe: RouteProbe = probe_provider_route,
+) -> dict[str, Any]:
+    """Return a support-bundle-safe egress probe response for a validated route."""
+    if route.get("transport") == "ssh":
+        if not isinstance(tunnel, Mapping) or tunnel.get("ready") is not True:
+            raise EgressError(503, "ssh_tunnel_not_ready", "SSH tunnel is not ready")
+    probe_result = probe(
+        route,
+        provider_secret=provider_secret,
+        timeout=timeout,
+    )
+    return {
+        "schema": PROBE_RESPONSE_SCHEMA,
+        "ok": True,
+        "transport": route.get("transport"),
+        "probe": public_probe_receipt(probe_result, verified_at=verified_at),
+        "tunnel": dict(tunnel) if isinstance(tunnel, Mapping) else None,
+    }
+
+
+__all__ = [
+    "PROBE_RESPONSE_SCHEMA",
+    "ProbeError",
+    "probe_route_response",
+]

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -8,6 +8,7 @@ injects provider credentials from a private file at the final egress boundary.
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping
 
@@ -27,6 +28,12 @@ from remote_provider.egress import (
     validate_direct_provider_resolution,
 )
 from remote_provider.policy import DEFAULT_POLICY_PATH, load_policy
+from remote_provider.probe import (
+    DEFAULT_PROBE_TIMEOUT_SECONDS,
+    ProbeError,
+    probe_provider_route,
+    public_probe_receipt,
+)
 
 
 ROUTE_PATH = Path(
@@ -54,6 +61,13 @@ SSH_TUNNEL_HEALTH_URL = os.environ.get(
 SSH_TUNNEL_HEALTH_TIMEOUT_SECONDS = float(
     os.environ.get("ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_TIMEOUT", "2")
 )
+PROBE_TIMEOUT_SECONDS = float(
+    os.environ.get(
+        "ODS_REMOTE_PROVIDER_PROBE_TIMEOUT",
+        str(DEFAULT_PROBE_TIMEOUT_SECONDS),
+    )
+)
+PROBE_RESPONSE_SCHEMA = "ods.remote-provider-egress-probe.v1"
 
 app = FastAPI(title="ODS Remote Provider Egress", docs_url=None, redoc_url=None, openapi_url=None)
 
@@ -107,12 +121,29 @@ def _error_response(exc: EgressError) -> JSONResponse:
     )
 
 
+def _probe_error_response(exc: ProbeError) -> JSONResponse:
+    return JSONResponse(
+        {
+            "error": {
+                "message": exc.message,
+                "type": exc.code,
+                "code": str(exc.status),
+            }
+        },
+        status_code=exc.status,
+    )
+
+
 def _response_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return {
         name: value
         for name, value in headers.items()
         if name.lower() not in _HOP_BY_HOP_RESPONSE_HEADERS
     }
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _safe_tunnel_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -264,6 +295,39 @@ async def list_models() -> Response:
         {"id": provider["model"], "object": "model", "owned_by": "remote-provider"},
     ]
     return JSONResponse({"object": "list", "data": data, "ods": _safe_route_summary(route)})
+
+
+@app.post("/probe")
+async def probe() -> Response:
+    tunnel = None
+    try:
+        route = _load_route()
+        if route.get("transport") == "ssh":
+            tunnel = await _ssh_tunnel_status()
+            if tunnel["ready"] is not True:
+                return _error_response(
+                    EgressError(503, "ssh_tunnel_not_ready", "SSH tunnel is not ready")
+                )
+        secret = read_provider_secret(SECRET_PATH)
+        probe_result = probe_provider_route(
+            route,
+            provider_secret=secret,
+            timeout=PROBE_TIMEOUT_SECONDS,
+        )
+    except EgressError as exc:
+        return _error_response(exc)
+    except ProbeError as exc:
+        return _probe_error_response(exc)
+
+    return JSONResponse(
+        {
+            "schema": PROBE_RESPONSE_SCHEMA,
+            "ok": True,
+            "transport": route.get("transport"),
+            "probe": public_probe_receipt(probe_result, verified_at=_iso_now()),
+            "tunnel": tunnel,
+        }
+    )
 
 
 @app.api_route(

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -27,12 +27,11 @@ from remote_provider.egress import (
     route_from_state,
     validate_direct_provider_resolution,
 )
+from remote_provider.egress_probe import probe_route_response
 from remote_provider.policy import DEFAULT_POLICY_PATH, load_policy
 from remote_provider.probe import (
     DEFAULT_PROBE_TIMEOUT_SECONDS,
     ProbeError,
-    probe_provider_route,
-    public_probe_receipt,
 )
 
 
@@ -67,8 +66,6 @@ PROBE_TIMEOUT_SECONDS = float(
         str(DEFAULT_PROBE_TIMEOUT_SECONDS),
     )
 )
-PROBE_RESPONSE_SCHEMA = "ods.remote-provider-egress-probe.v1"
-
 app = FastAPI(title="ODS Remote Provider Egress", docs_url=None, redoc_url=None, openapi_url=None)
 
 _HOP_BY_HOP_RESPONSE_HEADERS = {
@@ -304,14 +301,12 @@ async def probe() -> Response:
         route = _load_route()
         if route.get("transport") == "ssh":
             tunnel = await _ssh_tunnel_status()
-            if tunnel["ready"] is not True:
-                return _error_response(
-                    EgressError(503, "ssh_tunnel_not_ready", "SSH tunnel is not ready")
-                )
         secret = read_provider_secret(SECRET_PATH)
-        probe_result = probe_provider_route(
+        payload = probe_route_response(
             route,
             provider_secret=secret,
+            verified_at=_iso_now(),
+            tunnel=tunnel,
             timeout=PROBE_TIMEOUT_SECONDS,
         )
     except EgressError as exc:
@@ -319,15 +314,7 @@ async def probe() -> Response:
     except ProbeError as exc:
         return _probe_error_response(exc)
 
-    return JSONResponse(
-        {
-            "schema": PROBE_RESPONSE_SCHEMA,
-            "ok": True,
-            "transport": route.get("transport"),
-            "probe": public_probe_receipt(probe_result, verified_at=_iso_now()),
-            "tunnel": tunnel,
-        }
-    )
+    return JSONResponse(payload)
 
 
 @app.api_route(

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -3,9 +3,7 @@
 
 from __future__ import annotations
 
-import importlib
 import json
-import os
 import socket
 import sys
 import tempfile
@@ -14,7 +12,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "bin"))
-sys.path.insert(0, str(ROOT / "extensions" / "services" / "remote-provider-egress"))
 
 from remote_provider.egress import (  # noqa: E402
     EgressError,
@@ -23,6 +20,10 @@ from remote_provider.egress import (  # noqa: E402
     route_from_state,
     upstream_base_url_for_route,
     validate_direct_provider_resolution,
+)
+from remote_provider.egress_probe import (  # noqa: E402
+    PROBE_RESPONSE_SCHEMA,
+    probe_route_response,
 )
 
 
@@ -49,24 +50,6 @@ def assert_egress_error(func, code: str) -> EgressError:
         assert_true(exc.code == code, f"expected {code}, got {exc.code}")
         return exc
     raise AssertionError(f"expected EgressError {code}")
-
-
-class patched_env:
-    def __init__(self, **values: str) -> None:
-        self.values = values
-        self.previous: dict[str, str | None] = {}
-
-    def __enter__(self) -> None:
-        for key, value in self.values.items():
-            self.previous[key] = os.environ.get(key)
-            os.environ[key] = value
-
-    def __exit__(self, *_args: object) -> None:
-        for key, value in self.previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
 
 
 def ssh_metadata(**overrides: object) -> dict[str, object]:
@@ -127,41 +110,6 @@ def resolver_for(*addresses: str):
         return results
 
     return _resolver
-
-
-def _egress_app(route_path: Path, secret_path: Path):
-    for name in ("app.main", "app"):
-        sys.modules.pop(name, None)
-    with patched_env(
-        ODS_REMOTE_PROVIDER_ROUTE_PATH=str(route_path),
-        ODS_REMOTE_PROVIDER_API_KEY_FILE=str(secret_path),
-    ):
-        return importlib.import_module("app.main")
-
-
-def _probe_fixture(
-    root: Path,
-    *,
-    transport: str = "ssh",
-) -> tuple[Path, Path]:
-    route_path = root / "routing-state.json"
-    secret_path = root / "secrets" / "provider-api-key"
-    secret_path.parent.mkdir(parents=True)
-    route_path.write_text(
-        json.dumps(
-            route_state(
-                transport=transport,
-                baseUrl=(
-                    "http://127.0.0.1:8000/v1"
-                    if transport == "ssh"
-                    else "https://gpu.example.test/v1"
-                ),
-            )
-        ),
-        encoding="utf-8",
-    )
-    secret_path.write_text("unit-test-provider-token\n", encoding="utf-8")
-    return route_path, secret_path
 
 
 def test_compose_service_is_internal_only_and_hardened() -> None:
@@ -320,104 +268,92 @@ def test_secret_file_status_is_support_bundle_safe() -> None:
         assert_true("unit-test-provider-token" not in dumped, "secret status must not include secret value")
 
 
-def test_probe_endpoint_returns_redacted_ssh_receipt_through_tunnel_boundary() -> None:
-    from fastapi.testclient import TestClient
+def test_probe_response_returns_redacted_ssh_receipt_through_tunnel_boundary() -> None:
+    route = route_from_state(
+        route_state(transport="ssh", baseUrl="http://127.0.0.1:8000/v1")
+    )
+    calls: list[dict[str, object]] = []
 
-    with tempfile.TemporaryDirectory() as tmp:
-        route_path, secret_path = _probe_fixture(Path(tmp), transport="ssh")
-        app_mod = _egress_app(route_path, secret_path)
-        calls: list[dict[str, object]] = []
-
-        async def fake_tunnel() -> dict[str, object]:
-            return app_mod._safe_tunnel_summary(
-                {
-                    "ready": True,
-                    "status": "running",
-                    "reason": "ready",
-                    "process": {
-                        "status": "running",
-                        "pid": 4242,
-                        "argv": ["ssh", "-i", "/state/remote-provider/secrets/ssh-identity"],
-                    },
-                    "secretValue": "unit-test-ssh-key",
-                }
-            )
-
-        def fake_probe(route, *, provider_secret, timeout):
-            calls.append(
-                {
-                    "route": route,
-                    "provider_secret": provider_secret,
-                    "timeout": timeout,
-                }
-            )
-            return {
-                "ok": True,
-                "status": 200,
-                "endpoint": "/v1/models",
-                "transport": "ssh",
-                "contentType": "application/json",
-                "modelCount": 1,
-                "resolution": {"ok": True, "addressCount": 0, "raw": "127.0.0.1"},
-                "value": "unit-test-provider-token",
+    def fake_probe(route, *, provider_secret, timeout):
+        calls.append(
+            {
+                "route": route,
+                "provider_secret": provider_secret,
+                "timeout": timeout,
             }
-
-        app_mod._ssh_tunnel_status = fake_tunnel
-        app_mod.probe_provider_route = fake_probe
-        app_mod._iso_now = lambda: "2026-07-26T00:00:00+00:00"
-
-        response = TestClient(app_mod.app).post("/probe")
-
-        body = response.json()
-        dumped = json.dumps(body, sort_keys=True)
-        assert_true(response.status_code == 200, "probe endpoint should succeed")
-        assert_true(body["schema"] == "ods.remote-provider-egress-probe.v1", "probe schema drifted")
-        assert_true(body["transport"] == "ssh", "probe should report SSH transport")
-        assert_true(body["probe"] == {
-            "schema": "ods.remote-provider-probe-receipt.v1",
+        )
+        return {
             "ok": True,
-            "verifiedAt": "2026-07-26T00:00:00+00:00",
+            "status": 200,
             "endpoint": "/v1/models",
-            "httpStatus": 200,
-            "modelCount": 1,
-            "resolution": {"ok": True, "addressCount": 0},
+            "transport": "ssh",
             "contentType": "application/json",
-        }, "probe receipt must be public and stable")
-        assert_true(body["tunnel"]["process"] == {"status": "running", "pid": 4242}, "tunnel process summary drifted")
-        assert_true(calls[0]["provider_secret"] == "unit-test-provider-token", "probe must use private secret custody")
-        assert_true(calls[0]["route"]["transport"] == "ssh", "probe must run against SSH route")
-        assert_true("unit-test-provider-token" not in dumped, "probe response must not leak provider secret")
-        assert_true("unit-test-ssh-key" not in dumped, "probe response must not leak SSH material")
-        assert_true("ssh-identity" not in dumped, "probe response must not leak secret paths")
+            "modelCount": 1,
+            "resolution": {"ok": True, "addressCount": 0, "raw": "127.0.0.1"},
+            "value": "unit-test-provider-token",
+        }
+
+    body = probe_route_response(
+        route,
+        provider_secret="unit-test-provider-token",
+        verified_at="2026-07-26T00:00:00+00:00",
+        tunnel={
+            "ok": True,
+            "ready": True,
+            "status": "running",
+            "reason": "ready",
+            "process": {"status": "running", "pid": 4242},
+        },
+        timeout=7.0,
+        probe=fake_probe,
+    )
+
+    dumped = json.dumps(body, sort_keys=True)
+    assert_true(body["schema"] == PROBE_RESPONSE_SCHEMA, "probe schema drifted")
+    assert_true(body["transport"] == "ssh", "probe should report SSH transport")
+    assert_true(body["probe"] == {
+        "schema": "ods.remote-provider-probe-receipt.v1",
+        "ok": True,
+        "verifiedAt": "2026-07-26T00:00:00+00:00",
+        "endpoint": "/v1/models",
+        "httpStatus": 200,
+        "modelCount": 1,
+        "resolution": {"ok": True, "addressCount": 0},
+        "contentType": "application/json",
+    }, "probe receipt must be public and stable")
+    assert_true(body["tunnel"]["process"] == {"status": "running", "pid": 4242}, "tunnel process summary drifted")
+    assert_true(calls[0]["provider_secret"] == "unit-test-provider-token", "probe must use private secret custody")
+    assert_true(calls[0]["route"]["transport"] == "ssh", "probe must run against SSH route")
+    assert_true(calls[0]["timeout"] == 7.0, "probe timeout should be forwarded")
+    assert_true("unit-test-provider-token" not in dumped, "probe response must not leak provider secret")
+    assert_true("raw" not in dumped, "probe response must not leak raw resolver output")
 
 
-def test_probe_endpoint_fails_closed_when_ssh_tunnel_is_not_ready() -> None:
-    from fastapi.testclient import TestClient
+def test_probe_response_fails_closed_when_ssh_tunnel_is_not_ready() -> None:
+    route = route_from_state(
+        route_state(transport="ssh", baseUrl="http://127.0.0.1:8000/v1")
+    )
 
-    with tempfile.TemporaryDirectory() as tmp:
-        route_path, secret_path = _probe_fixture(Path(tmp), transport="ssh")
-        app_mod = _egress_app(route_path, secret_path)
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("probe must not run before SSH tunnel is ready")
 
-        async def fake_tunnel() -> dict[str, object]:
-            return {
+    exc = assert_egress_error(
+        lambda: probe_route_response(
+            route,
+            provider_secret="unit-test-provider-token",
+            verified_at="2026-07-26T00:00:00+00:00",
+            tunnel={
                 "ok": False,
                 "ready": False,
                 "status": "planned",
                 "reason": "tunnel_process_not_started",
                 "process": {"status": "stopped", "pid": None},
-            }
-
-        def fail_if_called(*_args, **_kwargs):
-            raise AssertionError("probe must not run before SSH tunnel is ready")
-
-        app_mod._ssh_tunnel_status = fake_tunnel
-        app_mod.probe_provider_route = fail_if_called
-
-        response = TestClient(app_mod.app).post("/probe")
-
-        body = response.json()
-        assert_true(response.status_code == 503, "probe must fail closed when tunnel is down")
-        assert_true(body["error"]["type"] == "ssh_tunnel_not_ready", "tunnel readiness error drifted")
+            },
+            probe=fail_if_called,
+        ),
+        "ssh_tunnel_not_ready",
+    )
+    assert_true(exc.status == 503, "tunnel readiness failure should be a 503")
 
 
 def test_service_source_avoids_public_env_secret_names() -> None:
@@ -428,8 +364,7 @@ def test_service_source_avoids_public_env_secret_names() -> None:
     assert_true("validate_direct_provider_resolution" in text, "app must enforce runtime DNS/address policy")
     assert_true("ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL" in text, "app must check SSH tunnel readiness")
     assert_true('@app.post("/probe")' in text, "app must expose an internal probe endpoint")
-    assert_true("probe_provider_route" in text, "probe endpoint must use the shared route probe helper")
-    assert_true("public_probe_receipt" in text, "probe endpoint must return a redacted public receipt")
+    assert_true("probe_route_response" in text, "probe endpoint must use the shared egress probe helper")
     assert_true("ssh_tunnel_not_ready" in text, "app must fail closed when the SSH tunnel is down")
     assert_true(POLICY.exists(), "policy document must exist for mounted service config")
 
@@ -445,8 +380,8 @@ def main() -> int:
         test_ssh_route_uses_internal_tunnel_without_direct_dns,
         test_egress_fails_closed_without_secret_or_supported_transport,
         test_secret_file_status_is_support_bundle_safe,
-        test_probe_endpoint_returns_redacted_ssh_receipt_through_tunnel_boundary,
-        test_probe_endpoint_fails_closed_when_ssh_tunnel_is_not_ready,
+        test_probe_response_returns_redacted_ssh_receipt_through_tunnel_boundary,
+        test_probe_response_fails_closed_when_ssh_tunnel_is_not_ready,
         test_service_source_avoids_public_env_secret_names,
     ]
     for test in tests:

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+import os
 import socket
 import sys
 import tempfile
@@ -12,6 +14,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "bin"))
+sys.path.insert(0, str(ROOT / "extensions" / "services" / "remote-provider-egress"))
 
 from remote_provider.egress import (  # noqa: E402
     EgressError,
@@ -46,6 +49,24 @@ def assert_egress_error(func, code: str) -> EgressError:
         assert_true(exc.code == code, f"expected {code}, got {exc.code}")
         return exc
     raise AssertionError(f"expected EgressError {code}")
+
+
+class patched_env:
+    def __init__(self, **values: str) -> None:
+        self.values = values
+        self.previous: dict[str, str | None] = {}
+
+    def __enter__(self) -> None:
+        for key, value in self.values.items():
+            self.previous[key] = os.environ.get(key)
+            os.environ[key] = value
+
+    def __exit__(self, *_args: object) -> None:
+        for key, value in self.previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def ssh_metadata(**overrides: object) -> dict[str, object]:
@@ -106,6 +127,41 @@ def resolver_for(*addresses: str):
         return results
 
     return _resolver
+
+
+def _egress_app(route_path: Path, secret_path: Path):
+    for name in ("app.main", "app"):
+        sys.modules.pop(name, None)
+    with patched_env(
+        ODS_REMOTE_PROVIDER_ROUTE_PATH=str(route_path),
+        ODS_REMOTE_PROVIDER_API_KEY_FILE=str(secret_path),
+    ):
+        return importlib.import_module("app.main")
+
+
+def _probe_fixture(
+    root: Path,
+    *,
+    transport: str = "ssh",
+) -> tuple[Path, Path]:
+    route_path = root / "routing-state.json"
+    secret_path = root / "secrets" / "provider-api-key"
+    secret_path.parent.mkdir(parents=True)
+    route_path.write_text(
+        json.dumps(
+            route_state(
+                transport=transport,
+                baseUrl=(
+                    "http://127.0.0.1:8000/v1"
+                    if transport == "ssh"
+                    else "https://gpu.example.test/v1"
+                ),
+            )
+        ),
+        encoding="utf-8",
+    )
+    secret_path.write_text("unit-test-provider-token\n", encoding="utf-8")
+    return route_path, secret_path
 
 
 def test_compose_service_is_internal_only_and_hardened() -> None:
@@ -264,6 +320,106 @@ def test_secret_file_status_is_support_bundle_safe() -> None:
         assert_true("unit-test-provider-token" not in dumped, "secret status must not include secret value")
 
 
+def test_probe_endpoint_returns_redacted_ssh_receipt_through_tunnel_boundary() -> None:
+    from fastapi.testclient import TestClient
+
+    with tempfile.TemporaryDirectory() as tmp:
+        route_path, secret_path = _probe_fixture(Path(tmp), transport="ssh")
+        app_mod = _egress_app(route_path, secret_path)
+        calls: list[dict[str, object]] = []
+
+        async def fake_tunnel() -> dict[str, object]:
+            return app_mod._safe_tunnel_summary(
+                {
+                    "ready": True,
+                    "status": "running",
+                    "reason": "ready",
+                    "process": {
+                        "status": "running",
+                        "pid": 4242,
+                        "argv": ["ssh", "-i", "/state/remote-provider/secrets/ssh-identity"],
+                    },
+                    "secretValue": "unit-test-ssh-key",
+                }
+            )
+
+        def fake_probe(route, *, provider_secret, timeout):
+            calls.append(
+                {
+                    "route": route,
+                    "provider_secret": provider_secret,
+                    "timeout": timeout,
+                }
+            )
+            return {
+                "ok": True,
+                "status": 200,
+                "endpoint": "/v1/models",
+                "transport": "ssh",
+                "contentType": "application/json",
+                "modelCount": 1,
+                "resolution": {"ok": True, "addressCount": 0, "raw": "127.0.0.1"},
+                "value": "unit-test-provider-token",
+            }
+
+        app_mod._ssh_tunnel_status = fake_tunnel
+        app_mod.probe_provider_route = fake_probe
+        app_mod._iso_now = lambda: "2026-07-26T00:00:00+00:00"
+
+        response = TestClient(app_mod.app).post("/probe")
+
+        body = response.json()
+        dumped = json.dumps(body, sort_keys=True)
+        assert_true(response.status_code == 200, "probe endpoint should succeed")
+        assert_true(body["schema"] == "ods.remote-provider-egress-probe.v1", "probe schema drifted")
+        assert_true(body["transport"] == "ssh", "probe should report SSH transport")
+        assert_true(body["probe"] == {
+            "schema": "ods.remote-provider-probe-receipt.v1",
+            "ok": True,
+            "verifiedAt": "2026-07-26T00:00:00+00:00",
+            "endpoint": "/v1/models",
+            "httpStatus": 200,
+            "modelCount": 1,
+            "resolution": {"ok": True, "addressCount": 0},
+            "contentType": "application/json",
+        }, "probe receipt must be public and stable")
+        assert_true(body["tunnel"]["process"] == {"status": "running", "pid": 4242}, "tunnel process summary drifted")
+        assert_true(calls[0]["provider_secret"] == "unit-test-provider-token", "probe must use private secret custody")
+        assert_true(calls[0]["route"]["transport"] == "ssh", "probe must run against SSH route")
+        assert_true("unit-test-provider-token" not in dumped, "probe response must not leak provider secret")
+        assert_true("unit-test-ssh-key" not in dumped, "probe response must not leak SSH material")
+        assert_true("ssh-identity" not in dumped, "probe response must not leak secret paths")
+
+
+def test_probe_endpoint_fails_closed_when_ssh_tunnel_is_not_ready() -> None:
+    from fastapi.testclient import TestClient
+
+    with tempfile.TemporaryDirectory() as tmp:
+        route_path, secret_path = _probe_fixture(Path(tmp), transport="ssh")
+        app_mod = _egress_app(route_path, secret_path)
+
+        async def fake_tunnel() -> dict[str, object]:
+            return {
+                "ok": False,
+                "ready": False,
+                "status": "planned",
+                "reason": "tunnel_process_not_started",
+                "process": {"status": "stopped", "pid": None},
+            }
+
+        def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("probe must not run before SSH tunnel is ready")
+
+        app_mod._ssh_tunnel_status = fake_tunnel
+        app_mod.probe_provider_route = fail_if_called
+
+        response = TestClient(app_mod.app).post("/probe")
+
+        body = response.json()
+        assert_true(response.status_code == 503, "probe must fail closed when tunnel is down")
+        assert_true(body["error"]["type"] == "ssh_tunnel_not_ready", "tunnel readiness error drifted")
+
+
 def test_service_source_avoids_public_env_secret_names() -> None:
     text = read(APP_MAIN)
     assert_true("REMOTE_LLM_API_KEY" not in text, "app must not read provider key from public env")
@@ -271,6 +427,9 @@ def test_service_source_avoids_public_env_secret_names() -> None:
     assert_true("read_provider_secret" in text, "app must use shared secret-file helper")
     assert_true("validate_direct_provider_resolution" in text, "app must enforce runtime DNS/address policy")
     assert_true("ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL" in text, "app must check SSH tunnel readiness")
+    assert_true('@app.post("/probe")' in text, "app must expose an internal probe endpoint")
+    assert_true("probe_provider_route" in text, "probe endpoint must use the shared route probe helper")
+    assert_true("public_probe_receipt" in text, "probe endpoint must return a redacted public receipt")
     assert_true("ssh_tunnel_not_ready" in text, "app must fail closed when the SSH tunnel is down")
     assert_true(POLICY.exists(), "policy document must exist for mounted service config")
 
@@ -286,6 +445,8 @@ def main() -> int:
         test_ssh_route_uses_internal_tunnel_without_direct_dns,
         test_egress_fails_closed_without_secret_or_supported_transport,
         test_secret_file_status_is_support_bundle_safe,
+        test_probe_endpoint_returns_redacted_ssh_receipt_through_tunnel_boundary,
+        test_probe_endpoint_fails_closed_when_ssh_tunnel_is_not_ready,
         test_service_source_avoids_public_env_secret_names,
     ]
     for test in tests:


### PR DESCRIPTION
## Summary
- Add an internal `POST /probe` endpoint to remote-provider-egress that verifies the active route through the correct transport boundary.
- For SSH routes, fail closed unless the internal SSH tunnel health endpoint reports ready.
- Return only the redacted public probe receipt plus a safe tunnel summary; provider and SSH custody values stay private.

## Validation
- `python -m py_compile ods\extensions\services\remote-provider-egress\app\main.py ods\tests\contracts\test-remote-provider-egress-service.py`
- `python -m ruff check ods\extensions\services\remote-provider-egress\app\main.py ods\tests\contracts\test-remote-provider-egress-service.py --select E,F,W --ignore E501,E701,E731,E741,E402`
- `python ods\tests\contracts\test-remote-provider-egress-service.py`
- `python ods\tests\contracts\test-remote-provider-egress-policy.py`
- `python ods\tests\contracts\test-remote-provider-ssh-tunnel-service.py`
- `pytest ods\extensions\services\dashboard-api\tests\test_remote_provider_status.py -q`
- `pytest ods\extensions\services\dashboard-api\tests\test_host_agent.py -q`
- `python ods\tests\contracts\test-network-exposure-contracts.py`
- `python ods\scripts\check-dependency-pins.py`
- `python -m ruff check ods\ --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check` (line-ending warnings only)
- Tower2 exact-SHA release gate for `a2468c8f7f1b6645d9b9eacff72a98df6957150f`: `/home/michael/ods-pr-egress-probe-a2468c8f7f1b.eQLzEX/pr-remote-provider-egress-probe-a2468c8f7f1b6645d9b9eacff72a98df6957150f.log` with `[PASS] release gate` and `[tower2] PASS sha=a2468c8f7f1b6645d9b9eacff72a98df6957150f`.