### PR TITLE
Expose Dashboard remote provider egress probe

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -31,6 +31,21 @@ EGRESS_TIMEOUT_SECONDS = 3.0
 _SAFE_PROVIDER_KEYS = {"capability", "baseUrl", "model", "transport"}
 _SAFE_PROJECTION_KEYS = {"publicModel", "gateway", "egressBaseUrl", "consumerRoute"}
 _SSH_SUPERVISOR_SCHEMA = "ods.remote-provider-ssh-supervisor-plan.v1"
+_EGRESS_PROBE_SCHEMA = "ods.remote-provider-egress-probe.v1"
+_EGRESS_ERROR_MESSAGES = {
+    "invalid_route": "Remote provider route is invalid",
+    "invalid_route_state": "Remote provider route state is invalid",
+    "missing_provider_secret": "Remote provider secret is missing",
+    "provider_http_error": "Remote provider probe returned an HTTP error",
+    "provider_probe_too_large": "Remote provider probe response exceeded the safety limit",
+    "provider_resolution_empty": "Remote provider DNS resolution returned no addresses",
+    "provider_resolution_rejected": "Remote provider DNS resolution was rejected",
+    "provider_unreachable": "Remote provider is unreachable",
+    "remote_route_disabled": "Remote provider route is disabled",
+    "route_policy_rejected": "Remote provider route was rejected by policy",
+    "ssh_tunnel_not_ready": "SSH tunnel is not ready",
+    "transport_probe_unavailable": "Remote provider test is unavailable for this transport",
+}
 
 
 def _state_path() -> Path:
@@ -353,6 +368,37 @@ def _sanitize_egress_health(payload: Any) -> dict[str, Any]:
     }
 
 
+def _safe_egress_error(payload: Any, status_code: int) -> dict[str, str]:
+    error = payload.get("error") if isinstance(payload, Mapping) else None
+    if not isinstance(error, Mapping):
+        error = {}
+    error_type = _safe_text(error.get("type"), max_length=128) or "egress_probe_failed"
+    return {
+        "type": error_type,
+        "message": _EGRESS_ERROR_MESSAGES.get(
+            error_type,
+            f"remote-provider egress returned HTTP {status_code}",
+        ),
+        "code": str(status_code),
+    }
+
+
+def _sanitize_egress_probe_response(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid_egress_probe_response")
+    schema = _safe_text(payload.get("schema"), max_length=80)
+    probe = _safe_probe_receipt(payload.get("probe"))
+    if schema != _EGRESS_PROBE_SCHEMA or probe is None:
+        raise ValueError("invalid_egress_probe_response")
+    return {
+        "schema": schema,
+        "ok": bool(payload.get("ok")),
+        "transport": _safe_text(payload.get("transport"), max_length=32),
+        "probe": probe,
+        "tunnel": _safe_egress_tunnel(payload.get("tunnel")),
+    }
+
+
 async def _fetch_egress_health() -> dict[str, Any]:
     url = f"{EGRESS_URL.rstrip('/')}/health"
     try:
@@ -399,6 +445,62 @@ async def _fetch_egress_health() -> dict[str, Any]:
     except ValueError:
         payload = None
     return _sanitize_egress_health(payload)
+
+
+async def _post_egress_probe() -> dict[str, Any]:
+    url = f"{EGRESS_URL.rstrip('/')}/probe"
+    try:
+        async with httpx.AsyncClient(timeout=EGRESS_TIMEOUT_SECONDS) as client:
+            response = await client.post(url)
+    except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as exc:
+        logger.debug("remote-provider-egress probe unavailable: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "type": "egress_unreachable",
+                "message": "Remote provider egress is unreachable",
+                "code": "503",
+            },
+        ) from exc
+    except httpx.HTTPError as exc:
+        logger.debug("remote-provider-egress probe request failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "type": "egress_request_failed",
+                "message": "Remote provider egress probe request failed",
+                "code": "502",
+            },
+        ) from exc
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "type": "invalid_egress_probe_response",
+                "message": "Remote provider egress returned an invalid probe response",
+                "code": "502",
+            },
+        ) from exc
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=_safe_egress_error(payload, response.status_code),
+        )
+    try:
+        return _sanitize_egress_probe_response(payload)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "type": "invalid_egress_probe_response",
+                "message": "Remote provider egress returned an invalid probe response",
+                "code": "502",
+            },
+        ) from exc
 
 
 def _overall_status(route_state: Mapping[str, Any], egress: Mapping[str, Any]) -> str:
@@ -451,6 +553,12 @@ async def remote_provider_plan(payload: dict[str, Any]) -> dict[str, Any]:
         raise HTTPException(status_code=503, detail=f"Host agent unreachable: {exc}") from exc
     except AgentProtocolError as exc:
         raise HTTPException(status_code=502, detail=f"Invalid host agent response: {exc}") from exc
+
+
+@router.post("/api/remote-provider/probe", dependencies=[Depends(verify_api_key)])
+async def remote_provider_probe() -> dict[str, Any]:
+    """Probe the configured remote provider through the internal egress boundary."""
+    return await _post_egress_probe()
 
 
 @router.post("/api/remote-provider/apply", dependencies=[Depends(verify_api_key)])

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -581,6 +581,166 @@ def test_remote_provider_plan_preserves_host_agent_validation_errors(
     assert resp.json()["detail"] == "remote provider base URL is required"
 
 
+def test_remote_provider_probe_requires_auth(test_client):
+    resp = test_client.post("/api/remote-provider/probe")
+    assert resp.status_code == 401
+
+
+def test_remote_provider_probe_posts_to_egress_and_sanitizes_receipt(
+    test_client,
+    monkeypatch,
+):
+    from routers import remote_provider_status as rps
+
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "schema": "ods.remote-provider-egress-probe.v1",
+                "ok": True,
+                "transport": "ssh",
+                "probe": {
+                    "schema": "ods.remote-provider-probe-receipt.v1",
+                    "ok": True,
+                    "verifiedAt": "2026-07-26T00:00:00+00:00",
+                    "endpoint": "/v1/models",
+                    "httpStatus": 200,
+                    "contentType": "application/json",
+                    "modelCount": 1,
+                    "resolution": {
+                        "ok": True,
+                        "addressCount": 0,
+                        "raw": "127.0.0.1",
+                    },
+                    "value": "unit-test-provider-token",
+                },
+                "tunnel": {
+                    "ok": True,
+                    "ready": True,
+                    "status": "running",
+                    "reason": "ready",
+                    "process": {
+                        "status": "running",
+                        "pid": 4242,
+                        "argv": ["ssh", "-i", "/state/remote-provider/secrets/ssh-identity"],
+                    },
+                    "secretValue": "unit-test-ssh-key",
+                },
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            calls.append(("timeout", kwargs.get("timeout")))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def post(self, url):
+            calls.append(("post", url))
+            return FakeResponse()
+
+    monkeypatch.setattr(rps, "EGRESS_URL", "http://egress.internal:8091/")
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.post(
+        "/api/remote-provider/probe",
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert resp.status_code == 200
+    assert body == {
+        "schema": "ods.remote-provider-egress-probe.v1",
+        "ok": True,
+        "transport": "ssh",
+        "probe": {
+            "schema": "ods.remote-provider-probe-receipt.v1",
+            "ok": True,
+            "verifiedAt": "2026-07-26T00:00:00+00:00",
+            "endpoint": "/v1/models",
+            "httpStatus": 200,
+            "contentType": "application/json",
+            "modelCount": 1,
+            "resolution": {"ok": True, "addressCount": 0},
+        },
+        "tunnel": {
+            "ok": True,
+            "ready": True,
+            "status": "running",
+            "reason": "ready",
+            "process": {"status": "running", "pid": 4242},
+        },
+    }
+    assert calls == [
+        ("timeout", 3.0),
+        ("post", "http://egress.internal:8091/probe"),
+    ]
+    assert "unit-test-provider-token" not in dumped
+    assert "unit-test-ssh-key" not in dumped
+    assert "ssh-identity" not in dumped
+    assert "127.0.0.1" not in dumped
+
+
+def test_remote_provider_probe_preserves_sanitized_egress_errors(
+    test_client,
+    monkeypatch,
+):
+    from routers import remote_provider_status as rps
+
+    class FakeResponse:
+        status_code = 503
+
+        def json(self):
+            return {
+                "error": {
+                    "type": "ssh_tunnel_not_ready",
+                    "message": (
+                        "SSH tunnel is not ready: unit-test-provider-token "
+                        "/state/remote-provider/secrets/ssh-identity"
+                    ),
+                    "code": "503",
+                }
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def post(self, _url):
+            return FakeResponse()
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.post(
+        "/api/remote-provider/probe",
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert resp.status_code == 503
+    assert body["detail"] == {
+        "type": "ssh_tunnel_not_ready",
+        "message": "SSH tunnel is not ready",
+        "code": "503",
+    }
+    assert "unit-test-provider-token" not in dumped
+    assert "ssh-identity" not in dumped
+
+
 def test_remote_provider_apply_requires_auth(test_client):
     resp = test_client.post("/api/remote-provider/apply", json=_lifecycle_payload())
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add authenticated Dashboard `POST /api/remote-provider/probe` for configured remote-provider probes through the internal egress service
- sanitize egress probe receipts, tunnel health, and error details before returning them to Dashboard/CLI consumers
- cover auth, success redaction, and error redaction in dashboard-api tests

## Local validation
- `python -m py_compile extensions/services/dashboard-api/routers/remote_provider_status.py extensions/services/dashboard-api/tests/test_remote_provider_status.py`
- `python -m pytest extensions/services/dashboard-api/tests/test_remote_provider_status.py -q`
- `python -m ruff check extensions/services/dashboard-api/routers/remote_provider_status.py extensions/services/dashboard-api/tests/test_remote_provider_status.py --select E,F,W --ignore E501,E701,E731,E741,E402`
- `python tests/contracts/test-remote-provider-egress-service.py`
- `python tests/contracts/test-remote-provider-egress-policy.py`
- `python tests/contracts/test-remote-provider-ssh-tunnel-service.py`
- `python tests/contracts/test-remote-provider-cli.py`
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py -q`
- `python tests/contracts/test-network-exposure-contracts.py`
- `python scripts/check-dependency-pins.py`
- `python -m ruff check . --select E,F,W --ignore E501,E701,E731,E741,E402`
- `git diff --check`