### PR TITLE
Record remote provider egress probe proof

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -65,6 +65,7 @@ try:
     )
     from remote_provider.policy import PolicyError as _RemoteProviderPolicyError
     from remote_provider.probe import (
+        PROBE_RECEIPT_SCHEMA as _REMOTE_PROVIDER_PROBE_RECEIPT_SCHEMA,
         ProbeError as _RemoteProviderProbeError,
         probe_direct_provider as _probe_remote_provider_direct,
         public_probe_receipt as _remote_provider_public_probe_receipt,
@@ -77,6 +78,7 @@ except Exception:  # pragma: no cover - import environment dependent
     _RemoteProviderLifecycleError = ValueError
     _RemoteProviderPolicyError = ValueError
     _RemoteProviderProbeError = RuntimeError
+    _REMOTE_PROVIDER_PROBE_RECEIPT_SCHEMA = "ods.remote-provider-probe-receipt.v1"
     _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA = "ods.remote-routing-state.v1"
     _REMOTE_PROVIDER_SSH_SUPERVISOR_PLAN_SCHEMA = "ods.remote-provider-ssh-supervisor-plan.v1"
     _plan_remote_provider_lifecycle_operation = None
@@ -126,6 +128,8 @@ GPU_COUNT: str = "1"
 CORE_SERVICE_IDS: set = set()
 _REMOTE_PROVIDER_EGRESS_UID = 10778
 _REMOTE_PROVIDER_EGRESS_GID = 10778
+_REMOTE_PROVIDER_EGRESS_PROBE_SCHEMA = "ods.remote-provider-egress-probe.v1"
+_REMOTE_PROVIDER_PROOF_RECORD_SCHEMA = "ods.remote-provider-proof-record.v1"
 _REMOTE_PROVIDER_SECRET_FIELD_TO_REF = {
     "apiKey": "REMOTE_LLM_API_KEY",
     "peerToken": "REMOTE_ODS_PEER_TOKEN",
@@ -1542,6 +1546,108 @@ def _remote_provider_route_state_from_plan(
             pending_reason=pending_reason,
             probe_receipt=probe_receipt,
         ),
+    }
+
+
+def _remote_provider_safe_text(value, *, max_length: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if any(ord(char) < 32 or ord(char) == 127 for char in text):
+        return ""
+    return text[:max_length]
+
+
+def _remote_provider_safe_int(value) -> int | None:
+    return value if type(value) is int else None
+
+
+def _remote_provider_sanitize_probe_receipt(value) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError("probe receipt must be an object")
+    schema = _remote_provider_safe_text(value.get("schema"), max_length=80)
+    if schema != _REMOTE_PROVIDER_PROBE_RECEIPT_SCHEMA:
+        raise ValueError("unsupported probe receipt schema")
+    if value.get("ok") is not True:
+        raise ValueError("probe receipt must be successful")
+    verified_at = _remote_provider_safe_text(value.get("verifiedAt"), max_length=64)
+    if not verified_at:
+        raise ValueError("probe receipt is missing verifiedAt")
+    resolution = value.get("resolution")
+    clean_resolution = None
+    if isinstance(resolution, dict):
+        clean_resolution = {
+            "ok": bool(resolution.get("ok")),
+            "addressCount": _remote_provider_safe_int(resolution.get("addressCount")),
+        }
+    receipt = {
+        "schema": schema,
+        "ok": True,
+        "verifiedAt": verified_at,
+        "endpoint": _remote_provider_safe_text(value.get("endpoint"), max_length=32),
+        "httpStatus": _remote_provider_safe_int(value.get("httpStatus")),
+        "modelCount": _remote_provider_safe_int(value.get("modelCount")),
+        "resolution": clean_resolution,
+    }
+    content_type = _remote_provider_safe_text(value.get("contentType"), max_length=128)
+    if content_type:
+        receipt["contentType"] = content_type
+    return receipt
+
+
+def _remote_provider_probe_receipt_from_egress(payload: dict) -> dict:
+    schema = _remote_provider_safe_text(payload.get("schema"), max_length=80)
+    if schema != _REMOTE_PROVIDER_EGRESS_PROBE_SCHEMA:
+        raise ValueError("unsupported egress probe schema")
+    if payload.get("ok") is not True:
+        raise ValueError("egress probe must be successful")
+    return _remote_provider_sanitize_probe_receipt(payload.get("probe"))
+
+
+def _read_remote_provider_route_state_for_update() -> dict:
+    path = _remote_provider_route_state_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise RuntimeError("remote-provider route state is missing") from exc
+    except OSError as exc:
+        raise RuntimeError(f"remote-provider route state is unreadable: {exc}") from exc
+    try:
+        state = json.loads(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"remote-provider route state is not valid JSON: {exc}") from exc
+    if not isinstance(state, dict):
+        raise RuntimeError("remote-provider route state root must be an object")
+    if state.get("schema") != _REMOTE_PROVIDER_ROUTING_STATE_SCHEMA:
+        raise RuntimeError("remote-provider route state schema is unsupported")
+    if state.get("enabled") is not True:
+        raise RuntimeError("remote-provider route is disabled")
+    if not isinstance(state.get("provider"), dict):
+        raise RuntimeError("remote-provider route state is missing provider metadata")
+    return state
+
+
+def _record_remote_provider_egress_probe(payload: dict) -> dict:
+    probe_receipt = _remote_provider_probe_receipt_from_egress(payload)
+    state = _read_remote_provider_route_state_for_update()
+    provider = state.get("provider") if isinstance(state.get("provider"), dict) else {}
+    payload_transport = _remote_provider_safe_text(payload.get("transport"), max_length=32)
+    active_transport = str(provider.get("transport") or "direct")
+    if payload_transport != active_transport:
+        raise RuntimeError("remote-provider proof transport does not match active route")
+    state["status"] = _remote_provider_route_status(
+        enabled=True,
+        probe_receipt=probe_receipt,
+    )
+    _atomic_write_text(
+        _remote_provider_route_state_path(),
+        json.dumps(state, indent=2, sort_keys=True) + "\n",
+        0o644,
+    )
+    return {
+        "schema": _REMOTE_PROVIDER_PROOF_RECORD_SCHEMA,
+        "recorded": True,
+        "status": state["status"],
     }
 
 
@@ -3966,6 +4072,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_remote_provider_plan()
         elif self.path == "/v1/remote-provider/apply":
             self._handle_remote_provider_apply()
+        elif self.path == "/v1/remote-provider/proof":
+            self._handle_remote_provider_proof()
         elif self.path == "/v1/runtime/lemonade/ensure":
             self._handle_windows_lemonade_runtime_ensure()
         elif self.path == "/v1/model/delete":
@@ -4045,6 +4153,27 @@ class AgentHandler(BaseHTTPRequestHandler):
         except Exception as exc:
             logger.exception("remote-provider lifecycle apply failed")
             json_response(self, 500, {"error": f"Remote provider apply failed: {exc}"})
+            return
+        json_response(self, 200, result)
+
+    def _handle_remote_provider_proof(self):
+        """Record a successful egress-owned remote-provider probe in host state."""
+        if not check_auth(self):
+            return
+        body = read_optional_json_body(self)
+        if body is None:
+            return
+        try:
+            result = _record_remote_provider_egress_probe(body)
+        except ValueError as exc:
+            json_response(self, 400, {"error": str(exc)})
+            return
+        except RuntimeError as exc:
+            json_response(self, 409, {"error": str(exc)})
+            return
+        except Exception as exc:
+            logger.exception("remote-provider proof recording failed")
+            json_response(self, 500, {"error": f"Remote provider proof recording failed: {exc}"})
             return
         json_response(self, 200, result)
 

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -32,6 +32,7 @@ _SAFE_PROVIDER_KEYS = {"capability", "baseUrl", "model", "transport"}
 _SAFE_PROJECTION_KEYS = {"publicModel", "gateway", "egressBaseUrl", "consumerRoute"}
 _SSH_SUPERVISOR_SCHEMA = "ods.remote-provider-ssh-supervisor-plan.v1"
 _EGRESS_PROBE_SCHEMA = "ods.remote-provider-egress-probe.v1"
+_PROOF_RECORD_SCHEMA = "ods.remote-provider-proof-record.v1"
 _EGRESS_ERROR_MESSAGES = {
     "invalid_route": "Remote provider route is invalid",
     "invalid_route_state": "Remote provider route state is invalid",
@@ -399,6 +400,60 @@ def _sanitize_egress_probe_response(payload: Any) -> dict[str, Any]:
     }
 
 
+def _proof_record_failure(
+    reason: str,
+    *,
+    reachable: bool,
+    status_code: int | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "recorded": False,
+        "reachable": reachable,
+        "reason": reason,
+    }
+    if status_code is not None:
+        result["statusCode"] = status_code
+    return result
+
+
+def _safe_proof_record(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        return _proof_record_failure("invalid_host_agent_response", reachable=True)
+    schema = _safe_text(payload.get("schema"), max_length=80)
+    if schema != _PROOF_RECORD_SCHEMA or payload.get("recorded") is not True:
+        return _proof_record_failure("invalid_host_agent_response", reachable=True)
+    return {
+        "recorded": True,
+        "reachable": True,
+        "schema": schema,
+        "status": _safe_route_status(payload.get("status")),
+    }
+
+
+async def _record_egress_probe_proof(probe_response: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        payload = await async_request_agent_json(
+            "POST",
+            "/v1/remote-provider/proof",
+            payload=dict(probe_response),
+            timeout=5,
+        )
+    except AgentHTTPError as exc:
+        logger.debug(
+            "remote-provider proof recording returned HTTP %s",
+            exc.status_code,
+        )
+        return _proof_record_failure(
+            f"host_agent_http_{exc.status_code}",
+            reachable=True,
+            status_code=exc.status_code,
+        )
+    except (AgentUnavailable, AgentProtocolError):
+        logger.debug("remote-provider proof recording unavailable")
+        return _proof_record_failure("host_agent_unavailable", reachable=False)
+    return _safe_proof_record(payload)
+
+
 async def _fetch_egress_health() -> dict[str, Any]:
     url = f"{EGRESS_URL.rstrip('/')}/health"
     try:
@@ -558,7 +613,9 @@ async def remote_provider_plan(payload: dict[str, Any]) -> dict[str, Any]:
 @router.post("/api/remote-provider/probe", dependencies=[Depends(verify_api_key)])
 async def remote_provider_probe() -> dict[str, Any]:
     """Probe the configured remote provider through the internal egress boundary."""
-    return await _post_egress_probe()
+    result = await _post_egress_probe()
+    result["routeProof"] = await _record_egress_probe_proof(result)
+    return result
 
 
 @router.post("/api/remote-provider/apply", dependencies=[Depends(verify_api_key)])

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2057,6 +2057,35 @@ class TestRemoteProviderLifecycle:
         )
         return probes
 
+    def _egress_probe_response(self):
+        return {
+            "schema": "ods.remote-provider-egress-probe.v1",
+            "ok": True,
+            "transport": "ssh",
+            "probe": {
+                "schema": "ods.remote-provider-probe-receipt.v1",
+                "ok": True,
+                "verifiedAt": "2026-07-26T00:00:00+00:00",
+                "endpoint": "/v1/models",
+                "httpStatus": 200,
+                "contentType": "application/json",
+                "modelCount": 1,
+                "resolution": {
+                    "ok": True,
+                    "addressCount": 0,
+                    "raw": "127.0.0.1",
+                },
+                "value": "unit-test-provider-token",
+            },
+            "tunnel": {
+                "ok": True,
+                "ready": True,
+                "status": "running",
+                "reason": "ready",
+                "secretValue": "unit-test-ssh-key",
+            },
+        }
+
     def test_plans_redacted_lifecycle_operation(self):
         payload = {
             "action": "test",
@@ -2251,6 +2280,117 @@ class TestRemoteProviderLifecycle:
         assert "unit-test-provider-token" not in dumped
         assert "unit-test-key" not in dumped
         assert "AAAATEST" not in dumped
+
+    def test_records_egress_probe_as_route_proof(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        root = tmp_path / "remote-provider"
+        root.mkdir(parents=True)
+        payload = self._ssh_configure_payload()
+        plan = _mod._plan_remote_provider_lifecycle_operation(payload)
+        state = _mod._remote_provider_route_state_from_plan(plan)
+        (root / "routing-state.json").write_text(json.dumps(state), encoding="utf-8")
+        handler = _FakeHandler(
+            json.dumps(self._egress_probe_response()).encode("utf-8")
+        )
+
+        _mod.AgentHandler._handle_remote_provider_proof(handler)
+
+        body = handler.parse_response()
+        recorded_state = json.loads(
+            (root / "routing-state.json").read_text(encoding="utf-8")
+        )
+        dumped = json.dumps({"body": body, "state": recorded_state}, sort_keys=True)
+        expected_status = {
+            "proven": True,
+            "reason": "provider-handshake-ok",
+            "lastProbe": {
+                "schema": "ods.remote-provider-probe-receipt.v1",
+                "ok": True,
+                "verifiedAt": "2026-07-26T00:00:00+00:00",
+                "endpoint": "/v1/models",
+                "httpStatus": 200,
+                "contentType": "application/json",
+                "modelCount": 1,
+                "resolution": {"ok": True, "addressCount": 0},
+            },
+        }
+        assert handler.response_code == 200
+        assert body == {
+            "schema": "ods.remote-provider-proof-record.v1",
+            "recorded": True,
+            "status": expected_status,
+        }
+        assert recorded_state["provider"]["transport"] == "ssh"
+        assert recorded_state["ssh"]["host"] == "gpu.example.test"
+        assert recorded_state["status"] == expected_status
+        assert "unit-test-provider-token" not in dumped
+        assert "unit-test-ssh-key" not in dumped
+        assert '"raw"' not in dumped
+
+    def test_rejects_failed_egress_probe_without_overwriting_route_proof(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        root = tmp_path / "remote-provider"
+        root.mkdir(parents=True)
+        payload = self._ssh_configure_payload()
+        plan = _mod._plan_remote_provider_lifecycle_operation(payload)
+        state = _mod._remote_provider_route_state_from_plan(plan)
+        (root / "routing-state.json").write_text(json.dumps(state), encoding="utf-8")
+        proof_payload = self._egress_probe_response()
+        proof_payload["probe"]["ok"] = False
+        proof_payload["probe"]["value"] = "unit-test-provider-token"
+        handler = _FakeHandler(json.dumps(proof_payload).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_proof(handler)
+
+        body = handler.parse_response()
+        recorded_state = json.loads(
+            (root / "routing-state.json").read_text(encoding="utf-8")
+        )
+        dumped = json.dumps({"body": body, "state": recorded_state}, sort_keys=True)
+        assert handler.response_code == 400
+        assert body["error"] == "probe receipt must be successful"
+        assert recorded_state["status"] == {
+            "proven": False,
+            "reason": "pending-ssh-tunnel-proof",
+        }
+        assert "unit-test-provider-token" not in dumped
+
+    def test_rejects_mismatched_egress_probe_transport(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        root = tmp_path / "remote-provider"
+        root.mkdir(parents=True)
+        payload = self._ssh_configure_payload()
+        plan = _mod._plan_remote_provider_lifecycle_operation(payload)
+        state = _mod._remote_provider_route_state_from_plan(plan)
+        (root / "routing-state.json").write_text(json.dumps(state), encoding="utf-8")
+        proof_payload = self._egress_probe_response()
+        proof_payload["transport"] = "direct"
+        handler = _FakeHandler(json.dumps(proof_payload).encode("utf-8"))
+
+        _mod.AgentHandler._handle_remote_provider_proof(handler)
+
+        body = handler.parse_response()
+        recorded_state = json.loads(
+            (root / "routing-state.json").read_text(encoding="utf-8")
+        )
+        assert handler.response_code == 409
+        assert body["error"] == "remote-provider proof transport does not match active route"
+        assert recorded_state["status"] == {
+            "proven": False,
+            "reason": "pending-ssh-tunnel-proof",
+        }
 
     def test_apply_test_does_not_write_state(
         self,

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -593,6 +593,7 @@ def test_remote_provider_probe_posts_to_egress_and_sanitizes_receipt(
     from routers import remote_provider_status as rps
 
     calls = []
+    agent_calls = []
 
     class FakeResponse:
         status_code = 200
@@ -647,6 +648,19 @@ def test_remote_provider_probe_posts_to_egress_and_sanitizes_receipt(
 
     monkeypatch.setattr(rps, "EGRESS_URL", "http://egress.internal:8091/")
     monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+    async def fake_agent_request(method, path, *, payload, timeout):
+        agent_calls.append((method, path, payload, timeout))
+        return {
+            "schema": "ods.remote-provider-proof-record.v1",
+            "recorded": True,
+            "status": {
+                "proven": True,
+                "reason": "provider-handshake-ok",
+                "lastProbe": payload["probe"],
+            },
+        }
+
+    monkeypatch.setattr(rps, "async_request_agent_json", fake_agent_request)
 
     resp = test_client.post(
         "/api/remote-provider/probe",
@@ -677,15 +691,127 @@ def test_remote_provider_probe_posts_to_egress_and_sanitizes_receipt(
             "reason": "ready",
             "process": {"status": "running", "pid": 4242},
         },
+        "routeProof": {
+            "recorded": True,
+            "reachable": True,
+            "schema": "ods.remote-provider-proof-record.v1",
+            "status": {
+                "proven": True,
+                "reason": "provider-handshake-ok",
+                "lastProbe": {
+                    "schema": "ods.remote-provider-probe-receipt.v1",
+                    "ok": True,
+                    "verifiedAt": "2026-07-26T00:00:00+00:00",
+                    "endpoint": "/v1/models",
+                    "httpStatus": 200,
+                    "contentType": "application/json",
+                    "modelCount": 1,
+                    "resolution": {"ok": True, "addressCount": 0},
+                },
+            },
+        },
     }
     assert calls == [
         ("timeout", 3.0),
         ("post", "http://egress.internal:8091/probe"),
     ]
+    assert agent_calls == [
+        (
+            "POST",
+            "/v1/remote-provider/proof",
+            {
+                "schema": "ods.remote-provider-egress-probe.v1",
+                "ok": True,
+                "transport": "ssh",
+                "probe": {
+                    "schema": "ods.remote-provider-probe-receipt.v1",
+                    "ok": True,
+                    "verifiedAt": "2026-07-26T00:00:00+00:00",
+                    "endpoint": "/v1/models",
+                    "httpStatus": 200,
+                    "contentType": "application/json",
+                    "modelCount": 1,
+                    "resolution": {"ok": True, "addressCount": 0},
+                },
+                "tunnel": {
+                    "ok": True,
+                    "ready": True,
+                    "status": "running",
+                    "reason": "ready",
+                    "process": {"status": "running", "pid": 4242},
+                },
+            },
+            5,
+        )
+    ]
     assert "unit-test-provider-token" not in dumped
     assert "unit-test-ssh-key" not in dumped
     assert "ssh-identity" not in dumped
     assert "127.0.0.1" not in dumped
+
+
+def test_remote_provider_probe_reports_nonfatal_proof_record_failure(
+    test_client,
+    monkeypatch,
+):
+    from routers import remote_provider_status as rps
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "schema": "ods.remote-provider-egress-probe.v1",
+                "ok": True,
+                "transport": "ssh",
+                "probe": {
+                    "schema": "ods.remote-provider-probe-receipt.v1",
+                    "ok": True,
+                    "verifiedAt": "2026-07-26T00:00:00+00:00",
+                    "endpoint": "/v1/models",
+                    "httpStatus": 200,
+                    "modelCount": 1,
+                    "resolution": {"ok": True, "addressCount": 0},
+                },
+                "tunnel": {"ok": True, "ready": True, "status": "running", "reason": "ready"},
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def post(self, _url):
+            return FakeResponse()
+
+    async def fake_agent_request(*_args, **_kwargs):
+        raise rps.AgentHTTPError(409, "unit-test-provider-token ssh-identity")
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(rps, "async_request_agent_json", fake_agent_request)
+
+    resp = test_client.post(
+        "/api/remote-provider/probe",
+        headers=test_client.auth_headers,
+    )
+
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert resp.status_code == 200
+    assert body["ok"] is True
+    assert body["routeProof"] == {
+        "recorded": False,
+        "reachable": True,
+        "reason": "host_agent_http_409",
+        "statusCode": 409,
+    }
+    assert "unit-test-provider-token" not in dumped
+    assert "ssh-identity" not in dumped
 
 
 def test_remote_provider_probe_preserves_sanitized_egress_errors(

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3840,6 +3840,16 @@ _remote_provider_print_probe_result() {
         (if .tunnel then
             "Tunnel: \(.tunnel.status // "unknown")" +
             (if (.tunnel.reason // "") != "" then " (\(.tunnel.reason))" else "" end)
+         else empty end),
+        (if .routeProof then
+            "Route proof: " +
+            (if .routeProof.recorded == true then
+                "recorded" +
+                (if (.routeProof.status.reason // "") != "" then " (\(.routeProof.status.reason))" else "" end)
+             else
+                "not recorded" +
+                (if (.routeProof.reason // "") != "" then " (\(.routeProof.reason))" else "" end)
+             end)
          else empty end)
     ' "$response_file"
 }

--- a/ods/tests/contracts/test-remote-provider-cli.py
+++ b/ods/tests/contracts/test-remote-provider-cli.py
@@ -109,6 +109,16 @@ def main() -> int:
         "configured remote-provider test must call the egress probe endpoint",
     )
     require(
+        r"Route proof: ",
+        text,
+        "configured remote-provider test output must show route proof recording status",
+    )
+    require(
+        r"\.routeProof\.recorded",
+        text,
+        "configured remote-provider test output must inspect the routeProof result",
+    )
+    require(
         r"if \[\[ \"\$use_configured_probe\" == \"true\" \]\]; then[\s\S]*_remote_provider_probe_configured \"\$@\"",
         body,
         "remote-provider test must use configured-route probe when provider options are absent",


### PR DESCRIPTION
## Summary
- add an authenticated host-agent `/v1/remote-provider/proof` endpoint that records successful egress probe receipts into `remote-provider/routing-state.json`
- have Dashboard `/api/remote-provider/probe` persist sanitized egress proof through host-agent and report `routeProof` status without failing successful probes when recording is unavailable
- show route proof recording status in `ods remote-provider test` human output and pin the CLI contract

## Validation
- Local: `python -m pytest ods\\extensions\\services\\dashboard-api\\tests\\test_host_agent.py -q`
- Local: `python -m pytest ods\\extensions\\services\\dashboard-api\\tests\\test_remote_provider_status.py -q`
- Local: `python ods\\tests\\contracts\\test-remote-provider-cli.py`
- Local: remote-provider egress/policy/SSH tunnel contracts, network exposure contracts, dependency pins, full `ruff`, `git diff --check`
- Tower2 exact SHA: `0e062338b6aedc80e567db3c917bc7a17c825a05`
- Tower2 log: `/home/michael/ods-pr-proof-recording-0e062338b6ae.u84dGp/pr-remote-provider-proof-recording-0e062338b6aedc80e567db3c917bc7a17c825a05.log`
- Tower2 result: `[tower2] PASS sha=0e062338b6aedc80e567db3c917bc7a17c825a05`