### PR TITLE
Expose remote provider lifecycle in Dashboard

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AlertCircle,
+  CheckCircle2,
+  Cloud,
+  KeyRound,
+  Loader2,
+  Play,
+  RefreshCw,
+  Route,
+  Server,
+  ShieldCheck,
+} from 'lucide-react'
+
+const REQUEST_TIMEOUT_MS = 12000
+const PROBE_TIMEOUT_MS = 22000
+
+const STATUS_META = {
+  ready: { label: 'Ready', dot: 'bg-emerald-400', text: 'text-emerald-300' },
+  disabled: { label: 'Disabled', dot: 'bg-zinc-500', text: 'text-zinc-400' },
+  degraded: { label: 'Degraded', dot: 'bg-amber-400', text: 'text-amber-300' },
+  invalid: { label: 'Invalid', dot: 'bg-red-400', text: 'text-red-300' },
+  unknown: { label: 'Unknown', dot: 'bg-zinc-500', text: 'text-zinc-400' },
+}
+
+function titleize(value) {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (!text) return 'Unknown'
+  return text
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/^./, char => char.toUpperCase())
+}
+
+function boolLabel(value) {
+  return value ? 'Yes' : 'No'
+}
+
+function valueOrDash(value) {
+  if (value === null || value === undefined || value === '') return 'None'
+  return String(value)
+}
+
+async function responsePayload(response) {
+  try {
+    return await response.json()
+  } catch {
+    return {}
+  }
+}
+
+function errorMessage(payload, fallback) {
+  if (typeof payload?.detail === 'string' && payload.detail.trim()) return payload.detail
+  if (payload?.detail && typeof payload.detail === 'object') {
+    if (typeof payload.detail.message === 'string' && payload.detail.message.trim()) return payload.detail.message
+    if (typeof payload.detail.error === 'string' && payload.detail.error.trim()) return payload.detail.error
+  }
+  if (typeof payload?.message === 'string' && payload.message.trim()) return payload.message
+  if (typeof payload?.error === 'string' && payload.error.trim()) return payload.error
+  return fallback
+}
+
+async function fetchJson(url, options = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal })
+    const payload = await responsePayload(response)
+    if (!response.ok) throw new Error(errorMessage(payload, `Request failed (${response.status})`))
+    return payload
+  } catch (err) {
+    if (err?.name === 'AbortError') throw new Error('Request timed out')
+    throw err
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function StatusPill({ status }) {
+  const meta = STATUS_META[status] || STATUS_META.unknown
+  return (
+    <span className={`inline-flex items-center gap-2 rounded-full border border-theme-border px-3 py-1 text-xs font-semibold ${meta.text}`}>
+      <span className={`h-2 w-2 rounded-full ${meta.dot}`} />
+      {meta.label}
+    </span>
+  )
+}
+
+function Panel({ icon: Icon, title, children, actions = null }) {
+  return (
+    <section className="rounded-lg border border-theme-border bg-theme-card p-4 shadow-sm">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Icon size={18} className="text-theme-accent" />
+          <h2 className="text-sm font-semibold text-theme-text">{title}</h2>
+        </div>
+        {actions}
+      </div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  )
+}
+
+function Field({ label, value, tone = 'text-theme-text' }) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-sm">
+      <span className="text-theme-text-muted">{label}</span>
+      <span className={`text-right font-medium ${tone}`}>{valueOrDash(value)}</span>
+    </div>
+  )
+}
+
+function ProbeReceipt({ receipt }) {
+  if (!receipt) return <p className="text-sm text-theme-text-muted">No probe receipt</p>
+  return (
+    <div className="rounded-lg border border-theme-border/70 bg-black/10 p-3 text-xs">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Field label="Endpoint" value={receipt.endpoint} />
+        <Field label="HTTP" value={receipt.httpStatus} />
+        <Field label="Models" value={receipt.modelCount ?? 'Unknown'} />
+        <Field label="Verified" value={receipt.verifiedAt} />
+      </div>
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div className="flex min-h-[360px] items-center justify-center p-8 text-theme-text-muted">
+      <Loader2 className="mr-2 animate-spin" size={18} />
+      Loading remote GPU status
+    </div>
+  )
+}
+
+export default function RemoteProvider() {
+  const [statusData, setStatusData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState(null)
+  const [testError, setTestError] = useState(null)
+
+  const loadStatus = useCallback(async ({ quiet = false } = {}) => {
+    if (!quiet) setLoading(true)
+    try {
+      const payload = await fetchJson('/api/remote-provider/status')
+      setStatusData(payload)
+      setError(null)
+      return payload
+    } catch (err) {
+      setError(err?.message || 'Failed to load remote GPU status')
+      return null
+    } finally {
+      if (!quiet) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadStatus()
+  }, [loadStatus])
+
+  const runProbe = async () => {
+    setTesting(true)
+    setTestError(null)
+    try {
+      const payload = await fetchJson('/api/remote-provider/probe', { method: 'POST' }, PROBE_TIMEOUT_MS)
+      setTestResult(payload)
+      await loadStatus({ quiet: true })
+    } catch (err) {
+      setTestError(err?.message || 'Remote GPU test failed')
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const routeState = statusData?.routeState || {}
+  const provider = routeState.provider || {}
+  const routeStatus = routeState.status || {}
+  const egress = statusData?.egress || {}
+  const sshSupervisor = statusData?.sshSupervisor || {}
+  const testEnabled = Boolean(statusData?.availableActions?.test)
+  const statusMeta = STATUS_META[statusData?.status] || STATUS_META.unknown
+  const proofReceipt = testResult?.probe || routeStatus.lastProbe
+  const proofRecorded = testResult?.routeProof?.recorded
+  const proofSummary = useMemo(() => {
+    if (!testResult?.routeProof) return null
+    if (proofRecorded) return 'Route proof recorded'
+    return `Route proof not recorded: ${titleize(testResult.routeProof.reason)}`
+  }, [proofRecorded, testResult])
+
+  if (loading) return <LoadingState />
+
+  return (
+    <div className="p-3 sm:p-6 lg:p-8">
+      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-theme-text">Remote GPU</h1>
+          <p className="mt-1 text-sm text-theme-text-muted">
+            Switchboard route, egress health, and SSH tunnel proof.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {statusData && <StatusPill status={statusData.status} />}
+          <button
+            type="button"
+            onClick={() => loadStatus()}
+            className="inline-flex items-center gap-2 rounded-lg border border-theme-border px-3 py-2 text-sm text-theme-text transition-colors hover:bg-theme-card-hover"
+          >
+            <RefreshCw size={16} />
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={runProbe}
+            disabled={!testEnabled || testing}
+            className="inline-flex items-center gap-2 rounded-lg bg-theme-accent px-3 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {testing ? <Loader2 className="animate-spin" size={16} /> : <Play size={16} />}
+            Test route
+          </button>
+        </div>
+      </header>
+
+      {error && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          <AlertCircle size={16} />
+          {error}
+        </div>
+      )}
+      {testError && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          <AlertCircle size={16} />
+          {testError}
+        </div>
+      )}
+      {proofSummary && (
+        <div className={`mb-4 flex items-center gap-2 rounded-lg border px-4 py-3 text-sm ${
+          proofRecorded
+            ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100'
+            : 'border-amber-500/30 bg-amber-500/10 text-amber-100'
+        }`}>
+          {proofRecorded ? <CheckCircle2 size={16} /> : <AlertCircle size={16} />}
+          {proofSummary}
+        </div>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Panel icon={Route} title="Route">
+          <Field label="State" value={routeState.enabled ? 'Enabled' : 'Disabled'} tone={routeState.enabled ? 'text-emerald-300' : 'text-zinc-400'} />
+          <Field label="Mode" value={routeState.mode} />
+          <Field label="Transport" value={provider.transport} />
+          <Field label="Model" value={provider.model} />
+          <Field label="Proof" value={titleize(routeStatus.reason)} tone={routeStatus.proven ? 'text-emerald-300' : 'text-amber-300'} />
+          <ProbeReceipt receipt={proofReceipt} />
+          {Array.isArray(routeState.errors) && routeState.errors.length > 0 && (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-200">
+              {routeState.errors.join('; ')}
+            </div>
+          )}
+        </Panel>
+
+        <Panel icon={Cloud} title="Egress">
+          <Field label="Status" value={titleize(egress.status)} tone={egress.ready ? 'text-emerald-300' : 'text-amber-300'} />
+          <Field label="Ready" value={boolLabel(egress.ready)} />
+          <Field label="Reachable" value={boolLabel(egress.reachable)} />
+          <Field label="Secret" value={egress.secret?.configured ? 'Configured' : 'Missing'} tone={egress.secret?.configured ? 'text-emerald-300' : 'text-amber-300'} />
+          <Field label="Resolved addresses" value={egress.resolution?.addressCount ?? 'Unknown'} />
+          <Field label="Reason" value={titleize(egress.reason)} />
+        </Panel>
+
+        <Panel icon={Server} title="SSH Tunnel">
+          <Field label="Status" value={titleize(sshSupervisor.status)} tone={sshSupervisor.ready ? 'text-emerald-300' : 'text-amber-300'} />
+          <Field label="Ready" value={boolLabel(sshSupervisor.ready)} />
+          <Field label="Ready to start" value={boolLabel(sshSupervisor.readyToStart)} />
+          <Field label="Reachable" value={boolLabel(sshSupervisor.reachable)} />
+          <Field label="Reason" value={titleize(sshSupervisor.reason)} />
+          <Field label="Missing secrets" value={(sshSupervisor.missingSecrets || []).length} />
+        </Panel>
+
+        <Panel icon={ShieldCheck} title="Capabilities">
+          <Field label="Inference" value={boolLabel(statusData?.capabilities?.inference)} tone={statusData?.capabilities?.inference ? 'text-emerald-300' : 'text-zinc-400'} />
+          <Field label="ODS peer lifecycle" value={boolLabel(statusData?.capabilities?.odsPeerLifecycle)} />
+          <Field label="Available test" value={boolLabel(testEnabled)} />
+          <Field label="Configure" value={boolLabel(statusData?.availableActions?.configure)} />
+          <div className={`mt-2 flex items-center gap-2 rounded-lg border border-theme-border px-3 py-2 text-xs ${statusMeta.text}`}>
+            <KeyRound size={14} />
+            {statusMeta.label}
+          </div>
+        </Panel>
+      </div>
+    </div>
+  )
+}

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import RemoteProvider from './RemoteProvider'
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+const statusPayload = {
+  status: 'ready',
+  routeState: {
+    exists: true,
+    valid: true,
+    enabled: true,
+    mode: 'cloud',
+    provider: {
+      capability: 'openai-compatible',
+      baseUrl: 'http://127.0.0.1:8000/v1',
+      model: 'qwen/remote:latest',
+      transport: 'ssh',
+    },
+    projection: {
+      publicModel: 'ods/current',
+      gateway: 'litellm-cloud',
+      egressBaseUrl: 'http://remote-provider-egress:8091/v1',
+      consumerRoute: 'gateway',
+    },
+    status: {
+      proven: true,
+      reason: 'provider-handshake-ok',
+      lastProbe: {
+        schema: 'ods.remote-provider-probe-receipt.v1',
+        ok: true,
+        verifiedAt: '2026-07-26T00:00:00+00:00',
+        endpoint: '/v1/models',
+        httpStatus: 200,
+        modelCount: 1,
+        resolution: { ok: true, addressCount: 0 },
+      },
+    },
+    errors: [],
+  },
+  sshSupervisor: {
+    reachable: true,
+    valid: true,
+    status: 'running',
+    ready: true,
+    readyToStart: true,
+    reason: 'ready',
+    missingSecrets: [],
+  },
+  egress: {
+    reachable: true,
+    valid: true,
+    ready: true,
+    status: 'ok',
+    reason: 'ready',
+    secret: { configured: true, bytes: 24 },
+    resolution: { ok: true, addressCount: 0 },
+  },
+  capabilities: {
+    inference: true,
+    odsPeerLifecycle: false,
+  },
+  availableActions: {
+    configure: true,
+    test: true,
+    disable: true,
+    remove: true,
+  },
+}
+
+const probePayload = {
+  schema: 'ods.remote-provider-egress-probe.v1',
+  ok: true,
+  transport: 'ssh',
+  probe: {
+    schema: 'ods.remote-provider-probe-receipt.v1',
+    ok: true,
+    verifiedAt: '2026-07-26T00:05:00+00:00',
+    endpoint: '/v1/models',
+    httpStatus: 200,
+    modelCount: 2,
+    resolution: { ok: true, addressCount: 0 },
+  },
+  tunnel: {
+    ok: true,
+    ready: true,
+    status: 'running',
+    reason: 'ready',
+  },
+  routeProof: {
+    recorded: true,
+    reachable: true,
+    schema: 'ods.remote-provider-proof-record.v1',
+    status: {
+      proven: true,
+      reason: 'provider-handshake-ok',
+      lastProbe: {
+        schema: 'ods.remote-provider-probe-receipt.v1',
+        ok: true,
+        verifiedAt: '2026-07-26T00:05:00+00:00',
+        endpoint: '/v1/models',
+        httpStatus: 200,
+        modelCount: 2,
+        resolution: { ok: true, addressCount: 0 },
+      },
+    },
+  },
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('renders remote provider status and proof receipt', async () => {
+  globalThis.fetch.mockResolvedValueOnce(response(statusPayload))
+
+  render(createElement(RemoteProvider))
+
+  expect(await screen.findByRole('heading', { name: 'Remote GPU' })).toBeInTheDocument()
+  expect(screen.getByText('qwen/remote:latest')).toBeInTheDocument()
+  expect(screen.getByText('Provider handshake ok')).toBeInTheDocument()
+  expect(screen.getByText('2026-07-26T00:00:00+00:00')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /test route/i })).toBeEnabled()
+})
+
+test('runs configured route probe and shows proof recording result', async () => {
+  globalThis.fetch
+    .mockResolvedValueOnce(response(statusPayload))
+    .mockResolvedValueOnce(response(probePayload))
+    .mockResolvedValueOnce(response(statusPayload))
+
+  render(createElement(RemoteProvider))
+
+  fireEvent.click(await screen.findByRole('button', { name: /test route/i }))
+
+  await waitFor(() => {
+    expect(globalThis.fetch.mock.calls.map(call => call[0])).toEqual([
+      '/api/remote-provider/status',
+      '/api/remote-provider/probe',
+      '/api/remote-provider/status',
+    ])
+  })
+  expect(screen.getByText('Route proof recorded')).toBeInTheDocument()
+  expect(screen.getByText('2026-07-26T00:05:00+00:00')).toBeInTheDocument()
+})

--- a/ods/extensions/services/dashboard/src/plugins/core.js
+++ b/ods/extensions/services/dashboard/src/plugins/core.js
@@ -6,6 +6,7 @@ import {
   Activity,
   Box,
   Network,
+  Cloud,
   UserPlus,
   CreditCard,
 } from 'lucide-react'
@@ -15,6 +16,7 @@ const SettingsPage = lazy(() => import('../pages/Settings'))
 const Extensions = lazy(() => import('../pages/Extensions'))
 const GPUMonitor = lazy(() => import('../pages/GPUMonitor'))
 const Models = lazy(() => import('../pages/Models'))
+const RemoteProvider = lazy(() => import('../pages/RemoteProvider'))
 const ServiceMap = lazy(() => import('../pages/ServiceMap'))
 const Invites = lazy(() => import('../pages/Invites'))
 const Usage = lazy(() => import('../pages/Usage'))
@@ -70,6 +72,16 @@ export const coreRoutes = [
     getProps: () => ({}),
     sidebar: true,
     order: 3,
+  },
+  {
+    id: 'remote-provider',
+    path: '/remote-provider',
+    label: 'Remote GPU',
+    icon: Cloud,
+    component: RemoteProvider,
+    getProps: () => ({}),
+    sidebar: true,
+    order: 3.2,
   },
   // Usage + Setup / Owner are reachable from Settings rather than the top-level
   // sidebar. Setup / Owner is a factory/distributor/service-provider flow, not


### PR DESCRIPTION
## Summary
- add a first-class Dashboard `Remote GPU` route for configured remote-provider status
- show route proof, egress readiness, SSH tunnel state, and capability/action availability from `/api/remote-provider/status`
- wire a Dashboard `Test route` action through `/api/remote-provider/probe` and display whether route proof was recorded

## Validation
- Local: `npm.cmd test` in `ods/extensions/services/dashboard` (26 files, 234 tests)
- Local: `npm.cmd run lint`
- Local: `npm.cmd run build`
- Local: `git diff --check`
- Tower2 exact SHA: `ea1a4ac343c660501d0f58720ca680bd0d46bc68`
- Tower2 log: `/home/michael/ods-pr-dashboard-remote-provider-ui-ea1a4ac343c6.nlUt0g/pr-dashboard-remote-provider-ui-ea1a4ac343c660501d0f58720ca680bd0d46bc68.log`
- Tower2 result: `[tower2] PASS sha=ea1a4ac343c660501d0f58720ca680bd0d46bc68`