### PR TITLE
Add Dashboard remote provider lifecycle actions

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -3,17 +3,27 @@ import {
   AlertCircle,
   CheckCircle2,
   Cloud,
+  ClipboardCheck,
   KeyRound,
   Loader2,
   Play,
+  Power,
   RefreshCw,
   Route,
+  Save,
   Server,
   ShieldCheck,
+  Trash2,
 } from 'lucide-react'
 
 const REQUEST_TIMEOUT_MS = 12000
 const PROBE_TIMEOUT_MS = 22000
+const LIFECYCLE_TIMEOUT_MS = 30000
+const INITIAL_FORM = {
+  baseUrl: '',
+  model: '',
+  apiKey: '',
+}
 
 const STATUS_META = {
   ready: { label: 'Ready', dot: 'bg-emerald-400', text: 'text-emerald-300' },
@@ -39,6 +49,54 @@ function boolLabel(value) {
 function valueOrDash(value) {
   if (value === null || value === undefined || value === '') return 'None'
   return String(value)
+}
+
+function jsonOptions(payload) {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }
+}
+
+function configurePayload(form) {
+  return {
+    action: 'configure',
+    provider: {
+      transport: 'direct',
+      baseUrl: form.baseUrl.trim(),
+      model: form.model.trim(),
+    },
+    secrets: {
+      apiKey: form.apiKey.trim(),
+    },
+  }
+}
+
+function writesSummary(writes) {
+  const plan = writes && typeof writes === 'object' ? writes : {}
+  const labels = []
+  if (plan.routingState) labels.push('routing state')
+  if (plan.providerSecret) labels.push('provider secret')
+  if (plan.sshIdentity) labels.push('ssh identity')
+  if (plan.sshKnownHosts) labels.push('ssh known hosts')
+  if (plan.removesRoutingState) labels.push('routing state removal')
+  if (plan.removesSecrets) labels.push('stored secret removal')
+  return labels.length ? labels.join(', ') : 'None'
+}
+
+function routeSummary(result) {
+  const provider = result?.route?.provider || {}
+  if (provider.model) return `${provider.model} via ${provider.transport || 'direct'}`
+  if (result?.route?.enabled === false) return 'Disabled route'
+  return 'None'
+}
+
+function lifecycleTitle(result) {
+  const action = titleize(result?.action)
+  if (result?.applied) return `${action} applied`
+  if (result?.ok) return `${action} plan ready`
+  return `${action} completed`
 }
 
 async function responsePayload(response) {
@@ -86,9 +144,9 @@ function StatusPill({ status }) {
   )
 }
 
-function Panel({ icon: Icon, title, children, actions = null }) {
+function Panel({ icon: Icon, title, children, actions = null, className = '' }) {
   return (
-    <section className="rounded-lg border border-theme-border bg-theme-card p-4 shadow-sm">
+    <section className={`rounded-lg border border-theme-border bg-theme-card p-4 shadow-sm ${className}`}>
       <div className="mb-4 flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Icon size={18} className="text-theme-accent" />
@@ -101,11 +159,75 @@ function Panel({ icon: Icon, title, children, actions = null }) {
   )
 }
 
+function ActionButton({ icon: Icon, children, onClick, disabled = false, primary = false, danger = false, type = 'button' }) {
+  const tone = primary
+    ? 'bg-theme-accent text-white hover:opacity-90'
+    : danger
+      ? 'border-red-500/40 text-red-200 hover:bg-red-500/10'
+      : 'border-theme-border text-theme-text hover:bg-theme-card-hover'
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${tone}`}
+    >
+      <Icon size={16} />
+      {children}
+    </button>
+  )
+}
+
+function TextInput({ label, value, onChange, type = 'text', autoComplete = 'off', placeholder = '' }) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block text-xs font-semibold uppercase text-theme-text-muted">{label}</span>
+      <input
+        type={type}
+        value={value}
+        onChange={event => onChange(event.target.value)}
+        autoComplete={autoComplete}
+        placeholder={placeholder}
+        className="h-10 w-full rounded-lg border border-theme-border bg-theme-bg px-3 text-sm text-theme-text outline-none transition-colors placeholder:text-theme-text-muted/50 focus:border-theme-accent"
+      />
+    </label>
+  )
+}
+
 function Field({ label, value, tone = 'text-theme-text' }) {
   return (
     <div className="flex items-center justify-between gap-4 text-sm">
       <span className="text-theme-text-muted">{label}</span>
       <span className={`text-right font-medium ${tone}`}>{valueOrDash(value)}</span>
+    </div>
+  )
+}
+
+function LifecycleSummary({ result }) {
+  if (!result) return null
+  const secretRefs = Object.keys(result.secretRefs || {}).join(', ') || 'None'
+  return (
+    <div className="space-y-3 rounded-lg border border-theme-border/70 bg-black/10 p-3" role="status">
+      <div className="flex items-center gap-2 text-sm font-semibold text-emerald-200">
+        <CheckCircle2 size={16} />
+        {lifecycleTitle(result)}
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Field label="Route" value={routeSummary(result)} />
+        <Field label="Writes" value={writesSummary(result.writes)} />
+        <Field label="Secret refs" value={secretRefs} />
+        <Field label="Mutated" value={result.mutated === undefined ? 'Pending' : boolLabel(result.mutated)} />
+      </div>
+      {result.probe && (
+        <Field
+          label="Probe"
+          value={`HTTP ${result.probe.httpStatus ?? 'unknown'} at ${result.probe.endpoint || '/v1/models'}`}
+          tone="text-emerald-300"
+        />
+      )}
+      {result.rollback?.attempted && (
+        <Field label="Rollback" value={result.rollback.ok ? 'Ok' : 'Failed'} tone={result.rollback.ok ? 'text-emerald-300' : 'text-red-300'} />
+      )}
     </div>
   )
 }
@@ -140,6 +262,13 @@ export default function RemoteProvider() {
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState(null)
   const [testError, setTestError] = useState(null)
+  const [form, setForm] = useState(INITIAL_FORM)
+  const [formDirty, setFormDirty] = useState(false)
+  const [planning, setPlanning] = useState(false)
+  const [applyingAction, setApplyingAction] = useState(null)
+  const [planResult, setPlanResult] = useState(null)
+  const [lifecycleResult, setLifecycleResult] = useState(null)
+  const [lifecycleError, setLifecycleError] = useState(null)
 
   const loadStatus = useCallback(async ({ quiet = false } = {}) => {
     if (!quiet) setLoading(true)
@@ -160,6 +289,21 @@ export default function RemoteProvider() {
     void loadStatus()
   }, [loadStatus])
 
+  useEffect(() => {
+    const provider = statusData?.routeState?.provider
+    if (formDirty || !provider) return
+    setForm(current => ({
+      ...current,
+      baseUrl: provider.baseUrl || '',
+      model: provider.model || '',
+    }))
+  }, [formDirty, statusData])
+
+  const updateForm = (key, value) => {
+    setFormDirty(true)
+    setForm(current => ({ ...current, [key]: value }))
+  }
+
   const runProbe = async () => {
     setTesting(true)
     setTestError(null)
@@ -174,6 +318,45 @@ export default function RemoteProvider() {
     }
   }
 
+  const planConfigure = async () => {
+    setPlanning(true)
+    setLifecycleError(null)
+    setLifecycleResult(null)
+    try {
+      const payload = await fetchJson('/api/remote-provider/plan', jsonOptions(configurePayload(form)), LIFECYCLE_TIMEOUT_MS)
+      setPlanResult(payload)
+    } catch (err) {
+      setLifecycleError(err?.message || 'Remote GPU plan failed')
+    } finally {
+      setPlanning(false)
+    }
+  }
+
+  const applyLifecycle = async action => {
+    if (action === 'remove' && typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      if (!window.confirm('Remove remote GPU route and stored secrets?')) return
+    }
+    setApplyingAction(action)
+    setLifecycleError(null)
+    setPlanResult(null)
+    setTestResult(null)
+    setTestError(null)
+    try {
+      const payload = action === 'configure' ? configurePayload(form) : { action }
+      const result = await fetchJson('/api/remote-provider/apply', jsonOptions(payload), LIFECYCLE_TIMEOUT_MS)
+      setLifecycleResult(result)
+      if (action === 'configure') {
+        setForm(current => ({ ...current, apiKey: '' }))
+        setFormDirty(false)
+      }
+      await loadStatus({ quiet: true })
+    } catch (err) {
+      setLifecycleError(err?.message || `Remote GPU ${action} failed`)
+    } finally {
+      setApplyingAction(null)
+    }
+  }
+
   const routeState = statusData?.routeState || {}
   const provider = routeState.provider || {}
   const routeStatus = routeState.status || {}
@@ -181,6 +364,8 @@ export default function RemoteProvider() {
   const sshSupervisor = statusData?.sshSupervisor || {}
   const testEnabled = Boolean(statusData?.availableActions?.test)
   const statusMeta = STATUS_META[statusData?.status] || STATUS_META.unknown
+  const lifecycleBusy = planning || Boolean(applyingAction)
+  const configureReady = Boolean(form.baseUrl.trim() && form.model.trim() && form.apiKey.trim()) && !lifecycleBusy
   const proofReceipt = testResult?.probe || routeStatus.lastProbe
   const proofRecorded = testResult?.routeProof?.recorded
   const proofSummary = useMemo(() => {
@@ -244,6 +429,12 @@ export default function RemoteProvider() {
           {proofSummary}
         </div>
       )}
+      {lifecycleError && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          <AlertCircle size={16} />
+          {lifecycleError}
+        </div>
+      )}
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Panel icon={Route} title="Route">
@@ -287,6 +478,46 @@ export default function RemoteProvider() {
             <KeyRound size={14} />
             {statusMeta.label}
           </div>
+        </Panel>
+
+        <Panel icon={KeyRound} title="Configure" className="lg:col-span-2">
+          <div className="grid gap-3 md:grid-cols-[1.2fr_1fr_1fr]">
+            <TextInput
+              label="Base URL"
+              value={form.baseUrl}
+              onChange={value => updateForm('baseUrl', value)}
+              placeholder="https://gpu.example/v1"
+            />
+            <TextInput
+              label="Model"
+              value={form.model}
+              onChange={value => updateForm('model', value)}
+              placeholder="qwen/remote:latest"
+            />
+            <TextInput
+              label="API key"
+              value={form.apiKey}
+              onChange={value => updateForm('apiKey', value)}
+              type="password"
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <ActionButton icon={ClipboardCheck} onClick={planConfigure} disabled={!configureReady}>
+              {planning ? 'Planning' : 'Plan'}
+            </ActionButton>
+            <ActionButton icon={Save} onClick={() => applyLifecycle('configure')} disabled={!configureReady} primary>
+              {applyingAction === 'configure' ? 'Configuring' : 'Configure'}
+            </ActionButton>
+            <ActionButton icon={Power} onClick={() => applyLifecycle('disable')} disabled={!statusData?.availableActions?.disable || lifecycleBusy}>
+              {applyingAction === 'disable' ? 'Disabling' : 'Disable'}
+            </ActionButton>
+            <ActionButton icon={Trash2} onClick={() => applyLifecycle('remove')} disabled={!statusData?.availableActions?.remove || lifecycleBusy} danger>
+              {applyingAction === 'remove' ? 'Removing' : 'Remove'}
+            </ActionButton>
+          </div>
+          <LifecycleSummary result={planResult} />
+          <LifecycleSummary result={lifecycleResult} />
         </Panel>
       </div>
     </div>

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -112,6 +112,112 @@ const probePayload = {
   },
 }
 
+const configurePlanPayload = {
+  schema: 'ods.remote-provider-lifecycle-operation.v1',
+  action: 'configure',
+  ok: true,
+  route: {
+    enabled: true,
+    provider: {
+      capability: 'openai-compatible',
+      baseUrl: 'https://gpu.example.test/v1',
+      model: 'qwen/remote:latest',
+      transport: 'direct',
+    },
+  },
+  writes: {
+    routingState: true,
+    providerSecret: true,
+    sshIdentity: false,
+    sshKnownHosts: false,
+    removesRoutingState: false,
+    removesSecrets: false,
+  },
+  secretRefs: {
+    REMOTE_LLM_API_KEY: { present: true, value: '[REDACTED]' },
+  },
+}
+
+const configureApplyPayload = {
+  ...configurePlanPayload,
+  applied: true,
+  mutated: true,
+  rollback: { attempted: false, ok: null },
+  probe: {
+    ok: true,
+    endpoint: '/v1/models',
+    httpStatus: 200,
+    modelCount: 2,
+  },
+}
+
+const disabledStatusPayload = {
+  ...statusPayload,
+  status: 'disabled',
+  routeState: {
+    ...statusPayload.routeState,
+    enabled: false,
+    provider: null,
+    status: { proven: false, reason: 'disabled' },
+  },
+  capabilities: {
+    inference: false,
+    odsPeerLifecycle: false,
+  },
+  availableActions: {
+    configure: true,
+    test: false,
+    disable: false,
+    remove: true,
+  },
+}
+
+const disableApplyPayload = {
+  schema: 'ods.remote-provider-lifecycle-operation.v1',
+  action: 'disable',
+  ok: true,
+  applied: true,
+  mutated: true,
+  rollback: { attempted: false, ok: null },
+  route: { enabled: false },
+  writes: {
+    routingState: true,
+    providerSecret: false,
+    removesRoutingState: false,
+    removesSecrets: false,
+  },
+  secretRefs: {},
+}
+
+const removeApplyPayload = {
+  ...disableApplyPayload,
+  action: 'remove',
+  route: { enabled: false },
+  writes: {
+    routingState: false,
+    providerSecret: false,
+    removesRoutingState: true,
+    removesSecrets: true,
+  },
+}
+
+async function fillConfigureForm() {
+  await screen.findByRole('heading', { name: 'Remote GPU' })
+  fireEvent.change(screen.getByLabelText('Base URL'), {
+    target: { value: 'https://gpu.example.test/v1' },
+  })
+  fireEvent.change(screen.getByLabelText('Model'), {
+    target: { value: 'qwen/remote:latest' },
+  })
+  fireEvent.change(screen.getByLabelText('API key'), {
+    target: { value: 'unit-test-provider-token' },
+  })
+}
+
+function requestBody(callIndex) {
+  return JSON.parse(globalThis.fetch.mock.calls[callIndex][1].body)
+}
+
 beforeEach(() => {
   globalThis.fetch = vi.fn()
 })
@@ -151,4 +257,103 @@ test('runs configured route probe and shows proof recording result', async () =>
   })
   expect(screen.getByText('Route proof recorded')).toBeInTheDocument()
   expect(screen.getByText('2026-07-26T00:05:00+00:00')).toBeInTheDocument()
+})
+
+test('plans direct provider configuration without rendering secret material', async () => {
+  globalThis.fetch
+    .mockResolvedValueOnce(response(statusPayload))
+    .mockResolvedValueOnce(response(configurePlanPayload))
+
+  render(createElement(RemoteProvider))
+  await fillConfigureForm()
+
+  fireEvent.click(screen.getByRole('button', { name: /plan/i }))
+
+  await waitFor(() => {
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+  })
+  expect(globalThis.fetch.mock.calls[1][0]).toBe('/api/remote-provider/plan')
+  expect(requestBody(1)).toEqual({
+    action: 'configure',
+    provider: {
+      transport: 'direct',
+      baseUrl: 'https://gpu.example.test/v1',
+      model: 'qwen/remote:latest',
+    },
+    secrets: {
+      apiKey: 'unit-test-provider-token',
+    },
+  })
+  expect(await screen.findByText('Configure plan ready')).toBeInTheDocument()
+  expect(screen.getByText('REMOTE_LLM_API_KEY')).toBeInTheDocument()
+  expect(screen.queryByText('unit-test-provider-token')).not.toBeInTheDocument()
+})
+
+test('applies direct provider configuration and clears the secret input', async () => {
+  globalThis.fetch
+    .mockResolvedValueOnce(response(statusPayload))
+    .mockResolvedValueOnce(response(configureApplyPayload))
+    .mockResolvedValueOnce(response(statusPayload))
+
+  render(createElement(RemoteProvider))
+  await fillConfigureForm()
+  const apiKeyInput = screen.getByLabelText('API key')
+
+  fireEvent.click(screen.getByRole('button', { name: /^configure$/i }))
+
+  await waitFor(() => {
+    expect(globalThis.fetch.mock.calls.map(call => call[0])).toEqual([
+      '/api/remote-provider/status',
+      '/api/remote-provider/apply',
+      '/api/remote-provider/status',
+    ])
+  })
+  expect(requestBody(1).secrets.apiKey).toBe('unit-test-provider-token')
+  expect(await screen.findByText('Configure applied')).toBeInTheDocument()
+  expect(apiKeyInput).toHaveValue('')
+  expect(screen.queryByText('unit-test-provider-token')).not.toBeInTheDocument()
+})
+
+test('applies disable lifecycle action and refreshes status', async () => {
+  globalThis.fetch
+    .mockResolvedValueOnce(response(statusPayload))
+    .mockResolvedValueOnce(response(disableApplyPayload))
+    .mockResolvedValueOnce(response(disabledStatusPayload))
+
+  render(createElement(RemoteProvider))
+
+  fireEvent.click(await screen.findByRole('button', { name: /^disable$/i }))
+
+  await waitFor(() => {
+    expect(globalThis.fetch.mock.calls.map(call => call[0])).toEqual([
+      '/api/remote-provider/status',
+      '/api/remote-provider/apply',
+      '/api/remote-provider/status',
+    ])
+  })
+  expect(requestBody(1)).toEqual({ action: 'disable' })
+  expect(screen.getByText('Disable applied')).toBeInTheDocument()
+})
+
+test('confirms remove before deleting route state and stored secrets', async () => {
+  const confirmSpy = vi.spyOn(window, 'confirm').mockImplementation(() => true)
+  globalThis.fetch
+    .mockResolvedValueOnce(response(statusPayload))
+    .mockResolvedValueOnce(response(removeApplyPayload))
+    .mockResolvedValueOnce(response(disabledStatusPayload))
+
+  render(createElement(RemoteProvider))
+
+  fireEvent.click(await screen.findByRole('button', { name: /^remove$/i }))
+
+  await waitFor(() => {
+    expect(globalThis.fetch.mock.calls.map(call => call[0])).toEqual([
+      '/api/remote-provider/status',
+      '/api/remote-provider/apply',
+      '/api/remote-provider/status',
+    ])
+  })
+  expect(confirmSpy).toHaveBeenCalledWith('Remove remote GPU route and stored secrets?')
+  expect(requestBody(1)).toEqual({ action: 'remove' })
+  expect(screen.getByText('Remove applied')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- Adds Dashboard controls to plan and apply direct remote-provider configuration through the existing authenticated lifecycle endpoints.
- Adds disable and confirmed remove actions for route state and stored secret lifecycle management.
- Shows redacted lifecycle plan/apply results and clears the API key field after successful configure.

## Validation
- `npm.cmd test -- RemoteProvider.test.jsx`
- `npm.cmd run lint`
- `npm.cmd test`
- `npm.cmd run build`
- `git diff --check`
- Tower2 exact-SHA fresh clone: `99a3fc02445c2f2d7041e51f0fe5becf06be748c`
- Tower2 log: `/home/michael/ods-pr-dashboard-lifecycle-actions-99a3fc02445c.RIJb1X/pr-dashboard-lifecycle-actions-99a3fc02445c2f2d7041e51f0fe5becf06be748c.log`
- Final Tower2 assertion: `[tower2] PASS sha=99a3fc02445c2f2d7041e51f0fe5becf06be748c`