### PR TITLE
Add remote provider ODS peer readiness

### DIFF
--- a/ods/bin/remote_provider/lifecycle.py
+++ b/ods/bin/remote_provider/lifecycle.py
@@ -104,6 +104,7 @@ def _read_ssh_field(
 
 def _route_env(payload: Mapping[str, Any]) -> dict[str, str]:
     provider = _mapping(payload.get("provider"), "provider")
+    peer = _mapping(payload.get("peer"), "peer")
     ssh = _mapping(payload.get("ssh"), "ssh")
     env = {
         "ODS_MODE": _string(payload.get("mode") or "cloud"),
@@ -130,6 +131,14 @@ def _route_env(payload: Mapping[str, Any]) -> dict[str, str]:
         value = _read_ssh_field(payload, ssh, env_name, camel_name)
         if value:
             env[env_name] = value
+    peer_url = _string(
+        peer.get("controlBaseUrl")
+        or peer.get("baseUrl")
+        or payload.get("peerUrl")
+        or payload.get("REMOTE_ODS_PEER_URL")
+    )
+    if peer_url:
+        env["REMOTE_ODS_PEER_URL"] = peer_url
     return env
 
 
@@ -192,6 +201,7 @@ def _write_plan(action: str, secret_refs: Mapping[str, str]) -> dict[str, bool]:
     return {
         "routingState": action in {"configure", "disable"},
         "providerSecret": action == "configure" and "apiKey" in secret_refs,
+        "peerToken": action == "configure" and "peerToken" in secret_refs,
         "sshIdentity": action == "configure" and "sshPrivateKey" in secret_refs,
         "sshKnownHosts": action == "configure" and "sshKnownHosts" in secret_refs,
         "removesRoutingState": action == "remove",

--- a/ods/bin/remote_provider/policy.py
+++ b/ods/bin/remote_provider/policy.py
@@ -24,6 +24,7 @@ REMOTE_ROUTE_SCHEMA = "ods.remote-provider-route.v1"
 ACTIVATION_RECEIPT_SCHEMA = "ods.remote-provider-activation-receipt.v1"
 PUBLIC_MODEL_ALIAS = "ods/current"
 INTERNAL_EGRESS_BASE_URL = "http://remote-provider-egress:8091/v1"
+INTERNAL_SSH_CONTROL_BASE_URL = "http://remote-provider-ssh-tunnel:18092"
 REDACTED = "[REDACTED]"
 
 REMOTE_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,255}$")
@@ -206,6 +207,72 @@ def normalize_provider_base_url(
     )
 
 
+def normalize_peer_control_url(value: str, *, transport: str) -> str:
+    """Normalize a paired ODS control-plane root URL or raise PolicyError."""
+    transport_name = transport.strip().lower()
+    if transport_name not in {"direct", "ssh"}:
+        raise PolicyError("REMOTE_LLM_TRANSPORT must be direct or ssh")
+
+    raw = value.strip()
+    if not raw:
+        raise PolicyError("remote ODS peer URL is required")
+    if _has_control_chars(raw):
+        raise PolicyError("remote ODS peer URL contains control characters")
+    if "\\" in raw:
+        raise PolicyError("remote ODS peer URL must use forward slashes")
+
+    parts = urlsplit(raw)
+    if not parts.scheme or not parts.netloc:
+        raise PolicyError("remote ODS peer URL must include scheme and host")
+    allowed_schemes = {"https"} if transport_name == "direct" else {"http", "https"}
+    if parts.scheme.lower() not in allowed_schemes:
+        allowed = ", ".join(sorted(allowed_schemes))
+        raise PolicyError(f"{transport_name} peer transport requires scheme: {allowed}")
+    if parts.username or parts.password:
+        raise PolicyError("remote ODS peer URL must not embed credentials")
+    if parts.query:
+        raise PolicyError("remote ODS peer URL must not include a query string")
+    if parts.fragment:
+        raise PolicyError("remote ODS peer URL must not include a fragment")
+
+    try:
+        port = parts.port
+    except ValueError as exc:
+        raise PolicyError(f"remote ODS peer URL has an invalid port: {exc}") from exc
+
+    host = parts.hostname or ""
+    if not host:
+        raise PolicyError("remote ODS peer URL must include a host")
+    if _has_control_chars(host) or any(char.isspace() for char in host):
+        raise PolicyError("remote ODS peer URL host is invalid")
+    if "%" in host:
+        raise PolicyError("remote ODS peer URL host must not include a zone id")
+
+    lower_host = host.lower()
+    if transport_name == "direct":
+        if lower_host in LOCAL_HOSTNAMES or lower_host.endswith(".localhost"):
+            raise PolicyError("direct remote ODS peer URL must not target local hostnames")
+        forbidden_class = classify_forbidden_ip_address(lower_host)
+        if forbidden_class:
+            raise PolicyError(
+                f"direct remote ODS peer URL must not use {forbidden_class} IP literals"
+            )
+
+    path = parts.path.rstrip("/")
+    if path:
+        raise PolicyError("remote ODS peer URL must be the control-plane root")
+
+    return urlunsplit(
+        (
+            parts.scheme.lower(),
+            _normalize_netloc(host, port),
+            "",
+            "",
+            "",
+        )
+    )
+
+
 def validate_remote_model_id(model_id: str) -> str:
     """Return a trimmed remote model id if it is safe for public config."""
     model = model_id.strip()
@@ -261,6 +328,34 @@ def _ssh_metadata(env: Mapping[str, object]) -> dict[str, object]:
     return metadata
 
 
+def _peer_metadata(
+    env: Mapping[str, object],
+    *,
+    transport: str,
+    ssh: Mapping[str, object] | None,
+) -> dict[str, str] | None:
+    peer_url = _string(env.get("REMOTE_ODS_PEER_URL"))
+    if peer_url:
+        return {
+            "controlBaseUrl": normalize_peer_control_url(
+                peer_url,
+                transport=transport,
+            ),
+            "transport": transport,
+        }
+    if (
+        transport == "ssh"
+        and isinstance(ssh, Mapping)
+        and _string(ssh.get("controlHost"))
+        and _string(ssh.get("controlPort"))
+    ):
+        return {
+            "controlBaseUrl": INTERNAL_SSH_CONTROL_BASE_URL,
+            "transport": "ssh",
+        }
+    return None
+
+
 def plan_route(
     env: Mapping[str, object],
     *,
@@ -278,6 +373,7 @@ def plan_route(
             "transport": None,
             "provider": None,
             "ssh": None,
+            "peer": None,
             "egress": {
                 "internalBaseUrl": INTERNAL_EGRESS_BASE_URL,
                 "publicModel": PUBLIC_MODEL_ALIAS,
@@ -296,6 +392,7 @@ def plan_route(
     )
     model = validate_remote_model_id(_string(env.get("REMOTE_LLM_MODEL")))
     ssh = _ssh_metadata(env) if transport == "ssh" else None
+    peer = _peer_metadata(env, transport=transport, ssh=ssh)
     return {
         "schema": REMOTE_ROUTE_SCHEMA,
         "enabled": True,
@@ -308,6 +405,7 @@ def plan_route(
             "transport": transport,
         },
         "ssh": ssh,
+        "peer": peer,
         "egress": {
             "internalBaseUrl": INTERNAL_EGRESS_BASE_URL,
             "publicModel": PUBLIC_MODEL_ALIAS,
@@ -359,6 +457,7 @@ def public_activation_receipt(
         "mode": route.get("mode"),
         "transport": route.get("transport"),
         "provider": route.get("provider") if route.get("enabled") else None,
+        "peer": route.get("peer") if route.get("enabled") else None,
         "egress": route.get("egress"),
         "secretRefs": redacted_secret_refs(secret_refs),
     }

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -56,6 +56,10 @@ def _state_path() -> Path:
     return Path(DATA_DIR) / "remote-provider" / "routing-state.json"
 
 
+def _peer_token_path() -> Path:
+    return Path(DATA_DIR) / "remote-provider" / "secrets" / "peer-token"
+
+
 def _safe_string_map(value: Any, keys: set[str]) -> dict[str, str]:
     if not isinstance(value, Mapping):
         return {}
@@ -64,6 +68,19 @@ def _safe_string_map(value: Any, keys: set[str]) -> dict[str, str]:
         item = value.get(key)
         if isinstance(item, str):
             clean[key] = item
+    return clean
+
+
+def _safe_peer_metadata(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    clean: dict[str, str] = {}
+    control_base_url = _safe_text(value.get("controlBaseUrl"), max_length=512)
+    transport = _safe_text(value.get("transport"), max_length=32)
+    if control_base_url:
+        clean["controlBaseUrl"] = control_base_url
+    if transport:
+        clean["transport"] = transport
     return clean
 
 
@@ -125,6 +142,7 @@ def _state_response(
     errors: list[str] | None = None,
     mode: str | None = None,
     provider: Mapping[str, Any] | None = None,
+    peer: Mapping[str, Any] | None = None,
     projection: Mapping[str, Any] | None = None,
     status: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -134,6 +152,7 @@ def _state_response(
         "enabled": enabled,
         "mode": mode,
         "provider": _safe_string_map(provider, _SAFE_PROVIDER_KEYS) if enabled else None,
+        "peer": _safe_peer_metadata(peer) if enabled else None,
         "projection": _safe_string_map(projection, _SAFE_PROJECTION_KEYS),
         "status": _safe_route_status(status),
         "errors": errors or [],
@@ -172,6 +191,7 @@ def _read_route_state() -> dict[str, Any]:
         enabled=enabled,
         mode=str(doc.get("mode") or "cloud"),
         provider=provider,
+        peer=doc.get("peer"),
         projection=doc.get("projection"),
         status=doc.get("status"),
     )
@@ -183,6 +203,54 @@ def _safe_secret_status(value: Any) -> dict[str, Any]:
     return {
         "configured": bool(secret.get("configured")),
         "bytes": raw_bytes if type(raw_bytes) is int or raw_bytes is None else None,
+    }
+
+
+def _safe_secret_file_status(path: Path) -> dict[str, Any]:
+    try:
+        if path.is_symlink():
+            return {"configured": False, "bytes": None}
+        metadata = path.stat()
+    except FileNotFoundError:
+        return {"configured": False, "bytes": 0}
+    except OSError:
+        return {"configured": False, "bytes": None}
+    return {"configured": metadata.st_size > 0, "bytes": metadata.st_size}
+
+
+def _peer_status(
+    route_state: Mapping[str, Any],
+    ssh_supervisor: Mapping[str, Any],
+) -> dict[str, Any]:
+    peer = _safe_peer_metadata(route_state.get("peer"))
+    configured = bool(route_state.get("enabled")) and bool(peer.get("controlBaseUrl"))
+    token = (
+        _safe_secret_file_status(_peer_token_path())
+        if configured
+        else {"configured": False, "bytes": 0}
+    )
+    reason = "not_configured"
+    ready = False
+    if not route_state.get("valid"):
+        reason = "invalid_route_state"
+    elif not configured:
+        reason = "not_configured"
+    elif not token.get("configured"):
+        reason = "missing_peer_token"
+    elif peer.get("transport") == "ssh" and not (
+        ssh_supervisor.get("ready") or ssh_supervisor.get("readyToStart")
+    ):
+        reason = "ssh_control_tunnel_not_ready"
+    else:
+        ready = True
+        reason = "ready"
+    return {
+        "configured": configured,
+        "ready": ready,
+        "reason": reason,
+        "controlBaseUrl": peer.get("controlBaseUrl") if configured else None,
+        "transport": peer.get("transport") if configured else None,
+        "token": token,
     }
 
 
@@ -574,14 +642,16 @@ async def remote_provider_status() -> dict[str, Any]:
     route_state = _read_route_state()
     egress = await _fetch_egress_health()
     ssh_supervisor = await _fetch_ssh_supervisor_status()
+    peer = _peer_status(route_state, ssh_supervisor)
     return {
         "status": _overall_status(route_state, egress),
         "routeState": route_state,
         "sshSupervisor": ssh_supervisor,
+        "peer": peer,
         "egress": egress,
         "capabilities": {
             "inference": bool(route_state.get("enabled")),
-            "odsPeerLifecycle": False,
+            "odsPeerLifecycle": bool(peer.get("ready")),
         },
         "availableActions": {
             "configure": True,

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -8,10 +8,11 @@ import json
 def _route_state(
     model: str = "qwen/remote:latest",
     *,
+    peer: dict[str, object] | None = None,
     status: dict[str, object] | None = None,
     transport: str = "direct",
 ) -> dict[str, object]:
-    return {
+    state = {
         "schema": "ods.remote-routing-state.v1",
         "enabled": True,
         "mode": "cloud",
@@ -29,6 +30,9 @@ def _route_state(
         },
         "status": status or {"proven": False, "reason": "pending-provider-handshake"},
     }
+    if peer is not None:
+        state["peer"] = peer
+    return state
 
 
 def _lifecycle_payload() -> dict[str, object]:
@@ -170,6 +174,156 @@ def test_remote_provider_status_sanitizes_egress_secret_health(
     assert "unit-test-provider-token" not in dumped
     assert "provider-api-key" not in dumped
     assert body["sshSupervisor"]["status"] == "inactive"
+    assert body["capabilities"]["odsPeerLifecycle"] is False
+
+
+def test_remote_provider_status_reports_peer_lifecycle_readiness(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    secret_dir = state_root / "secrets"
+    secret_dir.mkdir(parents=True)
+    secret_bytes = b"unit-test-peer-token\n"
+    (secret_dir / "peer-token").write_bytes(secret_bytes)
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "https://peer.example.test",
+                    "transport": "direct",
+                    "secretValue": "unit-test-peer-token",
+                    "tokenPath": "/state/remote-provider/secrets/peer-token",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+
+    async def fake_fetch():
+        return {
+            "reachable": True,
+            "valid": True,
+            "ready": True,
+            "status": "ok",
+            "reason": "ready",
+            "secret": {"configured": True, "bytes": 24},
+            "resolution": {"ok": True, "addressCount": 1},
+        }
+
+    async def fake_ssh_supervisor():
+        return rps._safe_ssh_supervisor_status(
+            {
+                "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+                "status": "inactive",
+                "ready": False,
+                "readyToStart": False,
+                "reason": "not_ssh_transport",
+                "tunnelBaseUrl": None,
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            }
+        )
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", fake_ssh_supervisor)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert body["peer"] == {
+        "configured": True,
+        "ready": True,
+        "reason": "ready",
+        "controlBaseUrl": "https://peer.example.test",
+        "transport": "direct",
+        "token": {"configured": True, "bytes": len(secret_bytes)},
+    }
+    assert body["routeState"]["peer"] == {
+        "controlBaseUrl": "https://peer.example.test",
+        "transport": "direct",
+    }
+    assert body["capabilities"]["odsPeerLifecycle"] is True
+    assert "unit-test-peer-token" not in dumped
+    assert "peer-token" not in dumped
+
+
+def test_remote_provider_status_blocks_peer_lifecycle_without_token(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    state_root.mkdir(parents=True)
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "https://peer.example.test",
+                    "transport": "direct",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+
+    async def fake_fetch():
+        return {
+            "reachable": True,
+            "valid": True,
+            "ready": True,
+            "status": "ok",
+            "reason": "ready",
+            "secret": {"configured": True, "bytes": 24},
+            "resolution": {"ok": True, "addressCount": 1},
+        }
+
+    async def fake_ssh_supervisor():
+        return rps._safe_ssh_supervisor_status(
+            {
+                "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+                "status": "inactive",
+                "ready": False,
+                "readyToStart": False,
+                "reason": "not_ssh_transport",
+                "tunnelBaseUrl": None,
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            }
+        )
+
+    monkeypatch.setattr(rps, "_fetch_egress_health", fake_fetch)
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", fake_ssh_supervisor)
+
+    resp = test_client.get(
+        "/api/remote-provider/status",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["peer"] == {
+        "configured": True,
+        "ready": False,
+        "reason": "missing_peer_token",
+        "controlBaseUrl": "https://peer.example.test",
+        "transport": "direct",
+        "token": {"configured": False, "bytes": 0},
+    }
     assert body["capabilities"]["odsPeerLifecycle"] is False
 
 

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -16,11 +16,13 @@ from remote_provider.policy import (  # noqa: E402
     ACTIVATION_RECEIPT_SCHEMA,
     FORBIDDEN_PUBLIC_SECRET_ENV,
     INTERNAL_EGRESS_BASE_URL,
+    INTERNAL_SSH_CONTROL_BASE_URL,
     PUBLIC_MODEL_ALIAS,
     REDACTED,
     SCHEMA,
     PolicyError,
     load_policy,
+    normalize_peer_control_url,
     normalize_provider_base_url,
     plan_route,
     public_activation_receipt,
@@ -219,6 +221,54 @@ def test_direct_normalizes_public_https_roots() -> None:
     )
 
 
+def test_direct_peer_lifecycle_requires_safe_public_control_url() -> None:
+    route = plan_route(
+        cloud_direct_env(REMOTE_ODS_PEER_URL="https://Peer.example.test/")
+    )
+    assert_true(
+        route["peer"] == {
+            "controlBaseUrl": "https://peer.example.test",
+            "transport": "direct",
+        },
+        "direct peer control URL should normalize to a public HTTPS root",
+    )
+    assert_true(
+        normalize_peer_control_url(
+            "https://Peer.example.test:9443/",
+            transport="direct",
+        )
+        == "https://peer.example.test:9443",
+        "direct peer control URL should preserve a safe explicit port",
+    )
+    receipt = public_activation_receipt(
+        route,
+        phase="validate",
+        ok=True,
+        detail="metadata accepted",
+    )
+    assert_true(
+        receipt["peer"] == route["peer"],
+        "activation receipts should expose safe peer metadata",
+    )
+    unsafe_urls = [
+        "http://peer.example.test",
+        "https://user:token@peer.example.test",
+        "https://peer.example.test?tenant=ods",
+        "https://peer.example.test#fragment",
+        "https://peer.example.test/api",
+        "https://peer.example.test\\api",
+        "https://127.0.0.1:8091",
+        "https://10.0.0.5",
+        "https://localhost",
+        "https://host.docker.internal",
+    ]
+    for url in unsafe_urls:
+        assert_raises_policy_error(
+            lambda url=url: plan_route(cloud_direct_env(REMOTE_ODS_PEER_URL=url)),
+            f"direct transport accepted unsafe peer URL: {url}",
+        )
+
+
 def test_direct_rejects_unsafe_urls() -> None:
     unsafe_urls = [
         "http://gpu.example.test/v1",
@@ -256,6 +306,38 @@ def test_ssh_allows_remote_side_http_with_required_metadata() -> None:
     assert_true(
         route["ssh"]["inferencePort"] == 8000,
         "SSH inference port must be numeric",
+    )
+
+
+def test_ssh_peer_lifecycle_uses_control_tunnel_boundary() -> None:
+    route = plan_route(
+        cloud_ssh_env(
+            REMOTE_LLM_SSH_CONTROL_HOST="127.0.0.1",
+            REMOTE_LLM_SSH_CONTROL_PORT="8091",
+        )
+    )
+    assert_true(
+        route["peer"] == {
+            "controlBaseUrl": INTERNAL_SSH_CONTROL_BASE_URL,
+            "transport": "ssh",
+        },
+        "SSH peer lifecycle should default to the owned control tunnel",
+    )
+    dumped = json.dumps(route, sort_keys=True)
+    assert_true("REMOTE_ODS_PEER_TOKEN" not in dumped, "peer token ref leaked into route")
+    assert_true(
+        plan_route(cloud_ssh_env())["peer"] is None,
+        "SSH routes without a control tunnel should not imply peer lifecycle",
+    )
+    explicit = plan_route(
+        cloud_ssh_env(REMOTE_ODS_PEER_URL="http://127.0.0.1:8091/")
+    )
+    assert_true(
+        explicit["peer"] == {
+            "controlBaseUrl": "http://127.0.0.1:8091",
+            "transport": "ssh",
+        },
+        "SSH peer lifecycle should accept explicit remote-side HTTP roots",
     )
 
 
@@ -516,6 +598,40 @@ def test_lifecycle_configure_operation_is_redacted_and_typed() -> None:
     assert_true("unit-test-provider-token" not in dumped, "provider secret leaked into lifecycle operation")
 
 
+def test_lifecycle_peer_operation_tracks_peer_token_without_leaks() -> None:
+    operation = plan_lifecycle_operation(
+        {
+            "action": "configure",
+            "provider": {
+                "transport": "direct",
+                "baseUrl": "https://gpu.example.test",
+                "model": "qwen/remote:latest",
+            },
+            "peer": {"controlBaseUrl": "https://peer.example.test/"},
+            "secrets": {
+                "apiKey": "unit-test-provider-token",
+                "peerToken": "unit-test-peer-token",
+            },
+        }
+    )
+    dumped = json.dumps(operation, sort_keys=True)
+    assert_true(
+        operation["route"]["peer"] == {
+            "controlBaseUrl": "https://peer.example.test",
+            "transport": "direct",
+        },
+        "peer route metadata missing from lifecycle operation",
+    )
+    assert_true(operation["writes"]["peerToken"] is True, "configure must write peer token custody")
+    assert_true("REMOTE_ODS_PEER_TOKEN" in operation["secretRefs"], "peer token ref missing")
+    assert_true(
+        operation["secretRefs"]["REMOTE_ODS_PEER_TOKEN"]["value"] == REDACTED,
+        "peer token must be redacted",
+    )
+    assert_true("unit-test-peer-token" not in dumped, "peer token leaked")
+    assert_true("peer-token" not in dumped, "peer token file name leaked")
+
+
 def test_lifecycle_test_disable_and_remove_write_intent() -> None:
     validate = plan_lifecycle_operation(
         {
@@ -531,6 +647,7 @@ def test_lifecycle_test_disable_and_remove_write_intent() -> None:
         validate["writes"] == {
             "routingState": False,
             "providerSecret": False,
+            "peerToken": False,
             "sshIdentity": False,
             "sshKnownHosts": False,
             "removesRoutingState": False,
@@ -768,8 +885,10 @@ def main() -> int:
     tests = [
         test_policy_document_shape,
         test_direct_normalizes_public_https_roots,
+        test_direct_peer_lifecycle_requires_safe_public_control_url,
         test_direct_rejects_unsafe_urls,
         test_ssh_allows_remote_side_http_with_required_metadata,
+        test_ssh_peer_lifecycle_uses_control_tunnel_boundary,
         test_ssh_requires_transport_metadata,
         test_ssh_transport_specs_are_structured_and_hardened,
         test_ssh_transport_specs_reject_unsafe_tokens,
@@ -781,6 +900,7 @@ def main() -> int:
         test_activation_transaction_orders_phases,
         test_activation_transaction_fails_closed_and_rolls_back_after_commit,
         test_lifecycle_configure_operation_is_redacted_and_typed,
+        test_lifecycle_peer_operation_tracks_peer_token_without_leaks,
         test_lifecycle_test_disable_and_remove_write_intent,
         test_lifecycle_ssh_operation_tracks_secret_custody_without_leaks,
         test_lifecycle_rejects_unsafe_or_secret_public_inputs,


### PR DESCRIPTION
## Summary
- Add safe remote ODS peer control-plane metadata to remote-provider route planning.
- Carry peer lifecycle inputs through host-agent lifecycle planning and expose a redacted peer-token write intent.
- Report Dashboard peer lifecycle readiness from sanitized route state plus host-owned peer-token custody status.

## Why
This adds the read-only foundation for authenticated ODS-to-ODS model management without exposing peer tokens or unsafe direct peer URLs in public route state or support bundles.

## Validation
- Local: `python ods/tests/contracts/test-remote-provider-egress-policy.py`
- Local: `python ods/tests/contracts/test-remote-provider-cli.py`
- Local: `python ods/tests/contracts/test-ods-cli-contracts.py`
- Local: `python -m pytest tests/test_remote_provider_status.py` from `ods/extensions/services/dashboard-api`
- Local: `python -m compileall ods/bin/remote_provider ods/extensions/services/dashboard-api/routers/remote_provider_status.py`
- Local: `git diff --check`
- Tower2 exact SHA `c3c97ce30ff351c93af219dd1c3f175243200f68`: targeted checks plus full `bash scripts/release-gate.sh`
- Tower2 log: `/home/michael/ods-pr-peer-readiness-c3c97ce30ff3.log`