### PR TITLE
Add remote ODS peer model proxy

### DIFF
--- a/ods/bin/remote_provider/policy.py
+++ b/ods/bin/remote_provider/policy.py
@@ -224,9 +224,15 @@ def normalize_peer_control_url(value: str, *, transport: str) -> str:
     parts = urlsplit(raw)
     if not parts.scheme or not parts.netloc:
         raise PolicyError("remote ODS peer URL must include scheme and host")
-    allowed_schemes = {"https"} if transport_name == "direct" else {"http", "https"}
-    if parts.scheme.lower() not in allowed_schemes:
-        allowed = ", ".join(sorted(allowed_schemes))
+    scheme = parts.scheme.lower()
+    if scheme != "https" and not (
+        transport_name == "ssh"
+        and scheme == "http"
+        and (parts.hostname or "").lower() == "remote-provider-ssh-tunnel"
+    ):
+        allowed = "https"
+        if transport_name == "ssh":
+            allowed += ", or http for remote-provider-ssh-tunnel"
         raise PolicyError(f"{transport_name} peer transport requires scheme: {allowed}")
     if parts.username or parts.password:
         raise PolicyError("remote ODS peer URL must not embed credentials")
@@ -249,13 +255,16 @@ def normalize_peer_control_url(value: str, *, transport: str) -> str:
         raise PolicyError("remote ODS peer URL host must not include a zone id")
 
     lower_host = host.lower()
-    if transport_name == "direct":
+    if lower_host == "remote-provider-ssh-tunnel":
+        if transport_name != "ssh" or scheme != "http" or port != 18092:
+            raise PolicyError("remote ODS peer tunnel URL must use the SSH control tunnel")
+    else:
         if lower_host in LOCAL_HOSTNAMES or lower_host.endswith(".localhost"):
-            raise PolicyError("direct remote ODS peer URL must not target local hostnames")
+            raise PolicyError("remote ODS peer URL must not target local hostnames")
         forbidden_class = classify_forbidden_ip_address(lower_host)
         if forbidden_class:
             raise PolicyError(
-                f"direct remote ODS peer URL must not use {forbidden_class} IP literals"
+                f"remote ODS peer URL must not use {forbidden_class} IP literals"
             )
 
     path = parts.path.rstrip("/")

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import os
 from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -27,12 +29,24 @@ router = APIRouter(tags=["remote-provider"])
 ROUTE_STATE_SCHEMA = "ods.remote-routing-state.v1"
 EGRESS_URL = os.environ.get("REMOTE_PROVIDER_EGRESS_URL", "http://remote-provider-egress:8091")
 EGRESS_TIMEOUT_SECONDS = 3.0
+PEER_PROXY_TIMEOUT_SECONDS = 30.0
+PEER_PROXY_LOAD_TIMEOUT_SECONDS = 2700.0
+PEER_PROXY_RESPONSE_MAX_BYTES = 2_000_000
+PEER_REDACTED = "[REDACTED]"
 
 _SAFE_PROVIDER_KEYS = {"capability", "baseUrl", "model", "transport"}
 _SAFE_PROJECTION_KEYS = {"publicModel", "gateway", "egressBaseUrl", "consumerRoute"}
 _SSH_SUPERVISOR_SCHEMA = "ods.remote-provider-ssh-supervisor-plan.v1"
 _EGRESS_PROBE_SCHEMA = "ods.remote-provider-egress-probe.v1"
 _PROOF_RECORD_SCHEMA = "ods.remote-provider-proof-record.v1"
+_SSH_CONTROL_TUNNEL_HOST = "remote-provider-ssh-tunnel"
+_SSH_CONTROL_TUNNEL_PORT = 18092
+_LOCAL_HOSTNAMES = {
+    "gateway.docker.internal",
+    "host.docker.internal",
+    "localhost",
+    "localhost.localdomain",
+}
 _EGRESS_ERROR_MESSAGES = {
     "invalid_route": "Remote provider route is invalid",
     "invalid_route_state": "Remote provider route state is invalid",
@@ -218,6 +232,169 @@ def _safe_secret_file_status(path: Path) -> dict[str, Any]:
     return {"configured": metadata.st_size > 0, "bytes": metadata.st_size}
 
 
+def _classify_forbidden_ip_address(host: str) -> str:
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return ""
+    if address.version == 4 and str(address) == "255.255.255.255":
+        return "broadcast"
+    if address.is_loopback:
+        return "loopback"
+    if address.is_link_local:
+        return "link_local"
+    if address.is_multicast:
+        return "multicast"
+    if address.is_unspecified:
+        return "unspecified"
+    if address.is_private:
+        return "private"
+    if address.is_reserved:
+        return "reserved"
+    if not address.is_global:
+        return "non_global"
+    return ""
+
+
+def _peer_model_error(reason: str, message: str, *, status_code: int = 409) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail={
+            "error": "remote_peer_unavailable",
+            "reason": reason,
+            "message": message,
+        },
+    )
+
+
+def _validated_peer_control_base_url(route_state: Mapping[str, Any]) -> str:
+    if route_state.get("valid") is not True:
+        raise _peer_model_error(
+            "invalid_route_state",
+            "Remote ODS peer route state is invalid.",
+        )
+    if route_state.get("enabled") is not True:
+        raise _peer_model_error(
+            "not_configured",
+            "Remote ODS peer lifecycle is not configured.",
+        )
+    peer = _safe_peer_metadata(route_state.get("peer"))
+    base_url = peer.get("controlBaseUrl") or ""
+    transport = peer.get("transport") or ""
+    if not base_url:
+        raise _peer_model_error(
+            "not_configured",
+            "Remote ODS peer lifecycle is not configured.",
+        )
+    try:
+        parts = urlsplit(base_url)
+        port = parts.port
+    except ValueError as exc:
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer control URL is invalid.",
+        ) from exc
+    if not parts.scheme or not parts.netloc:
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer control URL must include scheme and host.",
+        )
+    if parts.username or parts.password or parts.query or parts.fragment:
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer control URL must not include credentials, query, or fragment.",
+        )
+    path = parts.path.rstrip("/")
+    if path:
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer control URL must be the control-plane root.",
+        )
+    host = parts.hostname or ""
+    lower_host = host.lower()
+    scheme = parts.scheme.lower()
+    if any(char.isspace() for char in host) or "%" in host:
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer control URL host is invalid.",
+        )
+    if (
+        transport == "ssh"
+        and scheme == "http"
+        and lower_host == _SSH_CONTROL_TUNNEL_HOST
+        and port == _SSH_CONTROL_TUNNEL_PORT
+    ):
+        return urlunsplit((scheme, f"{_SSH_CONTROL_TUNNEL_HOST}:{port}", "", "", ""))
+    if lower_host == _SSH_CONTROL_TUNNEL_HOST:
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer tunnel URL must use the owned SSH control tunnel.",
+        )
+    if scheme != "https":
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer model management requires HTTPS or the owned SSH control tunnel.",
+        )
+    if lower_host in _LOCAL_HOSTNAMES or lower_host.endswith(".localhost"):
+        raise _peer_model_error(
+            "invalid_peer_url",
+            "Remote ODS peer control URL must not target local hostnames.",
+        )
+    forbidden_class = _classify_forbidden_ip_address(lower_host)
+    if forbidden_class:
+        raise _peer_model_error(
+            "invalid_peer_url",
+            f"Remote ODS peer control URL must not use {forbidden_class} IP literals.",
+        )
+    netloc = lower_host if port is None else f"{lower_host}:{port}"
+    if ":" in lower_host and not lower_host.startswith("["):
+        netloc = f"[{lower_host}]" if port is None else f"[{lower_host}]:{port}"
+    return urlunsplit((scheme, netloc, "", "", ""))
+
+
+def _read_peer_token() -> str:
+    path = _peer_token_path()
+    try:
+        if path.is_symlink():
+            raise _peer_model_error(
+                "missing_peer_token",
+                "Remote ODS peer token custody is not configured.",
+            )
+        value = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise _peer_model_error(
+            "missing_peer_token",
+            "Remote ODS peer token custody is not configured.",
+        ) from exc
+    except OSError as exc:
+        raise _peer_model_error(
+            "peer_token_unreadable",
+            "Remote ODS peer token custody is unreadable.",
+            status_code=503,
+        ) from exc
+    token = value.strip()
+    if not token or any(ord(char) < 32 or ord(char) == 127 for char in token):
+        raise _peer_model_error(
+            "invalid_peer_token",
+            "Remote ODS peer token custody is invalid.",
+        )
+    return token
+
+
+def _redact_peer_secret(value: Any, token: str) -> Any:
+    if isinstance(value, str):
+        return value.replace(token, PEER_REDACTED) if token else value
+    if isinstance(value, list):
+        return [_redact_peer_secret(item, token) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key).replace(token, PEER_REDACTED): _redact_peer_secret(item, token)
+            for key, item in value.items()
+            if isinstance(key, str)
+        }
+    return value
+
+
 def _peer_status(
     route_state: Mapping[str, Any],
     ssh_supervisor: Mapping[str, Any],
@@ -237,9 +414,7 @@ def _peer_status(
         reason = "not_configured"
     elif not token.get("configured"):
         reason = "missing_peer_token"
-    elif peer.get("transport") == "ssh" and not (
-        ssh_supervisor.get("ready") or ssh_supervisor.get("readyToStart")
-    ):
+    elif peer.get("transport") == "ssh" and not ssh_supervisor.get("ready"):
         reason = "ssh_control_tunnel_not_ready"
     else:
         ready = True
@@ -626,6 +801,114 @@ async def _post_egress_probe() -> dict[str, Any]:
         ) from exc
 
 
+def _safe_peer_model_id(model_id: str) -> str:
+    model = _safe_text(model_id, max_length=256)
+    if not model:
+        raise HTTPException(status_code=400, detail="Remote peer model id is required.")
+    if "/" in model or "\\" in model or model in {".", ".."}:
+        raise HTTPException(status_code=400, detail="Remote peer model id is invalid.")
+    return model
+
+
+def _peer_model_action_path(model_id: str, action: str = "") -> str:
+    encoded = quote(_safe_peer_model_id(model_id), safe="")
+    suffix = f"/{action}" if action else ""
+    return f"/api/models/{encoded}{suffix}"
+
+
+def _peer_response_json(response: httpx.Response, token: str) -> Any:
+    content = response.content
+    if len(content) > PEER_PROXY_RESPONSE_MAX_BYTES:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "remote_peer_response_too_large",
+                "message": "Remote ODS peer response exceeded the safety limit.",
+            },
+        )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "invalid_remote_peer_response",
+                "message": "Remote ODS peer returned an invalid JSON response.",
+            },
+        ) from exc
+    return _redact_peer_secret(payload, token)
+
+
+def _peer_http_error(response: httpx.Response, token: str) -> HTTPException:
+    try:
+        detail = _redact_peer_secret(response.json(), token)
+    except ValueError:
+        detail = {
+            "error": "remote_peer_http_error",
+            "message": f"Remote ODS peer returned HTTP {response.status_code}.",
+        }
+    return HTTPException(status_code=response.status_code, detail=detail)
+
+
+async def _peer_model_json_request(
+    method: str,
+    path: str,
+    *,
+    timeout: float = PEER_PROXY_TIMEOUT_SECONDS,
+) -> Any:
+    route_state = _read_route_state()
+    base_url = _validated_peer_control_base_url(route_state)
+    peer = _safe_peer_metadata(route_state.get("peer"))
+    if peer.get("transport") == "ssh":
+        ssh_supervisor = await _fetch_ssh_supervisor_status()
+        if not ssh_supervisor.get("ready"):
+            raise _peer_model_error(
+                "ssh_control_tunnel_not_ready",
+                "Remote ODS peer SSH control tunnel is not running.",
+            )
+    token = _read_peer_token()
+    url = f"{base_url}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.request(
+                method,
+                url,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/json",
+                },
+            )
+    except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "remote_peer_unreachable",
+                "message": "Remote ODS peer is unreachable.",
+            },
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "remote_peer_request_failed",
+                "message": "Remote ODS peer request failed.",
+            },
+        ) from exc
+
+    if response.status_code in {401, 403}:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "remote_peer_auth_rejected",
+                "message": "Remote ODS peer rejected the configured peer token.",
+                "status": response.status_code,
+            },
+        )
+    if response.status_code >= 400:
+        raise _peer_http_error(response, token)
+    return _peer_response_json(response, token)
+
+
 def _overall_status(route_state: Mapping[str, Any], egress: Mapping[str, Any]) -> str:
     if not route_state.get("valid"):
         return "invalid"
@@ -660,6 +943,67 @@ async def remote_provider_status() -> dict[str, Any]:
             "remove": bool(route_state.get("exists")),
         },
     }
+
+
+@router.get("/api/remote-provider/peer/models", dependencies=[Depends(verify_api_key)])
+async def remote_provider_peer_models() -> Any:
+    """List models from the authenticated remote ODS peer."""
+    return await _peer_model_json_request("GET", "/api/models")
+
+
+@router.get(
+    "/api/remote-provider/peer/models/download-status",
+    dependencies=[Depends(verify_api_key)],
+)
+async def remote_provider_peer_model_download_status() -> Any:
+    """Return remote ODS peer model download status."""
+    return await _peer_model_json_request("GET", "/api/models/download-status")
+
+
+@router.post(
+    "/api/remote-provider/peer/models/download/cancel",
+    dependencies=[Depends(verify_api_key)],
+)
+async def remote_provider_peer_cancel_download() -> Any:
+    """Cancel an in-progress remote ODS peer model download."""
+    return await _peer_model_json_request("POST", "/api/models/download/cancel")
+
+
+@router.post(
+    "/api/remote-provider/peer/models/{model_id}/download",
+    dependencies=[Depends(verify_api_key)],
+)
+async def remote_provider_peer_download_model(model_id: str) -> Any:
+    """Start a model download on the authenticated remote ODS peer."""
+    return await _peer_model_json_request(
+        "POST",
+        _peer_model_action_path(model_id, "download"),
+    )
+
+
+@router.post(
+    "/api/remote-provider/peer/models/{model_id}/load",
+    dependencies=[Depends(verify_api_key)],
+)
+async def remote_provider_peer_load_model(model_id: str) -> Any:
+    """Activate a model on the authenticated remote ODS peer."""
+    return await _peer_model_json_request(
+        "POST",
+        _peer_model_action_path(model_id, "load"),
+        timeout=PEER_PROXY_LOAD_TIMEOUT_SECONDS,
+    )
+
+
+@router.delete(
+    "/api/remote-provider/peer/models/{model_id}",
+    dependencies=[Depends(verify_api_key)],
+)
+async def remote_provider_peer_delete_model(model_id: str) -> Any:
+    """Delete a downloaded model on the authenticated remote ODS peer."""
+    return await _peer_model_json_request(
+        "DELETE",
+        _peer_model_action_path(model_id),
+    )
 
 
 @router.post("/api/remote-provider/plan", dependencies=[Depends(verify_api_key)])

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -327,6 +327,262 @@ def test_remote_provider_status_blocks_peer_lifecycle_without_token(
     assert body["capabilities"]["odsPeerLifecycle"] is False
 
 
+def test_remote_provider_peer_models_proxies_with_redacted_peer_token(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    secret_dir = state_root / "secrets"
+    secret_dir.mkdir(parents=True)
+    (secret_dir / "peer-token").write_bytes(b"unit-test-peer-token\n")
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "https://peer.example.test",
+                    "transport": "direct",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        content = b'{"models":[{"id":"remote-qwen"}],"echo":"unit-test-peer-token"}'
+
+        def json(self):
+            return {"models": [{"id": "remote-qwen"}], "echo": "unit-test-peer-token"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def request(self, method, url, headers):
+            captured.update({"method": method, "url": url, "headers": headers})
+            return FakeResponse()
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.get(
+        "/api/remote-provider/peer/models",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    dumped = json.dumps(body, sort_keys=True)
+    assert body == {"models": [{"id": "remote-qwen"}], "echo": "[REDACTED]"}
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://peer.example.test/api/models"
+    assert captured["headers"]["Authorization"] == "Bearer unit-test-peer-token"
+    assert captured["timeout"] == rps.PEER_PROXY_TIMEOUT_SECONDS
+    assert "unit-test-peer-token" not in dumped
+
+
+def test_remote_provider_peer_model_load_uses_long_timeout_and_encoded_model_id(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    secret_dir = state_root / "secrets"
+    secret_dir.mkdir(parents=True)
+    (secret_dir / "peer-token").write_bytes(b"unit-test-peer-token\n")
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "https://peer.example.test",
+                    "transport": "direct",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        content = b'{"status":"activated"}'
+
+        def json(self):
+            return {"status": "activated"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def request(self, method, url, headers):
+            captured.update({"method": method, "url": url, "headers": headers})
+            return FakeResponse()
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.post(
+        "/api/remote-provider/peer/models/Qwen%203.5-9B/load",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "activated"}
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://peer.example.test/api/models/Qwen%203.5-9B/load"
+    assert captured["timeout"] == rps.PEER_PROXY_LOAD_TIMEOUT_SECONDS
+
+
+def test_remote_provider_peer_models_fail_closed_without_peer_token(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    state_root.mkdir(parents=True)
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "https://peer.example.test",
+                    "transport": "direct",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("missing peer token should prevent proxy request")
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.get(
+        "/api/remote-provider/peer/models",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason"] == "missing_peer_token"
+
+
+def test_remote_provider_peer_models_reject_unsafe_peer_url(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    secret_dir = state_root / "secrets"
+    secret_dir.mkdir(parents=True)
+    (secret_dir / "peer-token").write_bytes(b"unit-test-peer-token\n")
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "http://127.0.0.1:8091",
+                    "transport": "direct",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("unsafe peer URL should prevent proxy request")
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.get(
+        "/api/remote-provider/peer/models",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason"] == "invalid_peer_url"
+
+
+def test_remote_provider_peer_models_require_running_ssh_control_tunnel(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    secret_dir = state_root / "secrets"
+    secret_dir.mkdir(parents=True)
+    (secret_dir / "peer-token").write_bytes(b"unit-test-peer-token\n")
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "http://remote-provider-ssh-tunnel:18092",
+                    "transport": "ssh",
+                },
+                transport="ssh",
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+
+    async def fake_ssh_supervisor():
+        return rps._safe_ssh_supervisor_status(
+            {
+                "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+                "status": "planned",
+                "ready": False,
+                "readyToStart": True,
+                "reason": "tunnel_process_not_started",
+                "tunnelBaseUrl": "http://remote-provider-ssh-tunnel:18091/v1",
+                "tunnels": [],
+                "secrets": {},
+                "missingSecrets": [],
+            }
+        )
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("stopped SSH tunnel should prevent proxy request")
+
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", fake_ssh_supervisor)
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.get(
+        "/api/remote-provider/peer/models",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason"] == "ssh_control_tunnel_not_ready"
+
+
 def test_remote_provider_status_exposes_sanitized_egress_tunnel_health(
     test_client,
     monkeypatch,

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -329,15 +329,17 @@ def test_ssh_peer_lifecycle_uses_control_tunnel_boundary() -> None:
         plan_route(cloud_ssh_env())["peer"] is None,
         "SSH routes without a control tunnel should not imply peer lifecycle",
     )
-    explicit = plan_route(
-        cloud_ssh_env(REMOTE_ODS_PEER_URL="http://127.0.0.1:8091/")
-    )
+    explicit = plan_route(cloud_ssh_env(REMOTE_ODS_PEER_URL="https://peer.example.test/"))
     assert_true(
         explicit["peer"] == {
-            "controlBaseUrl": "http://127.0.0.1:8091",
+            "controlBaseUrl": "https://peer.example.test",
             "transport": "ssh",
         },
-        "SSH peer lifecycle should accept explicit remote-side HTTP roots",
+        "SSH peer lifecycle should accept explicit public HTTPS roots",
+    )
+    assert_raises_policy_error(
+        lambda: plan_route(cloud_ssh_env(REMOTE_ODS_PEER_URL="http://127.0.0.1:8091/")),
+        "SSH explicit peer URLs must not target container-local HTTP",
     )
 
 


### PR DESCRIPTION
## Summary
- Add authenticated Dashboard API proxy endpoints for remote ODS peer model inventory, download, load, cancel, and removal.
- Fail closed on unsafe peer control URLs while preserving the internal SSH control-tunnel boundary.
- Forward only the stored peer bearer token, require a running SSH tunnel before SSH peer proxying, and redact peer secrets from upstream JSON and error payloads.

## Validation
- `python ods\tests\contracts\test-remote-provider-egress-policy.py`
- `python ods\tests\contracts\test-remote-provider-cli.py`
- `python ods\tests\contracts\test-ods-cli-contracts.py`
- `(cd ods\extensions\services\dashboard-api; python -m pytest tests\test_remote_provider_status.py)`
- `python -m compileall ods\bin\remote_provider ods\extensions\services\dashboard-api\routers\remote_provider_status.py`
- `git diff --check`
- Tower2 exact-SHA gate for `4d1e42c1a6fd5f9532c6c22f6d6cd918134bcd58`: PASS, log `/home/michael/ods-pr-peer-model-proxy-4d1e42c1a6fd.log`