### PR TITLE
Add remote provider peer model UI

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -19,6 +19,8 @@ import {
 const REQUEST_TIMEOUT_MS = 12000
 const PROBE_TIMEOUT_MS = 22000
 const LIFECYCLE_TIMEOUT_MS = 30000
+const PEER_MODELS_TIMEOUT_MS = 30000
+const PEER_MODEL_LOAD_TIMEOUT_MS = 2705000
 const INITIAL_FORM = {
   baseUrl: '',
   model: '',
@@ -44,6 +46,11 @@ function titleize(value) {
 
 function boolLabel(value) {
   return value ? 'Yes' : 'No'
+}
+
+function percentLabel(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return `${Math.max(0, Math.min(100, Math.round(value)))}%`
 }
 
 function valueOrDash(value) {
@@ -90,6 +97,37 @@ function routeSummary(result) {
   if (provider.model) return `${provider.model} via ${provider.transport || 'direct'}`
   if (result?.route?.enabled === false) return 'Disabled route'
   return 'None'
+}
+
+function modelLabel(model) {
+  return model?.name || model?.id || 'Unnamed model'
+}
+
+function modelStatus(model, currentModel) {
+  if (model?.id && currentModel === model.id) return 'loaded'
+  return typeof model?.status === 'string' && model.status.trim() ? model.status.trim() : 'unknown'
+}
+
+function modelSize(model) {
+  if (model?.size) return model.size
+  if (typeof model?.sizeGb === 'number' && Number.isFinite(model.sizeGb)) return `${model.sizeGb.toFixed(1)} GB`
+  return null
+}
+
+function isDownloadedPeerModel(status) {
+  return status === 'downloaded' || status === 'loaded'
+}
+
+function peerDownloadActive(status) {
+  return Boolean(status?.active || status?.isDownloading || status?.status === 'downloading')
+}
+
+function peerDownloadSummary(status) {
+  if (!status || status.status === 'idle') return 'Idle'
+  const label = titleize(status.status)
+  const model = status.model || status.modelId || status.activeModelId
+  const percent = percentLabel(status.percent)
+  return [label, model, percent].filter(Boolean).join(' - ')
 }
 
 function lifecycleTitle(result) {
@@ -269,6 +307,11 @@ export default function RemoteProvider() {
   const [planResult, setPlanResult] = useState(null)
   const [lifecycleResult, setLifecycleResult] = useState(null)
   const [lifecycleError, setLifecycleError] = useState(null)
+  const [peerModelsData, setPeerModelsData] = useState(null)
+  const [peerDownloadStatus, setPeerDownloadStatus] = useState(null)
+  const [peerModelsLoading, setPeerModelsLoading] = useState(false)
+  const [peerModelsError, setPeerModelsError] = useState(null)
+  const [peerAction, setPeerAction] = useState(null)
 
   const loadStatus = useCallback(async ({ quiet = false } = {}) => {
     if (!quiet) setLoading(true)
@@ -285,9 +328,39 @@ export default function RemoteProvider() {
     }
   }, [])
 
+  const loadPeerModels = useCallback(async ({ quiet = false } = {}) => {
+    if (!quiet) setPeerModelsLoading(true)
+    setPeerModelsError(null)
+    try {
+      const [modelsPayload, downloadPayload] = await Promise.all([
+        fetchJson('/api/remote-provider/peer/models', {}, PEER_MODELS_TIMEOUT_MS),
+        fetchJson('/api/remote-provider/peer/models/download-status', {}, PEER_MODELS_TIMEOUT_MS),
+      ])
+      setPeerModelsData(modelsPayload)
+      setPeerDownloadStatus(downloadPayload)
+      return modelsPayload
+    } catch (err) {
+      setPeerModelsError(err?.message || 'Failed to load peer models')
+      return null
+    } finally {
+      if (!quiet) setPeerModelsLoading(false)
+    }
+  }, [])
+
   useEffect(() => {
     void loadStatus()
   }, [loadStatus])
+
+  useEffect(() => {
+    if (!statusData) return
+    if (!statusData.capabilities?.odsPeerLifecycle) {
+      setPeerModelsData(null)
+      setPeerDownloadStatus(null)
+      setPeerModelsError(null)
+      return
+    }
+    void loadPeerModels()
+  }, [loadPeerModels, statusData?.capabilities?.odsPeerLifecycle, statusData])
 
   useEffect(() => {
     const provider = statusData?.routeState?.provider
@@ -357,17 +430,59 @@ export default function RemoteProvider() {
     }
   }
 
+  const runPeerModelAction = async (kind, model) => {
+    const modelId = model?.id
+    if (!modelId) return
+    if (kind === 'delete' && typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      if (!window.confirm(`Delete ${modelLabel(model)} from the remote ODS peer?`)) return
+    }
+    const encodedModelId = encodeURIComponent(modelId)
+    const method = kind === 'delete' ? 'DELETE' : 'POST'
+    const path = kind === 'delete'
+      ? `/api/remote-provider/peer/models/${encodedModelId}`
+      : `/api/remote-provider/peer/models/${encodedModelId}/${kind}`
+    const timeout = kind === 'load' ? PEER_MODEL_LOAD_TIMEOUT_MS : PEER_MODELS_TIMEOUT_MS
+    setPeerAction({ kind, modelId })
+    setPeerModelsError(null)
+    try {
+      await fetchJson(path, { method }, timeout)
+      await loadPeerModels({ quiet: true })
+    } catch (err) {
+      setPeerModelsError(err?.message || `Peer model ${kind} failed`)
+    } finally {
+      setPeerAction(null)
+    }
+  }
+
+  const cancelPeerDownload = async () => {
+    setPeerAction({ kind: 'cancel', modelId: null })
+    setPeerModelsError(null)
+    try {
+      await fetchJson('/api/remote-provider/peer/models/download/cancel', { method: 'POST' }, PEER_MODELS_TIMEOUT_MS)
+      await loadPeerModels({ quiet: true })
+    } catch (err) {
+      setPeerModelsError(err?.message || 'Peer model download cancel failed')
+    } finally {
+      setPeerAction(null)
+    }
+  }
+
   const routeState = statusData?.routeState || {}
   const provider = routeState.provider || {}
   const routeStatus = routeState.status || {}
   const egress = statusData?.egress || {}
   const sshSupervisor = statusData?.sshSupervisor || {}
+  const peer = statusData?.peer || {}
   const testEnabled = Boolean(statusData?.availableActions?.test)
   const statusMeta = STATUS_META[statusData?.status] || STATUS_META.unknown
   const lifecycleBusy = planning || Boolean(applyingAction)
   const configureReady = Boolean(form.baseUrl.trim() && form.model.trim() && form.apiKey.trim()) && !lifecycleBusy
   const proofReceipt = testResult?.probe || routeStatus.lastProbe
   const proofRecorded = testResult?.routeProof?.recorded
+  const peerReady = Boolean(statusData?.capabilities?.odsPeerLifecycle)
+  const peerModels = Array.isArray(peerModelsData?.models) ? peerModelsData.models : []
+  const peerBusy = peerModelsLoading || Boolean(peerAction)
+  const peerDownloadBusy = peerDownloadActive(peerDownloadStatus)
   const proofSummary = useMemo(() => {
     if (!testResult?.routeProof) return null
     if (proofRecorded) return 'Route proof recorded'
@@ -478,6 +593,126 @@ export default function RemoteProvider() {
             <KeyRound size={14} />
             {statusMeta.label}
           </div>
+        </Panel>
+
+        <Panel
+          icon={Cloud}
+          title="ODS Peer Models"
+          className="lg:col-span-2"
+          actions={(
+            <ActionButton icon={RefreshCw} onClick={() => loadPeerModels()} disabled={!peerReady || peerBusy}>
+              {peerModelsLoading ? 'Refreshing' : 'Refresh peer models'}
+            </ActionButton>
+          )}
+        >
+          <div className="grid gap-2 md:grid-cols-4">
+            <Field label="Peer ready" value={boolLabel(peerReady)} tone={peerReady ? 'text-emerald-300' : 'text-amber-300'} />
+            <Field label="Transport" value={peer.transport} />
+            <Field label="Token" value={peer.token?.configured ? 'Configured' : 'Missing'} tone={peer.token?.configured ? 'text-emerald-300' : 'text-amber-300'} />
+            <Field label="Reason" value={titleize(peer.reason)} />
+          </div>
+
+          {!peerReady && (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100" role="status">
+              Peer model management unavailable: {titleize(peer.reason)}
+            </div>
+          )}
+
+          {peerModelsError && (
+            <div className="flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+              <AlertCircle size={16} />
+              {peerModelsError}
+            </div>
+          )}
+
+          {peerReady && (
+            <>
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-theme-border/70 bg-black/10 px-3 py-2 text-sm">
+                <span className="text-theme-text-muted">Download status</span>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={peerDownloadBusy ? 'font-semibold text-amber-300' : 'font-medium text-theme-text'}>
+                    {peerDownloadSummary(peerDownloadStatus)}
+                  </span>
+                  <ActionButton icon={Power} onClick={cancelPeerDownload} disabled={!peerDownloadBusy || peerBusy} danger>
+                    {peerAction?.kind === 'cancel' ? 'Cancelling' : 'Cancel download'}
+                  </ActionButton>
+                </div>
+              </div>
+
+              {peerModelsLoading && !peerModels.length ? (
+                <div className="flex min-h-[120px] items-center justify-center text-sm text-theme-text-muted">
+                  <Loader2 className="mr-2 animate-spin" size={16} />
+                  Loading peer models
+                </div>
+              ) : peerModels.length === 0 ? (
+                <div className="rounded-lg border border-theme-border/70 bg-black/10 p-3 text-sm text-theme-text-muted" role="status">
+                  No peer models found
+                </div>
+              ) : (
+                <div className="overflow-hidden rounded-lg border border-theme-border/70">
+                  <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-theme-border/70 bg-black/10 px-3 py-2 text-xs font-semibold uppercase text-theme-text-muted md:grid-cols-[minmax(0,1.2fr)_120px_120px_auto]">
+                    <span>Model</span>
+                    <span className="hidden md:block">Status</span>
+                    <span className="hidden md:block">Size</span>
+                    <span className="text-right">Actions</span>
+                  </div>
+                  <div className="divide-y divide-theme-border/70">
+                    {peerModels.map((model, index) => {
+                      const modelId = model?.id || ''
+                      const status = modelStatus(model, peerModelsData?.currentModel)
+                      const downloaded = isDownloadedPeerModel(status)
+                      const loaded = status === 'loaded'
+                      const rowBusy = peerAction?.modelId === modelId
+                      const actionDisabled = !modelId || peerBusy
+                      return (
+                        <div key={modelId || index} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-3 md:grid-cols-[minmax(0,1.2fr)_120px_120px_auto]">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-semibold text-theme-text">{modelLabel(model)}</div>
+                            {modelId && modelId !== modelLabel(model) && (
+                              <div className="truncate text-xs text-theme-text-muted">{modelId}</div>
+                            )}
+                            <div className="mt-1 flex flex-wrap gap-2 text-xs text-theme-text-muted md:hidden">
+                              <span>{titleize(status)}</span>
+                              {modelSize(model) && <span>{modelSize(model)}</span>}
+                            </div>
+                          </div>
+                          <span className={`hidden text-sm font-medium md:block ${loaded ? 'text-emerald-300' : downloaded ? 'text-theme-text' : 'text-theme-text-muted'}`}>
+                            {titleize(status)}
+                          </span>
+                          <span className="hidden text-sm text-theme-text-muted md:block">{valueOrDash(modelSize(model))}</span>
+                          <div className="flex flex-wrap justify-end gap-2">
+                            <ActionButton
+                              icon={Cloud}
+                              onClick={() => runPeerModelAction('download', model)}
+                              disabled={actionDisabled || downloaded}
+                            >
+                              {rowBusy && peerAction?.kind === 'download' ? 'Starting' : 'Download'}
+                            </ActionButton>
+                            <ActionButton
+                              icon={Play}
+                              onClick={() => runPeerModelAction('load', model)}
+                              disabled={actionDisabled || !downloaded || loaded}
+                              primary
+                            >
+                              {rowBusy && peerAction?.kind === 'load' ? 'Loading' : loaded ? 'Loaded' : 'Load'}
+                            </ActionButton>
+                            <ActionButton
+                              icon={Trash2}
+                              onClick={() => runPeerModelAction('delete', model)}
+                              disabled={actionDisabled || !downloaded || loaded}
+                              danger
+                            >
+                              {rowBusy && peerAction?.kind === 'delete' ? 'Deleting' : 'Delete'}
+                            </ActionButton>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
         </Panel>
 
         <Panel icon={KeyRound} title="Configure" className="lg:col-span-2">

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -43,6 +43,14 @@ const statusPayload = {
     },
     errors: [],
   },
+  peer: {
+    configured: false,
+    ready: false,
+    reason: 'missing_peer_token',
+    controlBaseUrl: null,
+    transport: null,
+    token: { configured: false, bytes: 0 },
+  },
   sshSupervisor: {
     reachable: true,
     valid: true,
@@ -71,6 +79,61 @@ const statusPayload = {
     disable: true,
     remove: true,
   },
+}
+
+const peerReadyStatusPayload = {
+  ...statusPayload,
+  peer: {
+    configured: true,
+    ready: true,
+    reason: 'ready',
+    controlBaseUrl: 'http://remote-provider-ssh-tunnel:18092',
+    transport: 'ssh',
+    token: { configured: true, bytes: 20 },
+  },
+  capabilities: {
+    ...statusPayload.capabilities,
+    odsPeerLifecycle: true,
+  },
+}
+
+const peerModelsPayload = {
+  models: [
+    {
+      id: 'Qwen/Qwen 3.5 9B',
+      name: 'Remote Qwen',
+      status: 'downloaded',
+      size: '5.2 GB',
+    },
+    {
+      id: 'remote-available',
+      name: 'Remote Available',
+      status: 'available',
+      sizeGb: 2.4,
+    },
+    {
+      id: 'remote-loaded',
+      name: 'Remote Loaded',
+      status: 'loaded',
+      size: '4.0 GB',
+    },
+  ],
+  currentModel: 'remote-loaded',
+  activationReadyModel: 'remote-loaded',
+}
+
+const peerDownloadStatusPayload = {
+  status: 'idle',
+  active: false,
+  isDownloading: false,
+}
+
+const peerActiveDownloadStatusPayload = {
+  status: 'downloading',
+  active: true,
+  isDownloading: true,
+  model: 'remote-available',
+  percent: 42,
 }
 
 const probePayload = {
@@ -356,4 +419,105 @@ test('confirms remove before deleting route state and stored secrets', async () 
   expect(confirmSpy).toHaveBeenCalledWith('Remove remote GPU route and stored secrets?')
   expect(requestBody(1)).toEqual({ action: 'remove' })
   expect(screen.getByText('Remove applied')).toBeInTheDocument()
+})
+
+test('renders peer model inventory when peer lifecycle is ready', async () => {
+  globalThis.fetch
+    .mockResolvedValueOnce(response(peerReadyStatusPayload))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerDownloadStatusPayload))
+
+  render(createElement(RemoteProvider))
+
+  expect(await screen.findByRole('heading', { name: 'Remote GPU' })).toBeInTheDocument()
+  expect(await screen.findByText('Remote Qwen')).toBeInTheDocument()
+  expect(screen.getByText('Remote Available')).toBeInTheDocument()
+  expect(screen.getByText('Remote Loaded')).toBeInTheDocument()
+  expect(screen.getByText('Idle')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /refresh peer models/i })).toBeEnabled()
+  expect(globalThis.fetch.mock.calls.map(call => call[0])).toEqual([
+    '/api/remote-provider/status',
+    '/api/remote-provider/peer/models',
+    '/api/remote-provider/peer/models/download-status',
+  ])
+})
+
+test('loads peer model through encoded proxy endpoint and refreshes inventory', async () => {
+  globalThis.fetch
+    .mockResolvedValueOnce(response(peerReadyStatusPayload))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerDownloadStatusPayload))
+    .mockResolvedValueOnce(response({ status: 'activated' }))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerDownloadStatusPayload))
+
+  render(createElement(RemoteProvider))
+
+  await screen.findByText('Remote Qwen')
+  fireEvent.click(screen.getAllByRole('button', { name: /^load$/i }).find(button => !button.disabled))
+
+  await waitFor(() => {
+    expect(globalThis.fetch).toHaveBeenCalledTimes(6)
+  })
+  expect(globalThis.fetch.mock.calls[3][0]).toBe('/api/remote-provider/peer/models/Qwen%2FQwen%203.5%209B/load')
+  expect(globalThis.fetch.mock.calls[3][1].method).toBe('POST')
+  expect(globalThis.fetch.mock.calls.slice(4).map(call => call[0])).toEqual([
+    '/api/remote-provider/peer/models',
+    '/api/remote-provider/peer/models/download-status',
+  ])
+})
+
+test('starts and cancels peer model download through proxy endpoints', async () => {
+  globalThis.fetch
+    .mockResolvedValueOnce(response(peerReadyStatusPayload))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerActiveDownloadStatusPayload))
+    .mockResolvedValueOnce(response({ status: 'download_started' }))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerActiveDownloadStatusPayload))
+    .mockResolvedValueOnce(response({ status: 'cancelled' }))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerDownloadStatusPayload))
+
+  render(createElement(RemoteProvider))
+
+  expect(await screen.findByText('Downloading - remote-available - 42%')).toBeInTheDocument()
+  fireEvent.click(screen.getAllByRole('button', { name: /^download$/i }).find(button => !button.disabled))
+
+  await waitFor(() => {
+    expect(globalThis.fetch).toHaveBeenCalledTimes(6)
+  })
+  expect(globalThis.fetch.mock.calls[3][0]).toBe('/api/remote-provider/peer/models/remote-available/download')
+  expect(globalThis.fetch.mock.calls[3][1].method).toBe('POST')
+
+  fireEvent.click(screen.getByRole('button', { name: /cancel download/i }))
+
+  await waitFor(() => {
+    expect(globalThis.fetch).toHaveBeenCalledTimes(9)
+  })
+  expect(globalThis.fetch.mock.calls[6][0]).toBe('/api/remote-provider/peer/models/download/cancel')
+  expect(globalThis.fetch.mock.calls[6][1].method).toBe('POST')
+})
+
+test('confirms peer model delete before proxying removal', async () => {
+  const confirmSpy = vi.spyOn(window, 'confirm').mockImplementation(() => true)
+  globalThis.fetch
+    .mockResolvedValueOnce(response(peerReadyStatusPayload))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerDownloadStatusPayload))
+    .mockResolvedValueOnce(response({ status: 'deleted' }))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerDownloadStatusPayload))
+
+  render(createElement(RemoteProvider))
+
+  await screen.findByText('Remote Qwen')
+  fireEvent.click(screen.getAllByRole('button', { name: /^delete$/i }).find(button => !button.disabled))
+
+  await waitFor(() => {
+    expect(globalThis.fetch).toHaveBeenCalledTimes(6)
+  })
+  expect(confirmSpy).toHaveBeenCalledWith('Delete Remote Qwen from the remote ODS peer?')
+  expect(globalThis.fetch.mock.calls[3][0]).toBe('/api/remote-provider/peer/models/Qwen%2FQwen%203.5%209B')
+  expect(globalThis.fetch.mock.calls[3][1].method).toBe('DELETE')
 })


### PR DESCRIPTION
## Summary
- Add an ODS Peer Models panel to the Remote GPU Dashboard page, gated by the sanitized `odsPeerLifecycle` capability.
- List authenticated remote peer inventory and download status through the peer proxy endpoints.
- Add safe Dashboard actions for peer download, load, cancel download, and delete, including encoded model IDs and delete confirmation.

## Validation
- `npm.cmd test -- RemoteProvider.test.jsx`
- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd test`
- `(cd ods\extensions\services\dashboard-api; python -m pytest tests\test_remote_provider_status.py)`
- `git diff --check`
- Tower2 exact-SHA gate for `238b519d64825f207777351aacf09baa1184827c`: PASS, log `/home/michael/ods-pr-peer-model-ui-238b519d6482.log`