### PR TITLE
Add remote provider peer model CLI

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3618,6 +3618,18 @@ Commands:
       Disable the remote-provider route while keeping stored secrets.
   remove
       Delete remote-provider route state and stored secrets.
+  peer-models list [--json]
+      List models from the authenticated remote ODS peer.
+  peer-models download-status [--json]
+      Show remote peer model download status.
+  peer-models download MODEL [--json]
+      Start a model download on the remote ODS peer.
+  peer-models load MODEL [--json]
+      Load a downloaded model on the remote ODS peer.
+  peer-models cancel-download [--json]
+      Cancel an active remote peer model download.
+  peer-models delete MODEL --yes [--json]
+      Delete a downloaded model from the remote ODS peer.
 
 Provider options for configure/test/plan configure/plan test:
   --transport direct|ssh  Provider transport (default direct)
@@ -4008,6 +4020,113 @@ _remote_provider_print_probe_result() {
     ' "$response_file"
 }
 
+_remote_provider_peer_models_usage() {
+    cat <<'EOF'
+Usage: ods remote-provider peer-models <command> [options]
+
+Commands:
+  list [--json]
+      List models from the authenticated remote ODS peer.
+  download-status [--json]
+      Show remote peer model download status.
+  download MODEL [--json]
+      Start a model download on the remote ODS peer.
+  load MODEL [--json]
+      Load a downloaded model on the remote ODS peer.
+  cancel-download [--json]
+      Cancel an active remote peer model download.
+  delete MODEL --yes [--json]
+      Delete a downloaded model from the remote ODS peer.
+
+The CLI talks only to the local Dashboard API. Peer credentials remain in ODS
+secret custody and are never accepted as command arguments.
+EOF
+}
+
+_remote_provider_urlencode() {
+    local value="$1"
+    jq -rn --arg value "$value" '$value | @uri' || \
+        error "Could not encode remote peer model id"
+}
+
+_remote_provider_peer_model_path() {
+    local model_id="$1" action="${2:-}" encoded
+    [[ -n "$model_id" ]] || error "Model id is required"
+    [[ "$model_id" != *$'\n'* && "$model_id" != *$'\r'* ]] || \
+        error "Model id contains invalid newline characters"
+    encoded="$(_remote_provider_urlencode "$model_id")"
+    [[ -n "$encoded" ]] || error "Model id is required"
+    if [[ -n "$action" ]]; then
+        printf '/api/remote-provider/peer/models/%s/%s' "$encoded" "$action"
+    else
+        printf '/api/remote-provider/peer/models/%s' "$encoded"
+    fi
+}
+
+_remote_provider_peer_call() {
+    local method="$1" path="$2" timeout="$3" response_file http_code curl_status detail
+    response_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-peer.XXXXXX") || \
+        error "Could not create a remote-provider peer response file"
+    chmod 600 "$response_file"
+    trap 'rm -f "$response_file"' INT TERM HUP
+    if http_code="$(_remote_provider_request "$method" "$path" "$response_file" "" "$timeout")"; then
+        curl_status=0
+    else
+        curl_status=$?
+    fi
+    if [[ $curl_status -ne 0 ]]; then
+        rm -f "$response_file"; trap - INT TERM HUP
+        error "Remote-provider peer model request failed before Dashboard API completed"
+    fi
+    if [[ "$http_code" != "200" ]]; then
+        detail="$(_remote_provider_response_error "$response_file")"
+        rm -f "$response_file"; trap - INT TERM HUP
+        error "Remote-provider peer model request failed (HTTP $http_code): $detail"
+    fi
+    printf '%s' "$response_file"
+    trap - INT TERM HUP
+}
+
+_remote_provider_print_peer_models() {
+    local response_file="$1"
+    jq -r '
+        (.models // []) as $models |
+        "Remote peer models: \($models | length)",
+        (if (.currentModel // "") != "" then "Current: \(.currentModel)" else empty end),
+        ($models[]? |
+            "- " + (.name // .id // "unknown") +
+            " [" + (.status // "unknown") + "]" +
+            (if (.size // "") != "" then " " + .size
+             elif (.sizeGb // null) != null then " " + ((.sizeGb | tostring) + " GB")
+             else "" end) +
+            (if (.id // "") != "" and (.name // "") != "" and .id != .name then " id=" + .id else "" end)
+        )
+    ' "$response_file"
+}
+
+_remote_provider_print_peer_download_status() {
+    local response_file="$1"
+    jq -r '
+        "Remote peer download: \(.status // "unknown")",
+        (if (.model // .modelId // .activeModelId // "") != "" then
+            "Model: \(.model // .modelId // .activeModelId)"
+         else empty end),
+        (if (.percent // null) != null then "Progress: \(.percent)%" else empty end),
+        (if (.active // .isDownloading // null) != null then
+            "Active: " + (if (.active == true or .isDownloading == true) then "yes" else "no" end)
+         else empty end)
+    ' "$response_file"
+}
+
+_remote_provider_print_peer_action_result() {
+    local label="$1" response_file="$2"
+    jq -r --arg label "$label" '
+        "Remote peer " + $label + ": " +
+            (.status // .message // (if .ok == true then "ok" else "completed" end)),
+        (if (.modelId // .model // "") != "" then "Model: \(.modelId // .model)" else empty end)
+    ' "$response_file"
+}
+
 _remote_provider_probe_configured() {
     local json_mode="false"
     while [[ $# -gt 0 ]]; do
@@ -4046,6 +4165,123 @@ _remote_provider_probe_configured() {
     rm -f "$response_file"; trap - INT TERM HUP
 }
 
+cmd_remote_provider_peer_models() {
+    local subcmd="${1:-list}"
+    shift || true
+
+    case "$subcmd" in
+        help|--help|-h)
+            _remote_provider_peer_models_usage
+            return 0
+            ;;
+        list)
+            local json_mode="false"
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --json) json_mode="true"; shift ;;
+                    --help|-h) _remote_provider_peer_models_usage; return 0 ;;
+                    *) error "Unknown remote-provider peer-models list option: $1" ;;
+                esac
+            done
+            local response_file
+            response_file="$(_remote_provider_peer_call GET /api/remote-provider/peer/models 30)"
+            if [[ "$json_mode" == "true" ]]; then
+                jq . "$response_file"
+            else
+                _remote_provider_print_peer_models "$response_file"
+            fi
+            rm -f "$response_file"
+            ;;
+        download-status|status)
+            local json_mode="false"
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --json) json_mode="true"; shift ;;
+                    --help|-h) _remote_provider_peer_models_usage; return 0 ;;
+                    *) error "Unknown remote-provider peer-models download-status option: $1" ;;
+                esac
+            done
+            local response_file
+            response_file="$(_remote_provider_peer_call GET /api/remote-provider/peer/models/download-status 30)"
+            if [[ "$json_mode" == "true" ]]; then
+                jq . "$response_file"
+            else
+                _remote_provider_print_peer_download_status "$response_file"
+            fi
+            rm -f "$response_file"
+            ;;
+        cancel-download|cancel)
+            local json_mode="false"
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --json) json_mode="true"; shift ;;
+                    --help|-h) _remote_provider_peer_models_usage; return 0 ;;
+                    *) error "Unknown remote-provider peer-models cancel-download option: $1" ;;
+                esac
+            done
+            local response_file
+            response_file="$(_remote_provider_peer_call POST /api/remote-provider/peer/models/download/cancel 30)"
+            if [[ "$json_mode" == "true" ]]; then
+                jq . "$response_file"
+            else
+                _remote_provider_print_peer_action_result "cancel download" "$response_file"
+            fi
+            rm -f "$response_file"
+            ;;
+        download|load|delete)
+            local json_mode="false" yes_mode="false" model_id=""
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --json) json_mode="true"; shift ;;
+                    --yes) yes_mode="true"; shift ;;
+                    --help|-h) _remote_provider_peer_models_usage; return 0 ;;
+                    --*) error "Unknown remote-provider peer-models $subcmd option: $1" ;;
+                    *)
+                        [[ -z "$model_id" ]] || error "Only one model id may be supplied"
+                        model_id="$1"; shift ;;
+                esac
+            done
+            [[ -n "$model_id" ]] || error "Usage: ods remote-provider peer-models $subcmd MODEL [--json]"
+            if [[ "$subcmd" != "delete" && "$yes_mode" == "true" ]]; then
+                error "--yes is only valid for remote-provider peer-models delete"
+            fi
+            if [[ "$subcmd" == "delete" && "$yes_mode" != "true" ]]; then
+                error "Use --yes to confirm remote peer model deletion"
+            fi
+            local path method timeout response_file label
+            method="POST"
+            timeout="30"
+            label="$subcmd"
+            case "$subcmd" in
+                download)
+                    path="$(_remote_provider_peer_model_path "$model_id" download)"
+                    label="download"
+                    ;;
+                load)
+                    path="$(_remote_provider_peer_model_path "$model_id" load)"
+                    timeout="2705"
+                    label="load"
+                    ;;
+                delete)
+                    path="$(_remote_provider_peer_model_path "$model_id")"
+                    method="DELETE"
+                    label="delete"
+                    ;;
+            esac
+            response_file="$(_remote_provider_peer_call "$method" "$path" "$timeout")"
+            if [[ "$json_mode" == "true" ]]; then
+                jq . "$response_file"
+            else
+                _remote_provider_print_peer_action_result "$label" "$response_file"
+            fi
+            rm -f "$response_file"
+            ;;
+        *)
+            error "Usage: ods remote-provider peer-models <list|download-status|download|load|cancel-download|delete>"
+            ;;
+    esac
+}
+
 cmd_remote_provider() {
     local subcmd="${1:-status}"
     shift || true
@@ -4063,6 +4299,9 @@ cmd_remote_provider() {
     _remote_provider_require_tools
 
     case "$subcmd" in
+        peer-models|peer-model)
+            cmd_remote_provider_peer_models "$@"
+            ;;
         status)
             local json_mode="false"
             while [[ $# -gt 0 ]]; do
@@ -4198,7 +4437,7 @@ cmd_remote_provider() {
             _remote_provider_usage
             ;;
         *)
-            error "Usage: ods remote-provider <status|plan|configure|test|disable|remove>"
+            error "Usage: ods remote-provider <status|plan|configure|test|disable|remove|peer-models>"
             ;;
     esac
 }
@@ -5648,7 +5887,7 @@ ${CYAN}Commands:${NC}
                       Switch between local/cloud/hybrid modes
   model [current|list|swap]
                       View or change the local LLM model tier
-  remote-provider [status|plan|configure|test|disable|remove]
+  remote-provider [status|plan|configure|test|disable|remove|peer-models]
                       Configure, test, disable, or inspect remote GPU provider routing
   stt [current|status|download] [MODEL]
                       View Whisper STT model, check cache, or trigger download
@@ -5710,6 +5949,12 @@ ${CYAN}Remote Provider Commands:${NC}
                       Probe the configured provider through egress
   remote-provider test --base-url URL --model MODEL --api-key-stdin
                       Probe a provider without writing state or secrets
+  remote-provider peer-models list [--json]
+                      List authenticated remote ODS peer models
+  remote-provider peer-models load MODEL
+                      Load a downloaded model on the remote ODS peer
+  remote-provider peer-models delete MODEL --yes
+                      Delete a downloaded model from the remote ODS peer
 
 ${CYAN}Service aliases:${NC}
 EOF
@@ -5745,6 +5990,8 @@ ${CYAN}Examples:${NC}
   ods remote-provider test      # Probe the configured remote provider route
   printf '%s\n' "\$REMOTE_LLM_API_KEY" | ods remote-provider test --base-url https://gpu.example/v1 --model qwen/remote:latest --api-key-stdin
                                   # Test a remote provider without persisting secrets
+  ods remote-provider peer-models list
+                                  # List models on the authenticated remote ODS peer
   ods preset save my-setup      # Snapshot your config
   ods preset load my-setup      # Restore it later
   ods preset export my-setup my-setup.tar.gz

--- a/ods/tests/contracts/test-ods-cli-contracts.py
+++ b/ods/tests/contracts/test-ods-cli-contracts.py
@@ -29,7 +29,7 @@ COMMANDS = {
     "model": ("cmd_model", "model [current|list|swap]"),
     "remote-provider": (
         "cmd_remote_provider",
-        "remote-provider [status|plan|configure|test|disable|remove]",
+        "remote-provider [status|plan|configure|test|disable|remove|peer-models]",
     ),
     "stt": ("cmd_stt", "stt [current|status|download]"),
     "backup": ("cmd_backup", "backup [options]"),

--- a/ods/tests/contracts/test-remote-provider-cli.py
+++ b/ods/tests/contracts/test-remote-provider-cli.py
@@ -30,7 +30,7 @@ def main() -> int:
         "ods-cli must implement remote-provider lifecycle command",
     )
     require(
-        r"remote-provider \[status\|plan\|configure\|test\|disable\|remove\]",
+        r"remote-provider \[status\|plan\|configure\|test\|disable\|remove\|peer-models\]",
         text,
         "remote-provider command must be visible in top-level help",
     )
@@ -44,6 +44,9 @@ def main() -> int:
         "/api/remote-provider/plan",
         "/api/remote-provider/probe",
         "/api/remote-provider/apply",
+        "/api/remote-provider/peer/models",
+        "/api/remote-provider/peer/models/download-status",
+        "/api/remote-provider/peer/models/download/cancel",
     ):
         require(re.escape(endpoint), text, f"CLI must call {endpoint}")
 
@@ -151,6 +154,40 @@ def main() -> int:
     for subcommand in ("status", "plan", "configure", "test", "disable", "remove"):
         if subcommand not in body:
             fail(f"remote-provider CLI missing subcommand: {subcommand}")
+    if "peer-models|peer-model)" not in body:
+        fail("remote-provider CLI missing peer-models subcommand")
+    require(
+        r"^cmd_remote_provider_peer_models\(\) \{",
+        text,
+        "remote-provider CLI must implement peer model management",
+    )
+    require(
+        r"jq -rn --arg value \"\$value\" '\$value \| @uri'",
+        text,
+        "peer model IDs must be URL-encoded with jq @uri",
+    )
+    require(
+        r"Use --yes to confirm remote peer model deletion",
+        text,
+        "peer model delete must require explicit --yes confirmation",
+    )
+    require(
+        r"_remote_provider_peer_model_path \"\$model_id\" load[\s\S]*timeout=\"2705\"",
+        text,
+        "peer model load must use the long Dashboard proxy timeout",
+    )
+    for command in (
+        "peer-models list [--json]",
+        "peer-models download-status [--json]",
+        "peer-models download MODEL [--json]",
+        "peer-models load MODEL [--json]",
+        "peer-models cancel-download [--json]",
+        "peer-models delete MODEL --yes [--json]",
+    ):
+        if command not in text:
+            fail(f"remote-provider peer model help missing: {command}")
+    if "--peer-token" in text or "REMOTE_ODS_PEER_TOKEN" in text:
+        fail("remote-provider CLI must not accept or print peer tokens")
     require(
         r"^_remote_provider_probe_configured\(\) \{",
         text,


### PR DESCRIPTION
## Summary
- Add `ods remote-provider peer-models` CLI commands for authenticated remote ODS peer model list, download status, download, load, cancel-download, and delete.
- Reuse the existing local Dashboard API bearer-token request path so peer tokens stay in ODS secret custody and never appear as CLI arguments.
- URL-encode peer model IDs with `jq @uri`, require `--yes` for destructive peer model delete, and use the long proxy timeout for remote load.

## Validation
- `python ods\tests\contracts\test-remote-provider-cli.py`
- `python ods\tests\contracts\test-ods-cli-contracts.py`
- `git diff --check`
- Tower2 exact-SHA gate for `1e7e4ea74d25dc062ea11e7f5da3ec4115121027`: PASS, log `/home/michael/ods-pr-peer-model-cli-1e7e4ea74d25.log`