### PR TITLE
fix(models): scope qwen coder 3b m5 talk incompatibility

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1116,13 +1116,13 @@
         },
         "hermes_talk": {
           "status": "unsupported_until_revalidated",
-          "label": "ODS Talk revalidation required on Tower2",
-          "reason": "Fresh exact-commit release coverage on tower2 loaded Qwen 2.5 Coder 3B 128K through the browser switchboard, but ODS Talk acknowledged that the verification phrase was correct without returning the challenge token. Keep this model out of Tower2 all-app release coverage until its literal-response behavior is revalidated. The prior windows-laptop full-app pass remains recorded by the host-scoped agent-viability verdict.",
-          "evidence": "fleet-test/runs/2026-07-24T23-54-27Z-release-product-b77641dd064f-harness-3930eeed3597-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/tower2",
-          "recordedAt": "2026-07-25T01:05:25Z",
-          "productSha": "b77641dd064ff573c419f9bf06d1d5d9b357b5d0",
-          "harnessSha": "3930eeed3597593c50a897533902ff6ce740bb32",
-          "hostScope": ["tower2"],
+          "label": "ODS Talk revalidation required on Tower2 and M5",
+          "reason": "Fresh exact-commit release coverage on tower2 loaded Qwen 2.5 Coder 3B 128K through the browser switchboard, but ODS Talk acknowledged that the verification phrase was correct without returning the challenge token. Final15 fresh exact-commit release coverage on m5-mbp loaded the same model in cycle 5, but ODS Talk returned reasoning/probe prose instead of the exact ODSVAL-8DB490CA32-3FC971DE20 verification phrase; cleanup succeeded, the original baseline was restored, the test model was deleted, and cycle 6 passed. Keep this model out of Tower2 and M5 ODS Talk release coverage until its literal-response behavior is revalidated. The prior windows-laptop full-app pass remains recorded by the host-scoped agent-viability verdict.",
+          "evidence": "fleet-test/runs/2026-07-24T23-54-27Z-release-product-b77641dd064f-harness-3930eeed3597-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/tower2; fleet-test/runs/2026-07-25T18-19-44Z-release-product-d5ef0b7ddfc8-harness-8b9f1a38027e-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/m5-mbp",
+          "recordedAt": "2026-07-25T18:19:44Z",
+          "productSha": "d5ef0b7ddfc8207600ec60813e5574dc516c5918",
+          "harnessSha": "8b9f1a38027ebafaad074eb7964ff65e7aa1e731",
+          "hostScope": ["tower2", "m5-mbp"],
           "expiresAt": "2026-08-25T00:00:00Z"
         },
         "opencode": {

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -851,6 +851,7 @@ def test_real_catalog_scopes_qwen25_coder_3b_host_failures():
     tower = model_app_compatibility(model, runtime_context={"hosts": ["tower2"]})
     halo = model_app_compatibility(model, runtime_context={"hosts": ["strix-halo"]})
     spark = model_app_compatibility(model, runtime_context={"hosts": ["spark"]})
+    m5_mbp = model_app_compatibility(model, runtime_context={"hosts": ["m5-mbp"]})
     windows = model_app_compatibility(model, runtime_context={"hosts": ["windows-laptop"]})
 
     assert tower["hermesTalk"]["status"] == "unsupported_until_revalidated"
@@ -862,9 +863,15 @@ def test_real_catalog_scopes_qwen25_coder_3b_host_failures():
     assert spark["hermesTalk"]["status"] == "unknown"
     assert spark["opencode"]["status"] == "unsupported_until_revalidated"
     assert spark["agentViability"]["status"] == "unknown"
+    assert m5_mbp["hermesTalk"]["status"] == "unsupported_until_revalidated"
+    assert "cycle-005/m5-mbp" in m5_mbp["hermesTalk"]["evidence"]
+    assert m5_mbp["opencode"]["status"] == "unknown"
+    assert m5_mbp["agentViability"]["status"] == "unknown"
+    assert any(_compatibility_blocks_release_coverage(entry) for entry in m5_mbp.values())
     assert windows["hermesTalk"]["status"] == "unknown"
     assert windows["opencode"]["status"] == "unknown"
     assert windows["agentViability"]["status"] == "verified"
+    assert not any(_compatibility_blocks_release_coverage(entry) for entry in windows.values())
 
 
 def test_installer_recommended_model_survives_bootstrap_env(data_dir, tmp_path):

--- a/ods/installers/lib/packaging.sh
+++ b/ods/installers/lib/packaging.sh
@@ -70,22 +70,41 @@ _pkg_prepare_pacman_keyrings() {
     done
 }
 
+_pkg_bounded_positive_int() {
+    local value="$1"
+    local default="$2"
+    local max="$3"
+
+    if [[ ! "$value" =~ ^[0-9]+$ ]] || (( value < 1 )); then
+        value="$default"
+    elif (( value > max )); then
+        value="$max"
+    fi
+
+    printf '%s\n' "$value"
+}
+
 _pkg_configure_zypper_ci_network() {
     [[ "$PKG_MANAGER" == "zypper" ]] || return 0
     [[ -n "${GITHUB_ACTIONS:-}" || -n "${CI:-}" ]] || return 0
 
-    local conf_dir="/etc/zypp/zypp.conf.d"
+    local conf_dir="${ODS_ZYPPER_CI_CONF_DIR:-/etc/zypp/zypp.conf.d}"
     local conf_file="${conf_dir}/99-ods-ci-network.conf"
+    local transfer_timeout connect_timeout max_silent_tries
     local tmp
+
+    transfer_timeout="$(_pkg_bounded_positive_int "${ODS_ZYPPER_CI_TRANSFER_TIMEOUT:-180}" 180 180)"
+    connect_timeout="$(_pkg_bounded_positive_int "${ODS_ZYPPER_CI_CONNECT_TIMEOUT:-30}" 30 30)"
+    max_silent_tries="$(_pkg_bounded_positive_int "${ODS_ZYPPER_CI_MAX_SILENT_TRIES:-3}" 3 3)"
 
     tmp="$(mktemp "${TMPDIR:-/tmp}/ods-zypp-ci-network.XXXXXX")" || return 0
 
-    cat >"$tmp" <<'EOF'
+    cat >"$tmp" <<EOF
 [main]
-download.transfer_timeout = 600
-download.connect_timeout = 120
+download.transfer_timeout = ${transfer_timeout}
+download.connect_timeout = ${connect_timeout}
 download.min_download_speed = 0
-download.max_silent_tries = 3
+download.max_silent_tries = ${max_silent_tries}
 download.max_concurrent_connections = 2
 EOF
 

--- a/ods/tests/bats-tests/packaging.bats
+++ b/ods/tests/bats-tests/packaging.bats
@@ -105,6 +105,30 @@ setup() {
     assert_output "devel_basis"
 }
 
+@test "zypper CI network config writes bounded timeouts" {
+    PKG_MANAGER="zypper"
+    GITHUB_ACTIONS="true"
+    CI="true"
+    _SUDO=""
+    ODS_ZYPPER_CI_CONF_DIR="$BATS_TEST_TMPDIR/zypp.conf.d"
+    ODS_ZYPPER_CI_TRANSFER_TIMEOUT="999"
+    ODS_ZYPPER_CI_CONNECT_TIMEOUT="999"
+    ODS_ZYPPER_CI_MAX_SILENT_TRIES="999"
+
+    run _pkg_configure_zypper_ci_network
+    assert_success
+
+    config_file="$ODS_ZYPPER_CI_CONF_DIR/99-ods-ci-network.conf"
+    [ -f "$config_file" ]
+
+    run grep -F "download.transfer_timeout = 180" "$config_file"
+    assert_success
+    run grep -F "download.connect_timeout = 30" "$config_file"
+    assert_success
+    run grep -F "download.max_silent_tries = 3" "$config_file"
+    assert_success
+}
+
 # ── pkg_resolve: apk ───────────────────────────────────────────────────────
 
 @test "pkg_resolve: apk maps docker-compose-plugin to docker-cli-compose" {

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -560,8 +560,11 @@ def test_qwen25_coder_3b_is_verified_on_windows_and_host_failures_are_scoped():
     assert compatibility["agent_viability"]["hostScope"] == ["windows-laptop"]
     assert "18-23-guardrail-fullapp" in compatibility["agent_viability"]["evidence"]
     assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
-    assert compatibility["hermes_talk"]["hostScope"] == ["tower2"]
+    assert compatibility["hermes_talk"]["hostScope"] == ["tower2", "m5-mbp"]
     assert "23-54-27Z-release" in compatibility["hermes_talk"]["evidence"]
+    assert "Final15" in compatibility["hermes_talk"]["reason"]
+    assert "cycle-005/m5-mbp" in compatibility["hermes_talk"]["evidence"]
+    assert "ODSVAL-8DB490CA32-3FC971DE20" in compatibility["hermes_talk"]["reason"]
     assert "acknowledged" in compatibility["hermes_talk"]["reason"]
     assert compatibility["opencode"]["status"] == "unsupported_until_revalidated"
     assert compatibility["opencode"]["hostScope"] == ["strix-halo", "spark"]
@@ -574,6 +577,7 @@ def test_qwen25_coder_3b_is_verified_on_windows_and_host_failures_are_scoped():
     assert not _agent_viable_for_release(model, host="tower2")
     assert not _agent_viable_for_release(model, host="strix-halo")
     assert not _agent_viable_for_release(model, host="spark")
+    assert not _agent_viable_for_release(model, host="m5-mbp")
 
 
 def test_falcon_h1_15b_is_not_talk_or_opencode_agent_viable_until_revalidated():


### PR DESCRIPTION
## Summary
- Add Final15 M5 ODS Talk compatibility evidence for `qwen2.5-coder-3b-128k-q4`.
- Scope the ODS Talk block to `tower2` and `m5-mbp` while preserving the existing host-scoped verified `windows-laptop` agent evidence.
- Extend model-library and performance-oracle tests so M5 release coverage excludes this model and Windows remains verified.

## Validation
- Local: `python -m pytest ods/tests/test-model-library-coverage.py ods/tests/test-model-library-verdicts.py ods/extensions/services/dashboard-api/tests/test_performance_oracle.py -q` -> 80 passed
- Tower2: `python3 -m pytest ods/tests/test-model-library-coverage.py ods/tests/test-model-library-verdicts.py ods/extensions/services/dashboard-api/tests/test_performance_oracle.py -q` in `/home/michael/ds-pr-fixes/dream-server-m5-qwen25-coder-compat-d77f2b38` -> 80 passed