### PR TITLE
Fix Windows LiteLLM selector recovery

### DIFF
--- a/ods/extensions/services/litellm/compose.yaml
+++ b/ods/extensions/services/litellm/compose.yaml
@@ -29,6 +29,10 @@ services:
     command:
       - |
         CONFIG_PATH=$$(sh /app/ods-select-config.sh)
+        if [ -z "$$CONFIG_PATH" ] || [ ! -r "$$CONFIG_PATH" ]; then
+          echo "ERROR: LiteLLM config selector returned an unreadable path: $${CONFIG_PATH:-<empty>}" >&2
+          exit 1
+        fi
         export CONFIG_PATH
         python3 -c "
         import os

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -96,6 +96,8 @@ $_expectedRegularFiles = @(
     "config\litellm\lemonade.yaml",
     "config\litellm\switchboard.yaml",
     "data\.extensions-lock",
+    "extensions\services\litellm\select-config.sh",
+    "extensions\services\litellm\ods_token_spy_callback.py",
     "extensions\services\hermes\cli-config.yaml.template",
     "extensions\services\hermes\SOUL.md.template",
     "extensions\services\hermes-proxy\Caddyfile",

--- a/ods/tests/test-litellm-config-selection.sh
+++ b/ods/tests/test-litellm-config-selection.sh
@@ -49,6 +49,15 @@ else
     failed=$((failed + 1))
 fi
 
+if grep -Fq '[ -z "$$CONFIG_PATH" ]' "$COMPOSE" \
+    && grep -Fq 'LiteLLM config selector returned an unreadable path' "$COMPOSE"; then
+    printf '[PASS] Compose fails closed when selector output is empty or unreadable\n'
+    passed=$((passed + 1))
+else
+    printf '[FAIL] Compose does not guard selector output before LiteLLM startup\n'
+    failed=$((failed + 1))
+fi
+
 if grep -Fq 'model_name: ods/current' "$CLOUD_CONFIG"; then
     printf '[PASS] Cloud config exposes the stable ods/current alias\n'
     passed=$((passed + 1))

--- a/ods/tests/test-windows-env-dotfile-recovery.sh
+++ b/ods/tests/test-windows-env-dotfile-recovery.sh
@@ -54,6 +54,8 @@ check 'file bind mounts' "$PHASE05" "phase 5 documents stale bind-mount director
 
 check '$_expectedRegularFiles = @(' "$PHASE06" "phase 6 uses explicit owned regular-file cleanup list"
 check 'config\litellm\switchboard.yaml' "$PHASE06" "phase 6 repairs malformed LiteLLM switchboard config directory"
+check 'extensions\services\litellm\select-config.sh' "$PHASE06" "phase 6 repairs malformed LiteLLM selector script directory"
+check 'extensions\services\litellm\ods_token_spy_callback.py' "$PHASE06" "phase 6 repairs malformed LiteLLM callback module directory"
 check 'extensions\services\hermes\cli-config.yaml.template' "$PHASE06" "phase 6 repairs malformed Hermes config template directory"
 check 'extensions\services\hermes\SOUL.md.template' "$PHASE06" "phase 6 repairs malformed Hermes SOUL template directory"
 check 'data\persona\SOUL.md' "$PHASE06" "phase 6 repairs malformed generated persona file directory"


### PR DESCRIPTION
﻿## Summary

Fixes a Windows install failure where a stale Docker bind mount or partial install can leave `extensions/services/litellm/select-config.sh` as a directory. When that happens, the LiteLLM container selector emits an empty config path, `/tmp/config.yaml` is never rendered, and `ods-litellm` restart-loops during model activation.

Changes:
- Teach Windows phase 06 malformed-file recovery to remove directory-shaped LiteLLM selector and callback paths before source copy.
- Make the LiteLLM compose entrypoint fail closed when the selector returns an empty or unreadable config path.
- Extend the existing LiteLLM selector and Windows malformed-dotfile tests.

## Root Cause

The Windows installer already removed several install-owned paths that must be regular files when stale Docker bind mounts turned them into directories, but it did not include the LiteLLM selector script. In switchboard mode, `ods-litellm` depends on that script to choose `/app/switchboard.yaml`; when the host path was a directory, `CONFIG_PATH` became empty and LiteLLM failed with `Config file not found: /tmp/config.yaml`.

## Validation

- `python ods/tests/test-render-runtime-configs.py`
- `C:\Program Files\Git\bin\bash.exe ods/tests/test-litellm-config-selection.sh`
- `C:\Program Files\Git\bin\bash.exe ods/tests/test-windows-env-dotfile-recovery.sh`
- `C:\Program Files\Git\bin\bash.exe ods/tests/contracts/test-windows-amd-local-compose.sh`
- `C:\Program Files\Git\bin\bash.exe ods/tests/test-litellm-amd-auth-enforced.sh`
- `git diff --check`
