### PR TITLE
fix(uninstall): scope container and volume discovery to this project

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -147,8 +147,10 @@ if command -v docker &>/dev/null; then
         log_warn "No compose files resolved; falling back to container/volume discovery"
     fi
 
-    # Remove any remaining ods-* containers
-    ods_containers=$(docker ps -a --filter "name=ods-" --format "{{.Names}}" 2>/dev/null || true)
+    # Remove any remaining ods-* containers.
+    # Docker's name filter matches anywhere in the name, so filter on the
+    # printed names instead: only this project's ods-<service> containers.
+    ods_containers=$(docker ps -a --format "{{.Names}}" 2>/dev/null | grep -E '^ods-' || true)
     if [[ -n "$ods_containers" ]]; then
         log_info "Removing ODS containers..."
         echo "$ods_containers" | xargs docker rm -f 2>/dev/null || true
@@ -158,7 +160,12 @@ if command -v docker &>/dev/null; then
     if [[ "$KEEP_DATA" == "true" ]]; then
         log_info "Keeping Docker volumes (--keep-data)"
     else
-        ods_volumes=$(docker volume ls --filter "name=ods" --format "{{.Name}}" 2>/dev/null || true)
+        # Compose names project volumes ods_<volume> (docker-compose.base.yml
+        # declares `name: ods`); older installs also produced ods-<volume>.
+        # An unanchored "ods" filter would additionally select unrelated
+        # volumes that merely contain it (pods, methods, ...) and this branch
+        # removes what it finds, so anchor on the project prefix.
+        ods_volumes=$(docker volume ls --format "{{.Name}}" 2>/dev/null | grep -E '^ods[_-]' || true)
         if [[ -n "$ods_volumes" ]]; then
             log_info "Removing Docker volumes..."
             echo "$ods_volumes" | xargs docker volume rm 2>/dev/null || true

--- a/ods/tests/test-uninstall-compose-flags.sh
+++ b/ods/tests/test-uninstall-compose-flags.sh
@@ -19,13 +19,38 @@ pass() {
 make_stub_bin() {
     local stub_dir="$1"
 
+    # The discovery fallback feeds these listings straight into `docker rm -f`
+    # and `docker volume rm`, so the stub reports unrelated names that merely
+    # contain "ods" next to this project's own.
     cat > "$stub_dir/docker" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+
+# Emit names the way `docker ps` / `docker volume ls` would, honouring
+# `--filter name=<expr>` with Docker's own semantics: the expression is matched
+# anywhere in the name, so an unanchored "ods" also matches "k3s_pods".
+emit_filtered() {
+    local expr="" arg name
+    for arg in "$@"; do
+        case "$arg" in
+            name=*) expr="${arg#name=}" ;;
+        esac
+    done
+    for name in $NAMES; do
+        if [[ -z "$expr" || "$name" =~ $expr ]]; then
+            printf '%s\n' "$name"
+        fi
+    done
+}
+
 if [[ "${1:-}" == "ps" ]]; then
+    NAMES="ods-litellm ods-llama-server kube-pods-proxy methods-runner"
+    emit_filtered "$@"
     exit 0
 fi
 if [[ "${1:-}" == "volume" && "${2:-}" == "ls" ]]; then
+    NAMES="ods_perplexica-data ods-legacy-cache k3s_pods methods_cache"
+    emit_filtered "$@"
     exit 0
 fi
 exit 0
@@ -137,6 +162,34 @@ EOF
         fail "uninstall must not execute command substitutions from .env"
     fi
     pass "uninstall loads .env without executing shell substitutions"
+
+    # Docker's `--filter name=` matches anywhere in the name, so the discovery
+    # fallback must select on the project prefix (containers ods-<service>,
+    # compose volumes ods_<volume>) and leave unrelated names alone.
+    local removed_containers removed_volumes
+    removed_containers="$(grep -E '^rm -f ' "$log_purge" || true)"
+    removed_volumes="$(grep -E '^volume rm ' "$log_purge" || true)"
+
+    local name
+    for name in ods-litellm ods-llama-server; do
+        [[ "$removed_containers" == *"$name"* ]] \
+            || fail "uninstall must remove project container $name (got: '$removed_containers')"
+    done
+    for name in kube-pods-proxy methods-runner; do
+        [[ "$removed_containers" != *"$name"* ]] \
+            || fail "uninstall must not remove unrelated container $name (got: '$removed_containers')"
+    done
+    pass "container discovery stays on the ods- prefix"
+
+    for name in ods_perplexica-data ods-legacy-cache; do
+        [[ "$removed_volumes" == *"$name"* ]] \
+            || fail "uninstall must remove project volume $name (got: '$removed_volumes')"
+    done
+    for name in k3s_pods methods_cache; do
+        [[ "$removed_volumes" != *"$name"* ]] \
+            || fail "uninstall must not remove unrelated volume $name (got: '$removed_volumes')"
+    done
+    pass "volume discovery stays on the ods project prefix"
 }
 
 main "$@"


### PR DESCRIPTION
## Problem

After `docker compose down`, `ods-uninstall.sh` sweeps up leftovers. That sweep is the destructive part — whatever it finds goes straight into `docker rm -f` / `docker volume rm` with errors silenced:

```bash
ods_containers=$(docker ps -a --filter "name=ods-" --format "{{.Names}}" ...)
echo "$ods_containers" | xargs docker rm -f 2>/dev/null || true

ods_volumes=$(docker volume ls --filter "name=ods" --format "{{.Name}}" ...)
echo "$ods_volumes" | xargs docker volume rm 2>/dev/null || true
```

Docker's `name=` filter matches **anywhere** in the name, so neither filter is scoped to ODS:

| filter | also selects |
|---|---|
| `name=ods` (volumes) | `k3s_pods`, `methods_cache`, anything containing `ods` |
| `name=ods-` (containers) | `kube-pods-proxy`, `methods-runner` — `pods-` and `ods-` overlap |

`docker volume rm` refuses volumes attached to a running container, so the blast radius is unused volumes and volumes of stopped containers — exactly the "I'll get back to that project later" ones. There is no undo, and `2>/dev/null || true` means the operator sees nothing.

## Why this reads as an oversight, not a widening

- The container line one above already uses the tighter `ods-` prefix — the two lines in the same block disagree about scope.
- `install-core.sh:274` and `installers/macos/install-macos.sh:1092` anchor fully (`name=^/ods-openclaw$`), and `extensions/services/langfuse/hooks/post_install.sh:72` uses `name=^${name}$`. Anchoring is the established idiom here.
- The volume filter cannot simply adopt `ods-`: compose names project volumes `ods_<volume>` (`docker-compose.base.yml` declares `name: ods`), so `ods-` alone would stop reaping `ods_perplexica-data`, `ods_lemonade-cache`, etc. Dropping the dash was a way to catch `ods_`, and it took the substring match along with it.

## Fix

Filter the printed names instead of relying on Docker's substring match, anchored on the project prefix:

- containers → `^ods-`
- volumes → `^ods[_-]` (covers compose's `ods_<volume>` and legacy `ods-<volume>`)

Behaviour for ODS's own resources is unchanged; `--keep-data` still skips the volume branch entirely.

## Verification

Extended the existing CI-gated `tests/test-uninstall-compose-flags.sh`. Its docker stub now emits names and honours `--filter name=<expr>` with Docker's own semantics (match anywhere), so the test is fair to any correct fix — anchored server-side filter or client-side match:

```
stub containers: ods-litellm ods-llama-server kube-pods-proxy methods-runner
stub volumes:    ods_perplexica-data ods-legacy-cache k3s_pods methods_cache
```

```
$ bash tests/test-uninstall-compose-flags.sh          # this branch
[PASS] container discovery stays on the ods- prefix
[PASS] volume discovery stays on the ods project prefix

$ git checkout main -- ods-uninstall.sh && bash tests/test-uninstall-compose-flags.sh
[FAIL] uninstall must not remove unrelated container kube-pods-proxy
       (got: 'rm -f ods-litellm ods-llama-server kube-pods-proxy methods-runner')
```

The four pre-existing assertions in that file still pass. `bash -n` clean.