### PR TITLE
fix(dashboard): open the service UI path from the Settings routing table

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -95,6 +95,21 @@ const getErrorText = (err) => (
 const getDashboardHost = () => (typeof window !== 'undefined' ? window.location.hostname : 'localhost')
 const getExternalUrl = (port) => (port ? `http://${getDashboardHost()}:${port}` : null)
 
+// /api/status already resolves each service's manifest ui_path into `url`, but
+// against 127.0.0.1. Take the path from there and keep the browser's hostname
+// so a service whose UI is not at the port root (LiteLLM /ui/, Qdrant and
+// Token Spy /dashboard) opens its UI instead of the bare API root.
+const getServiceUiPath = (service) => {
+  const declared = service?.url || service?.href
+  if (!declared) return ''
+  try {
+    const { pathname, search } = new URL(declared)
+    return `${pathname === '/' ? '' : pathname}${search}`
+  } catch {
+    return ''
+  }
+}
+
 const todayKey = () => {
   const now = new Date()
   const month = String(now.getMonth() + 1).padStart(2, '0')
@@ -861,7 +876,8 @@ function RouteStatusCard({ tone, label, count, description }) {
 }
 
 function RouteRow({ service }) {
-  const href = getExternalUrl(service.port)
+  const base = getExternalUrl(service.port)
+  const href = base ? `${base}${getServiceUiPath(service)}` : null
   const healthy = service.status === 'healthy'
   const degraded = service.status === 'degraded'
   const dot = healthy ? 'bg-emerald-400' : degraded ? 'bg-amber-400' : 'bg-red-400'

--- a/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
@@ -214,4 +214,32 @@ describe('Settings', () => {
     expect(screen.getByDisplayValue('192.168.1.10')).toBeInTheDocument()
     expect(fetchMock.mock.calls.filter(([url]) => url === '/api/settings/env')).toHaveLength(3)
   })
+
+  test('routing table links open the service UI path, not the bare port root', async () => {
+    renderSettings((url) => (
+      url === '/api/settings/summary'
+        ? response({
+            ...summary,
+            services: [
+              // /api/status resolves manifest ui_path into url/href against 127.0.0.1.
+              { id: 'qdrant', name: 'Qdrant', status: 'healthy', port: 6333, url: 'http://127.0.0.1:6333/dashboard', href: 'http://127.0.0.1:6333/dashboard' },
+              { id: 'litellm', name: 'LiteLLM', status: 'healthy', port: 4000, url: 'http://127.0.0.1:4000/ui/', href: 'http://127.0.0.1:4000/ui/' },
+              { id: 'open-webui', name: 'Open WebUI', status: 'healthy', port: 3000, url: 'http://127.0.0.1:3000/', href: 'http://127.0.0.1:3000/' },
+              { id: 'internal-only', name: 'Internal Only', status: 'healthy', port: 0 },
+            ],
+          })
+        : null
+    ))
+
+    const host = window.location.hostname
+    expect(await screen.findByRole('link', { name: /Qdrant/ }))
+      .toHaveAttribute('href', `http://${host}:6333/dashboard`)
+    expect(screen.getByRole('link', { name: /LiteLLM/ }))
+      .toHaveAttribute('href', `http://${host}:4000/ui/`)
+    // A root ui_path must not gain a trailing path segment.
+    expect(screen.getByRole('link', { name: /Open WebUI/ }))
+      .toHaveAttribute('href', `http://${host}:3000`)
+    // Portless services stay unlinked.
+    expect(screen.queryByRole('link', { name: /Internal Only/ })).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Problem

`RouteRow` in the Settings routing table builds its link from the port alone:

```js
const href = getExternalUrl(service.port)   // http://<host>:<port>
```

Every service whose UI does not live at the port root therefore opens the wrong page:

| service | manifest `ui_path` | Settings link lands on |
|---|---|---|
| Qdrant (`:6333`) | `/dashboard` | version JSON blob |
| LiteLLM (`:4000`) | `/ui/` | `{"detail":"Not Found"}` |
| Token Spy (`:9092`) | `/dashboard` | not the dashboard |

(`privacy-shield` and `tts` declare `/docs`, `embeddings` `/info` — same shape.)

## The path is already available client-side

Two things already handle this correctly, which is what makes the Settings row the outlier:

- **Sidebar Quick Links** — `plugins/registry.js:69` appends `link.ui_path` whenever it is not `/`.
- **dashboard-api** — `_service_public_url` (`main.py:627`) resolves the manifest `ui_path` and `_serialize_services` ships it to the client as each service's `url`/`href`. Settings already consumes that payload (`/api/settings/summary` → `setServices(statusData.services)`), it just ignored the field.

The server builds that URL against `127.0.0.1`, so the host still has to come from the page — that is why the fix takes only the path and keeps `getDashboardHost()`. This keeps remote access (dashboard opened from another device on the LAN) working, which is the reason `getExternalUrl` exists in the first place.

## Fix

```js
const getServiceUiPath = (service) => { /* pathname (+search) from service.url/href */ }
...
const base = getExternalUrl(service.port)
const href = base ? `${base}${getServiceUiPath(service)}` : null
```

Root `ui_path` contributes nothing (no trailing `/` appended), a missing/unparseable `url` degrades to the previous behaviour, and portless services stay unlinked.

## Verification

New case in `src/pages/Settings.test.jsx` (existing harness, no fixture changes):

```
$ npx vitest run src/pages/Settings.test.jsx --no-cache     # this branch
Tests  9 passed (9)

$ git checkout main -- src/pages/Settings.jsx && npx vitest run src/pages/Settings.test.jsx --no-cache
× routing table links open the service UI path, not the bare port root
Tests  1 failed | 8 passed (9)
```

Asserts `/dashboard` and `/ui/` survive on the browser hostname, a `/` path does not become a trailing segment, and a portless service renders no link. `npm run lint` clean.