### PR TITLE
fix(windows): size the disk preflight to the selected model

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -88,6 +88,10 @@ jobs:
         shell: pwsh
         run: ./tests/test-windows-python-resolver.ps1
 
+      - name: Windows Disk Preflight Contract
+        shell: pwsh
+        run: ./tests/test-windows-disk-preflight.ps1
+
       - name: Windows Runtime Recovery Contract
         shell: pwsh
         run: ./tests/contracts/test-windows-runtime-recovery.ps1

--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -158,6 +158,28 @@ function Test-WindowsODSLemonadeOwnsPort {
     }).Count
 }
 
+function Get-WindowsModelDiskRequirementGB {
+    <#
+    .SYNOPSIS
+        Disk requirement for the tier, raised to fit the selected model.
+    .DESCRIPTION
+        The per-tier minimums assume the tier map's own model. The catalog
+        selector can promote a larger one, so the download would exceed a
+        minimum that already passed. Mirrors the model-aware recheck in
+        installers/phases/04-requirements.sh and installers/macos/
+        install-macos.sh: model size rounded up to GB plus 15GB for Docker
+        image layers. Never returns less than the tier minimum.
+    #>
+    param(
+        [int]$ModelSizeMB,
+        [int]$TierMinimumGB
+    )
+
+    if ($ModelSizeMB -le 0) { return $TierMinimumGB }
+    $modelGB = [int][Math]::Ceiling($ModelSizeMB / 1024.0)
+    return [Math]::Max($TierMinimumGB, $modelGB + 15)
+}
+
 function Stop-WindowsODSLemonadePortConflicts {
     <#
     .SYNOPSIS
@@ -246,6 +268,20 @@ $_minDiskGB = switch ($selectedTier) {
     "0"          {  15 }
     "CLOUD"      {  10 }
     default      {  30 }
+}
+
+# The catalog selector may promote a model larger than the one the tier
+# minimum was sized for, so require room for whatever was actually selected.
+$_selectedModelSizeMB = 0
+if ($tierConfig -and $tierConfig.ModelSizeMB) {
+    $_selectedModelSizeMB = [int]$tierConfig.ModelSizeMB
+}
+$_tierMinDiskGB = $_minDiskGB
+$_minDiskGB = Get-WindowsModelDiskRequirementGB `
+    -ModelSizeMB $_selectedModelSizeMB `
+    -TierMinimumGB $_tierMinDiskGB
+if ($_minDiskGB -gt $_tierMinDiskGB) {
+    Write-AI "Disk: selected model is $([Math]::Ceiling($_selectedModelSizeMB / 1024.0)) GB, raising the requirement to ${_minDiskGB} GB."
 }
 
 $_diskCheck = Test-DiskSpace -Path $installDir -RequiredGB $_minDiskGB

--- a/ods/tests/test-windows-disk-preflight.ps1
+++ b/ods/tests/test-windows-disk-preflight.ps1
@@ -1,0 +1,95 @@
+$ErrorActionPreference = "Stop"
+
+# Windows disk preflight contract.
+#
+# The per-tier disk minimums in phase 04 were sized for the tier map's own
+# model. The catalog selector can promote a larger one before anything is
+# downloaded, so the requirement has to follow the selected model — the same
+# recheck installers/phases/04-requirements.sh and installers/macos/
+# install-macos.sh already perform.
+
+$root = Split-Path -Parent $PSScriptRoot
+$phasePath = Join-Path $root "installers\windows\phases\04-requirements.ps1"
+
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $phasePath,
+    [ref]$tokens,
+    [ref]$errors
+)
+if ($errors.Count -gt 0) {
+    throw "Phase 04 failed to parse: $($errors[0].Message)"
+}
+
+$functionAst = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq "Get-WindowsModelDiskRequirementGB"
+}, $true)
+if (-not $functionAst) { throw "Function not found: Get-WindowsModelDiskRequirementGB" }
+. ([scriptblock]::Create($functionAst.Extent.Text))
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Label)
+    if ($Actual -ne $Expected) {
+        throw "$Label`: expected $Expected, got $Actual"
+    }
+    Write-Host "[PASS] $Label"
+}
+
+# No selected size (CLOUD, or the selector disabled) keeps the tier minimum.
+Assert-Equal (Get-WindowsModelDiskRequirementGB -ModelSizeMB 0 -TierMinimumGB 35) 35 `
+    "unknown model size keeps the tier minimum"
+Assert-Equal (Get-WindowsModelDiskRequirementGB -ModelSizeMB -1 -TierMinimumGB 15) 15 `
+    "negative model size keeps the tier minimum"
+
+# A model that fits inside the tier minimum must not lower the gate.
+Assert-Equal (Get-WindowsModelDiskRequirementGB -ModelSizeMB 5760 -TierMinimumGB 35) 35 `
+    "small model does not weaken the tier minimum"
+
+# Tier 3 minimum is 35GB; a 24GB pick needs 24 + 15 = 39GB.
+Assert-Equal (Get-WindowsModelDiskRequirementGB -ModelSizeMB 24576 -TierMinimumGB 35) 39 `
+    "tier 3 requirement follows a 24GB model"
+
+# Tier 4 minimum is 50GB; the 48500MB coder-next entry needs 48 + 15 = 63GB.
+Assert-Equal (Get-WindowsModelDiskRequirementGB -ModelSizeMB 48500 -TierMinimumGB 50) 63 `
+    "tier 4 requirement follows a 48500MB model"
+
+# Partial GB rounds up, matching (SIZE + 1023) / 1024 on Linux.
+Assert-Equal (Get-WindowsModelDiskRequirementGB -ModelSizeMB 21110 -TierMinimumGB 30) 36 `
+    "model size rounds up to whole GB"
+
+$phaseText = Get-Content -LiteralPath $phasePath -Raw
+
+# The gap this closes: the tier table's own number would have admitted a model
+# that cannot fit. Read tier 4's minimum out of the phase so the check tracks
+# the table instead of a copy of it.
+$phaseLines = Get-Content -LiteralPath $phasePath
+$diskSwitchStart = ($phaseLines | Select-String -SimpleMatch '$_minDiskGB = switch' | Select-Object -First 1).LineNumber
+if (-not $diskSwitchStart) { throw "Phase 04 no longer declares a per-tier disk switch" }
+$tier4MinimumGB = 0
+foreach ($line in $phaseLines[$diskSwitchStart..([Math]::Min($diskSwitchStart + 12, $phaseLines.Count - 1))]) {
+    if ($line -match '^\s*"4"\s*\{\s*(\d+)\s*\}') { $tier4MinimumGB = [int]$Matches[1]; break }
+}
+if ($tier4MinimumGB -le 0) {
+    throw "Phase 04 no longer declares a tier 4 disk minimum in the expected form"
+}
+$tier4Required = Get-WindowsModelDiskRequirementGB -ModelSizeMB 48500 -TierMinimumGB $tier4MinimumGB
+if ($tier4Required -le $tier4MinimumGB) {
+    throw ("Tier 4 minimum ${tier4MinimumGB}GB still admits a 48500MB model " +
+           "(requirement resolved to ${tier4Required}GB)")
+}
+Write-Host "[PASS] tier 4 minimum (${tier4MinimumGB}GB) is raised to ${tier4Required}GB for a 48500MB model"
+
+# The phase must feed the selected model size in, not just declare the helper.
+if ($phaseText -notmatch [regex]::Escape('$tierConfig.ModelSizeMB')) {
+    throw "Phase 04 does not read the selected model size from the tier config"
+}
+if ($phaseText -notmatch [regex]::Escape('Get-WindowsModelDiskRequirementGB')) {
+    throw "Phase 04 does not apply the model-aware disk requirement"
+}
+Write-Host "[PASS] phase 04 applies the requirement to the selected model"
+
+Write-Host ""
+Write-Host "All Windows disk preflight contract checks passed."


### PR DESCRIPTION
## Problem

The Windows disk gate in phase 04 is a static per-tier table:

```powershell
$_minDiskGB = switch ($selectedTier) {
    "NV_ULTRA" { 100 }  "SH_LARGE" { 100 }  "SH_COMPACT" { 50 }
    "4" { 50 }  "3" { 35 }  "2" { 30 }  "1" { 25 }  "0" { 15 }  "CLOUD" { 10 }
}
```

Those numbers were sized for the tier map's own model. The catalog selector (`Resolve-CatalogModelRecommendation`) runs in phase 02, before this check, and fits candidates against **memory**, not disk — so it can promote a considerably larger entry and still write it into `$tierConfig`.

Worked example on tier 4 (>=40GB VRAM, minimum 50GB):

| | |
|---|---|
| selected catalog entry | `size_mb: 48500` |
| disk needed (model + Docker image layers) | ceil(48500/1024) + 15 = **63GB** |
| preflight requirement | **50GB** |

Preflight reports "Disk: 55 GB free OK (>= 50 GB for Tier 4)", then the download runs out of space. Tier 3 has the same shape: minimum 35GB, and a 24GB pick needs 39GB.

## Linux and macOS already do this

Both other platforms re-check against the resolved size with identical arithmetic — Windows is the only one that skips it:

- `installers/phases/04-requirements.sh:139-148` — `_model_disk_gb=$(( (LLM_MODEL_SIZE_MB + 1023) / 1024 )); _model_needed_gb=$(( _model_disk_gb + 15 ))`
- `installers/macos/install-macos.sh:1405-1428` — same, with the comment *"Prefer the catalog selector's exact model size when available; it can choose entries that do not fit the older tier-map filename heuristics."*

## Fix

`Get-WindowsModelDiskRequirementGB -ModelSizeMB <n> -TierMinimumGB <n>` returns `max(tier minimum, ceil(MB/1024) + 15)`:

- the existing tier floor is never lowered, only raised
- no resolved size (CLOUD, or `ODS_DISABLE_CATALOG_MODEL_SELECTOR=true`) keeps the tier minimum, matching the `-gt 0` guards on Linux/macOS
- the raise is printed so the number in the failure message is explainable

## Verification

New `tests/test-windows-disk-preflight.ps1`, gated in `lint-powershell.yml` next to the existing port-preflight contract and following the same AST-extraction harness:

```
[PASS] unknown model size keeps the tier minimum
[PASS] negative model size keeps the tier minimum
[PASS] small model does not weaken the tier minimum
[PASS] tier 3 requirement follows a 24GB model
[PASS] tier 4 requirement follows a 48500MB model
[PASS] model size rounds up to whole GB
[PASS] tier 4 minimum (50GB) is raised to 63GB for a 48500MB model
[PASS] phase 04 applies the requirement to the selected model
```

Run on Windows PowerShell 5.1 (the edition the installer uses). Rounding is asserted against the Linux integer-division result for the same inputs (48500 → 63, 21110 → 36, 24576 → 39). The tier-4 case reads the minimum out of the phase's own switch rather than hardcoding 50, so it tracks the table.

On `main` the suite fails: the helper does not exist, and the two phase-text assertions confirm the phase never reads `$tierConfig.ModelSizeMB`.

PSScriptAnalyzer (`Error,Warning`, repo settings) clean on `04-requirements.ps1`.