### PR TITLE
feat(dashboard): add the Workflows page the n8n docs already describe

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Workflows.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Workflows.jsx
@@ -1,0 +1,224 @@
+import {
+  AlertCircle, Bot, Brain, Check, Code, Database, FileText, Image, Loader2,
+  MessageSquare, Mic, RefreshCw, Search, Shield, Trash2, Workflow, Zap,
+} from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+
+// Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" for /api/
+// requests, so relative URLs need no explicit auth here (see Extensions.jsx).
+const fetchJson = async (url, options = {}, ms = 8000) => {
+  const c = new AbortController()
+  const t = setTimeout(() => c.abort(), ms)
+  try {
+    return await fetch(url, { ...options, signal: c.signal })
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+// Catalog entries carry an icon name; anything unknown falls back to Workflow.
+const ICON_MAP = {
+  Bot, Brain, Code, Database, FileText, Image, MessageSquare, Mic,
+  Search, Shield, Workflow, Zap,
+}
+
+const STATUS_STYLES = {
+  active: 'bg-green-500/20 text-green-400',
+  installed: 'bg-blue-500/20 text-blue-400',
+  available: 'border border-theme-border text-theme-text-muted',
+}
+
+const STATUS_LABELS = {
+  active: 'Active',
+  installed: 'Installed',
+  available: 'Available',
+}
+
+export default function Workflows() {
+  const [catalog, setCatalog] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [notice, setNotice] = useState(null)
+  const [busyId, setBusyId] = useState(null)
+  const [category, setCategory] = useState('all')
+
+  const load = useCallback(async ({ quiet = false } = {}) => {
+    if (!quiet) setLoading(true)
+    try {
+      const response = await fetchJson('/api/workflows')
+      if (!response.ok) throw new Error(`Workflow catalog unavailable (${response.status})`)
+      setCatalog(await response.json())
+      setError(null)
+    } catch (err) {
+      setError(err?.name === 'AbortError' ? 'Workflow catalog request timed out' : (err?.message || 'Failed to load workflows'))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const runAction = async (workflow, action) => {
+    setBusyId(workflow.id)
+    setNotice(null)
+    try {
+      const response = await fetchJson(`/api/workflows/${workflow.id}/${action}`, { method: 'POST' }, 30000)
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(payload?.detail || `Request failed (${response.status})`)
+      setNotice({ tone: 'ok', text: payload?.message || `${workflow.name} updated` })
+      // n8n owns the truth about what is installed; re-read instead of guessing.
+      await load({ quiet: true })
+    } catch (err) {
+      setNotice({ tone: 'error', text: err?.message || `Could not ${action} ${workflow.name}` })
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const workflows = catalog?.workflows || []
+  const categories = catalog?.categories || {}
+  const visible = category === 'all' ? workflows : workflows.filter(w => w.category === category)
+
+  return (
+    <div className="p-8">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-theme-text">Workflows</h1>
+          <p className="mt-1 text-sm text-theme-text-muted">
+            Prebuilt n8n automations shipped with ODS. Installing one imports it into n8n and activates it.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => load()}
+          className="flex items-center gap-2 rounded-lg border border-theme-border bg-theme-card px-4 py-2 text-sm text-theme-text hover:border-theme-accent/50"
+        >
+          <RefreshCw size={15} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          <AlertCircle size={16} />
+          {error}
+        </div>
+      )}
+
+      {notice && (
+        <div className={`mb-4 rounded-lg border px-4 py-3 text-sm ${
+          notice.tone === 'ok'
+            ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-300'
+            : 'border-red-400/30 bg-red-500/10 text-red-300'
+        }`}>
+          {notice.text}
+        </div>
+      )}
+
+      {catalog && !catalog.n8nAvailable && (
+        <div className="mb-4 rounded-lg border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
+          n8n is not reachable, so workflows cannot be installed yet. Enable the n8n extension and try again.
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-theme-text-muted">
+          <Loader2 size={16} className="animate-spin" />
+          Loading workflow catalog...
+        </div>
+      ) : (
+        <>
+          <div className="mb-5 flex flex-wrap gap-2">
+            {[['all', 'All'], ...Object.entries(categories).map(([id, meta]) => [id, meta?.name || id])].map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setCategory(id)}
+                className={`rounded-full border px-4 py-1.5 text-sm transition-colors ${
+                  category === id
+                    ? 'border-theme-accent bg-theme-accent text-white'
+                    : 'border-theme-border bg-theme-card text-theme-text-muted hover:text-theme-text'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {visible.length === 0 ? (
+            <p className="text-sm text-theme-text-muted">No workflows in this category.</p>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {visible.map(workflow => {
+                const Icon = ICON_MAP[workflow.icon] || Workflow
+                const blockedBy = Object.entries(workflow.dependencyStatus || {})
+                  .filter(([, ok]) => !ok)
+                  .map(([dep]) => dep)
+                const busy = busyId === workflow.id
+                const canInstall = workflow.allDependenciesMet && catalog?.n8nAvailable
+
+                return (
+                  <div key={workflow.id} className="flex flex-col rounded-lg border border-theme-border bg-theme-card p-5">
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-3">
+                        <Icon size={20} className="text-theme-accent-light" />
+                        <h2 className="text-sm font-semibold text-theme-text">{workflow.name}</h2>
+                      </div>
+                      <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs ${STATUS_STYLES[workflow.status] || STATUS_STYLES.available}`}>
+                        {STATUS_LABELS[workflow.status] || workflow.status}
+                      </span>
+                    </div>
+
+                    <p className="mb-3 text-sm text-theme-text-muted">{workflow.description}</p>
+
+                    <div className="mb-4 flex flex-wrap gap-2 text-xs text-theme-text-muted">
+                      <span className="rounded border border-theme-border px-2 py-0.5">
+                        {categories[workflow.category]?.name || workflow.category}
+                      </span>
+                      {workflow.setupTime && (
+                        <span className="rounded border border-theme-border px-2 py-0.5">Setup {workflow.setupTime}</span>
+                      )}
+                      {workflow.installed && workflow.executions > 0 && (
+                        <span className="rounded border border-theme-border px-2 py-0.5">{workflow.executions} runs</span>
+                      )}
+                    </div>
+
+                    {blockedBy.length > 0 && (
+                      <p className="mb-3 text-xs text-amber-300">
+                        Needs {blockedBy.join(', ')} running first.
+                      </p>
+                    )}
+
+                    <div className="mt-auto">
+                      {workflow.installed ? (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => runAction(workflow, 'disable')}
+                          className="flex w-full items-center justify-center gap-2 rounded-lg border border-theme-border px-4 py-2 text-sm text-theme-text hover:border-red-400/50 hover:text-red-300 disabled:opacity-50"
+                        >
+                          {busy ? <Loader2 size={15} className="animate-spin" /> : <Trash2 size={15} />}
+                          Remove
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          disabled={busy || !canInstall}
+                          onClick={() => runAction(workflow, 'enable')}
+                          className="flex w-full items-center justify-center gap-2 rounded-lg bg-theme-accent px-4 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {busy ? <Loader2 size={15} className="animate-spin" /> : <Check size={15} />}
+                          Install
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/ods/extensions/services/dashboard/src/pages/Workflows.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Workflows.test.jsx
@@ -1,0 +1,177 @@
+import { fireEvent, screen, within } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import Workflows from './Workflows' // eslint-disable-line no-unused-vars
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+const catalog = {
+  n8nAvailable: true,
+  categories: {
+    productivity: { name: 'Productivity', description: 'Automate your daily tasks' },
+    voice: { name: 'Voice', description: 'Speech-to-text and text-to-speech' },
+  },
+  workflows: [
+    {
+      id: 'daily-digest',
+      name: 'Daily Digest',
+      description: 'Summarize your day every morning',
+      icon: 'FileText',
+      category: 'productivity',
+      status: 'available',
+      installed: false,
+      active: false,
+      dependencies: ['llama-server'],
+      dependencyStatus: { 'llama-server': true },
+      allDependenciesMet: true,
+      setupTime: '2 minutes',
+      executions: 0,
+    },
+    {
+      id: 'voice-transcription',
+      name: 'Voice Transcription',
+      description: 'Turn recordings into text',
+      icon: 'Mic',
+      category: 'voice',
+      status: 'active',
+      installed: true,
+      active: true,
+      dependencies: ['whisper'],
+      dependencyStatus: { whisper: true },
+      allDependenciesMet: true,
+      setupTime: '1 minute',
+      executions: 4,
+    },
+    {
+      id: 'code-assistant',
+      name: 'Code Assistant',
+      description: 'Review diffs on demand',
+      icon: 'Code',
+      category: 'productivity',
+      status: 'available',
+      installed: false,
+      active: false,
+      dependencies: ['openclaw'],
+      dependencyStatus: { openclaw: false },
+      allDependenciesMet: false,
+      setupTime: '3 minutes',
+      executions: 0,
+    },
+  ],
+}
+
+const renderWorkflows = (override = null) => {
+  const fetchMock = vi.fn(async (url, options) => {
+    if (override) {
+      const overridden = override(url, options)
+      if (overridden) return overridden
+    }
+    if (url === '/api/workflows') return response(catalog)
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return { ...render(<Workflows />), fetchMock }
+}
+
+describe('Workflows', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('lists the shipped catalog with its install state', async () => {
+    renderWorkflows()
+
+    expect(await screen.findByText('Daily Digest')).toBeInTheDocument()
+    expect(screen.getByText('Voice Transcription')).toBeInTheDocument()
+    expect(screen.getAllByText('Available')).toHaveLength(2)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('4 runs')).toBeInTheDocument()
+  })
+
+  test('filters the catalog by category', async () => {
+    renderWorkflows()
+    await screen.findByText('Daily Digest')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Voice' }))
+
+    expect(screen.getByText('Voice Transcription')).toBeInTheDocument()
+    expect(screen.queryByText('Daily Digest')).not.toBeInTheDocument()
+  })
+
+  test('installing a workflow posts to enable and re-reads the catalog', async () => {
+    const { fetchMock } = renderWorkflows((url) => (
+      url === '/api/workflows/daily-digest/enable'
+        ? response({ status: 'success', message: 'Daily Digest is now active!' })
+        : null
+    ))
+    await screen.findByText('Daily Digest')
+
+    const card = screen.getByText('Daily Digest').closest('div.rounded-lg')
+    fireEvent.click(within(card).getByRole('button', { name: /Install/ }))
+
+    expect(await screen.findByText('Daily Digest is now active!')).toBeInTheDocument()
+    const enableCall = fetchMock.mock.calls.find(([url]) => url === '/api/workflows/daily-digest/enable')
+    expect(enableCall[1].method).toBe('POST')
+    // n8n owns install state, so the page must re-read rather than assume.
+    expect(fetchMock.mock.calls.filter(([url]) => url === '/api/workflows')).toHaveLength(2)
+  })
+
+  test('an installed workflow offers removal instead of install', async () => {
+    const { fetchMock } = renderWorkflows((url) => (
+      url === '/api/workflows/voice-transcription/disable'
+        ? response({ status: 'success', message: 'Voice Transcription has been removed' })
+        : null
+    ))
+    await screen.findByText('Voice Transcription')
+
+    const card = screen.getByText('Voice Transcription').closest('div.rounded-lg')
+    fireEvent.click(within(card).getByRole('button', { name: /Remove/ }))
+
+    expect(await screen.findByText('Voice Transcription has been removed')).toBeInTheDocument()
+    expect(fetchMock.mock.calls.some(([url]) => url === '/api/workflows/voice-transcription/disable')).toBe(true)
+  })
+
+  test('blocks install while a dependency is down and names it', async () => {
+    renderWorkflows()
+    await screen.findByText('Code Assistant')
+
+    expect(screen.getByText('Needs openclaw running first.')).toBeInTheDocument()
+    const card = screen.getByText('Code Assistant').closest('div.rounded-lg')
+    expect(within(card).getByRole('button', { name: /Install/ })).toBeDisabled()
+  })
+
+  test('surfaces the API error instead of silently failing', async () => {
+    renderWorkflows((url) => (
+      url === '/api/workflows/daily-digest/enable'
+        ? response({ detail: 'Missing dependencies: llama-server. Enable these services first.' }, 400)
+        : null
+    ))
+    await screen.findByText('Daily Digest')
+
+    const card = screen.getByText('Daily Digest').closest('div.rounded-lg')
+    fireEvent.click(within(card).getByRole('button', { name: /Install/ }))
+
+    expect(await screen.findByText('Missing dependencies: llama-server. Enable these services first.')).toBeInTheDocument()
+  })
+
+  test('explains that nothing can be installed while n8n is unreachable', async () => {
+    renderWorkflows((url) => (
+      url === '/api/workflows'
+        ? response({ ...catalog, n8nAvailable: false })
+        : null
+    ))
+
+    expect(await screen.findByText(/n8n is not reachable/)).toBeInTheDocument()
+    const card = screen.getByText('Daily Digest').closest('div.rounded-lg')
+    expect(within(card).getByRole('button', { name: /Install/ })).toBeDisabled()
+  })
+
+  test('reports a catalog fetch failure', async () => {
+    renderWorkflows((url) => (url === '/api/workflows' ? response({}, 503) : null))
+
+    expect(await screen.findByText('Workflow catalog unavailable (503)')).toBeInTheDocument()
+  })
+})

--- a/ods/extensions/services/dashboard/src/plugins/core.js
+++ b/ods/extensions/services/dashboard/src/plugins/core.js
@@ -10,6 +10,7 @@ import {
   UserPlus,
   CreditCard,
   Code,
+  Workflow,
 } from 'lucide-react'
 
 const Dashboard = lazy(() => import('../pages/Dashboard'))
@@ -21,6 +22,7 @@ const RemoteProvider = lazy(() => import('../pages/RemoteProvider'))
 const ServiceMap = lazy(() => import('../pages/ServiceMap'))
 const Invites = lazy(() => import('../pages/Invites'))
 const Usage = lazy(() => import('../pages/Usage'))
+const Workflows = lazy(() => import('../pages/Workflows'))
 
 export const coreRoutes = [
   {
@@ -63,6 +65,20 @@ export const coreRoutes = [
     getProps: () => ({}),
     sidebar: true,
     order: 2.1,
+  },
+  {
+    id: 'workflows',
+    path: '/workflows',
+    label: 'Workflows',
+    icon: Workflow,
+    component: Workflows,
+    getProps: () => ({}),
+    // Route always registered so the n8n README's install links resolve; the
+    // sidebar entry only appears once n8n is actually part of the stack.
+    sidebar: ({ status }) => (status?.services || []).some(
+      service => (service.id || '').toLowerCase() === 'n8n' && service.status !== 'not_deployed'
+    ),
+    order: 2.2,
   },
   {
     id: 'models',

--- a/ods/extensions/services/dashboard/src/plugins/core.test.js
+++ b/ods/extensions/services/dashboard/src/plugins/core.test.js
@@ -1,0 +1,34 @@
+import { getInternalRoutes, getSidebarNavItems } from './registry'
+
+// Sidebar predicates receive the same context App passes: { status }.
+const withServices = (services) => ({ status: { services } })
+
+describe('core routes', () => {
+  test('the workflows route is always registered so direct links resolve', () => {
+    const paths = getInternalRoutes(withServices([])).map(route => route.path)
+    expect(paths).toContain('/workflows')
+  })
+
+  test('workflows stays out of the sidebar when n8n is not part of the stack', () => {
+    const ids = getSidebarNavItems(withServices([
+      { id: 'open-webui', status: 'healthy' },
+    ])).map(item => item.id)
+    expect(ids).not.toContain('workflows')
+  })
+
+  test('workflows stays out of the sidebar when n8n is not deployed', () => {
+    const ids = getSidebarNavItems(withServices([
+      { id: 'n8n', status: 'not_deployed' },
+    ])).map(item => item.id)
+    expect(ids).not.toContain('workflows')
+  })
+
+  test('workflows appears once n8n is deployed, even while it is down', () => {
+    for (const status of ['healthy', 'unhealthy', 'down']) {
+      const ids = getSidebarNavItems(withServices([
+        { id: 'n8n', status },
+      ])).map(item => item.id)
+      expect(ids).toContain('workflows')
+    }
+  })
+})


### PR DESCRIPTION
## Why

`extensions/services/n8n/README.md` tells operators:

> Templates are stored in `config/n8n/` as JSON files and **can be installed with one click from the Workflows page**.

There is no Workflows page. The backend has been complete for a while and nothing in the dashboard calls it:

| piece | state |
|---|---|
| `routers/workflows.py` | catalog, n8n status, enable, disable, executions — with tests |
| `config/n8n/catalog.json` | **18 workflows across 7 categories**, shipped |
| dashboard | zero references to `/api/workflows` |

So the templates ODS ships can only be installed with `curl` (which is exactly what the README's own examples fall back to) or by importing JSON by hand in n8n. This adds the missing surface; no backend changes.

## What

`src/pages/Workflows.jsx`, built against the existing response contract:

- catalog list with live state from n8n — `available` / `installed` / `active` — plus category, setup time, and execution count
- category filter chips built from the API's own `categories` map rather than a second hardcoded list
- **install / remove** call the existing `POST /api/workflows/{id}/enable|disable`, then re-read `/api/workflows`. n8n owns install state, so a locally-guessed update would drift from it — the test asserts the refetch happens.
- a workflow whose dependency is down cannot be installed and names the service that has to come up first, mirroring the `400 Missing dependencies: …` the API would otherwise return after a pointless round trip
- when n8n is unreachable (`n8nAvailable: false`) the page says so and disables installs instead of letting every click fail
- API errors surface their `detail` rather than failing silently

Route registration in `plugins/core.js` (order 2.2, next to Extensions/Integrations). The route is **always registered** so direct links and bookmarks resolve; the sidebar entry only appears once n8n is actually deployed, following the existing "GPU Monitor only on multi-GPU" pattern.

## Verification

```
$ npx vitest run --no-cache
Test Files  28 passed (28)
     Tests  259 passed (259)

$ npm run lint     # clean
$ npm run build    # ✓ built in 12.07s
```

New tests:

- `src/pages/Workflows.test.jsx` — listing and status badges, category filter, install round-trip (asserts `POST` + the catalog refetch), remove round-trip, blocked dependency disables the button and explains why, n8n-unreachable banner, catalog fetch failure
- `src/plugins/core.test.js` — the route is registered regardless of context; the sidebar entry is hidden with no n8n and when n8n is `not_deployed`, and present once n8n is deployed even while `unhealthy`/`down` (so the page is reachable precisely when it can explain itself)

## Notes

- `GET /api/workflows/{id}/executions` is deliberately left unused for now — a run-history drawer is a second interaction surface and belongs in its own change once this lands.
- Icons come from the catalog's `icon` field through a small map, falling back to `Workflow` for names the dashboard does not bundle.