### PR TITLE
feat(dashboard): surface the Privacy Shield toggle and counters

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PrivacyShieldCard.jsx
+++ b/ods/extensions/services/dashboard/src/components/PrivacyShieldCard.jsx
@@ -1,0 +1,131 @@
+import { Loader2, Shield, ShieldOff } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+
+// Auth: nginx injects the dashboard API key for /api/ requests, so relative
+// URLs need no explicit header here (see Extensions.jsx).
+const fetchJson = async (url, options = {}, ms = 8000) => {
+  const c = new AbortController()
+  const t = setTimeout(() => c.abort(), ms)
+  try {
+    return await fetch(url, { ...options, signal: c.signal })
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+// /api/privacy-shield/stats answers 200 with an {error} body when the shield
+// is unreachable or SHIELD_API_KEY is unset, so "no stats" is a normal state.
+const readStats = (payload) => (
+  payload && !payload.error && typeof payload.total_pii_scrubbed === 'number' ? payload : null
+)
+
+export default function PrivacyShieldCard({ deployed = false }) {
+  const [status, setStatus] = useState(null)
+  const [stats, setStats] = useState(null)
+  const [error, setError] = useState(null)
+  const [notice, setNotice] = useState(null)
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(async () => {
+    if (!deployed) return
+    try {
+      const [statusRes, statsRes] = await Promise.all([
+        fetchJson('/api/privacy-shield/status'),
+        fetchJson('/api/privacy-shield/stats'),
+      ])
+      if (!statusRes.ok) throw new Error(`Privacy Shield status unavailable (${statusRes.status})`)
+      setStatus(await statusRes.json())
+      setStats(statsRes.ok ? readStats(await statsRes.json()) : null)
+      setError(null)
+    } catch (err) {
+      setError(err?.name === 'AbortError' ? 'Privacy Shield status timed out' : (err?.message || 'Failed to read Privacy Shield status'))
+    }
+  }, [deployed])
+
+  useEffect(() => { load() }, [load])
+
+  if (!deployed) return null
+
+  const enabled = Boolean(status?.enabled)
+
+  const toggle = async () => {
+    setBusy(true)
+    setNotice(null)
+    try {
+      const response = await fetchJson(
+        '/api/privacy-shield/toggle',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enable: !enabled }),
+        },
+        35000,
+      )
+      const payload = await response.json().catch(() => ({}))
+      // The endpoint reports failures in the body with a 200, so success is
+      // the payload's own flag rather than the HTTP status.
+      setNotice({
+        tone: payload?.success ? 'ok' : 'error',
+        text: payload?.message || (payload?.success ? 'Privacy Shield updated' : 'Privacy Shield could not be updated'),
+      })
+      await load()
+    } catch (err) {
+      setNotice({ tone: 'error', text: err?.message || 'Privacy Shield could not be updated' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="mb-10 rounded-lg border border-theme-border bg-theme-card p-5" data-testid="privacy-shield-card">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          {enabled
+            ? <Shield size={20} className="text-emerald-400" />
+            : <ShieldOff size={20} className="text-theme-text-muted" />}
+          <div>
+            <h2 className="text-sm font-semibold text-theme-text">Privacy Shield</h2>
+            <p className="text-xs text-theme-text-muted">
+              {status?.message || 'PII is scrubbed before prompts leave this machine.'}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={toggle}
+          className={`shrink-0 rounded-lg px-4 py-2 text-sm disabled:opacity-50 ${
+            enabled
+              ? 'border border-theme-border text-theme-text hover:border-red-400/50 hover:text-red-300'
+              : 'bg-theme-accent text-white'
+          }`}
+        >
+          {busy ? <Loader2 size={15} className="animate-spin" /> : (enabled ? 'Stop' : 'Start')}
+        </button>
+      </div>
+
+      {error && <p className="mb-3 text-xs text-red-300">{error}</p>}
+      {notice && (
+        <p className={`mb-3 text-xs ${notice.tone === 'ok' ? 'text-emerald-300' : 'text-red-300'}`}>
+          {notice.text}
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Metric label="PII scrubbed" value={stats ? stats.total_pii_scrubbed : '—'} />
+        <Metric label="Active sessions" value={stats ? stats.active_sessions : '—'} />
+        <Metric label="Cache" value={stats ? (stats.cache_enabled ? `On (${stats.cache_size})` : 'Off') : '—'} />
+        <Metric label="Port" value={status?.port || '—'} />
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value }) {
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.18em] text-theme-text-muted">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-theme-text">{value}</p>
+    </div>
+  )
+}

--- a/ods/extensions/services/dashboard/src/components/PrivacyShieldCard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PrivacyShieldCard.test.jsx
@@ -1,0 +1,123 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import PrivacyShieldCard from './PrivacyShieldCard' // eslint-disable-line no-unused-vars
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+const activeStatus = {
+  enabled: true,
+  container_running: true,
+  port: 8085,
+  target_api: 'http://llama-server:8080/v1',
+  pii_cache_enabled: true,
+  message: 'Privacy Shield is active',
+}
+
+const stats = {
+  cache_enabled: true,
+  cache_size: 512,
+  active_sessions: 3,
+  total_pii_scrubbed: 47,
+}
+
+const renderCard = (override = null, props = {}) => {
+  const fetchMock = vi.fn(async (url, options) => {
+    if (override) {
+      const overridden = override(url, options)
+      if (overridden) return overridden
+    }
+    if (url === '/api/privacy-shield/status') return response(activeStatus)
+    if (url === '/api/privacy-shield/stats') return response(stats)
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return { ...render(<PrivacyShieldCard deployed {...props} />), fetchMock }
+}
+
+describe('PrivacyShieldCard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('renders nothing and makes no request when the service is not deployed', () => {
+    const { fetchMock } = renderCard(null, { deployed: false })
+
+    expect(screen.queryByTestId('privacy-shield-card')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('shows the shield state and its counters', async () => {
+    renderCard()
+
+    expect(await screen.findByText('Privacy Shield is active')).toBeInTheDocument()
+    expect(screen.getByText('47')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('On (512)')).toBeInTheDocument()
+    expect(screen.getByText('8085')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument()
+  })
+
+  test('stopping the shield posts enable:false and re-reads the status', async () => {
+    const { fetchMock } = renderCard((url) => (
+      url === '/api/privacy-shield/toggle'
+        ? response({ success: true, message: 'Privacy Shield stopped.' })
+        : null
+    ))
+    await screen.findByRole('button', { name: 'Stop' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+
+    expect(await screen.findByText('Privacy Shield stopped.')).toBeInTheDocument()
+    const toggleCall = fetchMock.mock.calls.find(([url]) => url === '/api/privacy-shield/toggle')
+    expect(toggleCall[1].method).toBe('POST')
+    expect(JSON.parse(toggleCall[1].body)).toEqual({ enable: false })
+    expect(fetchMock.mock.calls.filter(([url]) => url === '/api/privacy-shield/status')).toHaveLength(2)
+  })
+
+  test('offers to start the shield when it is down', async () => {
+    renderCard((url) => (
+      url === '/api/privacy-shield/status'
+        ? response({ ...activeStatus, enabled: false, container_running: false, message: 'Privacy Shield is not running.' })
+        : null
+    ))
+
+    expect(await screen.findByRole('button', { name: 'Start' })).toBeInTheDocument()
+  })
+
+  test('reports a failed toggle even though the endpoint answers 200', async () => {
+    renderCard((url) => (
+      url === '/api/privacy-shield/toggle'
+        ? response({ success: false, message: 'Host agent not reachable' })
+        : null
+    ))
+    await screen.findByRole('button', { name: 'Stop' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+
+    expect(await screen.findByText('Host agent not reachable')).toBeInTheDocument()
+  })
+
+  test('keeps the card usable when stats are unavailable', async () => {
+    renderCard((url) => (
+      url === '/api/privacy-shield/stats'
+        ? response({ error: 'SHIELD_API_KEY not configured', enabled: false })
+        : null
+    ))
+
+    expect(await screen.findByText('Privacy Shield is active')).toBeInTheDocument()
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument()
+  })
+
+  test('surfaces a status endpoint failure', async () => {
+    renderCard((url) => (
+      url === '/api/privacy-shield/status' ? response({}, 503) : null
+    ))
+
+    expect(await screen.findByText('Privacy Shield status unavailable (503)')).toBeInTheDocument()
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import PrivacyShieldCard from '../components/PrivacyShieldCard'
 import { serviceUrl } from '../lib/serviceUrls'
 
 // Compute overall health from services (excludes not_deployed from counts)
@@ -677,6 +678,14 @@ export default function Dashboard({ status, loading }) {
     () => buildServiceRows(status?.services, serviceResources?.services),
     [status?.services, serviceResources?.services]
   )
+  // Privacy Shield ships headless, so the dashboard is the only place its
+  // toggle and counters can appear — but only once it is part of the stack.
+  const privacyShieldDeployed = useMemo(
+    () => (status?.services || []).some(
+      service => (service.id || '').toLowerCase() === 'privacy-shield' && service.status !== 'not_deployed'
+    ),
+    [status?.services]
+  )
 
   if (loading) {
     return (
@@ -887,6 +896,10 @@ export default function Dashboard({ status, loading }) {
       </div>
 
       <ServicesPanel services={serviceRows} />
+
+      {/* Privacy Shield's toggle and counters have no other surface in the
+          dashboard; the card hides itself when the service is not deployed. */}
+      <PrivacyShieldCard deployed={privacyShieldDeployed} />
 
       {/* Feature Discovery is already shown at the top */}
     </div>


### PR DESCRIPTION
## Why

`extensions/services/privacy-shield/README.md`:

> Privacy Shield status is displayed in the ODS dashboard:
> - Service health indicator
> - **Enable/disable toggle**
> - **Statistics (requests processed, PII items scrubbed)**

Only the first one exists, and only because it falls out of the generic services list. The dashboard makes no request to `/api/privacy-shield/status`, `/stats`, or `/toggle` — all three endpoints are backend-only. Privacy Shield also ships headless (it is in the Extensions page's `HEADLESS_EXTENSIONS` set), so there is no service link that could stand in: starting, stopping, or inspecting the shield needs a terminal today.

## What

`components/PrivacyShieldCard.jsx`, mounted under the services panel on the Dashboard:

- current state plus the API's own `message`, with **Start / Stop** driving `POST /api/privacy-shield/toggle`
- counters from `/stats`: PII scrubbed, active sessions, cache state, port
- renders nothing — and issues no request — when `privacy-shield` is not deployed

Two contract details the card respects rather than assumes:

| endpoint behaviour | what the card does |
|---|---|
| `/toggle` answers **200** with `{"success": false, "message": …}` for host-agent failures (`AgentUnavailable`, `AgentTimeout`, …) | reads success from the payload, not the HTTP status |
| `/stats` answers **200** with `{"error": …}` when the shield is unreachable or `SHIELD_API_KEY` is unset | degrades counters to em dashes and leaves the toggle usable, instead of blanking the card |

Counters are limited to what `/stats` actually returns (`cache_enabled`, `cache_size`, `active_sessions`, `total_pii_scrubbed`). The README also advertises "requests processed", which the endpoint does not expose — I did not invent it.

## Verification

```
$ npx vitest run --no-cache
Test Files  29 passed (29)
     Tests  266 passed (266)

$ npm run lint     # clean
$ npm run build    # ✓ built
```

`components/PrivacyShieldCard.test.jsx` covers: not-deployed renders nothing and fetches nothing; counters render; the stop round-trip asserts `POST` with `{enable:false}` **and** the status refetch; the start affordance appears when the shield is down; a `200` + `success:false` toggle surfaces the host-agent message; missing stats keep the card usable; a failed status read is reported.

Placement note: the Dashboard was the only uncontended home that is always reachable — the shield has no page of its own and no service link. Happy to move it to Settings or a dedicated surface if you would rather it live elsewhere.