### PR TITLE
fix(perplexica): detect Lemonade runtime on AMD local installs

### DIFF
--- a/ods/installers/phases/12-health.sh
+++ b/ods/installers/phases/12-health.sh
@@ -387,9 +387,16 @@ if $DOCKER_CMD inspect ods-perplexica &>/dev/null; then
     PERPLEXICA_MODEL="${LLM_MODEL:-default}"
     if [[ -n "${GGUF_FILE:-}" ]]; then
         PERPLEXICA_MODEL="$GGUF_FILE"
-        _perplexica_backend="$(printf '%s' "${LLM_BACKEND:-${AMD_INFERENCE_RUNTIME:-}}" | tr '[:upper:]' '[:lower:]')"
-        if [[ "$_perplexica_backend" == "lemonade" ]]; then
-            PERPLEXICA_MODEL="extra.$GGUF_FILE"
+        # Lemonade serves the model under a separate id. An AMD local install
+        # runs Lemonade while LLM_BACKEND stays "llama-server", so the runtime
+        # and the backend have to be checked independently — same rule as
+        # scripts/bootstrap-upgrade.sh and the container-side
+        # extensions/services/perplexica/sync-model-config.js.
+        _perplexica_runtime="$(printf '%s' "${AMD_INFERENCE_RUNTIME:-}" | tr '[:upper:]' '[:lower:]')"
+        _perplexica_backend="$(printf '%s' "${LLM_BACKEND:-}" | tr '[:upper:]' '[:lower:]')"
+        if [[ "$_perplexica_runtime" == "lemonade" || "$_perplexica_backend" == "lemonade" ]]; then
+            PERPLEXICA_MODEL="${LEMONADE_MODEL:-}"
+            [[ -n "$PERPLEXICA_MODEL" ]] || PERPLEXICA_MODEL="extra.$GGUF_FILE"
         fi
     fi
     PERPLEXICA_LLM_BASE_URL="${LLM_API_URL:-http://llama-server:8080}"

--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -310,9 +310,17 @@ if ! $DRY_RUN; then
         _perplexica_model="${LLM_MODEL:-qwen3-30b-a3b}"
         if [[ -n "${GGUF_FILE:-}" ]]; then
             _perplexica_model="$GGUF_FILE"
-            _perplexica_backend="$(printf '%s' "${LLM_BACKEND:-${AMD_INFERENCE_RUNTIME:-}}" | tr '[:upper:]' '[:lower:]')"
-            if [[ "$_perplexica_backend" == "lemonade" ]]; then
-                _perplexica_model="extra.$GGUF_FILE"
+            # Lemonade serves the model under a separate id, so the expected
+            # route differs from the bare GGUF name. An AMD local install runs
+            # Lemonade while LLM_BACKEND stays "llama-server", so both
+            # variables have to be consulted independently — same rule as
+            # scripts/bootstrap-upgrade.sh and the container-side
+            # extensions/services/perplexica/sync-model-config.js.
+            _perplexica_runtime="$(printf '%s' "${AMD_INFERENCE_RUNTIME:-}" | tr '[:upper:]' '[:lower:]')"
+            _perplexica_backend="$(printf '%s' "${LLM_BACKEND:-}" | tr '[:upper:]' '[:lower:]')"
+            if [[ "$_perplexica_runtime" == "lemonade" || "$_perplexica_backend" == "lemonade" ]]; then
+                _perplexica_model="${LEMONADE_MODEL:-}"
+                [[ -n "$_perplexica_model" ]] || _perplexica_model="extra.$GGUF_FILE"
             fi
         fi
         _perplexica_status=$(curl -sf --max-time 5 "http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}/api/config" 2>>"$LOG_FILE" | \

--- a/ods/scripts/repair/repair-perplexica.sh
+++ b/ods/scripts/repair/repair-perplexica.sh
@@ -23,9 +23,15 @@ esac
 if [[ -z "$PERPLEXICA_MODEL" ]]; then
     if [[ -n "${GGUF_FILE:-}" ]]; then
         PERPLEXICA_MODEL="$GGUF_FILE"
-        _perplexica_backend="$(printf '%s' "${LLM_BACKEND:-${AMD_INFERENCE_RUNTIME:-}}" | tr '[:upper:]' '[:lower:]')"
-        if [[ "$_perplexica_backend" == "lemonade" ]]; then
-            PERPLEXICA_MODEL="extra.$GGUF_FILE"
+        # An AMD local install runs Lemonade while LLM_BACKEND stays
+        # "llama-server", so the runtime and the backend have to be checked
+        # independently — same rule as scripts/bootstrap-upgrade.sh and the
+        # container-side extensions/services/perplexica/sync-model-config.js.
+        _perplexica_runtime="$(printf '%s' "${AMD_INFERENCE_RUNTIME:-}" | tr '[:upper:]' '[:lower:]')"
+        _perplexica_backend="$(printf '%s' "${LLM_BACKEND:-}" | tr '[:upper:]' '[:lower:]')"
+        if [[ "$_perplexica_runtime" == "lemonade" || "$_perplexica_backend" == "lemonade" ]]; then
+            PERPLEXICA_MODEL="${LEMONADE_MODEL:-}"
+            [[ -n "$PERPLEXICA_MODEL" ]] || PERPLEXICA_MODEL="extra.$GGUF_FILE"
         fi
     else
         PERPLEXICA_MODEL="$LLM_MODEL"

--- a/ods/tests/test-perplexica-entrypoint.py
+++ b/ods/tests/test-perplexica-entrypoint.py
@@ -30,6 +30,9 @@ SYNC_SCRIPT = SERVICE_DIR / "sync-model-config.js"
 SEARCH_SYNC_SCRIPT = SERVICE_DIR / "sync-search-config.js"
 WHISPER_COMPOSE = ROOT / "extensions" / "services" / "whisper" / "compose.yaml"
 BRAVE_DIR = ROOT / "extensions" / "services" / "brave-search"
+HEALTH_PHASE = ROOT / "installers" / "phases" / "12-health.sh"
+SUMMARY_PHASE = ROOT / "installers" / "phases" / "13-summary.sh"
+REPAIR_SCRIPT = ROOT / "scripts" / "repair" / "repair-perplexica.sh"
 
 
 def _node_cmd_or_skip() -> str | None:
@@ -40,6 +43,39 @@ def _node_cmd_or_skip() -> str | None:
         pytest.skip("Node.js is required")
     print("[SKIP] Node.js is required")
     return None
+
+
+def _bash_cmd_or_skip() -> str | None:
+    bash = shutil.which("bash")
+    if bash:
+        return bash
+    if pytest is not None:
+        pytest.skip("bash is required")
+    print("[SKIP] bash is required")
+    return None
+
+
+def _slice_block(path: Path, start_marker: str, end_line: str) -> str:
+    """Return the shell block starting at `start_marker` up to `end_line`.
+
+    `end_line` is matched against the whole (untrimmed) line so indentation
+    picks the closing `fi` of the intended block rather than a nested one.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if start_marker in line)
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].rstrip() == end_line)
+    return "\n".join(lines[start:end + 1])
+
+
+def _resolve_expected_model(bash: str, block: str, env: dict[str, str], var: str) -> str:
+    """Run an extracted model-id block with a fixed environment and read `var`."""
+    assignments = "\n".join(f"{key}={value!r}" for key, value in sorted(env.items()))
+    script = f"set -euo pipefail\n{assignments}\n{block}\nprintf '%s\\n' \"${{{var}}}\"\n"
+    result = subprocess.run(
+        [bash, "-s"], input=script, capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
 
 
 def test_compose_uses_ods_entrypoint() -> None:
@@ -569,6 +605,98 @@ def test_invalid_search_adapter_fails_closed_without_mutating_config() -> None:
     assert writes == []
 
 
+# The model id Perplexica must end up with is decided in five places: the
+# container-side sync script, scripts/bootstrap-upgrade.sh, the seeding step in
+# phase 12, the post-install validation in phase 13, and the repair script. The
+# last three used to read `${LLM_BACKEND:-${AMD_INFERENCE_RUNTIME:-}}`, which
+# can never see AMD_INFERENCE_RUNTIME because phase 06 always writes a
+# non-empty LLM_BACKEND.
+# The matrix below pins the resolution rule for every runtime combination the
+# installer can produce.
+_MODEL_ID_CASES = (
+    (
+        "amd_local_runs_lemonade_under_llama_server_backend",
+        {
+            "GGUF_FILE": "Modern-Model.gguf",
+            "LLM_BACKEND": "llama-server",
+            "AMD_INFERENCE_RUNTIME": "lemonade",
+            "LEMONADE_MODEL": "",
+        },
+        "extra.Modern-Model.gguf",
+    ),
+    (
+        "external_lemonade_uses_the_discovered_model_id",
+        {
+            "GGUF_FILE": "Modern-Model.gguf",
+            "LLM_BACKEND": "lemonade",
+            "AMD_INFERENCE_RUNTIME": "lemonade",
+            "LEMONADE_MODEL": "Qwen3-8B-GGUF",
+        },
+        "Qwen3-8B-GGUF",
+    ),
+    (
+        "llama_server_backends_use_the_bare_gguf_id",
+        {
+            "GGUF_FILE": "Modern-Model.gguf",
+            "LLM_BACKEND": "llama-server",
+            "AMD_INFERENCE_RUNTIME": "",
+            "LEMONADE_MODEL": "",
+        },
+        "Modern-Model.gguf",
+    ),
+)
+
+
+def test_health_phase_seeds_the_same_model_id_as_the_sync_script() -> None:
+    bash = _bash_cmd_or_skip()
+    if bash is None:
+        return
+
+    block = _slice_block(
+        HEALTH_PHASE,
+        'PERPLEXICA_MODEL="${LLM_MODEL:-default}"',
+        "    fi",
+    )
+    for name, env, expected in _MODEL_ID_CASES:
+        resolved = _resolve_expected_model(
+            bash, block, {"LLM_MODEL": "qwen3-30b-a3b", **env}, "PERPLEXICA_MODEL"
+        )
+        assert resolved == expected, f"{name}: expected {expected}, got {resolved}"
+
+
+def test_post_install_validation_resolves_the_same_model_id_as_the_sync_script() -> None:
+    bash = _bash_cmd_or_skip()
+    if bash is None:
+        return
+
+    block = _slice_block(
+        SUMMARY_PHASE,
+        '_perplexica_model="${LLM_MODEL:-qwen3-30b-a3b}"',
+        "        fi",
+    )
+    for name, env, expected in _MODEL_ID_CASES:
+        resolved = _resolve_expected_model(
+            bash, block, {"LLM_MODEL": "qwen3-30b-a3b", **env}, "_perplexica_model"
+        )
+        assert resolved == expected, f"{name}: expected {expected}, got {resolved}"
+
+
+def test_repair_script_resolves_the_same_model_id_as_the_sync_script() -> None:
+    bash = _bash_cmd_or_skip()
+    if bash is None:
+        return
+
+    block = _slice_block(REPAIR_SCRIPT, 'if [[ -z "$PERPLEXICA_MODEL" ]]; then', "fi")
+    for name, env, expected in _MODEL_ID_CASES:
+        resolved = _resolve_expected_model(
+            bash,
+            block,
+            {"LLM_MODEL": "qwen3-30b-a3b", "PERPLEXICA_MODEL": "", **env},
+            "PERPLEXICA_MODEL",
+        )
+        assert resolved == expected, f"{name}: expected {expected}, got {resolved}"
+
+
 if __name__ == "__main__":
     test_compose_uses_ods_entrypoint()
     test_search_adapter_config_and_secret_contracts()
@@ -587,3 +715,6 @@ if __name__ == "__main__":
     test_empty_search_adapter_preserves_existing_searxng_setting()
     test_search_adapter_sync_is_idempotent()
     test_invalid_search_adapter_fails_closed_without_mutating_config()
+    test_health_phase_seeds_the_same_model_id_as_the_sync_script()
+    test_post_install_validation_resolves_the_same_model_id_as_the_sync_script()
+    test_repair_script_resolves_the_same_model_id_as_the_sync_script()


### PR DESCRIPTION
## Problem

Five places decide which model id Perplexica must be pointed at. Three of them resolve it with a rule that can never fire:

```bash
# installers/phases/12-health.sh:311, installers/phases/13-summary.sh:313,
# scripts/repair/repair-perplexica.sh:26
_perplexica_backend="$(printf '%s' "${LLM_BACKEND:-${AMD_INFERENCE_RUNTIME:-}}" | tr '[:upper:]' '[:lower:]')"
if [[ "$_perplexica_backend" == "lemonade" ]]; then
    ..._MODEL="extra.$GGUF_FILE"
fi
```

`${LLM_BACKEND:-...}` only falls through when `LLM_BACKEND` is empty, and phase 06 always writes it:

```bash
# installers/phases/06-directories.sh:701,703
LLM_BACKEND=$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "lemonade"; else echo "llama-server"; fi)
AMD_INFERENCE_RUNTIME=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" || ( "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ) ]]; then echo "lemonade"; else echo ""; fi)
```

So on a plain **AMD GPU install in the default local mode** the env is `LLM_BACKEND=llama-server` **and** `AMD_INFERENCE_RUNTIME=lemonade` — the `AMD_INFERENCE_RUNTIME` branch is dead code and all three conclude "not Lemonade".

The two implementations that get it right check the variables independently:

| Writer | Rule |
|---|---|
| `extensions/services/perplexica/sync-model-config.js:6-9` | `AMD_INFERENCE_RUNTIME \|\| LLM_BACKEND \|\| ODS_MODE` |
| `scripts/bootstrap-upgrade.sh:3108` | `[[ "$_runtime_for_perplexica" == "lemonade" \|\| "$_llm_backend_for_perplexica" == "lemonade" ]]` |

## Impact

On AMD the three broken copies produce a self-reinforcing loop:

1. **Phase 12** seeds `defaultChatModel` with the bare GGUF id — an id Lemonade does not serve.
2. The container entrypoint runs `sync-model-config.js` on every start and **corrects** it to the Lemonade id.
3. **Phase 13** compares the (now correct) stored value against its own wrong expectation, decides the config is `needed`, and runs the repair script:

```bash
# installers/phases/13-summary.sh:329-336
if [[ "$_perplexica_status" == "needed" ]]; then
    ai_warn "Perplexica config incomplete — running auto-setup..."
    ... bash "$INSTALL_DIR/scripts/repair/repair-perplexica.sh" ...
```

4. **The repair script** writes the broken id back, and reports `Perplexica configured`.

The same wrong id is written by the manual path documented in `docs/MODEL-MANAGEMENT.md:352` and `extensions/services/perplexica/README.md:45`.

A second mismatch on the external-Lemonade path: phase 06 can discover a real Lemonade model id into `LEMONADE_MODEL` (`06-directories.sh:418-424`), which `sync-model-config.js` and `bootstrap-upgrade.sh` both prefer. The three shell copies ignored it and always expected `extra.<GGUF_FILE>`, so seeding and validation were wrong there too.

## Fix

All three call sites now apply the rule the other two implementations already use: Lemonade when *either* variable says so, preferring `LEMONADE_MODEL` over the `extra.<GGUF_FILE>` fallback. No new abstraction — the logic stays inline next to its use, matching how `bootstrap-upgrade.sh` already carries its own copy.

## Tests

Extends `tests/test-perplexica-entrypoint.py`, which is already gated in CI (`.github/workflows/test-linux.yml:151`).

The three new tests slice the model-id block out of each shell file and execute it under `bash` against a fixed env matrix, so they assert real resolution rather than grepping for text:

| Case | `LLM_BACKEND` | `AMD_INFERENCE_RUNTIME` | `LEMONADE_MODEL` | expected id |
|---|---|---|---|---|
| AMD local | `llama-server` | `lemonade` | – | `extra.Modern-Model.gguf` |
| external Lemonade | `lemonade` | `lemonade` | `Qwen3-8B-GGUF` | `Qwen3-8B-GGUF` |
| NVIDIA/Apple/CPU | `llama-server` | – | – | `Modern-Model.gguf` |

Verified red on the pre-fix sources:

```
AssertionError: amd_local_runs_lemonade_under_llama_server_backend:
  expected extra.Modern-Model.gguf, got Modern-Model.gguf
```

Full module passes after the fix (`python3 tests/test-perplexica-entrypoint.py`, exit 0).
