### PR TITLE
fix(brave-search): declare the service env keys in the schema

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -546,6 +546,16 @@
       "secret": true,
       "minLength": 10
     },
+    "BRAVE_SEARCH_PORT": {
+      "type": "integer",
+      "description": "Brave Search proxy external port",
+      "default": 8585
+    },
+    "BRAVE_SEARCH_API_KEY": {
+      "type": "string",
+      "description": "Brave Search API subscription token (obtain at api.search.brave.com)",
+      "secret": true
+    },
     "PERPLEXICA_PORT": {
       "type": "integer",
       "description": "Perplexica external port",

--- a/ods/tests/test-validate-env.sh
+++ b/ods/tests/test-validate-env.sh
@@ -428,6 +428,60 @@ else
     fail "Remote provider API key must not be added as an ordinary .env field"
 fi
 
+# 20. Service manifests promise user-settable .env keys. validate-env.sh
+# rejects any key absent from the schema as "unknown", so a manifest key that
+# never made it into .env.schema.json turns following the service README into
+# a hard validation failure.
+manifest_env_contract() {
+    awk '
+        /^[[:space:]]+external_port_env:[[:space:]]*/ {
+            print FILENAME "	" $2
+            next
+        }
+        /^[[:space:]]+-[[:space:]]+key:[[:space:]]*/ {
+            pending = $3
+            next
+        }
+        pending != "" && /^[[:space:]]+required:[[:space:]]*true[[:space:]]*$/ {
+            print FILENAME "	" pending
+            pending = ""
+        }
+        /^[[:space:]]+-[[:space:]]+key:/ { pending = $3 }
+    ' "$ROOT_DIR"/extensions/services/*/manifest.yaml | sort -u
+}
+
+undeclared=""
+while IFS=$'	' read -r manifest key; do
+    [[ -n "$key" ]] || continue
+    if ! grep -q "\"$key\":" "$ROOT_DIR/.env.schema.json"; then
+        undeclared+="${key} (${manifest##*/services/}) "
+    fi
+done < <(manifest_env_contract)
+
+if [[ -z "$undeclared" ]]; then
+    pass "Every manifest port override and required env key is declared in the schema"
+else
+    fail "Manifest keys missing from .env.schema.json: ${undeclared% }"
+fi
+
+# 21. The same gap, from the user's side: setting the documented Brave Search
+# keys in .env must not be reported as unknown.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/brave.env"
+cat >> "$TMP_DIR/brave.env" <<'EOF'
+BRAVE_SEARCH_API_KEY=brave-subscription-token
+BRAVE_SEARCH_PORT=8585
+EOF
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/brave.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 0 ]]; then
+    pass "Documented Brave Search keys validate cleanly"
+else
+    fail "Brave Search keys should validate, got exit $r: $(echo "$out" | grep -i brave | tr '
+' ' ')"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Problem

`extensions/services/brave-search/manifest.yaml` declares two user-facing env keys:

```yaml
  external_port_env: BRAVE_SEARCH_PORT
  external_port_default: 8585
  env_vars:
    - key: BRAVE_SEARCH_API_KEY
      required: true
      secret: true
      description: Brave Search API subscription token (obtain at api.search.brave.com)
    - key: BRAVE_SEARCH_PORT
      required: false
      default: "8585"
```

and the service README tells users exactly where to put the key:

> Set the key in `.env`:
> ```
> BRAVE_SEARCH_API_KEY=<your-token>
> ```

Neither key exists in `.env.schema.json`.

## Impact

`scripts/validate-env.sh` treats every `.env` key with no schema entry as an error, not a warning:

```bash
# scripts/validate-env.sh:218-222
for key in "${!ENV_MAP[@]}"; do
    if [[ -z "${SCHEMA_KEY_SET[$key]-}" ]]; then
        unknown+=("$key")
    fi
done
# :522-527
if (( ${#unknown[@]} > 0 )); then
    had_errors=true
    log_error "Unknown keys not defined in schema:"
```

Reproduced on a `.env` that is otherwise valid:

```
[ERROR] Unknown keys not defined in schema:
  - BRAVE_SEARCH_PORT
  - BRAVE_SEARCH_API_KEY
exit 2
```

That validator runs on three paths:

| Caller | Consequence |
|---|---|
| `ods-cli:2166` (`ods config validate`) | documented command exits 2 |
| `installers/phases/06-directories.sh:1072` | `error "Generated .env failed schema validation."` — **aborts the install** |
| `installers/windows/phases/06-directories.ps1:651` | same gate on Windows |

Separately, the dashboard env editor refuses anything without a schema entry:

> `main.py:974` — "Field is not editable from the dashboard. Only schema-backed fields and existing local overrides can be changed here."

So the key the service cannot start without had no supported way in: the CLI validator rejects it and the UI will not edit it.

## Scope check

brave-search is the outlier, not a pattern:

- of the **22** services declaring `external_port_env`, it is the **only** one whose port key is missing from the schema;
- of the **5** services declaring a `required: true` env key (`litellm`, `n8n` ×2, `openclaw`, `brave-search`), it is the **only** one whose key is missing.

## Fix

Adds both keys to `.env.schema.json` next to the other optional-service entries, matching the existing style (`SEARXNG_PORT`, `SEARXNG_SECRET`).

Deliberately **not** added to the top-level `required` array — brave-search is an optional extension — and **no `minLength`** on the token: the existing `minLength: 10` secrets are ODS-generated values where a short string means "placeholder", whereas this is a third-party token whose length is not ours to constrain.

## Tests

Extends `tests/test-validate-env.sh` (already gated at `.github/workflows/test-linux.yml:124`) with two checks:

1. **Contract** — every `external_port_env` and every `required: true` env key across all service manifests is declared in `.env.schema.json`. Derived from the manifests, so a future service cannot repeat this.
2. **Behavioural** — the documented Brave Search keys appended to an otherwise-valid `.env` validate with exit 0.

Verified red against the pre-fix schema:

```
✗ FAIL Manifest keys missing from .env.schema.json: BRAVE_SEARCH_API_KEY (brave-search/manifest.yaml) BRAVE_SEARCH_PORT (brave-search/manifest.yaml)
✗ FAIL Brave Search keys should validate, got exit 2: - BRAVE_SEARCH_PORT (line 8) - BRAVE_SEARCH_API_KEY (line 7)
Result: 41 passed, 2 failed
```

Green after: **43 passed, 0 failed**.
