### PR TITLE
fix(macos): write the OpenCode config.json compat file

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -420,18 +420,24 @@ HERMES_AUTH_VERIFY_PY
 
 _write_macos_opencode_config() {
     local config_path="$1" model_name="$2" base_url="$3" api_key="$4" context_length="$5"
+    # OpenCode reads config.json, not opencode.json, so the same document has
+    # to land in both files — matching installers/phases/07-devtools.sh on
+    # Linux and installers/windows/lib/opencode-config.ps1 on Windows.
+    local compat_path
+    compat_path="$(dirname "$config_path")/config.json"
     mkdir -p "$(dirname "$config_path")"
     ODS_OPENCODE_MODEL="$model_name" \
     ODS_OPENCODE_BASE_URL="$base_url" \
     ODS_OPENCODE_API_KEY="$api_key" \
     ODS_OPENCODE_CONTEXT="$context_length" \
-        /usr/bin/python3 - "$config_path" <<'OPENCODE_CONFIG_PY'
+        /usr/bin/python3 - "$config_path" "$compat_path" <<'OPENCODE_CONFIG_PY'
 import json
 import os
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
+compat_path = Path(sys.argv[2])
 try:
     data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
 except (OSError, ValueError):
@@ -459,17 +465,25 @@ provider.update({
 data["model"] = f"{provider_id}/{model_name}"
 data.setdefault("$schema", "https://opencode.ai/config.json")
 
-tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-os.chmod(tmp, 0o600)
-os.replace(tmp, path)
+payload = json.dumps(data, indent=2) + "\n"
 
-check = json.loads(path.read_text(encoding="utf-8"))
-check_provider = check["provider"][provider_id]
-if check.get("model") != f"{provider_id}/{model_name}":
-    raise SystemExit("OpenCode model verification failed")
-if check_provider["options"] != {"baseURL": base_url, "apiKey": api_key}:
-    raise SystemExit("OpenCode route verification failed")
+
+def write_atomic(target):
+    tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, target)
+
+
+for target in (path, compat_path):
+    write_atomic(target)
+
+    check = json.loads(target.read_text(encoding="utf-8"))
+    check_provider = check["provider"][provider_id]
+    if check.get("model") != f"{provider_id}/{model_name}":
+        raise SystemExit(f"OpenCode model verification failed for {target.name}")
+    if check_provider["options"] != {"baseURL": base_url, "apiKey": api_key}:
+        raise SystemExit(f"OpenCode route verification failed for {target.name}")
 OPENCODE_CONFIG_PY
 }
 

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -276,5 +276,69 @@ grep -q '^  max_tokens: 2048$' "$tmp_hermes_custom" \
     || fail "Hermes patcher preserves a custom model output cap"
 pass "Hermes patcher preserves a custom model output cap"
 
+# ---------------------------------------------------------------------------
+# OpenCode reads config.json, not opencode.json. Every platform writer has to
+# produce both files or the native OpenCode install starts with no ODS
+# provider configured at all.
+# ---------------------------------------------------------------------------
+
+assert_grep "installers/phases/07-devtools.sh" \
+    'cp "\$OPENCODE_CONFIG_DIR/opencode\.json" "\$OPENCODE_CONFIG_DIR/config\.json"' \
+    "Linux OpenCode writer syncs config.json"
+
+assert_grep "installers/windows/lib/opencode-config.ps1" \
+    'WriteAllText\(\$_ocCompatConfigFile' \
+    "Windows OpenCode writer syncs config.json"
+
+assert_grep "installers/macos/install-macos.sh" \
+    'compat_path="\$\(dirname "\$config_path"\)/config\.json"' \
+    "macOS OpenCode writer syncs config.json"
+
+if [[ -n "$python_cmd" ]]; then
+    tmp_opencode_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_opencode_dir"' EXIT
+
+    # Run the real macOS writer: lift the function out of the installer and
+    # point its interpreter at whatever python3 this runner has.
+    opencode_writer="$tmp_opencode_dir/writer.sh"
+    awk '/^_write_macos_opencode_config\(\) \{$/ {inside=1}
+         inside {print}
+         inside && /^\}$/ {exit}' installers/macos/install-macos.sh \
+        | sed "s#/usr/bin/python3#$python_cmd#" > "$opencode_writer"
+
+    [[ -s "$opencode_writer" ]] || fail "could not extract _write_macos_opencode_config"
+
+    # shellcheck disable=SC1090
+    . "$opencode_writer"
+    _write_macos_opencode_config \
+        "$tmp_opencode_dir/config/opencode.json" \
+        "Modern-Model.gguf" "http://127.0.0.1:8080/v1" "no-key" 32768 \
+        || fail "macOS OpenCode writer failed"
+
+    [[ -f "$tmp_opencode_dir/config/config.json" ]] \
+        || fail "macOS OpenCode writer must also write config.json"
+    pass "macOS OpenCode writer produces config.json"
+
+    cmp -s "$tmp_opencode_dir/config/opencode.json" "$tmp_opencode_dir/config/config.json" \
+        || fail "macOS OpenCode config.json must match opencode.json"
+    pass "macOS OpenCode config.json matches opencode.json"
+
+    "$python_cmd" - "$tmp_opencode_dir/config/config.json" <<'OPENCODE_COMPAT_PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+provider = data["provider"]["llama-server"]
+assert data["model"] == "llama-server/Modern-Model.gguf", data.get("model")
+assert provider["options"] == {
+    "baseURL": "http://127.0.0.1:8080/v1",
+    "apiKey": "no-key",
+}, provider["options"]
+OPENCODE_COMPAT_PY
+    pass "macOS OpenCode config.json carries the active route"
+else
+    echo "  SKIP: python3 unavailable - macOS OpenCode writer behaviour not exercised"
+fi
+
 echo ""
 echo "Results: $PASS passed"


### PR DESCRIPTION
## Problem

OpenCode reads `config.json`, not `opencode.json`. Two of the three platform writers say so and act on it; macOS does not.

**Linux** — `installers/phases/07-devtools.sh:270-271`

```bash
# OpenCode reads config.json, not opencode.json — always sync
cp "$OPENCODE_CONFIG_DIR/opencode.json" "$OPENCODE_CONFIG_DIR/config.json"
```

**Windows** — `installers/windows/lib/opencode-config.ps1:139,183-184`

```powershell
$_ocCompatConfigFile = Join-Path $ConfigDir "config.json"
...
[System.IO.File]::WriteAllText($_ocConfigFile, $_configJson, $_utf8NoBom)
[System.IO.File]::WriteAllText($_ocCompatConfigFile, $_configJson, $_utf8NoBom)
```

**macOS** — `installers/macos/install-macos.sh:2701` calls `_write_macos_opencode_config` with a single path:

```bash
|| ! _write_macos_opencode_config \
     "$OPENCODE_CONFIG_DIR/opencode.json" \
     "$_opencode_model" "$_opencode_base_url" "$_opencode_api_key" \
     "${MAX_CONTEXT:-32768}"
```

and the writer only ever produces that one file. Nothing else on macOS writes `config.json` — `scripts/bootstrap-upgrade.sh` has a sync path for Windows only (`sync_windows_opencode_config`, line 500).

The directory is identical on all three platforms (`$HOME/.config/opencode` — `installers/macos/lib/constants.sh:64`, `installers/phases/07-devtools.sh:139`), so this is not a path-layout difference.

## Impact

A macOS install ends with OpenCode configured only in a file OpenCode does not read. The LaunchAgent (`installers/macos/install-macos.sh:2718+`) starts `opencode web`, it finds no `config.json`, and the `llama-server` provider, model id, base URL and API key the installer just wrote and verified are never loaded — while the installer prints:

```
OpenCode configured for <model> at <base-url>
```

The Windows compat write and the explicit Linux comment are the evidence that both files are intended; macOS is the odd one out.

## Fix

`_write_macos_opencode_config` derives the compat path next to the config path, renders the document once, and writes both through the same atomic `0600` replace it already used. The post-write verification now runs per file instead of only on the first, so a failure names which file failed.

No behaviour change on Linux or Windows.

## Tests

Extends `tests/test-installer-context-parity.sh` — the existing cross-platform installer parity suite, run by `make test` / `make gate`.

- Three static assertions pin the "writes config.json" contract for the Linux, Windows and macOS writers, so the next platform writer cannot quietly skip it.
- One behavioural check lifts `_write_macos_opencode_config` out of the installer, points its interpreter at the runner's `python3`, and runs it against a temp dir: both files must exist, be byte-identical, and the `config.json` must carry the active `model` and `options`. Skips cleanly when no `python3` is present.

Verified red against the pre-fix installer:

```
PASS: Linux OpenCode writer syncs config.json
PASS: Windows OpenCode writer syncs config.json
FAIL: macOS OpenCode writer syncs config.json
```

Green after: **73 passed**.
