### PR TITLE
fix(dashboard): report bootstrap download size in GiB

### DIFF
--- a/ods/extensions/services/dashboard/src/App.jsx
+++ b/ods/extensions/services/dashboard/src/App.jsx
@@ -169,7 +169,12 @@ function BootstrapBanner({ bootstrap }) {
 
   const formatBytes = (bytes) => {
     if (!bytes) return '0'
-    return (bytes / 1e9).toFixed(1)
+    // Binary GiB, not decimal GB. dashboard-api derives these bytes from
+    // BootstrapStatus.downloaded_gb / total_gb, which helpers.py builds with
+    // 1024**3, and useDownloadProgress renders the same payload the same way.
+    // Dividing by 1e9 here made the banner read ~7% higher than the download
+    // card for the same file.
+    return (bytes / 1024 ** 3).toFixed(1)
   }
 
   return (

--- a/ods/extensions/services/dashboard/src/App.test.jsx
+++ b/ods/extensions/services/dashboard/src/App.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom' // eslint-disable-line no-unused
 import { ThemeProvider } from './contexts/ThemeContext' // eslint-disable-line no-unused-vars
 import App from './App' // eslint-disable-line no-unused-vars
 import { useFirstRun } from './hooks/useFirstRun'
+import { useSystemStatus } from './hooks/useSystemStatus'
 
 vi.mock('./hooks/useSystemStatus', () => ({
   useSystemStatus: vi.fn(() => ({
@@ -64,6 +65,12 @@ vi.mock('./components/InstallPromptBanner', () => ({
   default: () => null,
 }))
 
+const IDLE_STATUS = {
+  status: { gpu: null, services: [], model: null, bootstrap: null, uptime: 0, version: '1.0.0' },
+  loading: false,
+  error: null,
+}
+
 describe('App', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(() =>
@@ -72,6 +79,7 @@ describe('App', () => {
     globalThis.localStorage.removeItem('ods-sidebar-collapsed')
     globalThis.sessionStorage.removeItem('ods-splash-shown')
     useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
+    useSystemStatus.mockReturnValue(IDLE_STATUS)
   })
 
   afterEach(() => {
@@ -119,6 +127,35 @@ describe('App', () => {
     expect(document.querySelector('aside')).not.toHaveClass('sm:w-64')
     expect(document.querySelector('main')).toHaveClass('ml-20')
     expect(document.querySelector('main')).not.toHaveClass('sm:ml-64')
+  })
+
+  test('bootstrap banner reports download size in the same GiB units as the download card', () => {
+    // dashboard-api sends bytes derived from BootstrapStatus.downloaded_gb /
+    // total_gb, which helpers.py computes with 1024**3. useDownloadProgress
+    // renders /api/models/download-status — the same bootstrap payload — the
+    // same way, so the banner has to agree with it.
+    const GIB = 1024 ** 3
+    useSystemStatus.mockReturnValue({
+      ...IDLE_STATUS,
+      status: {
+        ...IDLE_STATUS.status,
+        bootstrap: {
+          active: true,
+          model: 'Modern-Model.gguf',
+          percent: 50,
+          bytesDownloaded: 15 * GIB,
+          bytesTotal: 30 * GIB,
+          eta: 90,
+          speedMbps: 12.5,
+        },
+      },
+    })
+
+    render(<App />)
+
+    expect(screen.getByText(/15\.0 \/ 30\.0 GB/)).toBeInTheDocument()
+    // Decimal GB would render 16.1 / 32.2 for the same file.
+    expect(screen.queryByText(/16\.1 \/ 32\.2 GB/)).not.toBeInTheDocument()
   })
 
   test('renders ODS Talk without dashboard chrome on /talk', async () => {


### PR DESCRIPTION
## Problem

`BootstrapBanner` in `src/App.jsx:170-173` formats download bytes as decimal GB:

```jsx
const formatBytes = (bytes) => {
  if (!bytes) return '0'
  return (bytes / 1e9).toFixed(1)
}
```

Every other party in that data path uses binary GiB.

**Producer** — `extensions/services/dashboard-api/helpers.py:965-967`

```python
downloaded_gb=bytes_downloaded / (1024**3) if bytes_downloaded else None,
total_gb=bytes_total / (1024**3) if bytes_total else None,
```

**Both transports** re-expand with the same base — `main.py:1429-1430` for `/api/status` and `routers/models.py:1381-1382` for `/api/models/download-status`:

```python
"bytesDownloaded": int((bootstrap_info.downloaded_gb or 0) * 1024**3),
"bytesTotal": int((bootstrap_info.total_gb or 0) * 1024**3),
```

**The other renderer** — `src/hooks/useDownloadProgress.js:122-131`

```js
const gb = bytes / (1024 ** 3)
if (gb >= 1) return `${gb.toFixed(2)} GB`
```

Note `routers/models.py:1370-1384` serves `/api/models/download-status` **from `bootstrap_info`** while a bootstrap download is active — so the banner and the download card are rendering the *same* download from the *same* numbers.

## Impact

During a full-model bootstrap download both surfaces are on screen and disagree by 7.4%, both labelled `GB`:

| Surface | Formatter | 30 GiB model shows as |
|---|---|---|
| `BootstrapBanner` (App.jsx:202) | `bytes / 1e9` | `32.2 / 32.2 GB` |
| download card (`useDownloadProgress`) | `bytes / 1024**3` | `30.00 GB` |

The banner also overstates against the model catalogue: `components/model-library/HuggingFaceModelBrowser.jsx:455-458` uses `1024 ** 3` too, so the size a user picks never matches the size the banner counts up to.

`App.jsx:172` is the only `1e9` byte conversion among the four model-size formatters in the dashboard.

## Fix

One line: divide by `1024 ** 3`, matching the producer and the other renderer. Precision and layout are unchanged (`X / Y GB`, one decimal).

Left alone deliberately: `components/PreFlightChecks.jsx:171` (`data.free / 1e9`) reads a different endpoint and reports disk capacity, where decimal GB is the vendor convention.

## Tests

Extends `src/App.test.jsx`, gated by `npm run test` in `.github/workflows/dashboard.yml:32`.

The new case drives `useSystemStatus` with an active bootstrap of exactly 15 GiB / 30 GiB and asserts the banner renders `15.0 / 30.0 GB`, plus a negative assertion on `16.1 / 32.2 GB` so a silent flip back to decimal fails loudly. A shared `IDLE_STATUS` default is now applied in `beforeEach`, matching how the file already handles `useFirstRun`.

Verified red against the pre-fix `App.jsx`:

```
× bootstrap banner reports download size in the same GiB units as the download card
TestingLibraryElementError: Unable to find an element with the text: /15\.0 \/ 30\.0 GB/
Tests  1 failed | 7 passed (8)
```

Green after: **8 passed**. `npm run lint` clean.
