### PR TITLE
fix(workflows): resolve dependency aliases before health-checking

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -253,6 +253,7 @@ def load_extension_manifests(
                     "ui_path": service.get("ui_path", "/"),
                     "external_link": bool(service.get("external_link", True)),
                     "container_name": service.get("container_name", f"ods-{service_id}"),
+                    "aliases": [str(a) for a in (service.get("aliases") or [])],
                     "depends_on": service.get("depends_on", []),
                     "category": service.get("category", "optional"),
                     "host_network": bool(service.get("host_network", False)),
@@ -294,6 +295,22 @@ def load_extension_manifests(
 
 MANIFEST_SERVICES, MANIFEST_FEATURES, MANIFEST_ERRORS = load_extension_manifests(EXTENSIONS_DIR, GPU_BACKEND)
 SERVICES = MANIFEST_SERVICES
+
+
+def build_service_aliases(services: dict[str, dict[str, Any]]) -> dict[str, str]:
+    """Reverse the manifest `aliases` lists into alias -> service id."""
+    return {
+        alias: service_id
+        for service_id, config in services.items()
+        for alias in config.get("aliases", [])
+        if alias not in services
+    }
+
+
+# The CLI and the service manifests treat aliases as first-class service names
+# (`ods logs kokoro`), so anything that accepts a user- or catalog-supplied
+# service name has to resolve them before looking SERVICES up.
+SERVICE_ALIASES = build_service_aliases(SERVICES)
 if not SERVICES:
     logger.error("No services loaded from manifests in %s — dashboard will have no services", EXTENSIONS_DIR)
 

--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -9,7 +9,7 @@ import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
 
 from config import (
-    SERVICES, WORKFLOW_DIR, WORKFLOW_CATALOG_FILE,
+    SERVICES, SERVICE_ALIASES, WORKFLOW_DIR, WORKFLOW_CATALOG_FILE,
     DEFAULT_WORKFLOW_CATALOG, N8N_URL, N8N_API_KEY,
 )
 from security import verify_api_key
@@ -68,12 +68,16 @@ async def check_workflow_dependencies(deps: list[str], health_cache: dict[str, b
     """Check if required services are running. Uses health_cache to avoid duplicate checks."""
     from helpers import check_service_health
 
+    # Catalog entries name services the way the CLI does, so a dependency can
+    # be a manifest alias ("kokoro" for tts) rather than a service id. An
+    # unresolved name falls through to the permissive branch below and reports
+    # the dependency as met without ever probing it.
     _DEP_ALIASES = {"ollama": "llama-server"}
     if health_cache is None:
         health_cache = {}
     results = {}
     for dep in deps:
-        resolved = _DEP_ALIASES.get(dep, dep)
+        resolved = _DEP_ALIASES.get(dep) or SERVICE_ALIASES.get(dep, dep)
         if resolved in health_cache:
             results[dep] = health_cache[resolved]
         elif resolved in SERVICES:

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -289,6 +289,86 @@ def test_check_workflow_dependencies_uses_cache(test_client, monkeypatch):
     mock_fn.assert_not_called()
 
 
+def test_build_service_aliases_reverses_manifest_aliases():
+    """Manifest alias lists become an alias -> service id lookup."""
+    from config import build_service_aliases
+
+    aliases = build_service_aliases({
+        "tts": {"aliases": ["kokoro"]},
+        "whisper": {"aliases": ["stt", "voice"]},
+        "litellm": {"aliases": []},
+        "qdrant": {},
+    })
+
+    assert aliases == {"kokoro": "tts", "stt": "whisper", "voice": "whisper"}
+
+
+def test_build_service_aliases_never_shadows_a_real_service_id():
+    """A service id always wins over another service claiming it as an alias."""
+    from config import build_service_aliases
+
+    aliases = build_service_aliases({
+        "tts": {"aliases": ["kokoro"]},
+        "kokoro": {"aliases": []},
+    })
+
+    assert "kokoro" not in aliases
+
+
+def test_check_workflow_dependencies_probes_service_behind_manifest_alias(test_client, monkeypatch):
+    """A catalog dependency named by alias is health-checked, not assumed met."""
+    import routers.workflows as wf_mod
+    from models import ServiceStatus
+
+    monkeypatch.setitem(wf_mod.SERVICES, "tts", {"name": "Kokoro TTS", "port": 8880})
+    monkeypatch.setitem(wf_mod.SERVICE_ALIASES, "kokoro", "tts")
+
+    down_status = ServiceStatus(
+        id="tts", name="Kokoro TTS", port=8880, external_port=8880, status="down",
+    )
+    mock_fn = AsyncMock(return_value=down_status)
+    monkeypatch.setattr("helpers.check_service_health", mock_fn)
+
+    import asyncio
+    result = asyncio.run(wf_mod.check_workflow_dependencies(["kokoro"]))
+
+    assert result["kokoro"] is False
+    mock_fn.assert_awaited_once()
+
+
+def test_shipped_catalog_dependencies_all_resolve_to_a_known_service():
+    """Every dependency in the shipped catalog must name a service or alias.
+
+    An unresolved name falls through check_workflow_dependencies' permissive
+    branch and is reported as satisfied without ever being probed, so the
+    workflow installs against a service that is not running.
+    """
+    import yaml
+
+    ods_root = Path(__file__).resolve().parents[4]
+    catalog = json.loads((ods_root / "config" / "n8n" / "catalog.json").read_text(encoding="utf-8"))
+
+    known: set[str] = set()
+    for manifest_path in (ods_root / "extensions" / "services").glob("*/manifest.yaml"):
+        service = (yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}).get("service") or {}
+        if service.get("id"):
+            known.add(str(service["id"]))
+            known.update(str(alias) for alias in (service.get("aliases") or []))
+
+    assert known, "no service manifests found"
+
+    # Legacy catalog names that predate the manifest ids.
+    known.update({"ollama"})
+
+    unresolved = {
+        (workflow["id"], dep)
+        for workflow in catalog["workflows"]
+        for dep in workflow.get("dependencies", [])
+        if dep not in known
+    }
+    assert not unresolved, f"catalog dependencies that name no known service: {sorted(unresolved)}"
+
+
 # ---------------------------------------------------------------------------
 # check_n8n_available() unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`check_workflow_dependencies` resolves catalog dependency names through a two-entry hardcoded dict, then looks the result up in `SERVICES`:

```python
# routers/workflows.py:67-86
_DEP_ALIASES = {"ollama": "llama-server"}
...
for dep in deps:
    resolved = _DEP_ALIASES.get(dep, dep)
    if resolved in health_cache:
        results[dep] = health_cache[resolved]
    elif resolved in SERVICES:
        status = await check_service_health(resolved, SERVICES[resolved])
        ...
    else:
        results[dep] = True          # <-- never probed
```

`SERVICES` is keyed by manifest **service id**, but the catalog names services the way the CLI does — where aliases are first-class (`ods logs kokoro`, `ods restart stt`). A dependency that is an alias misses `SERVICES` entirely and lands in the `else` branch, which reports it as satisfied without any probe.

`config/n8n/catalog.json` has exactly one such name:

```json
{ "id": "voice-to-voice", "dependencies": ["whisper", "llama-server", "kokoro"] }
```

and `extensions/services/tts/manifest.yaml:7-9`:

```yaml
  id: tts
  aliases: [kokoro]
```

Every other dependency across the 18 catalog entries (`llama-server`, `qdrant`, `whisper`, `litellm`, `comfyui`, `privacy-shield`, `hermes`, `openclaw`) is a real service id.

## Impact

Kokoro TTS was always reported healthy for `voice-to-voice`:

- `GET /api/workflows` returns `dependencyStatus.kokoro = true` and `allDependenciesMet = true`, so the UI shows the dependency green with TTS stopped or never enabled.
- `POST /api/workflows/{id}/enable` only refuses when a dependency is `False` (`workflows.py:179-182`), so the workflow installs into n8n regardless.

The user gets a workflow that reports ready and fails at its TTS step at runtime, with nothing in the dashboard pointing at the cause.

## Fix

Aliases are already declared in the manifests, so this is a lookup that should be derived from data rather than hardcoded (the `ollama` entry stays — it is a legacy catalog name and *not* a manifest alias of `llama-server`, whose alias list is `[llm]`).

- `config.py` keeps `aliases` on the loaded service config and exposes `SERVICE_ALIASES`, a reversed alias → id map built by `build_service_aliases()`. A real service id is never shadowed by another service claiming it as an alias.
- `check_workflow_dependencies` resolves through `_DEP_ALIASES` first, then `SERVICE_ALIASES`.

The permissive `else: results[dep] = True` fallback is left as-is — flipping unknown names to "unmet" would be a separate behavioural decision about catalog entries that name non-services.

## Tests

`tests/test_workflows.py` (gated by `pytest tests/` in `.github/workflows/dashboard.yml:60`):

1. `test_check_workflow_dependencies_probes_service_behind_manifest_alias` — a dependency named `kokoro` must probe `tts` and report `False` when it is down; asserts the health check was actually awaited, so "assumed met" cannot pass.
2. `test_build_service_aliases_reverses_manifest_aliases` and `..._never_shadows_a_real_service_id` — pure-function coverage of the new map.
3. `test_shipped_catalog_dependencies_all_resolve_to_a_known_service` — reads the shipped catalogue and the real manifests and fails if any dependency names neither a service id nor an alias, so a future catalog entry cannot re-enter the silent branch.

Verified red by reverting only the resolution line (keeping the new `SERVICE_ALIASES` seam, so the failure is the defect and not a missing import):

```
>       assert result["kokoro"] is False
E       assert True is False
FAILED tests/test_workflows.py::test_check_workflow_dependencies_probes_service_behind_manifest_alias
1 failed, 3 passed
```

Green after: `tests/test_workflows.py` **49 passed**, `tests/test_config.py` **42 passed**.
