### PR TITLE
fix(linux): honour OPENCODE_PORT in the OpenCode systemd unit

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -153,6 +153,9 @@ jobs:
       - name: CPU-Only Path Tests
         run: bash tests/test-cpu-only-path.sh
 
+      - name: Linux OpenCode Path Tests
+        run: bash tests/test-linux-opencode-path.sh
+
       - name: Hermes Slash Worker Prune Tests
         run: |
           bash tests/test-hermes-slash-worker-prune.sh

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -40,6 +40,7 @@ test: ## Run unit and contract tests
 	@echo "=== Linux install preflight ==="
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
+	@bash tests/test-linux-opencode-path.sh
 	@bash tests/test-preflight-dashboard-port.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="

--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -17,7 +17,7 @@
 ods_progress 42 "devtools" "Installing developer tools"
 if $DRY_RUN; then
     log "[DRY RUN] Would install AI developer tools (Claude Code, Codex CLI, OpenCode)"
-    log "[DRY RUN] Would configure OpenCode for local llama-server (user-level systemd service on port 3003)"
+    log "[DRY RUN] Would configure OpenCode for local llama-server (user-level systemd service on \${OPENCODE_PORT:-3003})"
     log "[DRY RUN] Would install ODS host agent systemd service (system-mode, port 7710)"
     log "[DRY RUN] Would install ODS mDNS announcer systemd service (if zeroconf available)"
 else
@@ -275,6 +275,18 @@ OPENCODE_EOF
             SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
             mkdir -p "$SYSTEMD_USER_DIR"
 
+            # OPENCODE_PORT is the documented override (.env.schema.json,
+            # config/ports.json, the opencode manifest's external_port_env) and
+            # is what the dashboard builds its OpenCode link from. macOS and
+            # Windows already launch OpenCode on it; honour it here too instead
+            # of baking 3003 into the unit.
+            _opencode_port="$(grep -E '^OPENCODE_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || true)"
+            if [[ ! "$_opencode_port" =~ ^[0-9]+$ ]] || (( _opencode_port < 1 || _opencode_port > 65535 )); then
+                [[ -n "$_opencode_port" ]] && \
+                    ai_warn "OPENCODE_PORT='${_opencode_port}' is not a valid port; using 3003"
+                _opencode_port="3003"
+            fi
+
             svc_tmp="$(mktemp "${TMPDIR:-/tmp}/opencode-web.service.XXXXXX")" || svc_tmp=""
             if [[ -z "$svc_tmp" ]]; then
                 ai_warn "Failed to create secure temp file for opencode-web.service; skipping user-level unit install"
@@ -287,13 +299,14 @@ OPENCODE_EOF
                 _sed_i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN__|${_opencode_bin_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN_DIR__|${_opencode_bin_dir_esc}|g" "$svc_tmp"
+                _sed_i "s|__OPENCODE_PORT__|${_opencode_port}|g" "$svc_tmp"
                 cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
                 rm -f "$svc_tmp"
             fi
 
             systemctl --user daemon-reload 2>/dev/null || true
             systemctl --user enable --now opencode-web.service >> "$LOG_FILE" 2>&1 && \
-                ai_ok "OpenCode Web UI service installed (user-level, port 3003)" || \
+                ai_ok "OpenCode Web UI service installed (user-level, port ${_opencode_port})" || \
                 ai_warn "OpenCode Web UI service failed to start"
 
             # Enable lingering so service survives logout

--- a/ods/opencode/opencode-web.service
+++ b/ods/opencode/opencode-web.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=__HOME__
-ExecStart=__OPENCODE_BIN__ serve --port 3003 --hostname 127.0.0.1
+ExecStart=__OPENCODE_BIN__ serve --port __OPENCODE_PORT__ --hostname 127.0.0.1
 Restart=on-failure
 RestartSec=5
 

--- a/ods/tests/test-linux-opencode-path.sh
+++ b/ods/tests/test-linux-opencode-path.sh
@@ -38,4 +38,79 @@ if grep -q 'ExecStart=__HOME__/.opencode/bin/opencode' "$SERVICE"; then
   fail "systemd service still hard-codes ~/.opencode/bin/opencode"
 fi
 
+
+echo ""
+echo "--- OPENCODE_PORT override ---"
+
+grep -q '__OPENCODE_PORT__' "$SERVICE" \
+  && pass "systemd service templates the listen port" \
+  || fail "systemd service must template the listen port, not hard-code it"
+
+if grep -qE 'serve --port [0-9]+' "$SERVICE"; then
+  fail "systemd service still hard-codes a numeric --port"
+fi
+pass "systemd service has no hard-coded --port literal"
+
+grep -q '__OPENCODE_PORT__' "$PHASE" \
+  && pass "phase substitutes the port placeholder" \
+  || fail "phase must substitute __OPENCODE_PORT__"
+
+# Behavioural: run the phase's own resolution + rendering against fixtures.
+render_unit() {
+  # $1 = OPENCODE_PORT line to write into .env ("" writes no key)
+  local env_line="$1"
+  local work
+  work="$(mktemp -d)"
+  mkdir -p "$work/install/opencode"
+  cp "$SERVICE" "$work/install/opencode/opencode-web.service"
+  : > "$work/install/.env"
+  [[ -n "$env_line" ]] && printf '%s\n' "$env_line" >> "$work/install/.env"
+  mkdir -p "$work/systemd"
+
+  awk '/^            # OPENCODE_PORT is the documented override/ {inside=1}
+       inside {print}
+       inside && /rm -f "\$svc_tmp"/ {rendered=1}
+       inside && rendered && /^            fi$/ {exit}' "$PHASE" > "$work/block.sh"
+  [[ -s "$work/block.sh" ]] || fail "could not extract the port-resolution block from the phase"
+
+  (
+    set -euo pipefail
+    INSTALL_DIR="$work/install"
+    SYSTEMD_USER_DIR="$work/systemd"
+    OPENCODE_BIN="/usr/local/bin/opencode"
+    HOME="$work/home"
+    ai_warn() { printf 'WARN %s\n' "$*" >&2; }
+    _sed_i() {
+      local expr="$1" file="$2"
+      sed "$expr" "$file" > "$file.rendered" && mv "$file.rendered" "$file"
+    }
+    # shellcheck disable=SC1090
+    . "$work/block.sh"
+  ) 2>/dev/null
+
+  cat "$work/systemd/opencode-web.service" 2>/dev/null
+  rm -rf "$work"
+}
+
+rendered="$(render_unit 'OPENCODE_PORT=3103')"
+grep -q -- '--port 3103' <<<"$rendered" \
+  && pass "operator OPENCODE_PORT reaches the rendered unit" \
+  || fail "rendered unit ignored OPENCODE_PORT=3103: $(grep ExecStart <<<"$rendered")"
+
+rendered="$(render_unit '')"
+grep -q -- '--port 3003' <<<"$rendered" \
+  && pass "missing OPENCODE_PORT falls back to 3003" \
+  || fail "rendered unit did not fall back to 3003: $(grep ExecStart <<<"$rendered")"
+
+rendered="$(render_unit 'OPENCODE_PORT=not-a-port')"
+grep -q -- '--port 3003' <<<"$rendered" \
+  && pass "invalid OPENCODE_PORT falls back to 3003" \
+  || fail "rendered unit accepted a non-numeric port: $(grep ExecStart <<<"$rendered")"
+
+rendered="$(render_unit '')"
+if grep -q '__OPENCODE_PORT__' <<<"$rendered"; then
+  fail "rendered unit still contains an unsubstituted placeholder"
+fi
+pass "rendered unit has no unsubstituted placeholders"
+
 echo "[PASS] Linux OpenCode path tests"


### PR DESCRIPTION
## Problem

`OPENCODE_PORT` is the documented way to move the OpenCode Web UI:

- `.env.schema.json:677` declares it,
- `config/ports.json:127` maps it (`{"env_var": "OPENCODE_PORT", "external_default": 3003, "service_id": "opencode", "compose_managed": false}`),
- `extensions/services/opencode/manifest.yaml:13` names it as `external_port_env`, which is what `config.py` reads to build the OpenCode link shown in the dashboard.

macOS and Windows launch OpenCode on it:

| Platform | Launcher |
|---|---|
| macOS | `installers/macos/lib/constants.sh:65` + `install-macos.sh:2929,3165` use `$OPENCODE_PORT` |
| Windows | `installers/windows/phases/07-devtools.ps1:120` — `opencode.exe web --port $($script:OPENCODE_PORT)` |
| Linux | `opencode/opencode-web.service` — `ExecStart=__OPENCODE_BIN__ serve --port 3003 --hostname 127.0.0.1` |

The Linux unit hard-codes the port, and `installers/phases/07-devtools.sh:281-287` only substitutes `__HOME__`, `__OPENCODE_BIN__` and `__OPENCODE_BIN_DIR__` — there is no port placeholder to fill.

## Impact

On Linux, setting `OPENCODE_PORT` in `.env` moves everything *except* the listener:

- `SERVICES["opencode"]["external_port"]` picks up the new value, so the dashboard tile and the sidebar link point at the new port and 404;
- the service keeps serving on 3003;
- a port conflict on 3003 has no resolution — the one knob the schema, `ports.json` and the manifest all advertise does nothing.

Nothing warns: the installer prints `OpenCode Web UI service installed (user-level, port 3003)` regardless of what `.env` says.

## Fix

- The unit carries `__OPENCODE_PORT__` alongside the placeholders it already has.
- Phase 07 reads `OPENCODE_PORT` from `.env` (same `grep | cut | tr` idiom the phase already uses for `ODS_DEVICE_NAME` at line 523), validates it as a 1–65535 integer, and substitutes it.
- A present-but-invalid value falls back to 3003 **with a warning**, so a typo is visible instead of silently ignored. A missing key falls back silently — 3003 is the schema default.
- The success line and the dry-run line now report the port actually used.

Phase 06 still does not write `OPENCODE_PORT` to `.env` on Linux; that is unchanged and harmless, since the fallback equals the schema default. This PR only makes an explicitly-set value take effect.

## Tests

Extends `tests/test-linux-opencode-path.sh` — the existing home for this unit's templating contract — and wires it into `make test` and `.github/workflows/test-linux.yml` (it was previously in neither).

Static:
- the unit templates the port and contains no `serve --port <number>` literal;
- the phase substitutes the placeholder.

Behavioural — the test lifts the phase's own resolution + rendering block out of `07-devtools.sh`, runs it against a temp `INSTALL_DIR` with a stubbed `_sed_i`/`ai_warn`, and inspects the rendered unit:

| `.env` | rendered `ExecStart` |
|---|---|
| `OPENCODE_PORT=3103` | `--port 3103` |
| key absent | `--port 3003` |
| `OPENCODE_PORT=not-a-port` | `--port 3003` |

plus an assertion that no placeholder survives rendering.

Verified red against the pre-fix sources:

```
--- OPENCODE_PORT override ---
[FAIL] systemd service must template the listen port, not hard-code it
```

Green after (all 7 new checks pass, full file green). `bash -n` clean.
