### PR TITLE
fix(audit): check the feature display fields the dashboard renders

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-07-26T18:06:12Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -1660,7 +1660,8 @@
           "enabled_services_all": [
             "localai"
           ],
-          "priority": 5
+          "priority": 5,
+          "setup_time": "~5 minutes"
         },
         {
           "id": "localai-image-generation",
@@ -1677,7 +1678,8 @@
           "enabled_services_all": [
             "localai"
           ],
-          "priority": 6
+          "priority": 6,
+          "setup_time": "~5 minutes"
         },
         {
           "id": "audio-generation",
@@ -1694,7 +1696,8 @@
           "enabled_services_all": [
             "localai"
           ],
-          "priority": 7
+          "priority": 7,
+          "setup_time": "~5 minutes"
         },
         {
           "id": "video-generation",
@@ -1711,7 +1714,8 @@
           "enabled_services_all": [
             "localai"
           ],
-          "priority": 8
+          "priority": 8,
+          "setup_time": "~5 minutes"
         },
         {
           "id": "localai-voice-cloning",
@@ -1728,7 +1732,8 @@
           "enabled_services_all": [
             "localai"
           ],
-          "priority": 9
+          "priority": 9,
+          "setup_time": "~5 minutes"
         }
       ]
     },

--- a/ods/extensions/library/services/localai/manifest.yaml
+++ b/ods/extensions/library/services/localai/manifest.yaml
@@ -29,6 +29,7 @@ features:
       vram_gb: 4
     enabled_services_all: [localai]
     priority: 5
+    setup_time: ~5 minutes
   - id: localai-image-generation
     name: Image Generation
     description: Generate images with local diffusion models
@@ -39,6 +40,7 @@ features:
       vram_gb: 8
     enabled_services_all: [localai]
     priority: 6
+    setup_time: ~5 minutes
   - id: audio-generation
     name: Audio Generation
     description: Generate audio with local models
@@ -49,6 +51,7 @@ features:
       vram_gb: 4
     enabled_services_all: [localai]
     priority: 7
+    setup_time: ~5 minutes
   - id: video-generation
     name: Video Generation
     description: Generate video with local models
@@ -59,6 +62,7 @@ features:
       vram_gb: 16
     enabled_services_all: [localai]
     priority: 8
+    setup_time: ~5 minutes
   - id: localai-voice-cloning
     name: Voice Cloning
     description: Clone voices for TTS with local models
@@ -69,3 +73,4 @@ features:
       vram_gb: 4
     enabled_services_all: [localai]
     priority: 9
+    setup_time: ~5 minutes

--- a/ods/scripts/audit-extensions.py
+++ b/ods/scripts/audit-extensions.py
@@ -603,6 +603,19 @@ def validate_records(
                         path=record.manifest_path,
                     )
 
+            # The dashboard renders both of these. A missing setup_time reaches
+            # the Features page as the literal string "Unknown"
+            # (routers/features.py), and dashboard-api already logs a warning
+            # for either at startup, so surface it here where it can be fixed.
+            for expected in ("icon", "setup_time"):
+                if feature.get(expected) in (None, ""):
+                    record.add_issue(
+                        "warning",
+                        "feature-field-missing",
+                        f"feature is missing display field '{expected}'",
+                        path=record.manifest_path,
+                    )
+
             feature_id = str(feature.get("id") or "")
             if feature_id:
                 owners = feature_owners.get(feature_id, set())

--- a/ods/tests/test-extension-audit.sh
+++ b/ods/tests/test-extension-audit.sh
@@ -37,7 +37,7 @@ fail() {
 
 header() {
     echo ""
-    echo -e "${BOLD}${CYAN}[$1/7]${NC} ${BOLD}$2${NC}"
+    echo -e "${BOLD}${CYAN}[$1/8]${NC} ${BOLD}$2${NC}"
     echo -e "${CYAN}$(printf '%.0s─' {1..60})${NC}"
 }
 
@@ -102,8 +102,10 @@ features:
   - id: search-ui
     name: Search UI
     description: Search the web privately
+    icon: Search
     category: productivity
     priority: 3
+    setup_time: ~1 minute
     requirements:
       services: [search]
     enabled_services_all: [search]
@@ -215,7 +217,7 @@ PY
 
 header "1" "Valid Project Passes Cleanly"
 root=$(make_fixture_root)
-trap 'rm -rf "$root" "${root2:-}" "${root3:-}" "${root4:-}" "${root5:-}" "${root6:-}" "${root7:-}"' EXIT
+trap 'rm -rf "$root" "${root2:-}" "${root3:-}" "${root4:-}" "${root5:-}" "${root6:-}" "${root7:-}" "${root8:-}"' EXIT
 create_valid_project "$root"
 report=$(mktemp)
 if run_audit "$root" --json > "$report"; then
@@ -362,6 +364,40 @@ if run_audit "$root7" --json > "$report7" 2>/dev/null; then
     pass "external_port_default=0 fixture audits successfully"
 else
     fail "external_port_default=0 should be allowed for internal-only services"
+fi
+
+
+header "8" "Feature Display Fields Are Reported"
+root8=$(make_fixture_root)
+create_valid_project "$root8"
+python3 - "$root8/extensions/services/search/manifest.yaml" <<'PY'
+import sys
+
+import yaml
+
+path = sys.argv[1]
+doc = yaml.safe_load(open(path, encoding="utf-8"))
+for feature in doc["features"]:
+    feature.pop("icon", None)
+    feature.pop("setup_time", None)
+with open(path, "w", encoding="utf-8") as handle:
+    yaml.safe_dump(doc, handle, sort_keys=False)
+PY
+report8=$(mktemp)
+if run_audit "$root8" --json > "$report8" 2>/dev/null; then
+    pass "missing display fields do not fail a non-strict audit"
+else
+    fail "missing icon/setup_time must stay a warning, not an error"
+fi
+if assert_json_value "$report8" "payload['summary']['warnings'] >= 2" >/dev/null; then
+    pass "missing icon and setup_time are both reported"
+else
+    fail "audit did not warn about missing feature display fields"
+fi
+if assert_json_value "$report8" "any(issue['code'] == 'feature-field-missing' and 'setup_time' in issue['message'] for svc in payload['services'] for issue in svc['issues'])" >/dev/null; then
+    pass "the setup_time warning names the field"
+else
+    fail "no feature-field-missing warning mentions setup_time"
 fi
 
 echo ""


### PR DESCRIPTION
> Consistency fix, not a user-visible crash — three places disagree about which fields a manifest feature must carry, and the gate that should have caught it checks the smallest set.

## Problem

dashboard-api treats five fields as a feature's expected metadata:

```python
# config.py — on every startup, for every manifest feature
missing = [f for f in ("description", "icon", "category", "setup_time", "priority") if f not in feature]
if missing:
    logger.warning("Feature '%s' in %s missing optional fields: %s", feature["id"], path, ", ".join(missing))
```

and the API renders two of them straight into the UI:

```python
# routers/features.py:108
"setupTime": feature.get("setup_time", "Unknown"),
```
```jsx
// components/FeatureDiscovery.jsx:50
Setup time: {topSuggestion.setupTime}
```

`scripts/audit-extensions.py` — the contract gate, run in CI (`Extension Audit`) and by `ods audit` — checks a **different, smaller** set:

```python
for required in ("id", "name", "description", "category", "priority"):
```

`icon` and `setup_time` are validated by nothing. A manifest can ship, pass the audit, log five warnings on every dashboard-api start, and render `Setup time: Unknown` on the Features page.

## Scope of the drift today

Across all 60 shipped manifests, exactly one omits `setup_time`: `extensions/library/services/localai/manifest.yaml`, on all five of its features. Every other service sets it, and every service uses one value for all of its own features (`invokeai` → `~5 minutes` ×3, `text-generation-webui` → `~3 minutes` ×3).

No manifest omits `icon`.

## Fix

- The auditor now reports missing `icon` / `setup_time` as **warnings**, not errors. Warning is the right severity: `config.py` calls them optional and a third-party extension that omits them must stay installable, while `--strict` (used for release gating) still turns them into a failure.
- The five LocalAI features get `setup_time: ~5 minutes`, matching the per-service convention and its closest peer by image weight (`invokeai`).
- The "valid fixture" in the audit test now carries `icon` and `setup_time`, since it is the reference example of a complete manifest.

Deliberately **not** promoted to errors, and no third-party manifest becomes uninstallable.

## Tests

Extends `tests/test-extension-audit.sh` (gated by the `Extension Audit` step in `.github/workflows/test-linux.yml`) with case 8, which strips `icon` and `setup_time` from the valid fixture and asserts:

1. a non-strict audit still succeeds — the new checks are warnings, not errors;
2. at least two warnings are reported;
3. a `feature-field-missing` warning names `setup_time`, so the message stays actionable.

Verified red against the pre-fix auditor:

```
PASS  missing display fields do not fail a non-strict audit
FAIL  audit did not warn about missing feature display fields
FAIL  no feature-field-missing warning mentions setup_time
Results: 16 passed, 2 failed
```

Green after: **18 passed, 0 failed**, and `python3 scripts/audit-extensions.py --project-dir .` reports `27 services, 0 errors, 0 warnings, result=pass`.
