### PR TITLE
fix(token-spy): stop the postgres SSE cursor from dropping rows

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -8,6 +8,46 @@ on:
       - master
 
 jobs:
+  token-spy-postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: tokenspy
+          POSTGRES_USER: tokenspy
+          POSTGRES_PASSWORD: testpass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U tokenspy -d tokenspy"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    defaults:
+      run:
+        working-directory: ods/extensions/services/token-spy
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: "5432"
+      DB_NAME: tokenspy
+      DB_USER: tokenspy
+      DB_PASSWORD: testpass
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install "psycopg2-binary>=2.9.9,<3.0.0" "pytest>=8,<9"
+
+      - name: Test Postgres SSE cursor
+        run: python -m pytest tests/test_recent_events_cursor_postgres.py -v
+
   integration-smoke:
     runs-on: ubuntu-latest
     defaults:

--- a/ods/extensions/services/token-spy/db_postgres.py
+++ b/ods/extensions/services/token-spy/db_postgres.py
@@ -6,9 +6,9 @@ Set DB_BACKEND=postgres to use this module.
 
 import os
 import logging
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, Tuple
 from uuid import UUID, uuid4
 
 from psycopg2.extras import RealDictCursor, register_uuid
@@ -34,6 +34,8 @@ SINGLE_TENANT_SLUG = os.environ.get("SINGLE_TENANT_SLUG", "default")
 _pool: Optional[pool.ThreadedConnectionPool] = None
 _tenant_id: Optional[UUID] = None
 _agent_cache: dict[str, UUID] = {}
+
+EventCursor = Tuple[datetime, UUID]
 
 
 def _get_pool() -> pool.ThreadedConnectionPool:
@@ -624,19 +626,31 @@ def query_session_status(agent: str, char_limit: int = 200_000) -> dict:
         _put_conn(conn)
 
 
-def query_recent_events(limit: int = 100, after_id: Optional[UUID] = None):
+def query_recent_events(limit: int = 100, after_id=None):
     """Query recent token usage events for SSE streaming."""
     conn = _get_conn()
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             if after_id:
-                # r.id is a random uuid4(), unrelated to insertion order, so
-                # `id > after_id` drops or admits newer rows by chance. Page
-                # forward from after_id's own (timestamp, id) instead.
-                cur.execute("SELECT timestamp, id FROM requests WHERE id = %s", (after_id,))
-                cursor_row = cur.fetchone()
-                if cursor_row is None:
-                    return []
+                if isinstance(after_id, tuple):
+                    cursor_timestamp, cursor_id = after_id
+                else:
+                    # Backward compatibility for callers that still hold a
+                    # request UUID. New streams carry the composite cursor
+                    # directly, so retention cannot invalidate their cursor.
+                    cur.execute(
+                        """
+                        SELECT timestamp, id
+                        FROM requests
+                        WHERE tenant_id = %s AND id = %s
+                        """,
+                        (_tenant_id, after_id),
+                    )
+                    cursor_row = cur.fetchone()
+                    if cursor_row is None:
+                        return []
+                    cursor_timestamp = cursor_row["timestamp"]
+                    cursor_id = cursor_row["id"]
                 cur.execute(
                     """
                     SELECT
@@ -657,7 +671,7 @@ def query_recent_events(limit: int = 100, after_id: Optional[UUID] = None):
                     ORDER BY r.timestamp ASC, r.id ASC
                     LIMIT %s
                     """,
-                    (_tenant_id, cursor_row["timestamp"], cursor_row["id"], limit)
+                    (_tenant_id, cursor_timestamp, cursor_id, limit),
                 )
             else:
                 cur.execute(
@@ -676,17 +690,23 @@ def query_recent_events(limit: int = 100, after_id: Optional[UUID] = None):
                     FROM requests r
                     LEFT JOIN agents a ON r.agent_id = a.id
                     WHERE r.tenant_id = %s
-                    ORDER BY r.timestamp DESC
+                    ORDER BY r.timestamp DESC, r.id DESC
                     LIMIT %s
                     """,
-                    (_tenant_id, limit)
+                    (_tenant_id, limit),
                 )
             rows = cur.fetchall()
+            if not after_id:
+                # Select the newest window efficiently, then emit it oldest
+                # first so the stream cursor finishes at the newest event.
+                rows.reverse()
+
             # Convert datetime objects to ISO format strings for JSON serialization
             result = []
             for row in rows:
                 d = dict(row)
                 if d.get("timestamp"):
+                    d["_cursor"] = (d["timestamp"], d["id"])
                     d["timestamp"] = d["timestamp"].isoformat()
                 if d.get("cost_usd"):
                     d["cost_usd"] = float(d["cost_usd"])

--- a/ods/extensions/services/token-spy/db_postgres.py
+++ b/ods/extensions/services/token-spy/db_postgres.py
@@ -630,6 +630,13 @@ def query_recent_events(limit: int = 100, after_id: Optional[UUID] = None):
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             if after_id:
+                # r.id is a random uuid4(), unrelated to insertion order, so
+                # `id > after_id` drops or admits newer rows by chance. Page
+                # forward from after_id's own (timestamp, id) instead.
+                cur.execute("SELECT timestamp, id FROM requests WHERE id = %s", (after_id,))
+                cursor_row = cur.fetchone()
+                if cursor_row is None:
+                    return []
                 cur.execute(
                     """
                     SELECT
@@ -646,11 +653,11 @@ def query_recent_events(limit: int = 100, after_id: Optional[UUID] = None):
                     FROM requests r
                     LEFT JOIN agents a ON r.agent_id = a.id
                     WHERE r.tenant_id = %s
-                    AND r.id > %s
-                    ORDER BY r.timestamp DESC
+                    AND (r.timestamp, r.id) > (%s, %s)
+                    ORDER BY r.timestamp ASC, r.id ASC
                     LIMIT %s
                     """,
-                    (_tenant_id, after_id, limit)
+                    (_tenant_id, cursor_row["timestamp"], cursor_row["id"], limit)
                 )
             else:
                 cur.execute(

--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -2423,11 +2423,11 @@ def dashboard_charts_asset():
 async def token_events(request: Request):
     """Stream token usage events as Server-Sent Events."""
     async def event_stream():
-        last_id = None
+        last_cursor = None
         while True:
             try:
                 # Query recent events
-                events = query_recent_events(limit=50, after_id=last_id)
+                events = query_recent_events(limit=50, after_id=last_cursor)
 
                 for event in events:
                     # Format event as SSE
@@ -2445,7 +2445,9 @@ async def token_events(request: Request):
                     }
 
                     yield f"data: {json.dumps(event_data)}\n\n"
-                    last_id = event.get("id")
+                    # PostgreSQL supplies a stable (timestamp, UUID) cursor.
+                    # SQLite and older backends continue to use the row ID.
+                    last_cursor = event.get("_cursor", event.get("id"))
 
                 # Heartbeat to keep connection alive
                 yield ":heartbeat\n\n"

--- a/ods/extensions/services/token-spy/tests/test_recent_events_cursor_postgres.py
+++ b/ods/extensions/services/token-spy/tests/test_recent_events_cursor_postgres.py
@@ -1,0 +1,148 @@
+"""Postgres backend SSE cursor tests for /token_events.
+
+Requires a live Postgres reachable via the same DB_HOST/DB_PORT/DB_NAME/
+DB_USER/DB_PASSWORD env vars db_postgres.py itself reads. No workflow
+provisions Postgres for this repo's CI today, so these skip cleanly when
+none is configured rather than failing the run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+psycopg2 = pytest.importorskip("psycopg2")
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+def _connect():
+    return psycopg2.connect(
+        host=os.environ.get("DB_HOST", "localhost"),
+        port=os.environ.get("DB_PORT", "5434"),
+        dbname=os.environ.get("DB_NAME", "tokenspy"),
+        user=os.environ.get("DB_USER", "tokenspy"),
+        password=os.environ.get("DB_PASSWORD", ""),
+    )
+
+
+@pytest.fixture
+def pg_db():
+    try:
+        conn = _connect()
+    except psycopg2.OperationalError as exc:
+        pytest.skip(f"no live postgres reachable for db_postgres tests: {exc}")
+
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tenants (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            name TEXT, slug TEXT UNIQUE, plan TEXT, deleted_at TIMESTAMPTZ)
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agents (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID, name TEXT, slug TEXT)
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS requests (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID, agent_id UUID, request_id TEXT, provider TEXT,
+            model TEXT, input_tokens INT, output_tokens INT,
+            estimated_cost_usd NUMERIC, "timestamp" TIMESTAMPTZ)
+        """
+    )
+    cur.execute("TRUNCATE requests, agents, tenants CASCADE")
+    cur.execute("INSERT INTO tenants (name, slug, plan) VALUES ('Default', 'default', 'free')")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_postgres_db_{uuid4().hex}", TOKEN_SPY_DIR / "db_postgres.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.init_db()
+    try:
+        yield module
+    finally:
+        if module._pool is not None:
+            module._pool.closeall()
+
+
+def _insert_row(db, tenant_id, when, counter):
+    conn = _connect()
+    cur = conn.cursor()
+    row_id = uuid4()
+    cur.execute(
+        """
+        INSERT INTO requests (id, tenant_id, request_id, provider, model,
+            input_tokens, output_tokens, estimated_cost_usd, timestamp)
+        VALUES (%s, %s, %s, 'openai', 'gpt-4o', 100, 50, 0.01, %s)
+        """,
+        (row_id, tenant_id, f"req-{counter}", when),
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+    return row_id
+
+
+def test_forward_poll_delivers_every_row_inserted_after_connect(pg_db):
+    """r.id is a random uuid4(), so filtering `id > after_id` has no
+    relationship to insertion order and admits or drops rows by chance.
+    A client that connects, then polls forward as new rows arrive, must
+    see every one of them: none silently dropped."""
+    tenant_id = pg_db._tenant_id
+    base = datetime(2026, 7, 27, tzinfo=timezone.utc)
+    counter = 0
+    for _ in range(3):
+        _insert_row(pg_db, tenant_id, base + timedelta(seconds=counter), counter)
+        counter += 1
+
+    initial = pg_db.query_recent_events(limit=50, after_id=None)
+    last_id = initial[-1]["id"] if initial else None
+
+    delivered = set()
+    live_inserted = set()
+    for _ in range(8):
+        batch = [
+            _insert_row(pg_db, tenant_id, base + timedelta(seconds=counter + i), counter + i)
+            for i in range(3)
+        ]
+        counter += 3
+        live_inserted.update(str(row_id) for row_id in batch)
+
+        events = pg_db.query_recent_events(limit=50, after_id=last_id)
+        for event in events:
+            delivered.add(str(event["id"]))
+            last_id = event["id"]
+
+    assert live_inserted <= delivered
+
+
+def test_cursor_past_end_returns_empty_not_backlog(pg_db):
+    """Once the cursor is caught up to the newest row, the next poll must
+    return nothing, not silently resend part of the backlog."""
+    tenant_id = pg_db._tenant_id
+    base = datetime(2026, 7, 27, tzinfo=timezone.utc)
+    for i in range(5):
+        _insert_row(pg_db, tenant_id, base + timedelta(seconds=i), i)
+
+    # query_recent_events serves the newest page first (DESC), so the
+    # newest row is the first one, not the last.
+    initial = pg_db.query_recent_events(limit=50, after_id=None)
+    newest_id = initial[0]["id"]
+
+    assert pg_db.query_recent_events(limit=50, after_id=newest_id) == []

--- a/ods/extensions/services/token-spy/tests/test_recent_events_cursor_postgres.py
+++ b/ods/extensions/services/token-spy/tests/test_recent_events_cursor_postgres.py
@@ -1,10 +1,4 @@
-"""Postgres backend SSE cursor tests for /token_events.
-
-Requires a live Postgres reachable via the same DB_HOST/DB_PORT/DB_NAME/
-DB_USER/DB_PASSWORD env vars db_postgres.py itself reads. No workflow
-provisions Postgres for this repo's CI today, so these skip cleanly when
-none is configured rather than failing the run.
-"""
+"""Postgres backend SSE cursor tests for /token_events."""
 
 from __future__ import annotations
 
@@ -12,7 +6,7 @@ import importlib.util
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -81,10 +75,10 @@ def pg_db():
             module._pool.closeall()
 
 
-def _insert_row(db, tenant_id, when, counter):
+def _insert_row(db, tenant_id, when, counter, row_id=None):
     conn = _connect()
     cur = conn.cursor()
-    row_id = uuid4()
+    row_id = row_id or uuid4()
     cur.execute(
         """
         INSERT INTO requests (id, tenant_id, request_id, provider, model,
@@ -99,11 +93,26 @@ def _insert_row(db, tenant_id, when, counter):
     return row_id
 
 
+def test_initial_window_is_chronological_and_does_not_replay(pg_db):
+    tenant_id = pg_db._tenant_id
+    base = datetime(2026, 7, 27, tzinfo=timezone.utc)
+    inserted = [
+        _insert_row(pg_db, tenant_id, base + timedelta(seconds=i), i)
+        for i in range(5)
+    ]
+
+    initial = pg_db.query_recent_events(limit=3, after_id=None)
+
+    assert [event["id"] for event in initial] == inserted[-3:]
+    assert [event["timestamp"] for event in initial] == sorted(
+        event["timestamp"] for event in initial
+    )
+    assert pg_db.query_recent_events(
+        limit=50, after_id=initial[-1]["_cursor"]
+    ) == []
+
+
 def test_forward_poll_delivers_every_row_inserted_after_connect(pg_db):
-    """r.id is a random uuid4(), so filtering `id > after_id` has no
-    relationship to insertion order and admits or drops rows by chance.
-    A client that connects, then polls forward as new rows arrive, must
-    see every one of them: none silently dropped."""
     tenant_id = pg_db._tenant_id
     base = datetime(2026, 7, 27, tzinfo=timezone.utc)
     counter = 0
@@ -112,37 +121,88 @@ def test_forward_poll_delivers_every_row_inserted_after_connect(pg_db):
         counter += 1
 
     initial = pg_db.query_recent_events(limit=50, after_id=None)
-    last_id = initial[-1]["id"] if initial else None
+    cursor = initial[-1]["_cursor"]
 
-    delivered = set()
-    live_inserted = set()
+    delivered = []
+    live_inserted = []
     for _ in range(8):
         batch = [
             _insert_row(pg_db, tenant_id, base + timedelta(seconds=counter + i), counter + i)
             for i in range(3)
         ]
         counter += 3
-        live_inserted.update(str(row_id) for row_id in batch)
+        live_inserted.extend(batch)
 
-        events = pg_db.query_recent_events(limit=50, after_id=last_id)
+        events = pg_db.query_recent_events(limit=50, after_id=cursor)
         for event in events:
-            delivered.add(str(event["id"]))
-            last_id = event["id"]
+            delivered.append(event["id"])
+            cursor = event["_cursor"]
 
-    assert live_inserted <= delivered
+    assert delivered == live_inserted
 
 
-def test_cursor_past_end_returns_empty_not_backlog(pg_db):
-    """Once the cursor is caught up to the newest row, the next poll must
-    return nothing, not silently resend part of the backlog."""
+def test_composite_cursor_survives_source_row_deletion(pg_db):
     tenant_id = pg_db._tenant_id
     base = datetime(2026, 7, 27, tzinfo=timezone.utc)
-    for i in range(5):
-        _insert_row(pg_db, tenant_id, base + timedelta(seconds=i), i)
+    cursor_id = _insert_row(pg_db, tenant_id, base, 0)
+    cursor = pg_db.query_recent_events(limit=50, after_id=None)[-1]["_cursor"]
 
-    # query_recent_events serves the newest page first (DESC), so the
-    # newest row is the first one, not the last.
-    initial = pg_db.query_recent_events(limit=50, after_id=None)
-    newest_id = initial[0]["id"]
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM requests WHERE id = %s", (cursor_id,))
+    conn.commit()
+    cur.close()
+    conn.close()
 
-    assert pg_db.query_recent_events(limit=50, after_id=newest_id) == []
+    next_id = _insert_row(pg_db, tenant_id, base + timedelta(seconds=1), 1)
+    events = pg_db.query_recent_events(limit=50, after_id=cursor)
+
+    assert [event["id"] for event in events] == [next_id]
+
+
+def test_equal_timestamps_page_deterministically_by_uuid(pg_db):
+    tenant_id = pg_db._tenant_id
+    when = datetime(2026, 7, 27, tzinfo=timezone.utc)
+    row_ids = [UUID(int=value) for value in (3, 1, 2)]
+    for counter, row_id in enumerate(row_ids):
+        _insert_row(pg_db, tenant_id, when, counter, row_id=row_id)
+
+    initial = pg_db.query_recent_events(limit=2, after_id=None)
+    assert [event["id"] for event in initial] == [UUID(int=2), UUID(int=3)]
+    assert pg_db.query_recent_events(
+        limit=50, after_id=initial[-1]["_cursor"]
+    ) == []
+
+
+def test_legacy_uuid_cursor_is_tenant_scoped(pg_db):
+    tenant_id = pg_db._tenant_id
+    base = datetime(2026, 7, 27, tzinfo=timezone.utc)
+    own_id = _insert_row(pg_db, tenant_id, base, 0)
+    own_next_id = _insert_row(pg_db, tenant_id, base + timedelta(seconds=1), 1)
+
+    assert [
+        event["id"]
+        for event in pg_db.query_recent_events(limit=50, after_id=own_id)
+    ] == [own_next_id]
+
+    conn = _connect()
+    cur = conn.cursor()
+    foreign_tenant_id = uuid4()
+    foreign_id = uuid4()
+    cur.execute(
+        "INSERT INTO tenants (id, name, slug, plan) VALUES (%s, 'Other', 'other', 'free')",
+        (foreign_tenant_id,),
+    )
+    cur.execute(
+        """
+        INSERT INTO requests (id, tenant_id, request_id, provider, model,
+            input_tokens, output_tokens, estimated_cost_usd, timestamp)
+        VALUES (%s, %s, 'foreign', 'openai', 'gpt-4o', 1, 1, 0, %s)
+        """,
+        (foreign_id, foreign_tenant_id, base),
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    assert pg_db.query_recent_events(limit=50, after_id=foreign_id) == []


### PR DESCRIPTION
## Summary

PostgreSQL `requests.id` values are random UUIDv4 values. The previous SSE query used `id > after_id`, so paging order had no relationship to insertion order and `/token_events` silently lost usage rows.

This change gives PostgreSQL a stable composite cursor while preserving the existing SQLite path and the external SSE payload.

Closes #2173.

## Root Cause

The stream and query had three related consistency defects:

1. UUID comparison was used as insertion order.
2. The initial page was emitted newest-first, leaving the stream cursor on the oldest event and replaying the initial backlog on the next poll.
3. Every poll re-read the cursor row. If retention deleted that row, the stream returned no events forever.

## Implementation

- Page PostgreSQL rows by `(timestamp, id)` with matching ascending filter and ordering.
- Return the newest initial window in chronological order, so the cursor finishes at the newest emitted event.
- Carry the composite cursor privately as `_cursor`; it is not serialized into the public SSE event.
- Fall back to the row ID for SQLite and older backend responses.
- Preserve legacy PostgreSQL UUID cursors with tenant-scoped lookup.
- Add a dedicated GitHub Actions job backed by PostgreSQL 16.

No schema, Compose, installer, API authentication, or public event format is changed.

## Invariants

| Invariant | Evidence |
|---|---|
| Every row after the cursor is delivered once in keyset order | Live PostgreSQL forward-poll regression |
| Initial connection returns the newest bounded window without replay | Initial-window regression |
| Deleting the cursor source row does not freeze an active stream | Retention regression |
| Equal timestamps are deterministic | UUID tie-break regression |
| A legacy cursor cannot resolve through another tenant | Tenant-isolation regression |
| SQLite behavior remains selected by the existing backend switch | `main.py` ID fallback; token-spy suite |
| Private cursor metadata is not exposed over SSE | Existing explicit `event_data` serialization |

## Validation

Exact head: `cedb76effe8e9a8daebd5ff423c8d6710954b51f`

```text
PostgreSQL 16 container:
python -m pytest ods/extensions/services/token-spy/tests/test_recent_events_cursor_postgres.py -q
5 passed

Token Spy test suite:
python -m pytest ods/extensions/services/token-spy/tests -q
20 passed, 5 skipped

Python:
python -m py_compile <changed Python files>
ruff check <changed Python files> --select E,F,W --ignore E501,E701,E731,E741,E402
passed

Workflow YAML parse:
passed

git diff --check:
passed
```

The five skipped tests in the general local suite are existing environment-dependent tests. The PostgreSQL cursor suite itself ran without skips against the disposable PostgreSQL 16 container.

## Risk And Compatibility

- **Clean install / upgrade / rerun:** no schema or generated configuration change.
- **Service disabled:** no effect while token-spy is not running.
- **Partial failure / restart:** the cursor is connection-local; a reconnect intentionally receives the newest bounded snapshot, matching existing behavior.
- **Rollback:** reverting these commits restores the previous query without data migration.
- **Linux / Windows / macOS:** application-level Python/PostgreSQL behavior is platform-neutral; the new CI lane runs on Linux and does not alter platform installers.

## Residual Limitation

The composite key assumes database timestamps do not move backward. Removing that assumption requires a persistent monotonic sequence and a schema migration, which is intentionally outside this focused fix.
