### PR TITLE
feat(models): add NVIDIA Nemotron 3 Nano 4B

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -477,7 +477,49 @@
       "tokens_per_sec_estimate": 105,
       "llm_model_name": "NVIDIA-Nemotron3-Nano-4B",
       "llama_server_image": null,
-      "install_recommendation": false
+      "app_compatibility": {
+        "openai_chat": {
+          "status": "verified",
+          "label": "Fleet chat routes verified",
+          "reason": "Fresh exact-commit six-host validation loaded NVIDIA Nemotron 3 Nano 4B through the browser switchboard and passed every required deployed OpenAI-compatible LLM-consumer probe with signed route evidence naming the candidate runtime.",
+          "evidence": "fleet-test/runs/2026-07-27T02-32-10Z-model-ui-product-651e048b61d9-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T03:04:50Z",
+          "productSha": "651e048b61d9a5cc2133f342014b9ceb64800d41",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "hermes_talk": {
+          "status": "verified",
+          "label": "ODS Talk verified across fleet",
+          "reason": "Fresh exact-commit six-host validation passed challenge-bound ODS Talk after loading Nemotron and again after restoring each host's original model.",
+          "evidence": "fleet-test/runs/2026-07-27T02-32-10Z-model-ui-product-651e048b61d9-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T03:04:50Z",
+          "productSha": "651e048b61d9a5cc2133f342014b9ceb64800d41",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "perplexica": {
+          "status": "verified",
+          "label": "Perplexica verified across fleet",
+          "reason": "Fresh exact-commit six-host validation passed the challenge-bound Perplexica route on Nemotron with signed model-route evidence, then repeated the required consumer suite after clean baseline restoration.",
+          "evidence": "fleet-test/runs/2026-07-27T02-32-10Z-model-ui-product-651e048b61d9-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T03:04:50Z",
+          "productSha": "651e048b61d9a5cc2133f342014b9ceb64800d41",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "agent_viability": {
+          "status": "verified",
+          "label": "Agent workflow verified across fleet",
+          "reason": "Fresh exact-commit six-host validation passed Nemotron load, challenge-bound ODS Talk, every required deployed LLM consumer, original-model restore, repeated Talk and consumer probes, candidate deletion, and clean final inventory across Linux, macOS, and Windows backends.",
+          "evidence": "fleet-test/runs/2026-07-27T02-32-10Z-model-ui-product-651e048b61d9-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T03:04:50Z",
+          "productSha": "651e048b61d9a5cc2133f342014b9ceb64800d41",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        }
+      },
+      "install_recommendation": true
     },
     {
       "id": "granite4.1-3b-q4",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -461,6 +461,25 @@
       "install_recommendation": false
     },
     {
+      "id": "nvidia-nemotron3-nano-4b-q4",
+      "name": "NVIDIA Nemotron 3 Nano 4B",
+      "family": "nemotron",
+      "gguf_file": "NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF/resolve/main/NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf",
+      "gguf_sha256": "be5d9a656a51922f24f1f09a759cebb694e1f5d9728bf0ef9f8c972c5a0b5ef2",
+      "size_bytes": 2837072864,
+      "size_mb": 2838,
+      "vram_required_gb": 5,
+      "context_length": 262144,
+      "quantization": "Q4_K_M",
+      "specialty": "Agentic Reasoning",
+      "description": "NVIDIA's compact Nemotron 3 hybrid reasoning model with long-context and tool-use support. A diverse 5GB-class candidate for local agents, chat, and code.",
+      "tokens_per_sec_estimate": 105,
+      "llm_model_name": "NVIDIA-Nemotron3-Nano-4B",
+      "llama_server_image": null,
+      "install_recommendation": false
+    },
+    {
       "id": "granite4.1-3b-q4",
       "name": "Granite 4.1 3B",
       "family": "granite",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -614,7 +614,7 @@ def test_falcon_h1_3b_is_not_talk_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["falcon-h1-3b-instruct-q4"])
 
 
-def test_nemotron3_nano_4b_is_cataloged_for_fleet_validation():
+def test_nemotron3_nano_4b_is_recommended_after_six_host_validation():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["nvidia-nemotron3-nano-4b-q4"]
@@ -629,7 +629,16 @@ def test_nemotron3_nano_4b_is_cataloged_for_fleet_validation():
     assert model["size_bytes"] == 2837072864
     assert model["vram_required_gb"] <= 5
     assert model["context_length"] == 262144
-    assert model.get("install_recommendation") is False
+    assert model.get("install_recommendation") is True
+    compatibility = model["app_compatibility"]
+    assert compatibility["openai_chat"]["status"] == "verified"
+    assert compatibility["hermes_talk"]["status"] == "verified"
+    assert compatibility["perplexica"]["status"] == "verified"
+    assert compatibility["agent_viability"]["status"] == "verified"
+    assert "2026-07-27T02-32-10Z" in compatibility["agent_viability"]["evidence"]
+    assert compatibility["agent_viability"]["hostScope"] == [
+        "tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"
+    ]
     assert _agent_viable_for_release(model)
 
 
@@ -749,7 +758,6 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "granite4.0-h-1b-q4",
         "falcon-h1-1.5b-instruct-q4",
         "falcon-h1-3b-instruct-q4",
-        "nvidia-nemotron3-nano-4b-q4",
         "granite4.0-1b-q4",
         "granite4.0-h-350m-q4",
         "granite3.2-2b-instruct-q4",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -104,6 +104,7 @@ def test_release_model_switchboard_catalog_ids_exist():
         "granite4.0-h-1b-q4",
         "falcon-h1-1.5b-instruct-q4",
         "falcon-h1-3b-instruct-q4",
+        "nvidia-nemotron3-nano-4b-q4",
         "granite4.0-1b-q4",
         "granite4.0-h-350m-q4",
         "granite3.2-2b-instruct-q4",
@@ -613,6 +614,25 @@ def test_falcon_h1_3b_is_not_talk_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["falcon-h1-3b-instruct-q4"])
 
 
+def test_nemotron3_nano_4b_is_cataloged_for_fleet_validation():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["nvidia-nemotron3-nano-4b-q4"]
+
+    assert model["family"] == "nemotron"
+    assert model["gguf_file"] == "NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf"
+    assert model["gguf_url"] == (
+        "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF/"
+        "resolve/main/NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf"
+    )
+    assert model["gguf_sha256"] == "be5d9a656a51922f24f1f09a759cebb694e1f5d9728bf0ef9f8c972c5a0b5ef2"
+    assert model["size_bytes"] == 2837072864
+    assert model["vram_required_gb"] <= 5
+    assert model["context_length"] == 262144
+    assert model.get("install_recommendation") is False
+    assert _agent_viable_for_release(model)
+
+
 def test_qwen25_coder_15b_128k_has_scoped_app_blocks_until_revalidated():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
@@ -729,6 +749,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "granite4.0-h-1b-q4",
         "falcon-h1-1.5b-instruct-q4",
         "falcon-h1-3b-instruct-q4",
+        "nvidia-nemotron3-nano-4b-q4",
         "granite4.0-1b-q4",
         "granite4.0-h-350m-q4",
         "granite3.2-2b-instruct-q4",


### PR DESCRIPTION
## What changed

- adds NVIDIA Nemotron 3 Nano 4B Q4_K_M to the recommended ODS model library
- pins the official Hugging Face artifact URL, repository commit, byte size, and SHA-256
- records its 262K context window, 5 GB VRAM tier, agentic specialty, and `nemotron` family
- records verified ODS Talk, OpenAI chat, Perplexica, and agent-workflow compatibility
- adds catalog and switchboard contract coverage

## Why

ODS recommendations are currently weighted toward Qwen and Granite. Nemotron 3 Nano 4B adds an official NVIDIA hybrid Mamba2/Transformer model with a permissive commercial-use license and documented llama.cpp, Lemonade, Hermes Agent, and OpenClaw support. At validation time, its official Hugging Face repository had 184 likes and 8,910 downloads.

## Artifact

- Repository: `nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF`
- Repository commit: `ba223d14e45525f7fae81db77ea8cabeb2fc6c25`
- File: `NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf`
- Bytes: `2,837,072,864`
- SHA-256: `be5d9a656a51922f24f1f09a759cebb694e1f5d9728bf0ef9f8c972c5a0b5ef2`

## Fleet validation

Promotion commit: `44be32152ad35585c2464ac873a1063611aa3d97`

- exact-commit install PASS on tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy:
  `fleet-test/runs/2026-07-27T03-08-10Z-install-product-44be32152ad3-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
- strict final model rotation PASS on the same six hosts:
  `fleet-test/runs/2026-07-27T03-28-05Z-model-ui-product-44be32152ad3-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
- every host attested the exact promotion SHA with runner exit 0, artifact integrity true, and inventory integrity true
- each host passed Hugging Face explorer search and inspection, baseline discovery, exact candidate download, load, Talk inference, required consumer probes with signed route evidence, original-model restore, restored inference and probes, candidate deletion, and clean final inventory
- `ODS_MODEL_SWITCHBOARD=enabled` was verified directly on all six hosts

## Additional validation

- `python3 -m pytest -q ods/tests/test-model-library-coverage.py` (37 passed)
- focused synchronous dashboard model tests (90 passed, 10 async deselected locally); the complete dashboard API suite passed in CI
- fleet distro matrix (10 passed, 0 failed)
- Incus VM matrix: Ubuntu 24.04, Fedora 42, Rocky 9, Arch, and openSUSE passed
- all required GitHub checks passed, including API, frontend, integration smoke, Linux/macOS smoke, PowerShell lint, Ruff, mypy, ShellCheck, secret scan, environment tiers, and ten distro jobs
