### PR TITLE
feat(dashboard): refine the animated ODS splash

### DIFF
--- a/ods/extensions/services/dashboard/src/components/SplashScreen.jsx
+++ b/ods/extensions/services/dashboard/src/components/SplashScreen.jsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { gsap } from 'gsap'
+import { CustomEase } from 'gsap/CustomEase'
+
+gsap.registerPlugin(CustomEase)
 
 const SPLASH_DURATION_MS = 2800
 const EXIT_PAUSE_MS = 300
 const FADE_DURATION_MS = 600
-const LOW_END_ELLIPSE_COUNT = 14
-const STANDARD_ELLIPSE_COUNT = 22
+const LOW_END_ELLIPSE_COUNT = 31
+const STANDARD_ELLIPSE_COUNT = 31
 const visuallyHiddenStyle = {
   position: 'absolute',
   width: '1px',
@@ -54,7 +57,6 @@ function stopAnimationFrame(frameId) {
   clearTimeout(frameId)
 }
 
-// ─── Orb SVG animation — exact port of codepen.io/chrisgannon/pen/ZYQjZBr ───
 function OrbBackground({ reduced, lowPerformance }) {
   const svgRef = useRef(null)
 
@@ -63,20 +65,33 @@ function OrbBackground({ reduced, lowPerformance }) {
     if (!svg || reduced) return
 
     const allEll = Array.from(svg.querySelectorAll('.ell'))
-    const _ca = ['#f72585', '#7209b7', '#3a0ca3', '#4361ee', '#4cc9f0', '#D9F4FC']
-    const rxFactor = lowPerformance ? 2.4 : 3.2
-    const ryFactor = lowPerformance ? 1.5 : 2
-    const strokeStart = lowPerformance ? 8 : 10
-    const strokeEnd = lowPerformance ? 56 : 84
-    const colorInterp = gsap.utils.interpolate(_ca)
+    const palette = ['#f72585', '#7209b7', '#3a0ca3', '#4361ee', '#4cc9f0', '#d9f4fc']
+    const colorInterp = gsap.utils.interpolate(palette)
+    const standardEase = CustomEase.create(
+      'odsOrbStandard',
+      'M0,0 C0.2,0 0.432,0.147 0.507,0.374 0.59,0.629 0.822,1 1,1'
+    )
+    const easeOut = CustomEase.create(
+      'odsOrbOut',
+      'M0,0 C0.271,0.302 0.323,0.535 0.453,0.775 0.528,0.914 0.78,1 1,1'
+    )
+    const easeIn = CustomEase.create(
+      'odsOrbIn',
+      'M0,0 C0.594,0.062 0.79,0.698 1,1'
+    )
+    const rxFactor = 3.8
+    const ryFactor = 2.3
+    const strokeStart = 10
+    const strokeEnd = 100
 
     const ctx = gsap.context(() => {
       gsap.set(svg, { visibility: 'visible' })
+      const mainTimeline = gsap.timeline()
 
       function animateEllipse(el, index) {
         const offset = index + 1
         const timeline = gsap.timeline({
-          defaults: { duration: lowPerformance ? 1.25 : 1, ease: 'sine.inOut' },
+          defaults: { duration: 1, ease: standardEase },
           repeat: -1,
         })
 
@@ -89,28 +104,32 @@ function OrbBackground({ reduced, lowPerformance }) {
           .to(el, {
             attr: { rx: `+=${offset * rxFactor}`, ry: `-=${offset * ryFactor}` },
             strokeWidth: strokeStart,
-            ease: 'power2.in',
+            ease: easeIn,
           })
           .to(el, {
             strokeWidth: strokeEnd,
             attr: { rx: `-=${offset * rxFactor}`, ry: `+=${offset * ryFactor}` },
-            ease: 'power2.out',
+            ease: easeOut,
           })
           .to(el, {
-            duration: lowPerformance ? 2.5 : 2,
+            duration: 2,
             rotation: -360,
             transformOrigin: '50% 50%',
-            ease: 'none',
+            ease: standardEase,
           }, 0)
           .from(el, {
-            duration: lowPerformance ? 1.1 : 0.9,
+            duration: 1,
             scale: 0,
             transformOrigin: '50% 50%',
-            ease: 'power2.out',
+            ease: standardEase,
           }, 0)
-          .timeScale(lowPerformance ? 0.42 : 0.54)
+          .from(el, {
+            duration: 1.5,
+            ease: standardEase,
+          }, 0)
+          .timeScale(0.5)
 
-        timeline.progress((offset / allEll.length) * 0.35)
+        mainTimeline.add(timeline, offset / allEll.length)
       }
 
       allEll.forEach(animateEllipse)
@@ -131,10 +150,10 @@ function OrbBackground({ reduced, lowPerformance }) {
       focusable="false"
       style={{
         width: '100%',
-        height: '100%',
+        height: '90%',
         visibility: 'hidden',
         position: 'absolute',
-        inset: 0,
+        inset: '5% 0',
       }}
     >
       {Array.from({ length: lowPerformance ? LOW_END_ELLIPSE_COUNT : STANDARD_ELLIPSE_COUNT }, (_, i) => (

--- a/ods/extensions/services/dashboard/src/components/__tests__/SplashScreen.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/SplashScreen.test.jsx
@@ -6,6 +6,7 @@ vi.mock('gsap', () => {
     const timeline = {
       to: vi.fn(() => timeline),
       from: vi.fn(() => timeline),
+      add: vi.fn(() => timeline),
       progress: vi.fn(() => timeline),
       timeScale: vi.fn(() => timeline),
     }
@@ -15,6 +16,7 @@ vi.mock('gsap', () => {
 
   return {
     gsap: {
+      registerPlugin: vi.fn(),
       context: (callback) => {
         callback()
         return { revert: vi.fn() }
@@ -27,6 +29,12 @@ vi.mock('gsap', () => {
     },
   }
 })
+
+vi.mock('gsap/CustomEase', () => ({
+  CustomEase: {
+    create: vi.fn(() => 'custom-ease'),
+  },
+}))
 
 describe('SplashScreen', () => {
   beforeEach(() => {
@@ -49,11 +57,12 @@ describe('SplashScreen', () => {
   })
 
   test('renders accessible loading dialog with skip control', () => {
-    render(<SplashScreen onComplete={() => {}} />)
+    const { container } = render(<SplashScreen onComplete={() => {}} />)
 
     expect(screen.getByRole('dialog', { name: 'ODS' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'ODS', level: 1 })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Skip splash screen' })).toBeInTheDocument()
+    expect(container.querySelectorAll('.ell')).toHaveLength(31)
   })
 
   test('completes immediately when reduced motion is requested', () => {


### PR DESCRIPTION
## Summary

Refines the ODS startup splash into a layered animated identity treatment while preserving the existing loading, skip, accessibility, reduced-motion, and cleanup behavior.

- renders 31 synchronized ellipse layers with the ODS color palette
- uses registered custom easing curves for the intended deformation and rotation
- coordinates child animations through one master timeline
- keeps the SVG decorative and the loading state accessible
- removes stale external-source naming from the component
- locks the 31-layer visual contract in the focused component test

## AI Assistance

AI-assisted implementation review and regression-test drafting were used. The author reviewed the final diff, selected the validation scope, verified the live result, and is responsible for the submitted change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not applicable. This is a mainline dashboard presentation change.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Behavior And Invariants

| Invariant | Result |
|---|---|
| Existing splash duration and completion callback remain unchanged | Preserved |
| Skip button and Escape complete only once | Covered by regression test |
| Reduced-motion users bypass the animation | Preserved and tested |
| GSAP effects are scoped and reverted on unmount | Preserved through `gsap.context()` |
| Decorative SVG remains hidden from assistive technology | Preserved |
| Visual layer count remains stable | Asserted at 31 layers |

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: the change is confined to a decorative dashboard component and does not alter API, installer, Compose, model, network, or lifecycle contracts.

Commands/results:

```text
npm test -- --run src/components/__tests__/SplashScreen.test.jsx --reporter=dot
3 passed

npm test -- --reporter=dot
247 passed across 26 files

npm run lint
passed

npm run build
passed (Vite production build, 1769 modules)

git diff --check
passed

Live Windows Docker dashboard rebuild
healthy; animation visually verified; browser console clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The component continues to use the existing GSAP dependency. No package, service, environment, storage, or runtime contract changes are included.