### PR TITLE
fix(privacy-shield): scrub card numbers that are not 16 digits

### DIFF
--- a/ods/extensions/services/privacy-shield/PII_COVERAGE.md
+++ b/ods/extensions/services/privacy-shield/PII_COVERAGE.md
@@ -15,7 +15,7 @@ Privacy Shield provides PII (Personally Identifiable Information) detection and 
 | Email addresses | `\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b` | user@example.com |
 | Phone numbers (US) | `\b\d{3}[-.]?\d{3}[-.]?\d{4}\b` | 555-123-4567 |
 | Social Security Numbers | `\b\d{3}-\d{2}-\d{4}\b` | 123-45-6789 |
-| Credit card numbers | `\b(?:\d[ -]*?){13,16}\b` | 4111 1111 1111 1111 |
+| Credit card numbers | 13-19 digit PANs in 4-4-4-N or 4-6-N grouping, gated by a Luhn checksum | 4111 1111 1111 1111, 3782 822463 10005 |
 | IP addresses | `\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b` | 192.168.1.1 |
 
 ### Limitations

--- a/ods/extensions/services/privacy-shield/pii_scrubber.py
+++ b/ods/extensions/services/privacy-shield/pii_scrubber.py
@@ -27,8 +27,29 @@ class PIIDetector:
     # Stable session token (persisted, doesn't change on restart)
     session_token: str = field(default_factory=lambda: secrets.token_hex(16))
 
-    # Regex patterns for PII detection
+    # Card numbers are 13-19 digits (Visa 13/16/19, Diners 14, Amex 15,
+    # Maestro up to 19), written either unseparated or in issuer groupings.
+    # Two alternatives cover every grouping that occurs in practice:
+    # 4-4-4-N for the even-width brands and 4-6-N for Amex/Diners.
+    CREDIT_CARD_PATTERN = (
+        r'\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{1,7}\b'
+        r'|'
+        r'\b\d{4}[- ]?\d{6}[- ]?\d{4,5}\b'
+    )
+    # Shortest and longest PAN accepted by the Luhn gate. Below the floor a
+    # digit run is a phone number or an SSN, not a card.
+    MIN_PAN_DIGITS = 13
+    MAX_PAN_DIGITS = 19
+
+    # Regex patterns for PII detection.
+    #
+    # Order matters: patterns run in sequence over the same text, so a type
+    # whose matches can contain another type's shape must run first. A Diners
+    # PAN ("3056 930902 5904") holds a phone-shaped 10-digit run — with phone
+    # first, the phone pattern claims the tail and leaves the issuer digits in
+    # cleartext.
     PATTERNS = {
+        'credit_card': re.compile(CREDIT_CARD_PATTERN),
         'email': re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b'),
         'phone': re.compile(r'\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}\b'),
         'ssn': re.compile(r'\b(?!(?:19|20)\d{2}[-.\s]?\d{2}[-.\s]?\d{4}\b)\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b'),
@@ -44,14 +65,13 @@ class PIIDetector:
             r'(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}'  # Middle ::
         ),
         'api_key': re.compile(r'\b(?:api[_-]?key|apikey|token)[\s]*[=:]\s*["\']?[a-zA-Z0-9_\-]{16,}["\']?\b', re.IGNORECASE),
-        'credit_card': re.compile(r'\b(?:\d{4}[-\s]?){3}\d{4}\b'),
     }
 
     @staticmethod
     def _luhn_check(number_str: str) -> bool:
         """Validate a credit card number using the Luhn algorithm."""
         digits = [int(d) for d in number_str if d.isdigit()]
-        if len(digits) != 16:
+        if not PIIDetector.MIN_PAN_DIGITS <= len(digits) <= PIIDetector.MAX_PAN_DIGITS:
             return False
         checksum = 0
         for i, d in enumerate(reversed(digits)):

--- a/ods/extensions/services/privacy-shield/tests/test_pii_scrubber.py
+++ b/ods/extensions/services/privacy-shield/tests/test_pii_scrubber.py
@@ -170,6 +170,46 @@ class TestCreditCardDetection:
         assert PIIDetector._luhn_check("5500000000000004") is True  # Valid MC test number
         assert PIIDetector._luhn_check("1234567890123456") is False  # Invalid
 
+    # A PAN is 13-19 digits, not 16. Amex is 15 and Diners is 14, so a
+    # 16-digit-only detector hands those card numbers to the upstream provider
+    # in cleartext — the exact leak the shield exists to stop.
+    @pytest.mark.parametrize(
+        "label,number",
+        [
+            ("amex grouped", "3782 822463 10005"),
+            ("amex plain", "378282246310005"),
+            ("amex dashed", "3782-822463-10005"),
+            ("diners grouped", "3056 930902 5904"),
+            ("diners plain", "30569309025904"),
+            ("visa 13", "4222222222222"),
+            ("visa 19", "4111111111111111110"),
+        ],
+    )
+    def test_non_sixteen_digit_pans_are_scrubbed(self, detector, label, number):
+        result = detector.scrub(f"Card: {number} on file")
+        assert number not in result, label
+        assert "<PII_credit_card_" in result, label
+
+    def test_luhn_accepts_the_whole_pan_length_range(self):
+        assert PIIDetector._luhn_check("378282246310005") is True  # 15, Amex
+        assert PIIDetector._luhn_check("30569309025904") is True  # 14, Diners
+        assert PIIDetector._luhn_check("4222222222222") is True  # 13, Visa
+        assert PIIDetector._luhn_check("4111111111111111110") is True  # 19
+        assert PIIDetector._luhn_check("378282246310004") is False  # bad checksum
+        assert PIIDetector._luhn_check("123456789012") is False  # 12, too short
+        assert PIIDetector._luhn_check("12345678901234567890") is False  # 20, too long
+
+    def test_short_digit_runs_are_not_cards(self, detector):
+        """Phone numbers and SSNs sit below the PAN length floor."""
+        for text in ("Call 555-123-4567", "SSN 123-45-6789", "Ref 1234 5678"):
+            assert "<PII_credit_card_" not in detector.scrub(text), text
+
+    def test_card_wins_over_phone_on_overlap(self, detector):
+        """A Diners PAN contains a phone-shaped run; the card must claim it."""
+        result = detector.scrub("Card: 3056 930902 5904")
+        assert "<PII_phone_" not in result
+        assert "3056" not in result
+
 
 # ── Round-trip (scrub + restore) ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The Privacy Shield credit-card detector only recognises one PAN shape:

```python
'credit_card': re.compile(r'\b(?:\d{4}[-\s]?){3}\d{4}\b'),
```

and the Luhn gate hard-rejects anything that is not exactly 16 digits:

```python
if len(digits) != 16:
    return False
```

Real card numbers are 13-19 digits — Amex is 15, Diners is 14, Visa issues both 13 and 19. Those PANs are handed to the upstream provider in cleartext, which is exactly what the shield exists to prevent. `PII_COVERAGE.md` already advertised `{13,16}` coverage.

Verified against the deployed module before the change:

```
'Amex 3782 822463 10005 exp'  -> 'Amex 3782 822463 10005 exp'      # untouched
'Amex 378282246310005'        -> 'Amex 378282246310005'            # untouched
'Diners 3056 930902 5904'     -> 'Diners 3056 <PII_phone_...>'     # partial leak
```

The Diners case is worse than a plain miss: the PAN contains a phone-shaped 10-digit run, and because `phone` ran before `credit_card` the tail was tokenized as a phone number while the issuer digits stayed in cleartext — the payload still *looks* scrubbed.

## Fix

- Match the two groupings that occur in practice — 4-4-4-N for the even-width brands and 4-6-N for Amex/Diners — across the whole 13-19 digit range.
- Widen the Luhn gate to 13-19 digits. Luhn still carries the false-positive control, so short digit runs (phones, SSNs) stay below the floor and unchecksummed runs are still skipped.
- Move `credit_card` ahead of the shorter numeric patterns so it claims an overlapping match instead of losing the tail to `phone`.
- Correct the `PII_COVERAGE.md` row to describe what the detector actually does.

## Tests

`extensions/services/privacy-shield/tests/test_pii_scrubber.py` — new cases for Amex/Diners/13-digit/19-digit PANs (grouped, dashed and plain), the Luhn length window, the phone/SSN non-regression floor, and the card-wins-over-phone overlap.

```
# before: 9 failed, 30 passed
# after:  42 passed
python -m pytest tests/test_pii_scrubber.py tests/test_key_management.py -q
```