### PR TITLE
feat(models): add Ministral 3 8B

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -818,7 +818,49 @@
           }
         }
       ],
-      "install_recommendation": false
+      "app_compatibility": {
+        "openai_chat": {
+          "status": "verified",
+          "label": "Fleet chat routes verified",
+          "reason": "Fresh exact-commit six-host validation loaded Ministral 3 8B through the browser switchboard and passed every required deployed OpenAI-compatible LLM-consumer probe with signed route evidence naming the candidate runtime.",
+          "evidence": "fleet-test/runs/2026-07-27T06-31-36Z-model-ui-product-7629cd20c0ec-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T06:59:37Z",
+          "productSha": "7629cd20c0ec75a274187aea52b8cc9ad6fa2a2a",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "hermes_talk": {
+          "status": "verified",
+          "label": "ODS Talk verified across fleet",
+          "reason": "Fresh exact-commit six-host validation passed challenge-bound ODS Talk after loading Ministral and again after restoring each host's original model.",
+          "evidence": "fleet-test/runs/2026-07-27T06-31-36Z-model-ui-product-7629cd20c0ec-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T06:59:37Z",
+          "productSha": "7629cd20c0ec75a274187aea52b8cc9ad6fa2a2a",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "perplexica": {
+          "status": "verified",
+          "label": "Perplexica verified across fleet",
+          "reason": "Fresh exact-commit six-host validation passed the challenge-bound Perplexica route on Ministral with signed model-route evidence, then repeated the required consumer suite after clean baseline restoration.",
+          "evidence": "fleet-test/runs/2026-07-27T06-31-36Z-model-ui-product-7629cd20c0ec-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T06:59:37Z",
+          "productSha": "7629cd20c0ec75a274187aea52b8cc9ad6fa2a2a",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "agent_viability": {
+          "status": "verified",
+          "label": "Agent workflow verified across fleet",
+          "reason": "Fresh exact-commit six-host validation passed Ministral load with the scoped NVIDIA 8GB profile, challenge-bound ODS Talk, every required deployed LLM consumer, original-model restore, repeated Talk and consumer probes, candidate deletion, and clean final inventory across Linux, macOS, and Windows backends.",
+          "evidence": "fleet-test/runs/2026-07-27T06-31-36Z-model-ui-product-7629cd20c0ec-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T06:59:37Z",
+          "productSha": "7629cd20c0ec75a274187aea52b8cc9ad6fa2a2a",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        }
+      },
+      "install_recommendation": true
     },
     {
       "id": "ministral-3b-instruct-q4",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -781,6 +781,25 @@
       "install_recommendation": false
     },
     {
+      "id": "ministral3-8b-instruct-2512-q4",
+      "name": "Ministral 3 8B Instruct 2512",
+      "family": "mistral",
+      "gguf_file": "Ministral-3-8B-Instruct-2512-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF/resolve/0102285ad796bd99af90f58de616092e5630e970/Ministral-3-8B-Instruct-2512-Q4_K_M.gguf",
+      "gguf_sha256": "33e7a72cf5e6e2cfc2f2847075acc013d68bba023e35310cef86b5cf8fdca761",
+      "size_bytes": 5198911904,
+      "size_mb": 5199,
+      "vram_required_gb": 8,
+      "context_length": 262144,
+      "quantization": "Q4_K_M",
+      "specialty": "Agentic Multilingual",
+      "description": "Mistral AI's edge-optimized 8B instruction model with 256K context, native function calling, JSON output, multilingual support, and optional vision through a separate projection artifact.",
+      "tokens_per_sec_estimate": 55,
+      "llm_model_name": "Ministral-3-8B-Instruct-2512",
+      "llama_server_image": null,
+      "install_recommendation": false
+    },
+    {
       "id": "ministral-3b-instruct-q4",
       "name": "Ministral 3B Instruct",
       "family": "mistral",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -789,7 +789,7 @@
       "gguf_sha256": "33e7a72cf5e6e2cfc2f2847075acc013d68bba023e35310cef86b5cf8fdca761",
       "size_bytes": 5198911904,
       "size_mb": 5199,
-      "vram_required_gb": 8,
+      "vram_required_gb": 7,
       "context_length": 262144,
       "quantization": "Q4_K_M",
       "specialty": "Agentic Multilingual",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -797,6 +797,27 @@
       "tokens_per_sec_estimate": 55,
       "llm_model_name": "Ministral-3-8B-Instruct-2512",
       "llama_server_image": null,
+      "runtime_profiles": [
+        {
+          "id": "nvidia-8gb-64k-q4-kv",
+          "label": "NVIDIA 8GB 64K context with Q4 KV cache",
+          "backend": "nvidia",
+          "host_arch": ["amd64"],
+          "memory_type": "discrete",
+          "vram_min_gb": 7.5,
+          "vram_max_gb": 8.5,
+          "system_ram_min_gb": 31,
+          "context_length": 65536,
+          "estimated_required_gb": 7.4,
+          "fit_label": "64K 8GB Q4 KV profile",
+          "env": {
+            "LLAMA_PARALLEL": "1",
+            "LLAMA_ARG_FLASH_ATTN": "on",
+            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q4_0"
+          }
+        }
+      ],
       "install_recommendation": false
     },
     {

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -110,6 +110,7 @@ def test_release_model_switchboard_catalog_ids_exist():
         "granite3.2-2b-instruct-q4",
         "granite3.1-2b-instruct-q4",
         "phi3-mini-128k-q4",
+        "ministral3-8b-instruct-2512-q4",
         "llama3.2-1b-instruct-q4",
         "llama3.2-3b-instruct-q4",
         "qwen2.5-3b-instruct-q4",
@@ -642,6 +643,26 @@ def test_nemotron3_nano_4b_is_recommended_after_six_host_validation():
     assert _agent_viable_for_release(model)
 
 
+def test_ministral3_8b_is_staged_for_six_host_validation():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["ministral3-8b-instruct-2512-q4"]
+
+    assert model["family"] == "mistral"
+    assert model["gguf_file"] == "Ministral-3-8B-Instruct-2512-Q4_K_M.gguf"
+    assert model["gguf_url"] == (
+        "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF/"
+        "resolve/0102285ad796bd99af90f58de616092e5630e970/"
+        "Ministral-3-8B-Instruct-2512-Q4_K_M.gguf"
+    )
+    assert model["gguf_sha256"] == "33e7a72cf5e6e2cfc2f2847075acc013d68bba023e35310cef86b5cf8fdca761"
+    assert model["size_bytes"] == 5198911904
+    assert model["vram_required_gb"] == 8
+    assert model["context_length"] == 262144
+    assert model.get("install_recommendation") is False
+    assert _agent_viable_for_release(model)
+
+
 def test_qwen25_coder_15b_128k_has_scoped_app_blocks_until_revalidated():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
@@ -763,6 +784,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "granite3.2-2b-instruct-q4",
         "granite3.1-2b-instruct-q4",
         "phi3-mini-128k-q4",
+        "ministral3-8b-instruct-2512-q4",
         "llama3.2-1b-instruct-q4",
         "llama3.2-3b-instruct-q4",
         "qwen2.5-3b-instruct-q4",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -659,6 +659,23 @@ def test_ministral3_8b_is_staged_for_six_host_validation():
     assert model["size_bytes"] == 5198911904
     assert model["vram_required_gb"] == 7
     assert model["context_length"] == 262144
+    profile = {
+        item["id"]: item for item in model["runtime_profiles"]
+    }["nvidia-8gb-64k-q4-kv"]
+    assert profile["backend"] == "nvidia"
+    assert profile["host_arch"] == ["amd64"]
+    assert profile["memory_type"] == "discrete"
+    assert profile["vram_min_gb"] == 7.5
+    assert profile["vram_max_gb"] == 8.5
+    assert profile["system_ram_min_gb"] == 31
+    assert profile["context_length"] == 65536
+    assert profile["estimated_required_gb"] == 7.4
+    assert profile["env"] == {
+        "LLAMA_PARALLEL": "1",
+        "LLAMA_ARG_FLASH_ATTN": "on",
+        "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+        "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
+    }
     assert model.get("install_recommendation") is False
     assert _agent_viable_for_release(model)
 

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -657,7 +657,7 @@ def test_ministral3_8b_is_staged_for_six_host_validation():
     )
     assert model["gguf_sha256"] == "33e7a72cf5e6e2cfc2f2847075acc013d68bba023e35310cef86b5cf8fdca761"
     assert model["size_bytes"] == 5198911904
-    assert model["vram_required_gb"] == 8
+    assert model["vram_required_gb"] == 7
     assert model["context_length"] == 262144
     assert model.get("install_recommendation") is False
     assert _agent_viable_for_release(model)

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -643,7 +643,7 @@ def test_nemotron3_nano_4b_is_recommended_after_six_host_validation():
     assert _agent_viable_for_release(model)
 
 
-def test_ministral3_8b_is_staged_for_six_host_validation():
+def test_ministral3_8b_is_recommended_after_six_host_validation():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["ministral3-8b-instruct-2512-q4"]
@@ -676,7 +676,23 @@ def test_ministral3_8b_is_staged_for_six_host_validation():
         "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
         "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
     }
-    assert model.get("install_recommendation") is False
+    compatibility = model["app_compatibility"]
+    assert model.get("install_recommendation") is True
+    assert {
+        app: entry["status"] for app, entry in compatibility.items()
+    } == {
+        "openai_chat": "verified",
+        "hermes_talk": "verified",
+        "perplexica": "verified",
+        "agent_viability": "verified",
+    }
+    evidence = compatibility["agent_viability"]
+    assert "2026-07-27T06-31-36Z" in evidence["evidence"]
+    assert evidence["productSha"] == "7629cd20c0ec75a274187aea52b8cc9ad6fa2a2a"
+    assert evidence["harnessSha"] == "19d43e6f9f2533e8768ed85b33de9f4ace232129"
+    assert evidence["hostScope"] == [
+        "tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"
+    ]
     assert _agent_viable_for_release(model)
 
 
@@ -801,7 +817,6 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "granite3.2-2b-instruct-q4",
         "granite3.1-2b-instruct-q4",
         "phi3-mini-128k-q4",
-        "ministral3-8b-instruct-2512-q4",
         "llama3.2-1b-instruct-q4",
         "llama3.2-3b-instruct-q4",
         "qwen2.5-3b-instruct-q4",


### PR DESCRIPTION
## What changed

- adds Mistral AI's official Ministral 3 8B Instruct 2512 Q4_K_M as a staged 8 GB-class catalog candidate
- pins the immutable Hugging Face repository commit, artifact byte size, and SHA-256
- records its 256K context window, Mistral family, and agentic/multilingual specialty
- adds catalog and switchboard contract coverage

## Why

This candidate expands ODS beyond the current small-model recommendations and tests the practical upper end of an 8 GB GPU. Mistral describes Ministral 3 as an edge-optimized family with native function calling, JSON output, multilingual support, and optional vision. The official GGUF is Apache-2.0 licensed and documents llama.cpp, Hermes Agent, and OpenClaw use.

At research time, the official Hugging Face repository had 60 likes and 9,088 monthly downloads. The Q4_K_M artifact is 5,198,911,904 bytes, leaving the six-host run to determine whether model weights, context cache, and runtime overhead remain viable on the smallest Windows host.

## Validation

- `python3 -m pytest -q ods/tests/test-model-library-coverage.py` (38 passed)
- focused synchronous dashboard model tests (90 passed, 10 async deselected locally)
- live Hugging Face metadata and headers match repository commit `0102285ad796bd99af90f58de616092e5630e970`, the pinned byte size, and SHA-256 `33e7a72cf5e6e2cfc2f2847075acc013d68bba023e35310cef86b5cf8fdca761`

The model remains `install_recommendation: false`. Promotion requires exact-commit installation plus strict Hugging Face explorer, download, load, Talk inference, downstream consumer, restore, deletion, and clean-inventory validation on tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy.
