### PR TITLE
fix(voice): stop uninstalled LiveKit reporting voice as unavailable

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/voice.py
+++ b/ods/extensions/services/dashboard-api/routers/voice.py
@@ -10,6 +10,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["voice"])
 
+# Whisper (STT) and Kokoro (TTS) are the voice stack ODS ships, so both have to
+# be healthy for voice to be usable. LiveKit is an optional add-on that is
+# absent from SERVICES unless an operator installs it — an install without it
+# is complete, not degraded, and must not drag the verdict down.
+REQUIRED_VOICE_SERVICES = ("stt", "tts")
+NOT_CONFIGURED = "not_configured"
+
 
 @router.get("/api/voice/status")
 async def voice_status(api_key: str = Depends(verify_api_key)):
@@ -32,7 +39,7 @@ async def voice_status(api_key: str = Depends(verify_api_key)):
                 logger.warning("Health check failed for %s", svc_key, exc_info=True)
                 services_status[display_name] = {"status": "unavailable"}
         else:
-            services_status[display_name] = {"status": "not_configured"}
+            services_status[display_name] = {"status": NOT_CONFIGURED}
 
     # LiveKit is optional and not in SERVICES by default
     livekit_cfg = SERVICES.get("livekit")
@@ -44,9 +51,20 @@ async def voice_status(api_key: str = Depends(verify_api_key)):
             logger.warning("Health check failed for livekit", exc_info=True)
             services_status["livekit"] = {"status": "unavailable"}
     else:
-        services_status["livekit"] = {"status": "not_configured"}
+        services_status["livekit"] = {"status": NOT_CONFIGURED}
 
-    all_healthy = all(s.get("status") == "healthy" for s in services_status.values())
+    # An uninstalled optional service is not a failure, so it sits out the
+    # verdict. Everything that IS installed still has to be healthy.
+    required_healthy = all(
+        services_status.get(name, {}).get("status") == "healthy"
+        for name in REQUIRED_VOICE_SERVICES
+    )
+    installed_healthy = all(
+        entry["status"] == "healthy"
+        for entry in services_status.values()
+        if entry["status"] != NOT_CONFIGURED
+    )
+    all_healthy = required_healthy and installed_healthy
 
     return {
         "available": all_healthy,

--- a/ods/extensions/services/dashboard-api/tests/test_voice.py
+++ b/ods/extensions/services/dashboard-api/tests/test_voice.py
@@ -1,0 +1,97 @@
+"""Tests for routers/voice.py — voice services availability verdict.
+
+/api/voice/status is what the first-boot Success Validation card re-runs for
+its "Voice I/O" check (SuccessValidation.jsx reads `result.available`), so the
+verdict has to describe the voice stack ODS actually installed.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from routers.voice import voice_status
+
+
+def _health(statuses):
+    """check_service_health stub returning a status per service id."""
+
+    async def _check(service_id, config, **kwargs):
+        return SimpleNamespace(status=statuses[service_id])
+
+    return _check
+
+
+def _services(*service_ids):
+    return {sid: {"name": sid, "port": 1234} for sid in service_ids}
+
+
+@pytest.fixture()
+def voice_env(monkeypatch):
+    """Patch the helpers/config symbols voice_status imports at call time."""
+
+    def _apply(configured, statuses):
+        monkeypatch.setattr("config.SERVICES", _services(*configured))
+        monkeypatch.setattr("helpers.check_service_health", _health(statuses))
+
+    return _apply
+
+
+class TestVoiceStatus:
+
+    @pytest.mark.asyncio
+    async def test_available_when_stt_and_tts_are_healthy(self, voice_env):
+        """LiveKit ships uninstalled; its absence must not veto the verdict."""
+        voice_env(
+            configured=("whisper", "tts"),
+            statuses={"whisper": "healthy", "tts": "healthy"},
+        )
+
+        result = await voice_status(api_key="test")
+
+        assert result["available"] is True
+        assert result["services"]["livekit"]["status"] == "not_configured"
+        assert result["message"] == "All voice services operational"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_when_a_required_service_is_down(self, voice_env):
+        voice_env(
+            configured=("whisper", "tts"),
+            statuses={"whisper": "healthy", "tts": "down"},
+        )
+
+        result = await voice_status(api_key="test")
+
+        assert result["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_unavailable_when_a_required_service_is_missing(self, voice_env):
+        voice_env(configured=("tts",), statuses={"tts": "healthy"})
+
+        result = await voice_status(api_key="test")
+
+        assert result["available"] is False
+        assert result["services"]["stt"]["status"] == "not_configured"
+
+    @pytest.mark.asyncio
+    async def test_installed_livekit_still_has_to_be_healthy(self, voice_env):
+        """Opting in to the optional service opts in to its health too."""
+        voice_env(
+            configured=("whisper", "tts", "livekit"),
+            statuses={"whisper": "healthy", "tts": "healthy", "livekit": "down"},
+        )
+
+        result = await voice_status(api_key="test")
+
+        assert result["available"] is False
+        assert result["services"]["livekit"]["status"] == "down"
+
+    @pytest.mark.asyncio
+    async def test_available_with_a_healthy_livekit(self, voice_env):
+        voice_env(
+            configured=("whisper", "tts", "livekit"),
+            statuses={"whisper": "healthy", "tts": "healthy", "livekit": "healthy"},
+        )
+
+        result = await voice_status(api_key="test")
+
+        assert result["available"] is True


### PR DESCRIPTION
## Problem

`GET /api/voice/status` builds a status map and then folds every entry of it into one verdict:

```python
services_status["livekit"] = {"status": "not_configured"}   # the default branch
...
all_healthy = all(s.get("status") == "healthy" for s in services_status.values())
```

LiveKit is optional and is not in `SERVICES` on a stock install — the endpoint writes `not_configured` for it itself, then fails its own check against that value. So `available` is `False` on **every** install that did not add LiveKit, however healthy Whisper and Kokoro are.

That value is user-visible. `SuccessValidation.jsx` re-runs this endpoint for the first-boot "Voice I/O" check:

```js
testUrl: '/api/voice/status'
...
const success = Boolean(result.success ?? result.available)
```

The card seeds the check as *passed* from the service list, then flips it to *failed* as soon as the user presses "Run tests" — and `onAllPassed` never fires.

## Fix

Base the verdict on the voice stack ODS actually installs:

- Whisper (stt) and Kokoro (tts) must both be healthy — they are what the product ships.
- Any optional service the operator *did* install still has to be healthy, so a broken LiveKit is still reported.
- A service reporting `not_configured` sits the verdict out instead of vetoing it.

## Tests

New `extensions/services/dashboard-api/tests/test_voice.py`:

- healthy stt+tts with no LiveKit → `available: true` (fails on main)
- required service down → `available: false`
- required service not configured → `available: false`
- LiveKit installed but down → `available: false`
- LiveKit installed and healthy → `available: true`

```
# before: 1 failed, 4 passed
# after:  5 passed
python -m pytest tests/test_voice.py -q
python -m pytest tests/test_routers.py tests/test_main.py -q   # 126 passed
```