### PR TITLE
ci: run the whole remote-provider contract suite

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -167,6 +167,8 @@ jobs:
           python3 tests/contracts/test-network-exposure-contracts.py
           python3 tests/contracts/test-remote-provider-egress-policy.py
           python3 tests/contracts/test-remote-provider-egress-service.py
+          python3 tests/contracts/test-remote-provider-cli.py
+          python3 tests/contracts/test-remote-provider-ssh-tunnel-service.py
 
       - name: Linux install preflight tests
         run: |

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -30,6 +30,12 @@ test: ## Run unit and contract tests
 	@bash tests/test-hermes-slash-worker-prune.sh
 	@python3 tests/contracts/test-hermes-worker-guardrails.py
 	@echo ""
+	@echo "=== Remote provider contracts ==="
+	@python3 tests/contracts/test-remote-provider-egress-policy.py
+	@python3 tests/contracts/test-remote-provider-egress-service.py
+	@python3 tests/contracts/test-remote-provider-cli.py
+	@python3 tests/contracts/test-remote-provider-ssh-tunnel-service.py
+	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
 	@bash tests/test-phase03-multigpu-tty.sh


### PR DESCRIPTION
## Problem

The remote-provider subsystem ships four contract tests. CI runs two of them, and `make test` runs none:

| test | `make test` | `test-linux.yml` |
|---|---|---|
| `test-remote-provider-egress-policy.py` | no | yes |
| `test-remote-provider-egress-service.py` | no | yes |
| `test-remote-provider-cli.py` | **no** | **no** |
| `test-remote-provider-ssh-tunnel-service.py` | **no** | **no** |

The two files nothing runs carry the checks with the sharpest teeth — 600 lines of them:

- `ods-cli` still implements the `remote-provider` lifecycle command surface
- the SSH supervisor starts a single `ssh` child **without a shell**
- it stops that child when secret custody disappears
- it restarts when the route argv changes
- it honours the restart cooldown after a child exit
- the service source never names a public secret

A regression in any of those lands green today.

## Fix

Run all four from both entry points, in the same block as their existing siblings. All four are stdlib-only source and fixture inspections — no docker, network, or GPU — so they cost about a second.

## Verification

```
tests/contracts/test-remote-provider-egress-policy.py         PASS
tests/contracts/test-remote-provider-egress-service.py        PASS
tests/contracts/test-remote-provider-cli.py                   PASS
tests/contracts/test-remote-provider-ssh-tunnel-service.py    PASS
```

`make -n test` expands cleanly and the workflow still parses as YAML.