### PR TITLE
fix(models): read the catalog's filename key in the shared memory estimate

### DIFF
--- a/ods/extensions/services/dashboard-api/model_memory.py
+++ b/ods/extensions/services/dashboard-api/model_memory.py
@@ -23,11 +23,16 @@ def estimated_param_billions(model: dict[str, Any]) -> float:
             return value
 
     numbers: list[float] = []
+    # config/model-library.json spells the filename `gguf_file`; the oracle's
+    # normalized shape carries `gguf`. Read both — the filename is the only
+    # place some entries state their scale, and losing it drops the estimate
+    # onto the size heuristic, which disagrees with scripts/select-model.py.
     for text in (
         model.get("id"),
         model.get("name"),
         model.get("llm_model_name"),
         model.get("gguf"),
+        model.get("gguf_file"),
     ):
         numbers.extend(
             float(match)

--- a/ods/extensions/services/dashboard-api/tests/test_model_memory.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_memory.py
@@ -1,0 +1,107 @@
+"""Tests for model_memory.py — the shared selector/activation memory estimate.
+
+scripts/select-model.py (installer) and model_memory.py (dashboard-api) answer
+the same question — how much memory does this catalog entry need — for the same
+config/model-library.json. When they disagree, the installer picks a model the
+dashboard then refuses to activate. These tests pin the two together.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from model_memory import (
+    estimated_context_kv_gb,
+    estimated_param_billions,
+    required_model_memory_gb,
+)
+
+
+ODS_ROOT = Path(__file__).resolve().parents[4]
+CATALOG_PATH = ODS_ROOT / "config" / "model-library.json"
+SELECT_MODEL_PATH = ODS_ROOT / "scripts" / "select-model.py"
+
+
+def _load_select_model():
+    spec = importlib.util.spec_from_file_location("ods_select_model", SELECT_MODEL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _catalog_entries():
+    return json.loads(CATALOG_PATH.read_text(encoding="utf-8"))["models"]
+
+
+class TestParamScaleSources:
+
+    def test_reads_the_catalog_filename_key(self):
+        """model-library.json spells the filename `gguf_file`, not `gguf`."""
+        model = {
+            "id": "llama4-scout-q4",
+            "name": "Llama 4 Scout",
+            "llm_model_name": "llama-4-scout",
+            "gguf_file": "Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf",
+            "size_mb": 65300,
+        }
+        assert estimated_param_billions(model) == 17.0
+
+    def test_reads_the_normalized_filename_key(self):
+        """The oracle's normalized shape spells it `gguf`; both must work."""
+        model = {
+            "id": "llama4-scout-q4",
+            "gguf": "Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf",
+            "size_mb": 65300,
+        }
+        assert estimated_param_billions(model) == 17.0
+
+    def test_explicit_metadata_still_wins(self):
+        model = {"total_params_b": 8, "gguf_file": "Something-70B.gguf"}
+        assert estimated_param_billions(model) == 8.0
+
+    def test_size_heuristic_is_the_last_resort(self):
+        model = {"id": "mystery", "size_mb": 6000}
+        assert estimated_param_billions(model) == 10.0
+
+    def test_filename_scale_lowers_the_kv_estimate(self):
+        """A 17B model must not be charged the KV cost of a 108B one."""
+        model = {
+            "id": "llama4-scout-q4",
+            "gguf_file": "Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf",
+            "size_mb": 65300,
+            "context_length": 131072,
+        }
+        without_filename = dict(model)
+        without_filename.pop("gguf_file")
+        assert estimated_context_kv_gb(model) < estimated_context_kv_gb(without_filename)
+
+
+@pytest.mark.skipif(
+    not CATALOG_PATH.exists() or not SELECT_MODEL_PATH.exists(),
+    reason="repo checkout required",
+)
+class TestSelectorParity:
+
+    def test_every_catalog_entry_agrees_with_the_installer_selector(self):
+        select_model = _load_select_model()
+        mismatches = []
+        for raw in _catalog_entries():
+            dashboard_gb = required_model_memory_gb(raw)
+            installer_gb = select_model.selector_required_memory_gb(raw)
+            if dashboard_gb != installer_gb:
+                mismatches.append((raw.get("id"), dashboard_gb, installer_gb))
+        assert not mismatches, (
+            "dashboard-api and the installer selector disagree on required "
+            f"memory for: {mismatches}"
+        )
+
+    def test_param_scale_agrees_with_the_installer_selector(self):
+        select_model = _load_select_model()
+        mismatches = [
+            (raw.get("id"), estimated_param_billions(raw), select_model.estimated_param_billions(raw))
+            for raw in _catalog_entries()
+            if estimated_param_billions(raw) != select_model.estimated_param_billions(raw)
+        ]
+        assert not mismatches, f"param-scale estimates diverge for: {mismatches}"


### PR DESCRIPTION
## Problem

`model_memory.py` describes itself as *"Shared context-aware memory estimates for model selection and activation"*, and `required_model_memory_gb` as *"the shared selector/activation memory requirement"*. `scripts/select-model.py` carries the matching implementation for the installer side.

They read a different key for the model filename:

```python
# model_memory.py
model.get("gguf"),

# scripts/select-model.py
model.get("gguf_file"),
```

`config/model-library.json` spells it `gguf_file`. For any entry whose `id`, `name` and `llm_model_name` carry no parameter count, the filename is the only place the scale is stated — and losing it drops the estimate onto the `size_mb / 600` heuristic.

`llama4-scout-q4` is exactly that entry: id `llama4-scout-q4`, name `Llama 4 Scout`, model `llama-4-scout` — only the filename says 17B.

| | param scale | context KV | required |
|---|---|---|---|
| `scripts/select-model.py` | 17.0 B | 8.16 GB | **71.93 GB** |
| `model_memory.py` | 108.8 B | 14.0 GB | **77.77 GB** |

A 5.84 GB gap, on a model whose declared requirement is 70 GB — precisely the band where the installer's pick and the dashboard's activation gate stop agreeing. It is 1 of 52 catalog entries today; the next entry named without a `NNb` token joins it.

The oracle's `normalize_catalog_entry` happens to emit both spellings, so the divergence only bites callers handed a raw catalog record — but two copies of one contract silently disagreeing is the defect, not the current caller set.

## Fix

Read both spellings, and pin the contract with a test that walks the shipped catalog and asserts both implementations return the same number for every entry.

## Tests

New `extensions/services/dashboard-api/tests/test_model_memory.py`:

- filename scale is read from `gguf_file` (catalog shape) and `gguf` (normalized shape)
- explicit `total_params_b` still wins; the size heuristic stays the last resort
- a 17B model is not charged a 108B model's KV cost
- **selector parity**: every entry in `config/model-library.json` gets the same `required_model_memory_gb` from both implementations, and the same param-scale estimate

```
# on main
FAILED test_reads_the_catalog_filename_key
FAILED test_filename_scale_lowers_the_kv_estimate
FAILED test_every_catalog_entry_agrees_with_the_installer_selector
FAILED test_param_scale_agrees_with_the_installer_selector
    param-scale estimates diverge for: [('llama4-scout-q4', 108.83, 17.0)]
4 failed, 3 passed

# with this change
7 passed
pytest tests/test_model_memory.py tests/test_performance_oracle.py tests/test_models.py  ->  155 passed
```