### PR TITLE
test(installer): assert the docker temp-file invariant where it now lives

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -162,6 +162,7 @@ jobs:
         run: |
           bash tests/contracts/test-installer-contracts.sh
           bash tests/test-phase03-multigpu-tty.sh
+          bash tests/test-tmpfile-cleanup.sh
           bash tests/contracts/test-preflight-fixtures.sh
           bash tests/test-preflight-resolver-bug.sh
           python3 tests/contracts/test-network-exposure-contracts.py

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -85,6 +85,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods config show secret-mask matrix ==="
 	@bash tests/test-ods-config-secret-mask.sh
 	@echo ""
+	@echo "=== installer temp-file cleanup ==="
+	@bash tests/test-tmpfile-cleanup.sh
+	@echo ""
 	@echo "=== Manifest schema source of truth ==="
 	@bash tests/test-validate-manifest-schema.sh
 	@echo ""

--- a/ods/tests/test-tmpfile-cleanup.sh
+++ b/ods/tests/test-tmpfile-cleanup.sh
@@ -78,13 +78,41 @@ else
     FAILED=$((FAILED + 1))
 fi
 
-# Test 8: Phase 05 has explicit cleanup in error path
-printf "  %-50s " "Phase 05 has explicit cleanup in error path..."
-if grep -B 2 'error "Docker installation failed' "$ROOT_DIR/installers/phases/05-docker.sh" | grep -q "rm -f.*tmpfile"; then
+# Test 8: every exit from the download helper removes the temp file.
+#
+# The helper owns the temp file end to end: it mktemps, curls get.docker.com
+# into it, runs it, and must delete it before returning on either path. The
+# callers only see a return code, so an assertion anchored on the caller's
+# `error "Docker installation failed"` line proves nothing about the file —
+# it just happened to sit near the cleanup before the download moved into a
+# function.
+printf "  %-50s " "Phase 05 helper cleans up on every exit..."
+helper_body=$(awk '
+    /^_docker_install_from_script\(\) \{/ { inside = 1; next }
+    inside && /^\}/ { exit }
+    inside { print }
+' "$ROOT_DIR/installers/phases/05-docker.sh")
+
+# Every `return` must have a removal on it or within the two lines above it,
+# and the helper must end by removing the file on the success path.
+uncleaned_returns=$(awk '
+    { line[NR] = $0 }
+    /return/ {
+        cleaned = 0
+        for (i = NR; i >= NR - 2 && i >= 1; i--) {
+            if (line[i] ~ /rm -f[[:space:]]+"\$tmpfile"/) cleaned = 1
+        }
+        if (!cleaned) print NR ": " $0
+    }
+' <<< "$helper_body")
+last_statement=$(grep -v '^[[:space:]]*$' <<< "$helper_body" | tail -1)
+
+if [[ -n "$helper_body" ]]     && grep -q 'mktemp /tmp/install-docker' <<< "$helper_body"     && [[ -z "$uncleaned_returns" ]]     && grep -q 'rm -f[[:space:]]\+"\$tmpfile"' <<< "$last_statement"; then
     echo -e "${GREEN}✓ PASS${NC}"
     PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
+    [[ -n "$uncleaned_returns" ]] && echo "    return without cleanup: $uncleaned_returns"
     FAILED=$((FAILED + 1))
 fi
 


### PR DESCRIPTION
## Problem

`tests/test-tmpfile-cleanup.sh` **fails on main**:

```
2. Explicit Cleanup Tests
  Phase 05 has explicit cleanup after success...     ✓ PASS
  Phase 05 has explicit cleanup in error path...     ✗ FAIL
✗ Some tests failed (8 passed, 1 failed)
```

The assertion is anchored on the *caller*:

```bash
grep -B 2 'error "Docker installation failed' 05-docker.sh | grep -q "rm -f.*tmpfile"
```

That held only while the `mktemp`, the `curl`, and the failure branch sat inline next to the `error` call. The download has since moved into `_docker_install_from_script()`, which removes the temp file on **both** paths and returns a code the callers turn into an error. The grep window now contains only the caller's error line, so the check fails against correct code.

Nothing runs the suite — it is in neither `make test` nor any workflow — so the stale assertion has been sitting red unnoticed, and the invariant it was meant to protect (a shell script downloaded from `get.docker.com` never outlives the function that fetched it) has been unguarded the whole time.

## Fix

Assert the invariant where it now lives. Extract the helper body, then require:

- it still `mktemp`s the install script,
- every `return` inside it is preceded by `rm -f "$tmpfile"`,
- the body's last statement is that removal (the success path).

Then run the suite from `make test` and the Linux workflow so it cannot rot again.

## Verification

Mutation-tested against the real phase file:

| mutation | result |
|---|---|
| delete the error-path `rm -f` | ✗ FAIL — `return without cleanup: 4:         return 1` |
| delete the success-path `rm -f` | ✗ FAIL |
| unmodified | ✓ All tests passed (9/9) |

No change to `installers/phases/05-docker.sh` — the code was already right; the test was measuring the wrong thing.