### PR TITLE
fix(remote-provider): bracket IPv6 targets in the SSH forward spec

### DIFF
--- a/ods/bin/remote_provider/transport.py
+++ b/ods/bin/remote_provider/transport.py
@@ -124,7 +124,12 @@ def _tunnel_spec(
 ) -> SshTunnelSpec:
     if ":" in listen_host:
         raise TransportError("SSH local bind host must be an IPv4 or hostname token")
-    forward = f"{listen_host}:{listen_port}:{target_host}:{target_port}"
+    # ssh(1) splits -L on colons, so an IPv6 literal target has to be bracketed
+    # or the field boundaries are ambiguous and ssh rejects the whole forward.
+    # The host token itself stays unbracketed on the spec, which is what the
+    # redacted plan reports.
+    forward_target = f"[{target_host}]" if ":" in target_host else target_host
+    forward = f"{listen_host}:{listen_port}:{forward_target}:{target_port}"
     args = base_args[:-1] + ("-L", forward, base_args[-1])
     return SshTunnelSpec(
         name=name,

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -405,6 +405,37 @@ def test_ssh_transport_specs_are_structured_and_hardened() -> None:
         assert_true(";" not in joined and "\n" not in joined, "SSH argv must not contain shell separators")
 
 
+def test_ssh_forward_brackets_ipv6_targets() -> None:
+    """ssh(1) parses -L by splitting on colons, so IPv6 targets need brackets."""
+    route = plan_route(cloud_ssh_env(
+        REMOTE_LLM_SSH_CONTROL_HOST="127.0.0.1",
+        REMOTE_LLM_SSH_CONTROL_PORT="8091",
+    ))
+    ipv6_route = json.loads(json.dumps(route))
+    ipv6_route["ssh"]["inferenceHost"] = "2001:db8::1"
+    ipv6_route["ssh"]["controlHost"] = "fe80::2"
+    inference, control = build_ssh_tunnel_specs(ipv6_route)
+
+    assert_true(
+        "0.0.0.0:18091:[2001:db8::1]:8000" in inference.args,
+        "IPv6 inference target must be bracketed in the -L forward",
+    )
+    assert_true(
+        "0.0.0.0:18092:[fe80::2]:8091" in control.args,
+        "IPv6 control target must be bracketed in the -L forward",
+    )
+    # The spec metadata (and the redacted plan built from it) keeps the plain
+    # host token; only the ssh argument needs the brackets.
+    assert_true(inference.target_host == "2001:db8::1", "spec target host should stay unbracketed")
+
+    # IPv4 and hostname targets must be untouched.
+    v4_inference, _ = build_ssh_tunnel_specs(route)
+    assert_true(
+        "0.0.0.0:18091:127.0.0.1:8000" in v4_inference.args,
+        "IPv4 forward must not gain brackets",
+    )
+
+
 def test_ssh_transport_specs_reject_unsafe_tokens() -> None:
     route = plan_route(cloud_ssh_env())
     assert_raises_transport_error(
@@ -893,6 +924,7 @@ def main() -> int:
         test_ssh_peer_lifecycle_uses_control_tunnel_boundary,
         test_ssh_requires_transport_metadata,
         test_ssh_transport_specs_are_structured_and_hardened,
+        test_ssh_forward_brackets_ipv6_targets,
         test_ssh_transport_specs_reject_unsafe_tokens,
         test_ssh_supervisor_plan_is_redacted_and_start_gated,
         test_ssh_supervisor_plan_blocks_missing_secret_custody,


### PR DESCRIPTION
## Problem

`build_ssh_tunnel_specs` assembles the `-L` argument by joining four fields with colons:

```python
forward = f"{listen_host}:{listen_port}:{target_host}:{target_port}"
```

`ssh(1)` splits `-L` on those colons, so an IPv6 literal destination makes the field boundaries ambiguous — the documented form requires square brackets. And `_SAFE_SSH_HOST_RE` explicitly admits `:`, so an IPv6 inference host is a *policy-valid* route:

```python
route = {"enabled": True, "transport": "ssh", "ssh": {
    "host": "gpu.example.net", "user": "ods", "port": 22,
    "inferenceHost": "2001:db8::1", "inferencePort": 8000}}

build_ssh_tunnel_specs(route)[0].args
# -> ... "-L", "0.0.0.0:18091:2001:db8::1:8000"     # six colons, unparseable
```

The failure is silent and misdirecting: the supervisor starts an `ssh` child that exits immediately, `/health` never reports ready, and `remote-provider-egress` fails closed on every request with `ssh_tunnel_not_ready` — with nothing pointing at the forward string as the cause.

`_tunnel_spec` already refuses an IPv6 *local bind* host with a clear message, so the asymmetry is unintentional: the bind side is guarded, the destination side silently produces a broken argv.

## Fix

Bracket the destination host when it is an IPv6 literal, which is what `ssh(1)` documents:

```
-L 0.0.0.0:18091:[2001:db8::1]:8000
```

The `SshTunnelSpec` metadata field keeps the plain token, so the redacted supervisor plan and its support-bundle output are unchanged. IPv4 and hostname destinations are untouched.

## Tests

New `test_ssh_forward_brackets_ipv6_targets` in `tests/contracts/test-remote-provider-egress-policy.py`:

- IPv6 inference **and** control destinations are bracketed in their `-L` forwards
- the spec's host field stays unbracketed for the plan metadata
- an IPv4 route's forward is byte-identical to before

```
# on main
[FAIL] IPv6 inference target must be bracketed in the -L forward   (rc=1)

# with this change
[PASS] test_ssh_forward_brackets_ipv6_targets   — whole suite green
```

The other three remote-provider contract suites (`egress-service`, `ssh-tunnel-service`, `cli`) still pass.
