### PR TITLE
feat(models): stage AI21 Jamba Reasoning 3B and fix live Talk model

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -60,6 +60,25 @@
       }
     },
     {
+      "id": "jamba-reasoning-3b-q4",
+      "name": "AI21 Jamba Reasoning 3B",
+      "family": "jamba",
+      "gguf_file": "jamba-reasoning-3b-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B-GGUF/resolve/462e08a43c3c32f6b8b85f79ff0796e484d7b65a/jamba-reasoning-3b-Q4_K_M.gguf",
+      "gguf_sha256": "5c8edf36ec3ad9792a639db8d6865e479038226cf8fc71ef47331c611854f6c8",
+      "size_bytes": 1932698048,
+      "size_mb": 1933,
+      "vram_required_gb": 3,
+      "context_length": 65536,
+      "max_context_length": 262144,
+      "quantization": "Q4_K_M",
+      "specialty": "Efficient Reasoning",
+      "description": "AI21's compact reasoning model combines 26 Mamba layers with 2 attention layers for low-memory long-context work, instruction following, code, structured output, and multilingual use.",
+      "tokens_per_sec_estimate": 90,
+      "llm_model_name": "jamba-reasoning-3b",
+      "llama_server_image": null
+    },
+    {
       "id": "phi4-mini-q4",
       "name": "Phi-4 Mini",
       "family": "phi",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -73,10 +73,52 @@
       "max_context_length": 262144,
       "quantization": "Q4_K_M",
       "specialty": "Efficient Reasoning",
-      "description": "AI21's compact reasoning model combines 26 Mamba layers with 2 attention layers for low-memory long-context work, instruction following, code, structured output, and multilingual use.",
+      "description": "AI21's compact hybrid reasoning model combines 26 Mamba layers with 2 attention layers for low-memory long-context work. It remains available for manual testing, but is not agent-ready after required OpenCode probes failed on two independent fleet backends.",
       "tokens_per_sec_estimate": 90,
       "llm_model_name": "jamba-reasoning-3b",
-      "llama_server_image": null
+      "llama_server_image": null,
+      "app_compatibility": {
+        "openai_chat": {
+          "status": "verified",
+          "label": "App chat verified across fleet",
+          "reason": "Fresh exact-commit six-host validation loaded the pinned Jamba artifact and passed the required LiteLLM and Open WebUI exact-token probes everywhere while route evidence named the live Jamba model.",
+          "evidence": "fleet-test/runs/2026-07-27T10-47-19Z-model-ui-product-ca730791caca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T11:12:30Z",
+          "productSha": "ca730791cacaadb0280f63f3fc9f8b8ef70e4ebb",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "hermes_talk": {
+          "status": "verified",
+          "label": "ODS Talk verified across fleet",
+          "reason": "ODS Talk returned its challenge-bound verification phrase after the live Jamba swap on all six hosts, including both Windows Lemonade machines.",
+          "evidence": "fleet-test/runs/2026-07-27T10-47-19Z-model-ui-product-ca730791caca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T11:12:30Z",
+          "productSha": "ca730791cacaadb0280f63f3fc9f8b8ef70e4ebb",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo", "spark", "m5-mbp", "windows-laptop", "strixy"]
+        },
+        "opencode": {
+          "status": "unsupported_until_revalidated",
+          "label": "OpenCode needs revalidation",
+          "reason": "OpenCode routed to the exact live Jamba model but returned unrelated or repetitive reasoning instead of its requested verification phrase on tower2 through Linux llama-server and strix-halo through Lemonade. Four other hosts passed the same probe.",
+          "evidence": "fleet-test/runs/2026-07-27T10-47-19Z-model-ui-product-ca730791caca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo}",
+          "recordedAt": "2026-07-27T11:12:30Z",
+          "productSha": "ca730791cacaadb0280f63f3fc9f8b8ef70e4ebb",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["tower2", "strix-halo"]
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "label": "Not agent-ready",
+          "reason": "Four hosts completed the full rotation, but two independent backends failed the required OpenCode candidate probe after successful load and Talk inference. Every host restored its original model and deleted the test artifact cleanly.",
+          "evidence": "fleet-test/runs/2026-07-27T10-47-19Z-model-ui-product-ca730791caca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}",
+          "recordedAt": "2026-07-27T11:12:30Z",
+          "productSha": "ca730791cacaadb0280f63f3fc9f8b8ef70e4ebb",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129"
+        }
+      },
+      "install_recommendation": false
     },
     {
       "id": "phi4-mini-q4",

--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -23,7 +23,7 @@ from fastapi.responses import StreamingResponse
 import hermes_bridge
 import session_signer
 from config import INSTALL_DIR, SERVICES
-from helpers import check_service_health
+from helpers import check_service_health, get_loaded_model
 from performance_oracle import (
     find_catalog_model,
     load_model_catalog,
@@ -81,10 +81,16 @@ _TALK_BLOCKING_COMPATIBILITY_STATUSES = {
 }
 
 
-def _active_model_app_compatibility() -> dict[str, Any]:
-    model_name = read_env_file_value("LLM_MODEL", INSTALL_DIR) or read_env_value("LLM_MODEL", INSTALL_DIR)
-    gguf = read_env_file_value("GGUF_FILE", INSTALL_DIR) or read_env_value("GGUF_FILE", INSTALL_DIR)
-    entry = find_catalog_model(load_model_catalog(INSTALL_DIR), model_name, gguf)
+async def _active_model_app_compatibility() -> dict[str, Any]:
+    catalog = load_model_catalog(INSTALL_DIR)
+    loaded_model = await get_loaded_model()
+    if loaded_model:
+        model_name = loaded_model
+        gguf = loaded_model
+    else:
+        model_name = read_env_file_value("LLM_MODEL", INSTALL_DIR) or read_env_value("LLM_MODEL", INSTALL_DIR)
+        gguf = read_env_file_value("GGUF_FILE", INSTALL_DIR) or read_env_value("GGUF_FILE", INSTALL_DIR)
+    entry = find_catalog_model(catalog, model_name, gguf)
     compatibility = model_app_compatibility(
         entry or {},
         runtime_context=model_compatibility_runtime_context(INSTALL_DIR),
@@ -112,8 +118,8 @@ def _hermes_talk_block_reason(compatibility: dict[str, Any]) -> str | None:
     return reason or "The active model is not currently compatible with ODS Talk."
 
 
-def _require_hermes_talk_compatible() -> dict[str, Any]:
-    compatibility = _active_model_app_compatibility()
+async def _require_hermes_talk_compatible() -> dict[str, Any]:
+    compatibility = await _active_model_app_compatibility()
     reason = _hermes_talk_block_reason(compatibility)
     if reason:
         raise HTTPException(status_code=409, detail=reason)
@@ -554,12 +560,12 @@ async def _stream_hermes_sse(session_key: str, text: str, request: Request):
 @router.get("/api/talk/status")
 async def talk_status(request: Request) -> dict[str, Any]:
     _session_key, expires_at = _require_session(request)
-    hermes, whisper, tts = await asyncio.gather(
+    hermes, whisper, tts, model_compatibility = await asyncio.gather(
         _service_state("hermes"),
         _service_state("whisper"),
         _service_state("tts"),
+        _active_model_app_compatibility(),
     )
-    model_compatibility = _active_model_app_compatibility()
     talk_block_reason = _hermes_talk_block_reason(model_compatibility)
     text_chat_ready = hermes.get("status") == "healthy" and not talk_block_reason
     voice_ready = whisper.get("status") == "healthy" and tts.get("status") == "healthy"
@@ -585,7 +591,7 @@ async def talk_status(request: Request) -> dict[str, Any]:
 @router.post("/api/talk/session")
 async def talk_session(request: Request) -> dict[str, Any]:
     session_key, expires_at = _require_session(request)
-    _require_hermes_talk_compatible()
+    await _require_hermes_talk_compatible()
     try:
         session_id = await hermes_bridge.ensure_session(session_key)
     except hermes_bridge.HermesUnavailable as exc:
@@ -617,7 +623,7 @@ async def talk_message(payload: dict[str, Any], request: Request) -> dict[str, A
     visible feedback, which strands the UI on a "thinking" spinner.
     """
     session_key, _expires_at = _require_session(request)
-    _require_hermes_talk_compatible()
+    await _require_hermes_talk_compatible()
     text = _extract_message_text(payload)
     return await _send_to_hermes(session_key, text)
 
@@ -640,7 +646,7 @@ async def talk_message_stream(payload: dict[str, Any], request: Request) -> Stre
     than batching them.
     """
     session_key, _expires_at = _require_session(request)
-    _require_hermes_talk_compatible()
+    await _require_hermes_talk_compatible()
     text = _extract_message_text(payload)
     headers = {
         "Cache-Control": "no-cache",
@@ -736,7 +742,7 @@ async def talk_attachment(
         )
 
     # text-like
-    _require_hermes_talk_compatible()
+    await _require_hermes_talk_compatible()
     data = await file.read(MAX_DOC_BYTES + 1)
     if len(data) > MAX_DOC_BYTES:
         raise HTTPException(status_code=413, detail=f"File is too large (max {MAX_DOC_BYTES // (1024 * 1024)} MB).")
@@ -767,7 +773,7 @@ async def talk_attachment(
 @router.post("/api/talk/audio-message")
 async def talk_audio_message(request: Request, file: UploadFile = File(...)) -> dict[str, Any]:
     session_key, _expires_at = _require_session(request)
-    _require_hermes_talk_compatible()
+    await _require_hermes_talk_compatible()
     data = await file.read(MAX_AUDIO_BYTES + 1)
     if len(data) > MAX_AUDIO_BYTES:
         raise HTTPException(status_code=413, detail="Audio message is too large.")

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -1296,6 +1296,28 @@ def test_qwen35_2b_fits_4gb_but_is_not_recommended_after_fleet_failures(
     assert compatibility["agentViability"]["status"] == "not_agent_viable"
 
 
+def test_jamba_reasoning_3b_catalog_profile_fits_4gb_at_agent_context(data_dir, tmp_path):
+    install_dir = tmp_path / "ods"
+    (install_dir / "data" / "models").mkdir(parents=True)
+    payload = build_models_payload(
+        _gpu(total_mb=4096),
+        None,
+        0,
+        install_dir,
+        data_dir,
+        catalog=_official_model_catalog(),
+        evidence=[],
+    )
+    model = next(item for item in payload["models"] if item["id"] == "jamba-reasoning-3b-q4")
+
+    assert model["contextLength"] == 65536
+    assert model["maxContextLength"] == 262144
+    assert model["vramRequired"] == 3
+    assert model["estimatedRequired"] <= 4
+    assert model["fitsVram"] is True
+    assert model["recommended"] is False
+
+
 def test_pre_download_ranker_falls_back_to_smallest_model_without_gpu_info(data_dir):
     catalog = [
         _model(),

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -13,7 +13,11 @@ def signed_talk_cookie(monkeypatch):
 
 
 @pytest.fixture()
-def talk_client(test_client, signed_talk_cookie):
+def talk_client(test_client, signed_talk_cookie, monkeypatch):
+    async def no_loaded_model():
+        return None
+
+    monkeypatch.setattr("routers.talk.get_loaded_model", no_loaded_model)
     test_client.cookies.set("ods-session", signed_talk_cookie)
     return test_client
 
@@ -46,16 +50,19 @@ def test_talk_status_disables_text_chat_for_incompatible_active_model(talk_clien
         return {"configured": True, "status": "healthy", "id": service_id}
 
     monkeypatch.setattr("routers.talk._service_state", fake_state)
-    monkeypatch.setattr("routers.talk._active_model_app_compatibility", lambda: {
-        "agentViability": {
-            "status": "not_agent_viable",
-            "reason": "Phi direct chat works, but agent validation failed.",
-        },
-        "hermesTalk": {
-            "status": "unsupported_until_revalidated",
-            "reason": "Phi direct chat works, but ODS Talk is not revalidated.",
-        },
-    })
+    async def incompatible_model():
+        return {
+            "agentViability": {
+                "status": "not_agent_viable",
+                "reason": "Phi direct chat works, but agent validation failed.",
+            },
+            "hermesTalk": {
+                "status": "unsupported_until_revalidated",
+                "reason": "Phi direct chat works, but ODS Talk is not revalidated.",
+            },
+        }
+
+    monkeypatch.setattr("routers.talk._active_model_app_compatibility", incompatible_model)
 
     resp = talk_client.get("/api/talk/status")
     assert resp.status_code == 200, resp.text
@@ -72,21 +79,104 @@ def test_talk_message_rejects_incompatible_model_before_hermes(talk_client, monk
         return None
 
     monkeypatch.setattr("hermes_bridge.submit_prompt", fake_submit)
-    monkeypatch.setattr("routers.talk._active_model_app_compatibility", lambda: {
-        "agentViability": {
-            "status": "not_agent_viable",
-            "reason": "Active model is not agent ready.",
-        },
-        "hermesTalk": {
-            "status": "unsupported_until_revalidated",
-            "reason": "Active model is not Talk ready.",
-        },
-    })
+    async def incompatible_model():
+        return {
+            "agentViability": {
+                "status": "not_agent_viable",
+                "reason": "Active model is not agent ready.",
+            },
+            "hermesTalk": {
+                "status": "unsupported_until_revalidated",
+                "reason": "Active model is not Talk ready.",
+            },
+        }
+
+    monkeypatch.setattr("routers.talk._active_model_app_compatibility", incompatible_model)
 
     resp = talk_client.post("/api/talk/message", json={"text": "hello"})
     assert resp.status_code == 409, resp.text
     assert resp.json()["detail"] == "Active model is not agent ready."
     assert calls == []
+
+
+def test_talk_status_uses_live_model_instead_of_configured_bootstrap(talk_client, monkeypatch):
+    async def fake_state(service_id):
+        return {"configured": True, "status": "healthy", "id": service_id}
+
+    async def live_model():
+        return "jamba-reasoning-3b-Q4_K_M.gguf"
+
+    catalog = [
+        {
+            "id": "qwen3.5-2b-q4",
+            "name": "Qwen 3.5 2B",
+            "gguf_file": "Qwen3.5-2B-Q4_K_M.gguf",
+            "app_compatibility": {
+                "agent_viability": {
+                    "status": "not_agent_viable",
+                    "reason": "Configured bootstrap model is not agent ready.",
+                },
+            },
+        },
+        {
+            "id": "jamba-reasoning-3b-q4",
+            "name": "AI21 Jamba Reasoning 3B",
+            "gguf_file": "jamba-reasoning-3b-Q4_K_M.gguf",
+        },
+    ]
+
+    monkeypatch.setattr("routers.talk._service_state", fake_state)
+    monkeypatch.setattr("routers.talk.get_loaded_model", live_model)
+    monkeypatch.setattr("routers.talk.load_model_catalog", lambda _install_dir: catalog)
+    monkeypatch.setattr("routers.talk.read_env_file_value", lambda key, _install_dir: {
+        "LLM_MODEL": "qwen3.5-2b",
+        "GGUF_FILE": "Qwen3.5-2B-Q4_K_M.gguf",
+    }.get(key, ""))
+    monkeypatch.setattr("routers.talk.model_compatibility_runtime_context", lambda _install_dir: {})
+
+    resp = talk_client.get("/api/talk/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["capabilities"]["text_chat"] is True
+    assert data["modelCompatibility"]["activeModel"] == {
+        "id": "jamba-reasoning-3b-q4",
+        "model": "jamba-reasoning-3b-Q4_K_M.gguf",
+        "gguf": "jamba-reasoning-3b-Q4_K_M.gguf",
+    }
+
+
+def test_talk_status_falls_back_to_configured_model_without_live_runtime(talk_client, monkeypatch):
+    async def fake_state(service_id):
+        return {"configured": True, "status": "healthy", "id": service_id}
+
+    catalog = [{
+        "id": "qwen3.5-2b-q4",
+        "name": "Qwen 3.5 2B",
+        "gguf_file": "Qwen3.5-2B-Q4_K_M.gguf",
+        "app_compatibility": {
+            "agent_viability": {
+                "status": "not_agent_viable",
+                "reason": "Configured bootstrap model is not agent ready.",
+            },
+        },
+    }]
+
+    monkeypatch.setattr("routers.talk._service_state", fake_state)
+    monkeypatch.setattr("routers.talk.load_model_catalog", lambda _install_dir: catalog)
+    monkeypatch.setattr("routers.talk.read_env_file_value", lambda key, _install_dir: {
+        "LLM_MODEL": "qwen3.5-2b",
+        "GGUF_FILE": "Qwen3.5-2B-Q4_K_M.gguf",
+    }.get(key, ""))
+    monkeypatch.setattr("routers.talk.model_compatibility_runtime_context", lambda _install_dir: {})
+
+    resp = talk_client.get("/api/talk/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["capabilities"]["text_chat"] is False
+    assert data["reason"] == "Configured bootstrap model is not agent ready."
+    assert data["modelCompatibility"]["activeModel"]["id"] == "qwen3.5-2b-q4"
 
 
 def test_talk_message_routes_through_hermes_bridge(talk_client, monkeypatch):

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -833,6 +833,26 @@ def test_qwen35_2b_records_exact_artifact_and_failed_fleet_evidence():
     assert not _agent_viable_for_release(model)
 
 
+def test_jamba_reasoning_3b_is_staged_as_a_4gb_long_context_candidate():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["jamba-reasoning-3b-q4"]
+
+    assert model["gguf_url"] == (
+        "https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B-GGUF/"
+        "resolve/462e08a43c3c32f6b8b85f79ff0796e484d7b65a/"
+        "jamba-reasoning-3b-Q4_K_M.gguf"
+    )
+    assert model["gguf_sha256"] == "5c8edf36ec3ad9792a639db8d6865e479038226cf8fc71ef47331c611854f6c8"
+    assert model["size_bytes"] == 1932698048
+    assert model["size_mb"] == 1933
+    assert model["vram_required_gb"] == 3
+    assert model["context_length"] == HERMES_CONTEXT_FLOOR
+    assert model["max_context_length"] == 262144
+    assert "install_recommendation" not in model
+    assert _agent_viable_for_release(model)
+
+
 def test_new_switchboard_models_do_not_change_install_recommendations():
     expected_switchboard_only = {
         "phi3.5-mini-q4",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -833,7 +833,7 @@ def test_qwen35_2b_records_exact_artifact_and_failed_fleet_evidence():
     assert not _agent_viable_for_release(model)
 
 
-def test_jamba_reasoning_3b_is_staged_as_a_4gb_long_context_candidate():
+def test_jamba_reasoning_3b_records_fleet_compatibility_without_recommendation():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["jamba-reasoning-3b-q4"]
@@ -849,8 +849,18 @@ def test_jamba_reasoning_3b_is_staged_as_a_4gb_long_context_candidate():
     assert model["vram_required_gb"] == 3
     assert model["context_length"] == HERMES_CONTEXT_FLOOR
     assert model["max_context_length"] == 262144
-    assert "install_recommendation" not in model
-    assert _agent_viable_for_release(model)
+    assert model["install_recommendation"] is False
+    assert model["app_compatibility"]["openai_chat"]["status"] == "verified"
+    assert model["app_compatibility"]["hermes_talk"]["status"] == "verified"
+    assert model["app_compatibility"]["opencode"]["status"] == "unsupported_until_revalidated"
+    assert model["app_compatibility"]["agent_viability"]["status"] == "not_agent_viable"
+    assert model["app_compatibility"]["agent_viability"]["productSha"] == (
+        "ca730791cacaadb0280f63f3fc9f8b8ef70e4ebb"
+    )
+    assert model["app_compatibility"]["agent_viability"]["harnessSha"] == (
+        "19d43e6f9f2533e8768ed85b33de9f4ace232129"
+    )
+    assert not _agent_viable_for_release(model)
 
 
 def test_new_switchboard_models_do_not_change_install_recommendations():


### PR DESCRIPTION
## Summary
- stage AI21 Jamba Reasoning 3B as a 4 GB-class candidate with a 64K ODS operating context and 256K native ceiling
- pin the official Q4_K_M GGUF to immutable Hugging Face revision `462e08a43c3c32f6b8b85f79ff0796e484d7b65a`
- record exact artifact size `1932698048` and SHA-256 `5c8edf36ec3ad9792a639db8d6865e479038226cf8fc71ef47331c611854f6c8`
- evaluate Talk compatibility against the live swapped model, with configured-model fallback only when no runtime model is loaded
- keep recommendation disabled and record the exact six-host OpenCode incompatibility evidence

## Candidate rationale
- official Apache-2.0 AI21 release
- 3B hybrid architecture with 26 Mamba and 2 attention layers
- first-party llama.cpp GGUF and documented Windows/local runtime support
- 256K context, reasoning, code, structured output, and multilingual training
- 1.93 GB Q4_K_M artifact; ODS oracle estimates 3.0 GB at 64K context on a 4 GB GPU

## Validation
- full Dashboard API suite (2032 passed)
- focused model-library, performance-oracle, and Talk coverage (90 passed)
- Ruff and `git diff --check` clean
- one-off official-catalog oracle: 64K context, 3.0 GB estimated requirement, fits 4 GB, not recommended
- exact install at `ca730791cacaadb0280f63f3fc9f8b8ef70e4ebb`: PASS on tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy
- exact model rotation at the same product SHA and harness `19d43e6f9f2533e8768ed85b33de9f4ace232129`: full PASS on spark, m5-mbp, windows-laptop, and strixy
- all six hosts loaded the pinned Jamba artifact, passed ODS Talk, restored their original model, deleted Jamba, and finished with clean inventory
- tower2 and strix-halo routed OpenCode to the exact live Jamba model but received unrelated or repetitive reasoning instead of the requested verification phrase

## Recommendation decision
Jamba remains available for manual testing but is explicitly not recommended or agent-ready. The repeated OpenCode failure spans Linux llama-server and Lemonade, so the promotion gate did not pass. The successful live-model Talk fix and compatibility evidence are safe to merge independently of recommendation.

Fleet evidence:
- `fleet-test/runs/2026-07-27T10-22-46Z-install-product-ca730791caca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
- `fleet-test/runs/2026-07-27T10-47-19Z-model-ui-product-ca730791caca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
