### PR TITLE
fix: guard against empty artifact files in HF import record builder

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -1028,6 +1028,8 @@ def _hf_import_record(details: dict[str, Any], artifact: dict[str, Any]) -> dict
     if not re.fullmatch(r"[0-9a-fA-F]{40,64}", revision):
         raise HTTPException(status_code=502, detail="Hugging Face did not provide an immutable repository revision")
     remote_files = artifact["files"]
+    if not remote_files:
+        raise HTTPException(status_code=422, detail="The selected artifact contains no files")
     local_files = [
         _hf_local_filename(repo_id, item["filename"], revision)
         for item in remote_files


### PR DESCRIPTION
## Summary

Added an early validation check in `_hf_import_record()` to raise a clear HTTP 422 error when a Hugging Face artifact contains no files, preventing `IndexError` crashes downstream.

## Changes

**`ods/extensions/services/dashboard-api/routers/models.py`** (after line 1029)

Added:
```python
if not remote_files:
    raise HTTPException(status_code=422, detail="The selected artifact contains no files")
```

Without this check, if `artifact["files"]` is empty, the subsequent code accesses `local_files[0]`, `parts[0]["url"]`, `parts[0]["sha256"]`, and `parts[0]["size_bytes"]` — all of which crash with `IndexError`.

This can happen when a Hugging Face model artifact exists but has no downloadable files (e.g., gated models, or artifacts still being uploaded).

## Test plan

- [x] Verified the guard correctly raises HTTP 422 with a descriptive message when files list is empty
- [x] No behavioral change when files are present (happy path)