### PR TITLE
fix(security): pin validated remote-provider addresses

### DIFF
--- a/ods/bin/remote_provider/egress.py
+++ b/ods/bin/remote_provider/egress.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Mapping
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from .policy import (
     DEFAULT_POLICY_PATH,
@@ -78,6 +78,9 @@ class UpstreamRequest:
     requested_model: str
     provider_model: str
     stream: bool
+    tls_server_name: str = ""
+    host_header: str = ""
+    connection_key: str = ""
 
 
 def _disabled_route(mode: str = "cloud") -> dict[str, Any]:
@@ -325,6 +328,7 @@ def prepare_upstream_request(
     route: Mapping[str, Any],
     provider_secret: str,
     max_body_bytes: int = DEFAULT_MAX_BODY_BYTES,
+    resolved_addresses: list[str] | None = None,
 ) -> UpstreamRequest:
     """Validate and rewrite one OpenAI-compatible request for the provider."""
     required_method = FORWARD_PATHS.get(path)
@@ -348,6 +352,33 @@ def prepare_upstream_request(
     if not isinstance(provider, Mapping):
         raise EgressError(503, "invalid_route", "provider route is missing")
     upstream_base_url = upstream_base_url_for_route(route)
+    tls_server_name = ""
+    host_header = ""
+    connection_key = ""
+    if route.get("transport") == "direct" and resolved_addresses:
+        parts = urlsplit(upstream_base_url)
+        tls_server_name = parts.hostname or ""
+        ip_address = resolved_addresses[0]
+        if ":" in ip_address and not ip_address.startswith("["):
+            ip_address = f"[{ip_address}]"
+        netloc = ip_address
+        if parts.port is not None:
+            netloc = f"{ip_address}:{parts.port}"
+        original_host = tls_server_name
+        if ":" in original_host and not original_host.startswith("["):
+            original_host = f"[{original_host}]"
+        host_header = original_host
+        if parts.port is not None:
+            host_header = f"{original_host}:{parts.port}"
+        tls_port = parts.port or (443 if parts.scheme == "https" else 80)
+        connection_key = f"{parts.scheme}://{tls_server_name}:{tls_port}"
+        upstream_base_url = urlunsplit((
+            parts.scheme,
+            netloc,
+            parts.path,
+            parts.query,
+            parts.fragment
+        ))
     try:
         payload = json.loads(body.decode("utf-8"))
     except (UnicodeDecodeError, ValueError) as exc:
@@ -366,6 +397,9 @@ def prepare_upstream_request(
         requested_model=requested_model,
         provider_model=provider_model,
         stream=bool(payload.get("stream")),
+        tls_server_name=tls_server_name,
+        host_header=host_header,
+        connection_key=connection_key,
     )
 
 

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -97,10 +97,20 @@ def _load_route() -> dict[str, Any]:
     return route_from_state(load_route_state(ROUTE_PATH), policy=policy)
 
 
-def _http_client() -> httpx.AsyncClient:
+def _http_client(connection_key: str = "") -> httpx.AsyncClient:
+    if connection_key:
+        clients = getattr(app.state, "direct_http_clients", None)
+        if clients is None:
+            clients = {}
+            app.state.direct_http_clients = clients
+        client = clients.get(connection_key)
+        if client is None or client.is_closed:
+            client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
+            clients[connection_key] = client
+        return client
     client = getattr(app.state, "http", None)
     if client is None or client.is_closed:
-        client = httpx.AsyncClient(follow_redirects=False)
+        client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
         app.state.http = client
     return client
 
@@ -325,7 +335,7 @@ async def forward(full_path: str, request: Request) -> Response:
     path = "/" + full_path
     try:
         route = _load_route()
-        validate_direct_provider_resolution(route)
+        resolved_addresses = validate_direct_provider_resolution(route)
         secret = read_provider_secret(SECRET_PATH)
         if route.get("transport") == "ssh":
             tunnel = await _ssh_tunnel_status()
@@ -341,11 +351,18 @@ async def forward(full_path: str, request: Request) -> Response:
             route=route,
             provider_secret=secret,
             max_body_bytes=MAX_BODY_BYTES,
+            resolved_addresses=resolved_addresses,
         )
     except EgressError as exc:
         return _error_response(exc)
 
-    client = _http_client()
+    client = _http_client(upstream_request.connection_key)
+    headers = dict(upstream_request.headers)
+    extensions = {}
+    if upstream_request.tls_server_name:
+        extensions["sni_hostname"] = upstream_request.tls_server_name
+        headers["host"] = upstream_request.host_header
+
     ods_headers = {
         "X-ODS-Remote-Transport": str(route.get("transport") or ""),
         "X-ODS-Requested-Model": upstream_request.requested_model,
@@ -357,8 +374,9 @@ async def forward(full_path: str, request: Request) -> Response:
                 upstream_request.method,
                 upstream_request.url,
                 content=upstream_request.content,
-                headers=upstream_request.headers,
+                headers=headers,
                 timeout=UPSTREAM_TIMEOUT_SECONDS,
+                extensions=extensions,
             )
             upstream = await client.send(req, stream=True)
 
@@ -376,13 +394,15 @@ async def forward(full_path: str, request: Request) -> Response:
                 headers={**_response_headers(upstream.headers), **ods_headers},
             )
 
-        upstream = await client.request(
+        req = client.build_request(
             upstream_request.method,
             upstream_request.url,
             content=upstream_request.content,
-            headers=upstream_request.headers,
+            headers=headers,
             timeout=UPSTREAM_TIMEOUT_SECONDS,
+            extensions=extensions,
         )
+        upstream = await client.send(req)
     except httpx.TimeoutException:
         return _error_response(
             EgressError(504, "upstream_timeout", "remote provider timed out")
@@ -405,9 +425,14 @@ async def forward(full_path: str, request: Request) -> Response:
 
 @app.on_event("startup")
 async def _startup() -> None:
-    app.state.http = httpx.AsyncClient(follow_redirects=False)
+    app.state.http = httpx.AsyncClient(follow_redirects=False, trust_env=False)
+    app.state.direct_http_clients = {}
 
 
 @app.on_event("shutdown")
 async def _shutdown() -> None:
     await app.state.http.aclose()
+    clients = getattr(app.state, "direct_http_clients", {})
+    for client in clients.values():
+        await client.aclose()
+    clients.clear()

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -366,7 +366,90 @@ def test_service_source_avoids_public_env_secret_names() -> None:
     assert_true('@app.post("/probe")' in text, "app must expose an internal probe endpoint")
     assert_true("probe_route_response" in text, "probe endpoint must use the shared egress probe helper")
     assert_true("ssh_tunnel_not_ready" in text, "app must fail closed when the SSH tunnel is down")
+    assert_true("trust_env=False" in text, "egress requests must not delegate pinned connections or private headers to environment proxies")
     assert_true(POLICY.exists(), "policy document must exist for mounted service config")
+
+
+def test_prepare_upstream_request_with_resolved_addresses() -> None:
+    route = route_from_state(route_state())
+    upstream = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={
+            "authorization": "Bearer client-token",
+        },
+        body=json.dumps({"model": "ods/current", "messages": []}).encode("utf-8"),
+        route=route,
+        provider_secret="unit-test-provider-token",
+        resolved_addresses=["93.184.216.34"],
+    )
+    assert_true(upstream.url == "https://93.184.216.34/v1/chat/completions", f"expected url to be rewritten to IP, got {upstream.url}")
+    assert_true(upstream.tls_server_name == "gpu.example.test", f"expected TLS server name to be original host, got {upstream.tls_server_name}")
+    assert_true(upstream.host_header == "gpu.example.test", f"expected Host header to preserve original authority, got {upstream.host_header}")
+    assert_true(upstream.connection_key == "https://gpu.example.test:443", f"unexpected connection key: {upstream.connection_key}")
+
+
+def test_prepare_upstream_request_with_resolved_ipv6_addresses() -> None:
+    route = route_from_state(route_state())
+    upstream = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={
+            "authorization": "Bearer client-token",
+        },
+        body=json.dumps({"model": "ods/current", "messages": []}).encode("utf-8"),
+        route=route,
+        provider_secret="unit-test-provider-token",
+        resolved_addresses=["2606:2800:220:1:248:1893:25c8:1946"],
+    )
+    assert_true(upstream.url == "https://[2606:2800:220:1:248:1893:25c8:1946]/v1/chat/completions", f"expected IPv6 url formatting, got {upstream.url}")
+    assert_true(upstream.tls_server_name == "gpu.example.test", f"expected TLS server name to be original host, got {upstream.tls_server_name}")
+    assert_true(upstream.host_header == "gpu.example.test", f"expected Host header to preserve original authority, got {upstream.host_header}")
+    assert_true(
+        upstream.connection_key == "https://gpu.example.test:443",
+        f"unexpected IPv6 connection key: {upstream.connection_key}",
+    )
+
+
+def test_pinned_request_preserves_non_default_port_and_separates_tls_origins() -> None:
+    first_route = route_from_state(
+        route_state(baseUrl="https://gpu-a.example.test:8443/v1")
+    )
+    second_route = route_from_state(
+        route_state(baseUrl="https://gpu-b.example.test:8443/v1")
+    )
+    first = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={},
+        body=b'{"model":"ods/current","messages":[]}',
+        route=first_route,
+        provider_secret="unit-test-provider-token",
+        resolved_addresses=["93.184.216.34"],
+    )
+    second = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={},
+        body=b'{"model":"ods/current","messages":[]}',
+        route=second_route,
+        provider_secret="unit-test-provider-token",
+        resolved_addresses=["93.184.216.34"],
+    )
+    rotated_address = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={},
+        body=b'{"model":"ods/current","messages":[]}',
+        route=first_route,
+        provider_secret="unit-test-provider-token",
+        resolved_addresses=["93.184.216.35"],
+    )
+    assert_true(first.url == "https://93.184.216.34:8443/v1/chat/completions", f"unexpected pinned URL: {first.url}")
+    assert_true(first.host_header == "gpu-a.example.test:8443", f"non-default provider port was not preserved: {first.host_header}")
+    assert_true(first.tls_server_name == "gpu-a.example.test", f"SNI must not include the provider port: {first.tls_server_name}")
+    assert_true(first.connection_key != second.connection_key, "different TLS hostnames on the same IP must not share a connection pool")
+    assert_true(first.connection_key == rotated_address.connection_key, "DNS address rotation for one TLS identity must use a bounded client pool")
 
 
 def main() -> int:
@@ -383,6 +466,9 @@ def main() -> int:
         test_probe_response_returns_redacted_ssh_receipt_through_tunnel_boundary,
         test_probe_response_fails_closed_when_ssh_tunnel_is_not_ready,
         test_service_source_avoids_public_env_secret_names,
+        test_prepare_upstream_request_with_resolved_addresses,
+        test_prepare_upstream_request_with_resolved_ipv6_addresses,
+        test_pinned_request_preserves_non_default_port_and_separates_tls_origins,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary

Closes #2211 by removing the DNS time-of-check/time-of-use gap in the direct remote-provider egress path.

A direct provider hostname is now resolved and policy-validated once per request. The outbound socket connects to that validated IP instead of resolving the hostname again, while TLS SNI and the HTTP `Host` authority remain bound to the original provider URL.

## Security Contract

| Invariant | Enforcement |
|---|---|
| A rejected DNS answer is never contacted | Every resolved address must pass the existing global-address policy before request preparation |
| The network connection uses the validated answer | Direct URLs are rewritten to the selected validated IPv4/IPv6 address |
| TLS identity remains the configured provider | Original hostname is passed as `sni_hostname` |
| HTTP virtual-host routing remains correct | Original authority is sent in `Host`, including an explicit provider port |
| Different TLS identities never share a connection | HTTP clients are partitioned by scheme, SNI hostname, and port |
| DNS rotation cannot create an unbounded client map | Address changes for one TLS identity share HTTPX's bounded origin pool |
| Environment proxies cannot bypass pinning or receive provider credentials | Egress clients use `trust_env=False` |
| Redirects cannot introduce a second destination | Existing `follow_redirects=False` behavior is preserved |
| SSH transport behavior is unchanged | DNS pinning is applied only to direct transport |

## Changes

- Return validated direct-provider addresses from the runtime resolution check.
- Rewrite direct upstream URLs to the selected validated address, including bracketed IPv6 formatting.
- Preserve SNI and `Host` independently so non-default ports remain correct.
- Standardize streaming and non-streaming sends through HTTPX request extensions.
- Isolate reusable clients by TLS identity and close all clients during shutdown.
- Remove unrelated search-probe commits from the branch; the diff is now limited to three egress files.

## Regression Coverage

- Public IPv4 and IPv6 answers are accepted and pinned.
- Private, loopback, link-local, multicast, mixed unsafe, and empty DNS answers fail closed.
- SSH routes skip direct DNS resolution and continue through the tunnel boundary.
- Non-default provider ports are retained in `Host` but excluded from SNI.
- Two hostnames on the same IP receive separate connection pools.
- Address rotation for one hostname retains a bounded pool identity.
- Secret custody, hop-by-hop header filtering, streaming behavior, and disabled-route failures remain covered.

## Validation

- `python ods/tests/contracts/test-remote-provider-egress-service.py`
- `python ods/tests/contracts/test-remote-provider-egress-policy.py`
- `python ods/tests/contracts/test-network-exposure-contracts.py`
- `python ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py`
- `python ods/tests/test-render-runtime-configs.py`
- `python ods/tests/test-runtime-config-wiring.py`
- `python -m pytest ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py -q` (`26 passed`)
- Focused Ruff and Python compile checks
- `docker compose --env-file ods/.env.example -f ods/docker-compose.base.yml config --quiet`
- Local TLS integration receipt: connection opened to the pinned IP, certificate validated for the configured hostname, SNI observed as the configured hostname, and `Host` observed with the explicit port.
- `git diff --check osmantic/main...HEAD`

## Residual Limitation

The first validated DNS address is selected for a request. If that public address is unreachable while a later validated answer is reachable, the request fails normally instead of retrying another address. This is a bounded availability limitation, not an SSRF bypass; address fallback is intentionally outside this security fix.