### PR TITLE
feat(models): stage Qwen 3.6 27B

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -7820,6 +7820,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS",
                     "LLAMA_ARG_SPEC_TYPE",
                     "LLAMA_ARG_SPEC_DRAFT_N_MAX",
+                    "N_GPU_LAYERS",
                 }
                 if runtime_profile:
                     for key, value in runtime_env.items():
@@ -7838,6 +7839,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS",
                     "LLAMA_ARG_SPEC_TYPE",
                     "LLAMA_ARG_SPEC_DRAFT_N_MAX",
+                    "N_GPU_LAYERS",
                 }
                 if gpu_assignment_plan:
                     remove_keys.update(gpu_assignment_plan.get("env_removals") or [])
@@ -11634,7 +11636,7 @@ def _launch_native_llama_server(env_path: Path, llama_bin: Path, llama_log: Path
         "--host", bind_addr, "--port", str(port),
         "--model", str(model_path),
         "--ctx-size", ctx_size,
-        "--n-gpu-layers", "999",
+        "--n-gpu-layers", env.get("N_GPU_LAYERS", "999"),
         "--parallel", env.get("LLAMA_PARALLEL", "1"),
         "--reasoning-format", reasoning_fmt,
         "--metrics",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1726,6 +1726,60 @@
       "llama_server_image": null
     },
     {
+      "id": "qwen3.6-27b-q4",
+      "name": "Qwen 3.6 27B",
+      "family": "qwen",
+      "gguf_file": "Qwen3.6-27B-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/82d411acf4a06cfb8d9b073a5211bf410bfc29bf/Qwen3.6-27B-Q4_K_M.gguf",
+      "gguf_sha256": "5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0",
+      "size_bytes": 16817244384,
+      "size_mb": 16818,
+      "vram_required_gb": 20,
+      "context_length": 131072,
+      "max_context_length": 262144,
+      "total_params_b": 27.8,
+      "architecture": "dense",
+      "quantization": "Q4_K_M",
+      "specialty": "Reasoning, Coding & Agents",
+      "description": "Alibaba's Apache-2.0 dense flagship for practical high-end local systems. It leads Artificial Analysis' current 4B-40B open-weight intelligence ranking, supports native 262K context and Qwen tool calling, and is staged at 128K for agent workflows.",
+      "tokens_per_sec_estimate": 25,
+      "llm_model_name": "qwen3.6-27b",
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/qwen3-6-27b/",
+        "score": 37,
+        "rank": 1,
+        "rank_scope": "4B-40B open-weight models",
+        "assessed_at": "2026-07-27"
+      },
+      "runtime_profiles": [
+        {
+          "id": "nvidia-8gb-64k-partial-offload-q4-kv",
+          "label": "NVIDIA 8GB 64K partial GPU offload with Q4 KV cache",
+          "backend": "nvidia",
+          "host_arch": [
+            "amd64"
+          ],
+          "memory_type": "discrete",
+          "vram_min_gb": 7.5,
+          "vram_max_gb": 8.5,
+          "system_ram_min_gb": 31,
+          "context_length": 65536,
+          "estimated_required_gb": 7.4,
+          "fit_label": "64K 8GB candidate partial-offload profile",
+          "env": {
+            "LLAMA_PARALLEL": "1",
+            "LLAMA_ARG_FLASH_ATTN": "on",
+            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
+            "N_GPU_LAYERS": "20"
+          }
+        }
+      ]
+    },
+    {
       "id": "qwen3.5-27b-q4",
       "name": "Qwen 3.5 27B",
       "family": "qwen",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1754,30 +1754,72 @@
         "rank_scope": "4B-40B open-weight models",
         "assessed_at": "2026-07-27"
       },
-      "runtime_profiles": [
-        {
-          "id": "nvidia-8gb-64k-partial-offload-q4-kv",
-          "label": "NVIDIA 8GB 64K partial GPU offload with Q4 KV cache",
-          "backend": "nvidia",
-          "host_arch": [
-            "amd64"
+      "app_compatibility": {
+        "openai_chat": {
+          "status": "unsupported_until_revalidated",
+          "label": "8GB Windows chat runtime not viable",
+          "reason": "At corrected product commit fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef, windows-laptop loaded the exact Q4_K_M artifact at 65,536-token context with 20 of 65 layers offloaded, passed identity and direct inference, and passed challenge-bound ODS Talk. Generation nevertheless measured only 0.07-0.08 tok/s, and the required LiteLLM and Open WebUI probes timed out. Keep this dense 27B model out of 8GB Windows release coverage; the scoped verdict does not reject 20GB-plus hosts.",
+          "evidence": "fleet-test/runs/2026-07-28T00-15-34Z-model-ui-product-fdedd5dd090b-harness-19d43e6f9f25-hosts-windows-laptop-qwen36-27b-windows-fix-r12/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-28T01:22:28Z",
+          "productSha": "fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": [
+            "windows-laptop"
           ],
-          "memory_type": "discrete",
-          "vram_min_gb": 7.5,
-          "vram_max_gb": 8.5,
-          "system_ram_min_gb": 31,
-          "context_length": 65536,
-          "estimated_required_gb": 7.4,
-          "fit_label": "64K 8GB candidate partial-offload profile",
-          "env": {
-            "LLAMA_PARALLEL": "1",
-            "LLAMA_ARG_FLASH_ATTN": "on",
-            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
-            "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
-            "N_GPU_LAYERS": "20"
-          }
+          "gpuBackendScope": [
+            "nvidia"
+          ],
+          "llmBackendScope": [
+            "llama-server"
+          ],
+          "expiresAt": "2026-08-28T00:00:00Z"
+        },
+        "hermes_talk": {
+          "status": "verified",
+          "label": "ODS Talk verified during six-host staged trials",
+          "reason": "The pinned Qwen 3.6 27B artifact loaded with correct route identity and passed challenge-bound ODS Talk on tower2, strix-halo, spark, m5-mbp, strixy, and windows-laptop. Four larger-memory hosts completed the full rotation; strixy also passed every candidate consumer before a restored-baseline Perplexica cleanup flake, while the corrected Windows partial-offload run later failed other consumers on performance.",
+          "evidence": "fleet-test/runs/2026-07-27T22-56-10Z-model-ui-product-5e753f617ced-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-qwen36-27b-quality-first-r10/cycle-001/{tower2,strix-halo,spark,m5-mbp,strixy}; fleet-test/runs/2026-07-28T00-15-34Z-model-ui-product-fdedd5dd090b-harness-19d43e6f9f25-hosts-windows-laptop-qwen36-27b-windows-fix-r12/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-28T01:22:28Z",
+          "productSha": "fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": [
+            "tower2",
+            "strix-halo",
+            "spark",
+            "m5-mbp",
+            "windows-laptop",
+            "strixy"
+          ]
+        },
+        "perplexica": {
+          "status": "unsupported_until_revalidated",
+          "label": "8GB Windows Perplexica runtime not viable",
+          "reason": "The corrected Windows partial-offload run loaded and directly inferred with the exact Qwen 3.6 27B artifact, but Perplexica did not complete within the enforced consumer timeout at the observed 0.07-0.08 tok/s generation rate. Keep this model out of Perplexica release coverage on 8GB Windows hardware.",
+          "evidence": "fleet-test/runs/2026-07-28T00-15-34Z-model-ui-product-fdedd5dd090b-harness-19d43e6f9f25-hosts-windows-laptop-qwen36-27b-windows-fix-r12/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-28T01:22:28Z",
+          "productSha": "fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": [
+            "windows-laptop"
+          ],
+          "gpuBackendScope": [
+            "nvidia"
+          ],
+          "llmBackendScope": [
+            "llama-server"
+          ],
+          "expiresAt": "2026-08-28T00:00:00Z"
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "label": "Not fleet-wide agent-ready",
+          "reason": "The required six-host gate did not pass. Tower2, strix-halo, spark, and m5-mbp completed the full rotation; strixy passed the candidate load, Talk, and all candidate consumers before a restored-baseline cleanup flake; windows-laptop loaded the corrected 20-layer partial-offload route but ran at only 0.07-0.08 tok/s and timed out in LiteLLM, Open WebUI, and Perplexica. Keep install_recommendation false.",
+          "evidence": "fleet-test/runs/2026-07-27T22-56-10Z-model-ui-product-5e753f617ced-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-qwen36-27b-quality-first-r10/cycle-001/{tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy}; fleet-test/runs/2026-07-28T00-15-34Z-model-ui-product-fdedd5dd090b-harness-19d43e6f9f25-hosts-windows-laptop-qwen36-27b-windows-fix-r12/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-28T01:22:28Z",
+          "productSha": "fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129"
         }
-      ]
+      }
     },
     {
       "id": "qwen3.5-27b-q4",

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -38,7 +38,7 @@ services:
       - --port
       - "8080"
       - --n-gpu-layers
-      - "999"
+      - "${N_GPU_LAYERS:-999}"
       - --ctx-size
       - "${CTX_SIZE:-16384}"
       - --batch-size

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -1777,7 +1777,8 @@ class TestLaunchNativeLlamaServer:
             "GGUF_FILE=test-model.gguf\n"
             "CTX_SIZE=8192\n"
             "LLAMA_REASONING=on\n"
-            "AMD_INFERENCE_PORT=9090\n",
+            "AMD_INFERENCE_PORT=9090\n"
+            "N_GPU_LAYERS=20\n",
             encoding="utf-8",
         )
         (tmp_path / "data" / "models").mkdir(parents=True)
@@ -1811,6 +1812,7 @@ class TestLaunchNativeLlamaServer:
         assert "--ctx-size" in cmd
         assert "8192" in cmd
         assert "--reasoning-format" in cmd
+        assert cmd[cmd.index("--n-gpu-layers") + 1] == "20"
         assert "deepseek" in cmd
         assert _kwargs["cwd"] == str(tmp_path)
 
@@ -5229,6 +5231,7 @@ class TestModelActivateRollback:
                         "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS": "-1",
                         "LLAMA_ARG_SPEC_TYPE": "draft-mtp",
                         "LLAMA_ARG_SPEC_DRAFT_N_MAX": "3",
+                        "N_GPU_LAYERS": "20",
                     },
                 }],
             }]
@@ -5260,6 +5263,7 @@ class TestModelActivateRollback:
         assert "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS=-1" in env_text
         assert "LLAMA_ARG_SPEC_TYPE=draft-mtp" in env_text
         assert "LLAMA_ARG_SPEC_DRAFT_N_MAX=3" in env_text
+        assert "N_GPU_LAYERS=20" in env_text
 
     def test_explicit_context_overrides_profile_and_installer_recommendation(
         self, tmp_path, monkeypatch,

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -710,19 +710,21 @@ if ($dryRun) {
                 # Start native llama-server
                 Write-AI "Starting native llama-server (Vulkan)..."
                 $modelFullPath = Join-Path (Join-Path $installDir "data\models") $tierConfig.GgufFile
-                $llamaArgs = @(
-                    "--model", $modelFullPath,
-                    "--host", $bindAddr,
-                    "--port", [string]$script:LEMONADE_PORT,
-                    "--n-gpu-layers", "999",
-                    "--ctx-size", "$($tierConfig.MaxContext)"
-                )
                 $_llamaEnv = @{}
                 Get-Content -LiteralPath (Join-Path $installDir ".env") -ErrorAction SilentlyContinue | ForEach-Object {
                     if ($_ -match '^\s*#' -or $_ -notmatch '=') { return }
                     $parts = $_ -split '=', 2
                     $_llamaEnv[$parts[0].Trim()] = $parts[1].Trim().Trim('"')
                 }
+                $gpuLayers = $_llamaEnv["N_GPU_LAYERS"]
+                if (-not $gpuLayers) { $gpuLayers = "999" }
+                $llamaArgs = @(
+                    "--model", $modelFullPath,
+                    "--host", $bindAddr,
+                    "--port", [string]$script:LEMONADE_PORT,
+                    "--n-gpu-layers", $gpuLayers,
+                    "--ctx-size", "$($tierConfig.MaxContext)"
+                )
                 if ($_llamaEnv["LLAMA_ARG_FLASH_ATTN"]) { $llamaArgs += @("--flash-attn", $_llamaEnv["LLAMA_ARG_FLASH_ATTN"]) }
                 if ($_llamaEnv["LLAMA_ARG_CACHE_TYPE_K"]) { $llamaArgs += @("--cache-type-k", $_llamaEnv["LLAMA_ARG_CACHE_TYPE_K"]) }
                 if ($_llamaEnv["LLAMA_ARG_CACHE_TYPE_V"]) { $llamaArgs += @("--cache-type-v", $_llamaEnv["LLAMA_ARG_CACHE_TYPE_V"]) }

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1364,11 +1364,13 @@ function Start-NativeInferenceServer {
             return
         }
 
+        $gpuLayers = $envVars["N_GPU_LAYERS"]
+        if (-not $gpuLayers) { $gpuLayers = "999" }
         $llamaArgs = @(
             "--model", $modelPath,
             "--host", $bindAddr,
             "--port", [string]$script:LEMONADE_PORT,
-            "--n-gpu-layers", "999",
+            "--n-gpu-layers", $gpuLayers,
             "--ctx-size", $ctxSize
         )
         if ($envVars["LLAMA_ARG_FLASH_ATTN"]) { $llamaArgs += @("--flash-attn", $envVars["LLAMA_ARG_FLASH_ATTN"]) }

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -802,6 +802,49 @@ def test_qwen35_9b_meets_hermes_context_floor():
     assert by_id["qwen3.5-9b-q4"]["context_length"] >= HERMES_CONTEXT_FLOOR
 
 
+def test_qwen36_27b_is_audited_as_quality_first_large_candidate():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["qwen3.6-27b-q4"]
+
+    assert model["gguf_url"] == (
+        "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/"
+        "resolve/82d411acf4a06cfb8d9b073a5211bf410bfc29bf/"
+        "Qwen3.6-27B-Q4_K_M.gguf"
+    )
+    assert model["gguf_sha256"] == "5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0"
+    assert model["size_bytes"] == 16817244384
+    assert model["size_mb"] == 16818
+    assert model["total_params_b"] == 27.8
+    assert model["architecture"] == "dense"
+    assert model["context_length"] == 131072
+    assert model["max_context_length"] == 262144
+    assert model["install_recommendation"] is False
+
+    quality = model["quality_evidence"]
+    assert quality == {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/qwen3-6-27b/",
+        "score": 37,
+        "rank": 1,
+        "rank_scope": "4B-40B open-weight models",
+        "assessed_at": "2026-07-27",
+    }
+
+    profile = {
+        item["id"]: item for item in model["runtime_profiles"]
+    }["nvidia-8gb-64k-partial-offload-q4-kv"]
+    assert profile["context_length"] == HERMES_CONTEXT_FLOOR
+    assert profile["system_ram_min_gb"] == 31
+    assert profile["env"] == {
+        "LLAMA_PARALLEL": "1",
+        "LLAMA_ARG_FLASH_ATTN": "on",
+        "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+        "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
+        "N_GPU_LAYERS": "20",
+    }
+
+
 def test_qwen35_2b_records_exact_artifact_and_failed_fleet_evidence():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -802,7 +802,7 @@ def test_qwen35_9b_meets_hermes_context_floor():
     assert by_id["qwen3.5-9b-q4"]["context_length"] >= HERMES_CONTEXT_FLOOR
 
 
-def test_qwen36_27b_is_audited_as_quality_first_large_candidate():
+def test_qwen36_27b_is_audited_as_quality_first_large_candidate_with_fleet_verdict():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["qwen3.6-27b-q4"]
@@ -831,18 +831,28 @@ def test_qwen36_27b_is_audited_as_quality_first_large_candidate():
         "assessed_at": "2026-07-27",
     }
 
-    profile = {
-        item["id"]: item for item in model["runtime_profiles"]
-    }["nvidia-8gb-64k-partial-offload-q4-kv"]
-    assert profile["context_length"] == HERMES_CONTEXT_FLOOR
-    assert profile["system_ram_min_gb"] == 31
-    assert profile["env"] == {
-        "LLAMA_PARALLEL": "1",
-        "LLAMA_ARG_FLASH_ATTN": "on",
-        "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
-        "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
-        "N_GPU_LAYERS": "20",
+    assert "runtime_profiles" not in model
+
+    compatibility = model["app_compatibility"]
+    assert compatibility["openai_chat"]["status"] == "unsupported_until_revalidated"
+    assert compatibility["openai_chat"]["hostScope"] == ["windows-laptop"]
+    assert "0.07-0.08 tok/s" in compatibility["openai_chat"]["reason"]
+    assert compatibility["hermes_talk"]["status"] == "verified"
+    assert set(compatibility["hermes_talk"]["hostScope"]) == {
+        "tower2",
+        "strix-halo",
+        "spark",
+        "m5-mbp",
+        "windows-laptop",
+        "strixy",
     }
+    assert compatibility["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
+    assert "six-host gate did not pass" in compatibility["agent_viability"]["reason"]
+    assert compatibility["agent_viability"]["productSha"] == (
+        "fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef"
+    )
+    assert not _agent_viable_for_release(model)
 
 
 def test_qwen35_2b_records_exact_artifact_and_failed_fleet_evidence():

--- a/ods/tests/test_runtime_gpu_layer_profile.py
+++ b/ods/tests/test_runtime_gpu_layer_profile.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_partial_gpu_offload_profile_reaches_every_llama_launch_path():
+    compose = _read("docker-compose.base.yml")
+    host_agent = _read("bin/ods-host-agent.py")
+    windows_cli = _read("installers/windows/ods.ps1")
+    windows_installer = _read("installers/windows/install-windows.ps1")
+
+    assert '- "${N_GPU_LAYERS:-999}"' in compose
+    assert 'env.get("N_GPU_LAYERS", "999")' in host_agent
+    assert '$gpuLayers = $envVars["N_GPU_LAYERS"]' in windows_cli
+    assert '$gpuLayers = $_llamaEnv["N_GPU_LAYERS"]' in windows_installer
+    assert '"--n-gpu-layers", $gpuLayers' in windows_cli
+    assert '"--n-gpu-layers", $gpuLayers' in windows_installer


### PR DESCRIPTION
## Summary

- stage a pinned Qwen 3.6 27B Q4_K_M candidate with immutable artifact integrity
- record current independent quality evidence instead of limiting evaluation to tiny models
- let runtime profiles control native and Docker llama.cpp GPU-layer offload without changing existing defaults
- record the completed fleet verdict and keep installation recommendation disabled
- remove the rejected NVIDIA 8GB profile after measured app performance proved non-viable

## Why this candidate

Qwen 3.6 27B is the current Artificial Analysis leader in the 4B-40B open-weight class (Intelligence Index v4.1 score 37, assessed 2026-07-27). It is Apache-2.0 licensed, has 27.8B dense parameters, supports 262K native context and Qwen tool calling, and provides a quality-first larger-model target rather than optimizing only for small universal artifacts.

## Artifact

- repo: `unsloth/Qwen3.6-27B-GGUF`
- revision: `82d411acf4a06cfb8d9b073a5211bf410bfc29bf`
- file: `Qwen3.6-27B-Q4_K_M.gguf`
- bytes: `16817244384`
- sha256: `5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0`

## Fleet result

The model remains staged with `install_recommendation: false`.

- tower2, strix-halo, spark, and m5-mbp completed the full candidate/app/restore/cleanup rotation
- strixy loaded the exact artifact and passed ODS Talk plus every candidate consumer; its formal run later failed only on a restored-baseline Perplexica cleanup flake
- windows-laptop initially exposed a real product bug: Docker ignored the profile and hardcoded full GPU offload
- corrected commit `fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef` loaded the exact model on Windows at 65,536 context with 20 of 65 layers offloaded and passed identity, direct inference, and ODS Talk
- measured Windows generation was only 0.07-0.08 tok/s; LiteLLM, Open WebUI, and Perplexica timed out, so the 8GB profile was removed
- the Windows host was restored to Qwen 3.5 9B with fresh identity/completion proof, both test artifacts were deleted, and its upgrade task was restored

Evidence:

- `fleet-test/runs/2026-07-27T22-56-10Z-model-ui-product-5e753f617ced-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-qwen36-27b-quality-first-r10`
- `fleet-test/runs/2026-07-28T00-15-34Z-model-ui-product-fdedd5dd090b-harness-19d43e6f9f25-hosts-windows-laptop-qwen36-27b-windows-fix-r12`
- harness commit: `19d43e6f9f2533e8768ed85b33de9f4ace232129`

## Product impact

The generic `N_GPU_LAYERS` plumbing remains valuable and covered: model runtime profiles can now set partial GPU offload in Docker and the Windows native launcher. Existing models retain the previous default of `999` layers when no profile override exists.

Qwen 3.6 27B is cataloged for larger-memory experimentation but is not recommended or considered fleet-wide agent-ready. Its recorded app verdict explicitly scopes the 8GB failure so it does not misrepresent the successful larger-host results.

## Validation

- `python3 -m pytest -q ods/tests/test-model-library-coverage.py ods/tests/test_runtime_gpu_layer_profile.py` — 42 passed
- `python3 -m pytest -q ods/extensions/services/dashboard-api/tests/test_model_activate.py` — 238 passed
- `python3 -m pytest -q ods/tests` — 24 passed, 8 skipped
- isolated dashboard API environment — 2048 passed
- Windows installer exact-commit run at `fdedd5dd090b6fd8b6eaa246ff6117b0a6e6cfef` — passed
- PowerShell parse and installer flag checks — passed
- Docker Compose rendering with explicit `N_GPU_LAYERS=20` and default `999` — passed
- `git diff --check` — passed

## Promotion gate

Promotion requires a clean six-host pass. This candidate did not meet that gate and will remain unrecommended.
