### PR TITLE
feat(models): stage North Mini Code 30B-A3B

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -7820,6 +7820,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS",
                     "LLAMA_ARG_SPEC_TYPE",
                     "LLAMA_ARG_SPEC_DRAFT_N_MAX",
+                    "N_GPU_LAYERS",
                 }
                 if runtime_profile:
                     for key, value in runtime_env.items():
@@ -7838,6 +7839,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS",
                     "LLAMA_ARG_SPEC_TYPE",
                     "LLAMA_ARG_SPEC_DRAFT_N_MAX",
+                    "N_GPU_LAYERS",
                 }
                 if gpu_assignment_plan:
                     remove_keys.update(gpu_assignment_plan.get("env_removals") or [])
@@ -11634,7 +11636,7 @@ def _launch_native_llama_server(env_path: Path, llama_bin: Path, llama_log: Path
         "--host", bind_addr, "--port", str(port),
         "--model", str(model_path),
         "--ctx-size", ctx_size,
-        "--n-gpu-layers", "999",
+        "--n-gpu-layers", env.get("N_GPU_LAYERS", "999"),
         "--parallel", env.get("LLAMA_PARALLEL", "1"),
         "--reasoning-format", reasoning_fmt,
         "--metrics",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1777,6 +1777,75 @@
       "llama_server_image": null
     },
     {
+      "id": "north-mini-code-30b-a3b-q4",
+      "name": "North Mini Code 30B-A3B",
+      "family": "cohere",
+      "gguf_file": "North-Mini-Code-1.0-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/bartowski/North-Mini-Code-1.0-GGUF/resolve/6ff6563002170723a6f7a672bf4c99775be6c0dd/North-Mini-Code-1.0-Q4_K_M.gguf",
+      "gguf_sha256": "38a7f05a0bf703be5a9c474d205229d68ffa6c15f8e793923cd2d46c9b77a723",
+      "size_bytes": 18744024640,
+      "size_mb": 18745,
+      "vram_required_gb": 24,
+      "context_length": 131072,
+      "max_context_length": 262144,
+      "total_params_b": 30,
+      "active_params_b": 3,
+      "architecture": "moe",
+      "quantization": "Q4_K_M",
+      "specialty": "Agentic Coding",
+      "description": "Cohere's Apache-2.0 coding specialist uses 30B total parameters with only 3B active per token. Its current general Intelligence Index score is 20, while launch coding evaluation scored 33.4; it is staged as a diverse local coding candidate rather than presented as the general-intelligence leader.",
+      "tokens_per_sec_estimate": 55,
+      "llm_model_name": "north-mini-code-1.0",
+      "llama_server_image": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9641",
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/north-mini-code",
+        "score": 20,
+        "rank": 21,
+        "rank_scope": "4B-40B open-weight models",
+        "assessed_at": "2026-07-28"
+      },
+      "coding_evidence": {
+        "source": "Artificial Analysis North Mini Code launch evaluation",
+        "source_url": "https://artificialanalysis.ai/articles/north-mini-code-cohere-s-small-coding-focused-moe-model",
+        "score": 33.4,
+        "metric": "Artificial Analysis Coding Index",
+        "relative_position": "below Qwen3.6 35B-A3B at 35.2 and above GLM-4.7-Flash at 25.9",
+        "assessed_at": "2026-06-09",
+        "note": "Launch-era coding evidence; current v4.1 general intelligence is recorded separately."
+      },
+      "runtime_requirements": {
+        "llama_cpp_min_build": 9637,
+        "docker_image_build": 9641,
+        "reason": "Dedicated Cohere2-MoE chat parsing landed in llama.cpp b9637; b9641 is the first published official server image after that release."
+      },
+      "runtime_profiles": [
+        {
+          "id": "nvidia-8gb-64k-partial-offload-q4-kv",
+          "label": "NVIDIA 8GB 64K partial GPU offload with Q4 KV cache",
+          "backend": "nvidia",
+          "host_arch": [
+            "amd64"
+          ],
+          "memory_type": "discrete",
+          "vram_min_gb": 7.5,
+          "vram_max_gb": 8.5,
+          "system_ram_min_gb": 31,
+          "context_length": 65536,
+          "estimated_required_gb": 7.4,
+          "fit_label": "64K 8GB partial-offload candidate profile",
+          "env": {
+            "LLAMA_PARALLEL": "1",
+            "LLAMA_ARG_FLASH_ATTN": "on",
+            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
+            "N_GPU_LAYERS": "16"
+          }
+        }
+      ]
+    },
+    {
       "id": "gemma4-31b-q4",
       "name": "Gemma 4 31B",
       "family": "gemma4",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1797,6 +1797,46 @@
       "tokens_per_sec_estimate": 55,
       "llm_model_name": "north-mini-code-1.0",
       "llama_server_image": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9641",
+      "app_compatibility": {
+        "openai_chat": {
+          "status": "unsupported_until_revalidated",
+          "label": "AMD runtime dependency pending",
+          "reason": "The exact base candidate passed signed LiteLLM, Open WebUI, OpenCode, and Perplexica routes on tower2. On current-main Strix Halo, Lemonade 10.2.0 failed before load because its bundled llama.cpp did not recognize cohere2moe. An exact remediation stack selected the custom ROCm b9641 binary and then passed every required app route on Strix Halo, but that runtime fix is not yet in the candidate branch or main.",
+          "evidence": "fleet-test/runs/2026-07-28T02-12-14Z-model-ui-product-7af49e3c90d2-harness-19d43e6f9f25-hosts-tower2-north-mini-code-tower2-r7/cycle-001/tower2; fleet-test/runs/2026-07-28T02-40-20Z-model-ui-product-7af49e3c90d2-harness-19d43e6f9f25-hosts-strix-halo-north-mini-code-strix-halo-r1/cycle-001/strix-halo; fleet-test/runs/2026-07-28T03-36-36Z-model-ui-product-b1a9af7a5d4e-harness-19d43e6f9f25-hosts-strix-halo-north-mini-code-strix-halo-remediation-r3/cycle-001/strix-halo",
+          "recordedAt": "2026-07-28T04:02:27Z",
+          "productSha": "7af49e3c90d29a828e821d3c562dac35ea8ffa2a",
+          "remediationProductSha": "b1a9af7a5d4ee8ebcdf4bf1dd0565af9c3ccfac6",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": [
+            "tower2",
+            "strix-halo"
+          ]
+        },
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "label": "ODS Talk needs six-host validation",
+          "reason": "Challenge-bound ODS Talk passed on tower2 at the base candidate and on Strix Halo only after the custom ROCm b9641 remediation. Keep Talk compatibility unverified fleet-wide until the AMD runtime dependency lands and the exact six-host rotation passes.",
+          "evidence": "fleet-test/runs/2026-07-28T02-12-14Z-model-ui-product-7af49e3c90d2-harness-19d43e6f9f25-hosts-tower2-north-mini-code-tower2-r7/cycle-001/tower2; fleet-test/runs/2026-07-28T03-36-36Z-model-ui-product-b1a9af7a5d4e-harness-19d43e6f9f25-hosts-strix-halo-north-mini-code-strix-halo-remediation-r3/cycle-001/strix-halo",
+          "recordedAt": "2026-07-28T04:02:27Z",
+          "productSha": "7af49e3c90d29a828e821d3c562dac35ea8ffa2a",
+          "remediationProductSha": "b1a9af7a5d4ee8ebcdf4bf1dd0565af9c3ccfac6",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": [
+            "tower2",
+            "strix-halo"
+          ]
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "label": "Not fleet-ready",
+          "reason": "Tower2 completed the full exact candidate rotation on the base branch. Strix Halo completed the same rotation only on a remediation stack that selects a custom ROCm b9641 runtime; current main cannot load the Cohere2-MoE architecture. Promotion remains blocked on landing that dependency and passing one exact six-host run.",
+          "evidence": "fleet-test/runs/2026-07-28T02-12-14Z-model-ui-product-7af49e3c90d2-harness-19d43e6f9f25-hosts-tower2-north-mini-code-tower2-r7/cycle-001/tower2; fleet-test/runs/2026-07-28T02-40-20Z-model-ui-product-7af49e3c90d2-harness-19d43e6f9f25-hosts-strix-halo-north-mini-code-strix-halo-r1/cycle-001/strix-halo; fleet-test/runs/2026-07-28T03-36-36Z-model-ui-product-b1a9af7a5d4e-harness-19d43e6f9f25-hosts-strix-halo-north-mini-code-strix-halo-remediation-r3/cycle-001/strix-halo",
+          "recordedAt": "2026-07-28T04:02:27Z",
+          "productSha": "7af49e3c90d29a828e821d3c562dac35ea8ffa2a",
+          "remediationProductSha": "b1a9af7a5d4ee8ebcdf4bf1dd0565af9c3ccfac6",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129"
+        }
+      },
       "install_recommendation": false,
       "quality_evidence": {
         "source": "Artificial Analysis Intelligence Index v4.1",
@@ -1818,7 +1858,15 @@
       "runtime_requirements": {
         "llama_cpp_min_build": 9637,
         "docker_image_build": 9641,
-        "reason": "Dedicated Cohere2-MoE chat parsing landed in llama.cpp b9637; b9641 is the first published official server image after that release."
+        "reason": "Dedicated Cohere2-MoE chat parsing landed in llama.cpp b9637; b9641 is the first published official server image after that release.",
+        "amd_lemonade": {
+          "status": "blocked_on_runtime_fix",
+          "selector": "rocm",
+          "binary": "/opt/llama-custom/llama-server",
+          "validated_build": 9641,
+          "upstream_pr": "https://github.com/Osmantic/ODS/pull/1783",
+          "reason": "The current single-GPU AMD compose path selects Lemonade's bundled runtime, which predates Cohere2-MoE. Exact Strix Halo validation passed only after selecting the custom ROCm b9641 binary."
+        }
       },
       "runtime_profiles": [
         {

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -38,7 +38,7 @@ services:
       - --port
       - "8080"
       - --n-gpu-layers
-      - "999"
+      - "${N_GPU_LAYERS:-999}"
       - --ctx-size
       - "${CTX_SIZE:-16384}"
       - --batch-size

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -1777,7 +1777,8 @@ class TestLaunchNativeLlamaServer:
             "GGUF_FILE=test-model.gguf\n"
             "CTX_SIZE=8192\n"
             "LLAMA_REASONING=on\n"
-            "AMD_INFERENCE_PORT=9090\n",
+            "AMD_INFERENCE_PORT=9090\n"
+            "N_GPU_LAYERS=20\n",
             encoding="utf-8",
         )
         (tmp_path / "data" / "models").mkdir(parents=True)
@@ -1811,6 +1812,7 @@ class TestLaunchNativeLlamaServer:
         assert "--ctx-size" in cmd
         assert "8192" in cmd
         assert "--reasoning-format" in cmd
+        assert cmd[cmd.index("--n-gpu-layers") + 1] == "20"
         assert "deepseek" in cmd
         assert _kwargs["cwd"] == str(tmp_path)
 
@@ -5229,6 +5231,7 @@ class TestModelActivateRollback:
                         "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS": "-1",
                         "LLAMA_ARG_SPEC_TYPE": "draft-mtp",
                         "LLAMA_ARG_SPEC_DRAFT_N_MAX": "3",
+                        "N_GPU_LAYERS": "20",
                     },
                 }],
             }]
@@ -5260,6 +5263,7 @@ class TestModelActivateRollback:
         assert "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS=-1" in env_text
         assert "LLAMA_ARG_SPEC_TYPE=draft-mtp" in env_text
         assert "LLAMA_ARG_SPEC_DRAFT_N_MAX=3" in env_text
+        assert "N_GPU_LAYERS=20" in env_text
 
     def test_explicit_context_overrides_profile_and_installer_recommendation(
         self, tmp_path, monkeypatch,

--- a/ods/installers/macos/lib/constants.sh
+++ b/ods/installers/macos/lib/constants.sh
@@ -53,7 +53,7 @@ HOST_AGENT_BRIDGE_PLIST="$HOME/Library/LaunchAgents/${HOST_AGENT_BRIDGE_PLIST_LA
 HOST_AGENT_BRIDGE_LOG="$HOME/Library/Logs/ODS/ods-host-agent-bridge.log"
 
 # llama.cpp release for macOS Metal build (update when new releases ship)
-LLAMA_CPP_RELEASE_TAG="b8210"
+LLAMA_CPP_RELEASE_TAG="b9637"
 LLAMA_CPP_MACOS_ASSET="llama-${LLAMA_CPP_RELEASE_TAG}-bin-macos-arm64.tar.gz"
 LLAMA_CPP_MACOS_URL="https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_CPP_RELEASE_TAG}/${LLAMA_CPP_MACOS_ASSET}"
 

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -710,19 +710,21 @@ if ($dryRun) {
                 # Start native llama-server
                 Write-AI "Starting native llama-server (Vulkan)..."
                 $modelFullPath = Join-Path (Join-Path $installDir "data\models") $tierConfig.GgufFile
-                $llamaArgs = @(
-                    "--model", $modelFullPath,
-                    "--host", $bindAddr,
-                    "--port", [string]$script:LEMONADE_PORT,
-                    "--n-gpu-layers", "999",
-                    "--ctx-size", "$($tierConfig.MaxContext)"
-                )
                 $_llamaEnv = @{}
                 Get-Content -LiteralPath (Join-Path $installDir ".env") -ErrorAction SilentlyContinue | ForEach-Object {
                     if ($_ -match '^\s*#' -or $_ -notmatch '=') { return }
                     $parts = $_ -split '=', 2
                     $_llamaEnv[$parts[0].Trim()] = $parts[1].Trim().Trim('"')
                 }
+                $gpuLayers = $_llamaEnv["N_GPU_LAYERS"]
+                if (-not $gpuLayers) { $gpuLayers = "999" }
+                $llamaArgs = @(
+                    "--model", $modelFullPath,
+                    "--host", $bindAddr,
+                    "--port", [string]$script:LEMONADE_PORT,
+                    "--n-gpu-layers", $gpuLayers,
+                    "--ctx-size", "$($tierConfig.MaxContext)"
+                )
                 if ($_llamaEnv["LLAMA_ARG_FLASH_ATTN"]) { $llamaArgs += @("--flash-attn", $_llamaEnv["LLAMA_ARG_FLASH_ATTN"]) }
                 if ($_llamaEnv["LLAMA_ARG_CACHE_TYPE_K"]) { $llamaArgs += @("--cache-type-k", $_llamaEnv["LLAMA_ARG_CACHE_TYPE_K"]) }
                 if ($_llamaEnv["LLAMA_ARG_CACHE_TYPE_V"]) { $llamaArgs += @("--cache-type-v", $_llamaEnv["LLAMA_ARG_CACHE_TYPE_V"]) }

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1364,11 +1364,13 @@ function Start-NativeInferenceServer {
             return
         }
 
+        $gpuLayers = $envVars["N_GPU_LAYERS"]
+        if (-not $gpuLayers) { $gpuLayers = "999" }
         $llamaArgs = @(
             "--model", $modelPath,
             "--host", $bindAddr,
             "--port", [string]$script:LEMONADE_PORT,
-            "--n-gpu-layers", "999",
+            "--n-gpu-layers", $gpuLayers,
             "--ctx-size", $ctxSize
         )
         if ($envVars["LLAMA_ARG_FLASH_ATTN"]) { $llamaArgs += @("--flash-attn", $envVars["LLAMA_ARG_FLASH_ATTN"]) }

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -802,6 +802,56 @@ def test_qwen35_9b_meets_hermes_context_floor():
     assert by_id["qwen3.5-9b-q4"]["context_length"] >= HERMES_CONTEXT_FLOOR
 
 
+def test_north_mini_code_is_audited_as_current_specialist_candidate():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["north-mini-code-30b-a3b-q4"]
+
+    assert model["gguf_url"] == (
+        "https://huggingface.co/bartowski/North-Mini-Code-1.0-GGUF/"
+        "resolve/6ff6563002170723a6f7a672bf4c99775be6c0dd/"
+        "North-Mini-Code-1.0-Q4_K_M.gguf"
+    )
+    assert model["gguf_sha256"] == "38a7f05a0bf703be5a9c474d205229d68ffa6c15f8e793923cd2d46c9b77a723"
+    assert model["size_bytes"] == 18744024640
+    assert model["size_mb"] == 18745
+    assert model["total_params_b"] == 30
+    assert model["active_params_b"] == 3
+    assert model["architecture"] == "moe"
+    assert model["context_length"] == 131072
+    assert model["max_context_length"] == 262144
+    assert model["install_recommendation"] is False
+    assert model["llama_server_image"] == (
+        "ghcr.io/ggml-org/llama.cpp:server-cuda-b9641"
+    )
+
+    assert model["quality_evidence"] == {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/north-mini-code",
+        "score": 20,
+        "rank": 21,
+        "rank_scope": "4B-40B open-weight models",
+        "assessed_at": "2026-07-28",
+    }
+    assert model["coding_evidence"]["score"] == 33.4
+    assert "Launch-era" in model["coding_evidence"]["note"]
+    assert model["runtime_requirements"]["llama_cpp_min_build"] == 9637
+    assert model["runtime_requirements"]["docker_image_build"] == 9641
+
+    profile = {
+        item["id"]: item for item in model["runtime_profiles"]
+    }["nvidia-8gb-64k-partial-offload-q4-kv"]
+    assert profile["context_length"] == HERMES_CONTEXT_FLOOR
+    assert profile["system_ram_min_gb"] == 31
+    assert profile["env"] == {
+        "LLAMA_PARALLEL": "1",
+        "LLAMA_ARG_FLASH_ATTN": "on",
+        "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+        "LLAMA_ARG_CACHE_TYPE_V": "q4_0",
+        "N_GPU_LAYERS": "16",
+    }
+
+
 def test_qwen35_2b_records_exact_artifact_and_failed_fleet_evidence():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}

--- a/ods/tests/test_runtime_gpu_layer_profile.py
+++ b/ods/tests/test_runtime_gpu_layer_profile.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_partial_gpu_offload_profile_reaches_every_llama_launch_path():
+    compose = _read("docker-compose.base.yml")
+    host_agent = _read("bin/ods-host-agent.py")
+    windows_cli = _read("installers/windows/ods.ps1")
+    windows_installer = _read("installers/windows/install-windows.ps1")
+
+    assert '- "${N_GPU_LAYERS:-999}"' in compose
+    assert 'env.get("N_GPU_LAYERS", "999")' in host_agent
+    assert '$gpuLayers = $envVars["N_GPU_LAYERS"]' in windows_cli
+    assert '$gpuLayers = $_llamaEnv["N_GPU_LAYERS"]' in windows_installer
+    assert '"--n-gpu-layers", $gpuLayers' in windows_cli
+    assert '"--n-gpu-layers", $gpuLayers' in windows_installer
+
+
+def test_macos_native_runtime_includes_cohere2_moe_support():
+    constants = _read("installers/macos/lib/constants.sh")
+
+    assert 'LLAMA_CPP_RELEASE_TAG="b9637"' in constants


### PR DESCRIPTION
## Summary

- stage Cohere North Mini Code 1.0 as an exact, immutable 30B-total / 3B-active Q4_K_M candidate
- record current general-intelligence evidence separately from stronger launch-era coding evidence
- add the minimum Cohere2-MoE llama.cpp runtime floor and the first published official server image after dedicated chat parsing landed
- allow runtime profiles to control partial GPU offload across Docker and native Windows launch paths
- keep `install_recommendation: false` until the six-host fleet gate passes

## Why this candidate

This is a quality/specialization choice, not a convenience choice. North Mini Code is a current Apache-2.0 agentic-coding model with 30B total parameters and only 3B active per token. Artificial Analysis v4.1 currently scores its general intelligence at 20 (rank 21/130 in the 4B-40B open-weight class), while its June launch coding evaluation scored 33.4. The catalog records both figures and explicitly labels the older coding result instead of presenting the launch score as current general intelligence.

It adds a non-Qwen, non-Granite model family and is substantially more fleet-plausible than current 119B-1T frontier models while still testing a meaningful mid-size MoE.

## Artifact

- repo: `bartowski/North-Mini-Code-1.0-GGUF`
- revision: `6ff6563002170723a6f7a672bf4c99775be6c0dd`
- file: `North-Mini-Code-1.0-Q4_K_M.gguf`
- bytes: `18744024640`
- sha256: `38a7f05a0bf703be5a9c474d205229d68ffa6c15f8e793923cd2d46c9b77a723`

## Runtime

Dedicated Cohere2-MoE chat parsing landed in llama.cpp b9637. The model uses `server-cuda-b9641`, the first published official server image after that release, and the macOS native runtime floor is b9637. Both b9641 CPU and CUDA images were pulled and report build 9641.

The staged Windows 8GB profile uses 64K context, Q4 KV cache, parallelism 1, and 16 GPU layers. That is a candidate hypothesis only; it will be removed if measured throughput or app behavior is not release-viable.

## Validation so far

- catalog/runtime tests: 43 passed
- dashboard activation tests: 238 passed
- broader ODS tests: 25 passed, 8 skipped
- Python syntax checks: passed
- edited PowerShell launcher parse checks: passed
- official b9641 CPU/CUDA image manifest, pull, and version checks: passed
- `git diff --check`: passed
- tower2 exact base-candidate rotation: passed download/checksum, 131K load, ODS Talk, every required app route, baseline restore, artifact deletion, and clean environment
- Strix Halo exact base-candidate rotation: deterministic pre-load failure because Lemonade 10.2.0's bundled llama.cpp does not recognize `cohere2moe`; rollback and cleanup passed
- Strix Halo exact remediation rotation: passed the complete rotation after selecting a custom ROCm llama.cpp b9641 binary, including signed LiteLLM, Open WebUI, OpenCode, and Perplexica routes

The Strix remediation exposed a second runtime issue in the existing AMD fix from #1783: the single-GPU compose path hard-codes `--llamacpp auto`, so it ignores the custom ROCm selector and binary that the installer writes. The validated remediation changes that path to `${LEMONADE_LLAMACPP:-rocm}`, carries the selector into the container, and raises the custom build to b9641. This PR deliberately remains draft and unrecommended until that runtime dependency is merged.

### Fleet evidence

- tower2 base PASS: `fleet-test/runs/2026-07-28T02-12-14Z-model-ui-product-7af49e3c90d2-harness-19d43e6f9f25-hosts-tower2-north-mini-code-tower2-r7`
- Strix Halo current-main architecture FAIL with clean rollback: `fleet-test/runs/2026-07-28T02-40-20Z-model-ui-product-7af49e3c90d2-harness-19d43e6f9f25-hosts-strix-halo-north-mini-code-strix-halo-r1`
- Strix Halo remediation PASS: `fleet-test/runs/2026-07-28T03-36-36Z-model-ui-product-b1a9af7a5d4e-harness-19d43e6f9f25-hosts-strix-halo-north-mini-code-strix-halo-remediation-r3`

## Promotion gate

This remains staged and unrecommended. Tower2 passes the base candidate, but Strix Halo only passes with the unmerged AMD runtime remediation. Promotion requires the runtime dependency to land, followed by one exact candidate commit passing artifact download/checksum, model load, direct inference, ODS Talk, all required app consumers, original-model restore, test-artifact deletion, and clean environment verification on tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy.
