### PR TITLE
fix(linux): repair rootless bind-mount ownership

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -46,6 +46,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh
+	@echo "=== Docker rootless bind-mount ownership ==="
+	@bash tests/test-rootless-docker-ownership.sh
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -3106,10 +3106,58 @@ def _precreate_data_dirs(service_id: str):
                 logger.warning("Failed to pre-create %s: %s", dir_path, e)
 
 
+_ROOTLESS_BIND_OWNERSHIP_SERVICES = {
+    "ape",
+    "comfyui",
+    "hermes",
+    "langfuse",
+    "n8n",
+    "privacy-shield",
+    "token-spy",
+    "whisper",
+}
+
+
+def _repair_rootless_data_ownership(service_id: str) -> None:
+    """Apply the built-in rootless bind-mount ownership contract before start."""
+    if platform.system() != "Linux" or service_id not in _ROOTLESS_BIND_OWNERSHIP_SERVICES:
+        return
+
+    helper = INSTALL_DIR / "lib" / "rootless-ownership.sh"
+    if not helper.is_file():
+        raise RuntimeError(f"Rootless ownership helper not found: {helper}")
+    bash = _find_usable_bash()
+    if not bash:
+        raise RuntimeError("Bash is required for Docker rootless ownership repair")
+
+    try:
+        result = subprocess.run(
+            [bash, str(helper), str(INSTALL_DIR), service_id],
+            cwd=str(INSTALL_DIR),
+            env=os.environ.copy(),
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_START,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(
+            f"Rootless ownership repair could not run for {service_id}: {exc}"
+        ) from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "unknown error").strip()
+        raise RuntimeError(
+            f"Rootless ownership repair failed for {service_id}: {detail[-500:]}"
+        )
+
+
 def docker_compose_action(service_id: str, action: str) -> tuple:
     flags = resolve_compose_flags()
     if action == "start":
         _precreate_data_dirs(service_id)
+        try:
+            _repair_rootless_data_ownership(service_id)
+        except RuntimeError as exc:
+            return False, str(exc)
         cmd = ["docker", "compose"] + flags + ["up", "-d", service_id]
     elif action == "stop":
         cmd = ["docker", "compose"] + flags + ["stop", service_id]
@@ -3835,6 +3883,10 @@ def _run_post_install_hook(service_id: str, ext_dir: Path) -> tuple[bool, str]:
         "GPU_BACKEND": GPU_BACKEND,
         "HOOK_NAME": "post_install",
     }
+    for runtime_key in ("DOCKER_HOST", "XDG_RUNTIME_DIR"):
+        runtime_value = os.environ.get(runtime_key, "")
+        if runtime_value:
+            hook_env[runtime_key] = runtime_value
     bash = _find_usable_bash()
     if not bash:
         msg = "post_install hook requires a usable Bash runtime. Install Git Bash or run ODS through WSL/Linux."
@@ -6151,6 +6203,10 @@ class AgentHandler(BaseHTTPRequestHandler):
             "GPU_BACKEND": GPU_BACKEND,
             "HOOK_NAME": hook_name,
         }
+        for runtime_key in ("DOCKER_HOST", "XDG_RUNTIME_DIR"):
+            runtime_value = os.environ.get(runtime_key, "")
+            if runtime_value:
+                hook_env[runtime_key] = runtime_value
         bash = _find_usable_bash()
         if not bash:
             json_response(self, 500, {
@@ -6285,6 +6341,16 @@ class AgentHandler(BaseHTTPRequestHandler):
                 # Step 3: Start
                 _write_progress(service_id, "starting", "Starting container...")
                 _precreate_data_dirs(service_id)
+                try:
+                    _repair_rootless_data_ownership(service_id)
+                except RuntimeError as exc:
+                    _write_progress(
+                        service_id,
+                        "error",
+                        "Installation failed",
+                        error=str(exc),
+                    )
+                    return
                 start_result = subprocess.run(
                     ["docker", "compose"] + flags + ["up", "-d", service_id],
                     cwd=str(INSTALL_DIR), capture_output=True, text=True,

--- a/ods/docs/LINUX-TROUBLESHOOTING-GUIDE.md
+++ b/ods/docs/LINUX-TROUBLESHOOTING-GUIDE.md
@@ -162,6 +162,34 @@ docker run --rm hello-world
 
 ---
 
+## Rootless Docker bind-mount ownership
+
+**Symptoms:** An ODS container repeatedly exits with `Permission denied` while
+writing under `data/`, but the same install works with rootful Docker.
+
+ODS prepares active bind mounts inside Docker's rootless user namespace. It
+does not apply host-side numeric `chown` values that would map to the wrong
+container identity. Existing rootless installs can be repaired without a
+reinstall:
+
+```bash
+cd ~/ods
+./ods-cli stop
+./ods-cli repair rootless-ownership
+./ods-cli start
+```
+
+The repair is limited to active ODS services with a documented container UID.
+It rejects symlink escapes, verifies the resulting ownership, and refuses to
+recursively change a mismatched directory while its container is running.
+The first repair may pull the pinned `busybox:1.36.1` helper image; offline
+repairs require that image to be present already.
+
+This command does not configure low-port forwarding or Tailscale networking.
+Those are separate rootless Docker concerns.
+
+---
+
 ### KERNEL_INFO
 
 **Symptoms:** Always **pass** — prints `uname -r` (informational).

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1812,6 +1812,10 @@ class TestInstallHookEnvAllowlist:
         import inspect
         return inspect.getsource(_mod.AgentHandler._handle_install)
 
+    def _generic_hook_source(self):
+        import inspect
+        return inspect.getsource(_mod.AgentHandler._execute_hook)
+
     def test_setup_hook_subprocess_run_passes_env_kwarg(self):
         src = self._hook_helper_source()
         assert "env=hook_env" in src, (
@@ -1837,6 +1841,14 @@ class TestInstallHookEnvAllowlist:
             assert f'"{key}"' in src, (
                 f"setup_hook env allowlist missing required key {key}"
             )
+
+    def test_setup_hook_preserves_rootless_docker_routing(self):
+        for src in (self._hook_helper_source(), self._generic_hook_source()):
+            for key in ("DOCKER_HOST", "XDG_RUNTIME_DIR"):
+                assert f'"{key}"' in src, (
+                    f"extension hooks must preserve {key} so rootless Docker "
+                    "operations address the same daemon as the host agent"
+                )
 
     def test_setup_hook_uses_resolve_hook_with_post_install(self):
         src = self._hook_helper_source()
@@ -4066,6 +4078,78 @@ class TestPrecreateDataDirs:
         # Named volume must not materialize as a directory anywhere we own.
         assert not (ext_dir / "named_vol").exists()
         assert not (install_dir / "named_vol").exists()
+
+
+class TestRootlessDataOwnershipRepair:
+    def test_runs_targeted_helper_for_builtin_linux_service(
+        self, tmp_path, monkeypatch,
+    ):
+        helper = tmp_path / "lib" / "rootless-ownership.sh"
+        helper.parent.mkdir()
+        helper.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        calls = []
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(_mod, "_find_usable_bash", lambda: "/bin/bash")
+        monkeypatch.setenv("DOCKER_HOST", "unix:///run/user/1000/docker.sock")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return _mod.subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        _mod._repair_rootless_data_ownership("hermes")
+
+        assert calls[0][0] == [
+            "/bin/bash", str(helper), str(tmp_path), "hermes",
+        ]
+        assert calls[0][1]["env"]["DOCKER_HOST"].endswith("docker.sock")
+        assert calls[0][1]["env"]["XDG_RUNTIME_DIR"] == "/run/user/1000"
+
+    @pytest.mark.parametrize("system", ["Windows", "Darwin"])
+    def test_non_linux_is_side_effect_free(self, system, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: system)
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("helper ran outside Linux"),
+        )
+
+        _mod._repair_rootless_data_ownership("hermes")
+
+    def test_unsupported_service_is_side_effect_free(self, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("helper ran for unsupported service"),
+        )
+
+        _mod._repair_rootless_data_ownership("custom-extension")
+
+    def test_failure_prevents_compose_start(self, monkeypatch):
+        compose_calls = []
+        monkeypatch.setattr(_mod, "resolve_compose_flags", lambda: ["-f", "base.yml"])
+        monkeypatch.setattr(_mod, "_precreate_data_dirs", lambda _sid: None)
+        monkeypatch.setattr(
+            _mod,
+            "_repair_rootless_data_ownership",
+            lambda _sid: (_ for _ in ()).throw(RuntimeError("ownership mismatch")),
+        )
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda *args, **kwargs: compose_calls.append(args),
+        )
+
+        ok, error = _mod.docker_compose_action("hermes", "start")
+
+        assert ok is False
+        assert error == "ownership mismatch"
+        assert compose_calls == []
 
 
 class TestInstallRunningStateVerification:

--- a/ods/extensions/services/langfuse/hooks/post_install.sh
+++ b/ods/extensions/services/langfuse/hooks/post_install.sh
@@ -52,13 +52,22 @@ ROOTLESS_LIB="$INSTALL_DIR/lib/rootless-ownership.sh"
 if [[ -f "$ROOTLESS_LIB" ]]; then
     # shellcheck source=../../../../lib/rootless-ownership.sh
     source "$ROOTLESS_LIB"
-    if ods_is_rootless_docker; then
-        _ods_rootless_ensure_helper_image
-        _ods_rootless_fix_directory "$INSTALL_DIR" data/langfuse/postgres 70:70 ods-langfuse-postgres
-        _ods_rootless_fix_directory "$INSTALL_DIR" data/langfuse/clickhouse 101:101 ods-langfuse-clickhouse
-        log "done (Docker rootless ownership namespace)"
-        exit 0
-    fi
+    ROOTLESS_STATE=0
+    ods_docker_rootless_state || ROOTLESS_STATE=$?
+    case "$ROOTLESS_STATE" in
+        0)
+            _ods_rootless_ensure_helper_image
+            _ods_rootless_fix_directory "$INSTALL_DIR" data/langfuse/postgres 70:70 ods-langfuse-postgres
+            _ods_rootless_fix_directory "$INSTALL_DIR" data/langfuse/clickhouse 101:101 ods-langfuse-clickhouse
+            log "done (Docker rootless ownership namespace)"
+            exit 0
+            ;;
+        1) ;;
+        *)
+            log "ERROR: could not determine Docker rootless mode; refusing host-side chown"
+            exit 1
+            ;;
+    esac
 fi
 
 # Pick an elevator: sudo if available and we're not already root.

--- a/ods/extensions/services/langfuse/hooks/post_install.sh
+++ b/ods/extensions/services/langfuse/hooks/post_install.sh
@@ -48,6 +48,19 @@ fi
 POSTGRES_DIR="$INSTALL_DIR/data/langfuse/postgres"
 CLICKHOUSE_DIR="$INSTALL_DIR/data/langfuse/clickhouse"
 
+ROOTLESS_LIB="$INSTALL_DIR/lib/rootless-ownership.sh"
+if [[ -f "$ROOTLESS_LIB" ]]; then
+    # shellcheck source=../../../../lib/rootless-ownership.sh
+    source "$ROOTLESS_LIB"
+    if ods_is_rootless_docker; then
+        _ods_rootless_ensure_helper_image
+        _ods_rootless_fix_directory "$INSTALL_DIR" data/langfuse/postgres 70:70 ods-langfuse-postgres
+        _ods_rootless_fix_directory "$INSTALL_DIR" data/langfuse/clickhouse 101:101 ods-langfuse-clickhouse
+        log "done (Docker rootless ownership namespace)"
+        exit 0
+    fi
+fi
+
 # Pick an elevator: sudo if available and we're not already root.
 # If neither is possible, fall back to plain chown (may fail — log and
 # continue so the operator sees a clear warning rather than a silent abort).

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -48,7 +48,16 @@ else
     if [[ -f "$SCRIPT_DIR/lib/rootless-ownership.sh" ]]; then
         # shellcheck source=../../lib/rootless-ownership.sh
         source "$SCRIPT_DIR/lib/rootless-ownership.sh"
-        ods_is_rootless_docker && _phase06_rootless=true
+        _phase06_rootless_state=0
+        ods_docker_rootless_state || _phase06_rootless_state=$?
+        case "$_phase06_rootless_state" in
+            0) _phase06_rootless=true ;;
+            1) ;;
+            *)
+                error "Could not determine Docker rootless mode. Verify Docker access, then re-run the installer."
+                return 1
+                ;;
+        esac
     fi
 
     # Create directories

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -44,6 +44,13 @@ if $DRY_RUN; then
     [[ "$ENABLE_OPENCLAW" == "true" ]] && log "[DRY RUN] Would configure OpenClaw (model: $LLM_MODEL, config: ${OPENCLAW_CONFIG:-default})"
     log "[DRY RUN] Would validate .env against schema"
 else
+    _phase06_rootless=false
+    if [[ -f "$SCRIPT_DIR/lib/rootless-ownership.sh" ]]; then
+        # shellcheck source=../../lib/rootless-ownership.sh
+        source "$SCRIPT_DIR/lib/rootless-ownership.sh"
+        ods_is_rootless_docker && _phase06_rootless=true
+    fi
+
     # Create directories
     _phase06_step "create-directories"
     ods_progress 38 "directories" "Creating directory structure"
@@ -58,7 +65,8 @@ else
     # Upstream intentionally makes that directory 0700. A reinstall running
     # as the host user must not "repair" it back to uid 1000, or Hermes's web
     # status and ODS Talk JSON-RPC paths fail with PermissionError.
-    if [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
+    if ! $_phase06_rootless \
+        && [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
         sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
             warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
         sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
@@ -66,12 +74,14 @@ else
 
     # Fix ownership of data/config dirs that may have been created by containers
     # (e.g. SearXNG runs as uid 977, ComfyUI data owned by root)
-    for _data_dir in "$INSTALL_DIR"/data/*/; do
-        [[ "${ENABLE_HERMES:-false}" == "true" && "$_data_dir" == "$INSTALL_DIR/data/hermes/" ]] && continue
-        if [[ -d "$_data_dir" ]] && ! [[ -w "$_data_dir" ]]; then
-            sudo chown -R "$(id -u):$(id -g)" "$_data_dir" 2>/dev/null || true
-        fi
-    done
+    if ! $_phase06_rootless; then
+        for _data_dir in "$INSTALL_DIR"/data/*/; do
+            [[ "${ENABLE_HERMES:-false}" == "true" && "$_data_dir" == "$INSTALL_DIR/data/hermes/" ]] && continue
+            if [[ -d "$_data_dir" ]] && ! [[ -w "$_data_dir" ]]; then
+                sudo chown -R "$(id -u):$(id -g)" "$_data_dir" 2>/dev/null || true
+            fi
+        done
+    fi
     for _cfg_dir in "$INSTALL_DIR"/config/*/; do
         if [[ -d "$_cfg_dir" ]] && ! [[ -w "$_cfg_dir" ]]; then
             sudo chown -R "$(id -u):$(id -g)" "$_cfg_dir" 2>/dev/null || true
@@ -81,7 +91,9 @@ else
     # Ensure we can write to config/data subtrees (rsync will fail otherwise)
     if [[ "$SCRIPT_DIR" != "$INSTALL_DIR" ]]; then
         _cant_write=""
-        for _root in config data; do
+        _phase06_write_roots="config data"
+        $_phase06_rootless && _phase06_write_roots="config"
+        for _root in $_phase06_write_roots; do
             [[ -d "$INSTALL_DIR/$_root" ]] || continue
             for _d in "$INSTALL_DIR/$_root"/*/; do
                 [[ "${ENABLE_HERMES:-false}" == "true" && "$_d" == "$INSTALL_DIR/data/hermes/" ]] && continue
@@ -233,12 +245,16 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         # Pre-create data/openclaw so chown doesn't fail on a fresh install where
         # the directory hasn't been touched yet.
         mkdir -p "$INSTALL_DIR/data/openclaw"
-        chown -R 1000:1000 "$INSTALL_DIR/data/openclaw" "$INSTALL_DIR/config/openclaw/workspace" || warn "Failed to chown openclaw paths to 1000:1000 (non-fatal); container may need uid fixup"
+        if ! $_phase06_rootless; then
+            chown -R 1000:1000 "$INSTALL_DIR/data/openclaw" "$INSTALL_DIR/config/openclaw/workspace" || warn "Failed to chown openclaw paths to 1000:1000 (non-fatal); container may need uid fixup"
+        fi
     fi
 
-    # token-spy container runs as uid 1000 (baked in Dockerfile) — fix ownership
+    # Prepare service-specific ownership after compose selection is final.
     _phase06_step "prepare-service-permissions"
-    chown -R 1000:1000 "$INSTALL_DIR/data/token-spy" || warn "Failed to chown data/token-spy to 1000:1000 (non-fatal); container may crash if installer ran as a different uid"
+    if ! $_phase06_rootless; then
+        chown -R 1000:1000 "$INSTALL_DIR/data/token-spy" || warn "Failed to chown data/token-spy to 1000:1000 (non-fatal); container may crash if installer ran as a different uid"
+    fi
 
     # ── .env merge logic: preserve user-configured values on re-install ──
     _phase06_step "generate-env"
@@ -1000,6 +1016,18 @@ ENV_EOF
     chmod 600 "$INSTALL_DIR/.env"  # Secure secrets file
     ai_ok "Created $INSTALL_DIR"
     ai_ok "Generated secure secrets in .env (permissions: 600)"
+
+    # Apply rootless namespace ownership only after the final .env exists.
+    # This preserves legacy Token Spy key migration and makes UID/GID overrides
+    # from both fresh installs and reruns available to the ownership contract.
+    if $_phase06_rootless; then
+        export ODS_ROOTLESS_COMPOSE_FLAGS="${COMPOSE_FLAGS:-}"
+        if ! ods_fix_rootless_ownership "$INSTALL_DIR"; then
+            error "Docker rootless data ownership could not be prepared. Stop any affected ODS services, then re-run the installer."
+            return 1
+        fi
+        unset ODS_ROOTLESS_COMPOSE_FLAGS
+    fi
 
     # Generate LiteLLM config for Lemonade.
     # Lemonade exposes models as "extra.<GGUF_FILENAME>" — the wildcard

--- a/ods/lib/rootless-ownership.sh
+++ b/ods/lib/rootless-ownership.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Docker rootless bind-mount ownership helpers for native Linux.
+
+ODS_ROOTLESS_HELPER_IMAGE="${ODS_ROOTLESS_HELPER_IMAGE:-busybox:1.36.1}"
+
+ods_is_rootless_docker() {
+    case "${ODS_ASSUME_ROOTLESS:-}" in
+        1|true) return 0 ;;
+        0|false) return 1 ;;
+    esac
+    docker info --format '{{json .SecurityOptions}}' 2>/dev/null \
+        | grep -q '"name=rootless"\|rootless'
+}
+
+_ods_rootless_compose_flags() {
+    if [[ -n "${ODS_ROOTLESS_COMPOSE_FLAGS:-}" ]]; then
+        printf '%s\n' "$ODS_ROOTLESS_COMPOSE_FLAGS"
+    elif [[ -n "${INSTALL_DIR:-}" && -f "$INSTALL_DIR/.compose-flags" ]]; then
+        cat "$INSTALL_DIR/.compose-flags"
+    fi
+}
+
+_ods_rootless_service_enabled() {
+    local service="$1" flags="$2"
+
+    if [[ -n "$flags" ]]; then
+        case "$service" in
+            comfyui)
+                [[ "$flags" == *"extensions/services/comfyui/compose."* ]]
+                ;;
+            langfuse)
+                [[ "$flags" == *"extensions/services/langfuse/compose.yaml"* ]]
+                ;;
+            *)
+                [[ "$flags" == *"extensions/services/${service}/compose.yaml"* ]]
+                ;;
+        esac
+        return
+    fi
+
+    case "$service" in
+        ape|privacy-shield|token-spy) return 0 ;;
+        n8n)      [[ "${ENABLE_WORKFLOWS:-false}" == "true" ]] ;;
+        whisper)  [[ "${ENABLE_VOICE:-false}" == "true" ]] ;;
+        hermes)   [[ "${ENABLE_HERMES:-false}" == "true" ]] ;;
+        comfyui)  [[ "${ENABLE_COMFYUI:-false}" == "true" ]] ;;
+        langfuse) [[ "${ENABLE_LANGFUSE:-${LANGFUSE_ENABLED:-false}}" == "true" ]] ;;
+        *) return 1 ;;
+    esac
+}
+
+_ods_rootless_should_repair() {
+    local service="$1" flags="$2" target_service="${3:-}"
+
+    if [[ -n "$target_service" ]]; then
+        [[ "$service" == "$target_service" ]]
+        return
+    fi
+    _ods_rootless_service_enabled "$service" "$flags"
+}
+
+_ods_rootless_env_id_override() {
+    local install_dir="$1" key="$2" env_file="$install_dir/.env" value
+
+    [[ -f "$env_file" ]] || return 0
+    value=$(awk -v key="$key" '
+        index($0, key "=") == 1 { value = substr($0, length(key) + 2) }
+        END { print value }
+    ' "$env_file")
+    value="${value%$'\r'}"
+    if [[ "$value" =~ ^\"([0-9]+)\"$ || "$value" =~ ^\'([0-9]+)\'$ ]]; then
+        value="${BASH_REMATCH[1]}"
+    fi
+    [[ -z "$value" ]] && return 0
+    if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+        echo "[error] Invalid numeric $key override in $env_file: $value" >&2
+        return 1
+    fi
+    printf '%s\n' "$value"
+}
+
+_ods_rootless_resolve_target() {
+    local install_dir="$1" relative="$2" base target
+    base=$(readlink -f "$install_dir/data") || return 1
+    target=$(readlink -f "$install_dir/$relative") || return 1
+    case "$target" in
+        "$base"/*) printf '%s\n' "$target" ;;
+        *)
+            echo "[error] rootless ownership target escapes data/: $relative -> $target" >&2
+            return 1
+            ;;
+    esac
+}
+
+_ods_rootless_ensure_helper_image() {
+    if docker image inspect "$ODS_ROOTLESS_HELPER_IMAGE" >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "[ods] Pulling rootless ownership helper image $ODS_ROOTLESS_HELPER_IMAGE..."
+    if ! docker pull "$ODS_ROOTLESS_HELPER_IMAGE" >/dev/null; then
+        echo "[error] Could not pull $ODS_ROOTLESS_HELPER_IMAGE for rootless ownership repair." >&2
+        return 1
+    fi
+}
+
+_ods_rootless_container_state() {
+    local container="$1" states state
+
+    states=$(docker container ls -a --format '{{.Names}}:{{.State}}' 2>/dev/null) || {
+        echo "[error] Could not query Docker container state for $container." >&2
+        return 2
+    }
+    state=$(awk -F: -v name="$container" '$1 == name { print $2; exit }' <<<"$states")
+    case "$state" in
+        "") printf 'absent\n' ;;
+        exited|dead|created) printf 'stopped\n' ;;
+        running|restarting|paused|removing) printf 'running\n' ;;
+        *)
+            echo "[error] Unexpected container state for $container: $state" >&2
+            return 2
+            ;;
+    esac
+}
+
+_ods_rootless_stat_metadata() {
+    local target="$1"
+    docker run --rm --pull never --user 0:0 --network none \
+        -v "$target:/data:ro" \
+        "$ODS_ROOTLESS_HELPER_IMAGE" \
+        stat -c '%u:%g:%a' /data 2>/dev/null
+}
+
+_ods_rootless_fix_directory() {
+    local install_dir="$1" relative="$2" owner="$3" container="${4:-}" mode="${5:-}"
+    local target metadata current_owner current_mode container_state
+
+    [[ "$owner" =~ ^[0-9]+:[0-9]+$ ]] || {
+        echo "[error] Invalid rootless ownership value '$owner' for $relative." >&2
+        return 1
+    }
+    [[ -z "$mode" || "$mode" =~ ^[0-7]{3,4}$ ]] || {
+        echo "[error] Invalid rootless mode '$mode' for $relative." >&2
+        return 1
+    }
+    [[ -d "$install_dir/$relative" ]] || return 0
+    [[ ! -L "$install_dir/$relative" ]] || {
+        echo "[error] Refusing rootless ownership repair for symlink: $relative" >&2
+        return 1
+    }
+    target=$(_ods_rootless_resolve_target "$install_dir" "$relative") || return 1
+    metadata=$(_ods_rootless_stat_metadata "$target") || {
+        echo "[error] Could not inspect rootless ownership for $relative." >&2
+        return 1
+    }
+    current_owner="${metadata%:*}"
+    current_mode="${metadata##*:}"
+
+    if [[ -n "$container" ]]; then
+        container_state=$(_ods_rootless_container_state "$container") || return 1
+    else
+        container_state="absent"
+    fi
+    if [[ "$container_state" == "running" ]]; then
+        if [[ "$current_owner" == "$owner" && ( -z "$mode" || "$current_mode" == "$mode" ) ]]; then
+            echo "[ods]   $relative already matches $owner${mode:+ mode $mode}; $container is running"
+            return 0
+        fi
+        echo "[error] Refusing recursive ownership repair while $container is running." >&2
+        echo "        Current metadata: $current_owner mode $current_mode; expected: $owner${mode:+ mode $mode}." >&2
+        echo "        Stop the affected service or ODS, then run: ods repair rootless-ownership" >&2
+        return 1
+    fi
+
+    if ! docker run --rm --pull never --user 0:0 --network none \
+        -v "$target:/data" \
+        "$ODS_ROOTLESS_HELPER_IMAGE" \
+        chown -R "$owner" /data; then
+        echo "[error] Failed to set $relative ownership to $owner in the rootless namespace." >&2
+        return 1
+    fi
+    if [[ -n "$mode" ]] && ! docker run --rm --pull never --user 0:0 --network none \
+        -v "$target:/data" \
+        "$ODS_ROOTLESS_HELPER_IMAGE" \
+        chmod "$mode" /data; then
+        echo "[error] Failed to set $relative mode to $mode in the rootless namespace." >&2
+        return 1
+    fi
+    metadata=$(_ods_rootless_stat_metadata "$target") || return 1
+    current_owner="${metadata%:*}"
+    current_mode="${metadata##*:}"
+    if [[ "$current_owner" != "$owner" || ( -n "$mode" && "$current_mode" != "$mode" ) ]]; then
+        echo "[error] Rootless metadata verification failed for $relative:" >&2
+        echo "        expected $owner${mode:+ mode $mode}, got $current_owner mode $current_mode." >&2
+        return 1
+    fi
+    echo "[ods]   $relative -> $owner${mode:+ mode $mode}"
+}
+
+ods_fix_rootless_ownership() {
+    local install_dir="${1:-${INSTALL_DIR:-}}" target_service="${2:-}" flags failures=0
+    local uid_override gid_override service_uid service_gid hermes_uid hermes_gid
+
+    [[ -n "$install_dir" ]] || {
+        echo "[error] INSTALL_DIR is required for rootless ownership repair." >&2
+        return 2
+    }
+    if [[ -n "$target_service" ]]; then
+        case "$target_service" in
+            ape|comfyui|hermes|langfuse|n8n|privacy-shield|token-spy|whisper) ;;
+            *) return 0 ;;
+        esac
+    fi
+    ods_is_rootless_docker || return 0
+    [[ "$(uname -s)" == "Linux" ]] || return 0
+    _ods_rootless_ensure_helper_image || return 1
+    flags=$(_ods_rootless_compose_flags)
+    uid_override=$(_ods_rootless_env_id_override "$install_dir" UID) || return 1
+    gid_override=$(_ods_rootless_env_id_override "$install_dir" GID) || return 1
+    service_uid="${uid_override:-1000}"
+    service_gid="${gid_override:-1000}"
+    hermes_uid="${uid_override:-10000}"
+    hermes_gid="${gid_override:-10000}"
+
+    echo "[ods] Verifying bind-mount ownership for Docker rootless mode..."
+
+    if _ods_rootless_should_repair token-spy "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/token-spy 1000:1000 ods-token-spy || failures=$((failures + 1))
+    fi
+    if _ods_rootless_should_repair privacy-shield "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/privacy-shield "$service_uid:$service_gid" ods-privacy-shield || failures=$((failures + 1))
+    fi
+    if _ods_rootless_should_repair ape "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/ape 100:100 ods-ape || failures=$((failures + 1))
+    fi
+    if _ods_rootless_should_repair n8n "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/n8n "$service_uid:$service_gid" ods-n8n || failures=$((failures + 1))
+    fi
+    if _ods_rootless_should_repair whisper "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/whisper 1000:1000 ods-whisper || failures=$((failures + 1))
+    fi
+    if _ods_rootless_should_repair hermes "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/hermes "$hermes_uid:$hermes_gid" ods-hermes 700 || failures=$((failures + 1))
+    fi
+    if [[ "${GPU_BACKEND:-}" == "nvidia" ]] && _ods_rootless_should_repair comfyui "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/comfyui 1000:1000 ods-comfyui || failures=$((failures + 1))
+    fi
+    if _ods_rootless_should_repair langfuse "$flags" "$target_service"; then
+        _ods_rootless_fix_directory "$install_dir" data/langfuse/postgres 70:70 ods-langfuse-postgres || failures=$((failures + 1))
+        _ods_rootless_fix_directory "$install_dir" data/langfuse/clickhouse 101:101 ods-langfuse-clickhouse || failures=$((failures + 1))
+    fi
+
+    if [[ "$failures" -ne 0 ]]; then
+        echo "[error] Rootless ownership repair failed for $failures path(s)." >&2
+        return 1
+    fi
+    echo "[ods] Rootless ownership is ready."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    ods_fix_rootless_ownership "${1:-}" "${2:-}"
+fi

--- a/ods/lib/rootless-ownership.sh
+++ b/ods/lib/rootless-ownership.sh
@@ -212,15 +212,11 @@ _ods_rootless_fix_directory() {
     else
         container_state="absent"
     fi
-    if [[ "$current_owner" == "$owner" && ( -z "$mode" || "$current_mode" == "$mode" ) ]]; then
-        if [[ "$container_state" == "running" ]]; then
-            echo "[ods]   $relative already matches $owner${mode:+ mode $mode}; $container is running"
-        else
-            echo "[ods]   $relative already matches $owner${mode:+ mode $mode}"
-        fi
-        return 0
-    fi
     if [[ "$container_state" == "running" ]]; then
+        if [[ "$current_owner" == "$owner" && ( -z "$mode" || "$current_mode" == "$mode" ) ]]; then
+            echo "[ods]   $relative already matches $owner${mode:+ mode $mode}; $container is running"
+            return 0
+        fi
         echo "[error] Refusing recursive ownership repair while $container is running." >&2
         echo "        Current metadata: $current_owner mode $current_mode; expected: $owner${mode:+ mode $mode}." >&2
         echo "        Stop the affected service or ODS, then run: ods repair rootless-ownership" >&2

--- a/ods/lib/rootless-ownership.sh
+++ b/ods/lib/rootless-ownership.sh
@@ -3,13 +3,24 @@
 
 ODS_ROOTLESS_HELPER_IMAGE="${ODS_ROOTLESS_HELPER_IMAGE:-busybox:1.36.1}"
 
-ods_is_rootless_docker() {
+ods_docker_rootless_state() {
     case "${ODS_ASSUME_ROOTLESS:-}" in
         1|true) return 0 ;;
         0|false) return 1 ;;
     esac
-    docker info --format '{{json .SecurityOptions}}' 2>/dev/null \
-        | grep -q '"name=rootless"\|rootless'
+
+    local security_options
+    if ! security_options=$(docker info --format '{{json .SecurityOptions}}' 2>/dev/null); then
+        echo "[error] Could not determine whether Docker is running in rootless mode." >&2
+        return 2
+    fi
+    grep -q '"name=rootless"\|rootless' <<<"$security_options"
+}
+
+ods_is_rootless_docker() {
+    local state_rc=0
+    ods_docker_rootless_state || state_rc=$?
+    [[ "$state_rc" -eq 0 ]]
 }
 
 _ods_rootless_compose_flags() {
@@ -60,7 +71,8 @@ _ods_rootless_should_repair() {
 }
 
 _ods_rootless_env_id_override() {
-    local install_dir="$1" key="$2" env_file="$install_dir/.env" value
+    local install_dir="$1" key="$2" value
+    local env_file="$install_dir/.env"
 
     [[ -f "$env_file" ]] || return 0
     value=$(awk -v key="$key" '
@@ -68,6 +80,9 @@ _ods_rootless_env_id_override() {
         END { print value }
     ' "$env_file")
     value="${value%$'\r'}"
+    if [[ "$value" == '""' || "$value" == "''" ]]; then
+        value=""
+    fi
     if [[ "$value" =~ ^\"([0-9]+)\"$ || "$value" =~ ^\'([0-9]+)\'$ ]]; then
         value="${BASH_REMATCH[1]}"
     fi
@@ -101,6 +116,47 @@ _ods_rootless_ensure_helper_image() {
         echo "[error] Could not pull $ODS_ROOTLESS_HELPER_IMAGE for rootless ownership repair." >&2
         return 1
     fi
+}
+
+_ods_rootless_ensure_directory() {
+    local install_dir="$1" relative="$2" data_root subpath
+
+    case "$relative" in
+        data/*) subpath="${relative#data/}" ;;
+        *)
+            echo "[error] Refusing rootless ownership path outside data/: $relative" >&2
+            return 1
+            ;;
+    esac
+    [[ -n "$subpath" ]] || return 1
+    case "/$subpath/" in
+        */../*)
+            echo "[error] Refusing rootless ownership path traversal: $relative" >&2
+            return 1
+            ;;
+    esac
+
+    [[ ! -L "$install_dir/$relative" ]] || {
+        echo "[error] Refusing rootless ownership repair for symlink: $relative" >&2
+        return 1
+    }
+    [[ -d "$install_dir/$relative" ]] && return 0
+
+    data_root=$(readlink -f "$install_dir/data") || {
+        echo "[error] Could not resolve the ODS data directory: $install_dir/data" >&2
+        return 1
+    }
+    if ! docker run --rm --pull never --user 0:0 --network none \
+        -v "$data_root:/ods-data" \
+        "$ODS_ROOTLESS_HELPER_IMAGE" \
+        mkdir -p "/ods-data/$subpath"; then
+        echo "[error] Could not create rootless ownership target: $relative" >&2
+        return 1
+    fi
+    [[ -d "$install_dir/$relative" ]] || {
+        echo "[error] Rootless ownership target was not created: $relative" >&2
+        return 1
+    }
 }
 
 _ods_rootless_container_state() {
@@ -142,11 +198,7 @@ _ods_rootless_fix_directory() {
         echo "[error] Invalid rootless mode '$mode' for $relative." >&2
         return 1
     }
-    [[ -d "$install_dir/$relative" ]] || return 0
-    [[ ! -L "$install_dir/$relative" ]] || {
-        echo "[error] Refusing rootless ownership repair for symlink: $relative" >&2
-        return 1
-    }
+    _ods_rootless_ensure_directory "$install_dir" "$relative" || return 1
     target=$(_ods_rootless_resolve_target "$install_dir" "$relative") || return 1
     metadata=$(_ods_rootless_stat_metadata "$target") || {
         echo "[error] Could not inspect rootless ownership for $relative." >&2
@@ -160,11 +212,15 @@ _ods_rootless_fix_directory() {
     else
         container_state="absent"
     fi
-    if [[ "$container_state" == "running" ]]; then
-        if [[ "$current_owner" == "$owner" && ( -z "$mode" || "$current_mode" == "$mode" ) ]]; then
+    if [[ "$current_owner" == "$owner" && ( -z "$mode" || "$current_mode" == "$mode" ) ]]; then
+        if [[ "$container_state" == "running" ]]; then
             echo "[ods]   $relative already matches $owner${mode:+ mode $mode}; $container is running"
-            return 0
+        else
+            echo "[ods]   $relative already matches $owner${mode:+ mode $mode}"
         fi
+        return 0
+    fi
+    if [[ "$container_state" == "running" ]]; then
         echo "[error] Refusing recursive ownership repair while $container is running." >&2
         echo "        Current metadata: $current_owner mode $current_mode; expected: $owner${mode:+ mode $mode}." >&2
         echo "        Stop the affected service or ODS, then run: ods repair rootless-ownership" >&2
@@ -198,7 +254,7 @@ _ods_rootless_fix_directory() {
 
 ods_fix_rootless_ownership() {
     local install_dir="${1:-${INSTALL_DIR:-}}" target_service="${2:-}" flags failures=0
-    local uid_override gid_override service_uid service_gid hermes_uid hermes_gid
+    local uid_override gid_override service_uid service_gid hermes_uid hermes_gid rootless_state=0
 
     [[ -n "$install_dir" ]] || {
         echo "[error] INSTALL_DIR is required for rootless ownership repair." >&2
@@ -210,7 +266,12 @@ ods_fix_rootless_ownership() {
             *) return 0 ;;
         esac
     fi
-    ods_is_rootless_docker || return 0
+    ods_docker_rootless_state || rootless_state=$?
+    case "$rootless_state" in
+        0) ;;
+        1) return 0 ;;
+        *) return 1 ;;
+    esac
     [[ "$(uname -s)" == "Linux" ]] || return 0
     _ods_rootless_ensure_helper_image || return 1
     flags=$(_ods_rootless_compose_flags)

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -5994,10 +5994,6 @@ cmd_repair() {
             [[ -f "$script" ]] || error "Rootless ownership helper not found: $script"
             # shellcheck source=lib/rootless-ownership.sh
             source "$script"
-            if ! ods_is_rootless_docker; then
-                log "Docker is not running in rootless mode; no ownership repair is required."
-                return 0
-            fi
             ods_fix_rootless_ownership "$INSTALL_DIR"
             ;;
         voice|stt|tts)

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1480,6 +1480,10 @@ cmd_restart() {
         resolved_service=$(resolve_service "$resolved_service")
     fi
 
+    if ! _ods_cli_repair_rootless_ownership "$resolved_service"; then
+        error "Rootless bind-mount ownership is not ready; service restart was cancelled."
+    fi
+
     local refresh_soul="false"
     if [[ -z "$resolved_service" || "$resolved_service" == "hermes" ]]; then
         refresh_soul="true"
@@ -1634,6 +1638,16 @@ cmd_stop() {
     fi
 }
 
+_ods_cli_repair_rootless_ownership() {
+    local service="${1:-}"
+    local helper="$INSTALL_DIR/lib/rootless-ownership.sh"
+
+    [[ -f "$helper" ]] || return 0
+    # shellcheck source=lib/rootless-ownership.sh
+    source "$helper"
+    ods_fix_rootless_ownership "$INSTALL_DIR" "$service"
+}
+
 cmd_start() {
     check_install
     cd "$INSTALL_DIR"
@@ -1677,6 +1691,10 @@ cmd_start() {
         ensure_llama_cpu_budget
         flags_str=$(get_compose_flags)
         read -ra flags <<< "$flags_str"
+    fi
+
+    if ! _ods_cli_repair_rootless_ownership "$resolved_service"; then
+        error "Rootless bind-mount ownership is not ready; service start was cancelled."
     fi
 
     if [[ -z "$resolved_service" ]]; then
@@ -5971,6 +5989,17 @@ cmd_repair() {
             [[ -x "$script" ]] || error "Hermes slash worker repair script not found or not executable: $script"
             "$script" --force
             ;;
+        rootless-ownership|rootless)
+            local script="$INSTALL_DIR/lib/rootless-ownership.sh"
+            [[ -f "$script" ]] || error "Rootless ownership helper not found: $script"
+            # shellcheck source=lib/rootless-ownership.sh
+            source "$script"
+            if ! ods_is_rootless_docker; then
+                log "Docker is not running in rootless mode; no ownership repair is required."
+                return 0
+            fi
+            ods_fix_rootless_ownership "$INSTALL_DIR"
+            ;;
         voice|stt|tts)
             local flags_str
             flags_str=$(get_compose_flags)
@@ -6031,7 +6060,7 @@ cmd_repair() {
             success "Voice repair complete"
             ;;
         *)
-            log "Usage: ods repair [voice|hermes-workers]"
+            log "Usage: ods repair [voice|hermes-workers|rootless-ownership]"
             log_error "Unknown repair target: $target"
             return 1
             ;;
@@ -6380,6 +6409,7 @@ ${CYAN}Examples:${NC}
   ods agent status              # Check host agent health
   ods agent restart             # Restart host agent
   ods repair voice              # Start voice services and cache STT model
+  ods repair rootless-ownership # Repair active bind mounts for rootless Docker
   ods repair hermes-workers     # Prune leaked Hermes slash_worker children
 
 ${CYAN}Environment:${NC}

--- a/ods/tests/test-rootless-docker-ownership.sh
+++ b/ods/tests/test-rootless-docker-ownership.sh
@@ -30,6 +30,16 @@ pass "helper parses"
 ) || fail "rootless detection override"
 pass "rootless detection has deterministic test override"
 
+(
+    source "$LIB"
+    unset ODS_ASSUME_ROOTLESS
+    docker() { return 1; }
+    state_rc=0
+    ods_docker_rootless_state || state_rc=$?
+    [[ "$state_rc" -eq 2 ]]
+) || fail "docker-info failure was treated as rootful"
+pass "indeterminate Docker rootless state fails closed"
+
 INSTALL_DIR="$TMP_DIR/ods"
 mkdir -p "$INSTALL_DIR/data"/{ape,privacy-shield,token-spy,n8n,whisper,hermes,comfyui}
 mkdir -p "$INSTALL_DIR/data/langfuse"/{postgres,clickhouse}
@@ -38,7 +48,7 @@ CALLS="$TMP_DIR/calls"
 : > "$CALLS"
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 0; }
+    ods_docker_rootless_state() { return 0; }
     uname() { printf 'Linux\n'; }
     _ods_rootless_ensure_helper_image() { return 0; }
     _ods_rootless_fix_directory() {
@@ -56,7 +66,7 @@ pass "only active compose services are repaired"
 : > "$CALLS"
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 0; }
+    ods_docker_rootless_state() { return 0; }
     uname() { printf 'Linux\n'; }
     _ods_rootless_ensure_helper_image() { return 0; }
     _ods_rootless_fix_directory() {
@@ -74,7 +84,7 @@ pass "targeted repair covers newly enabled service only"
 : > "$CALLS"
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 0; }
+    ods_docker_rootless_state() { return 0; }
     uname() { printf 'Linux\n'; }
     _ods_rootless_ensure_helper_image() { return 0; }
     _ods_rootless_fix_directory() {
@@ -92,7 +102,7 @@ pass "backend-specific and nested database ownership is mapped"
 : > "$CALLS"
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 0; }
+    ods_docker_rootless_state() { return 0; }
     uname() { printf 'Linux\n'; }
     _ods_rootless_ensure_helper_image() { return 0; }
     _ods_rootless_fix_directory() {
@@ -112,7 +122,7 @@ GID=12002
 EOF
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 0; }
+    ods_docker_rootless_state() { return 0; }
     uname() { printf 'Linux\n'; }
     _ods_rootless_ensure_helper_image() { return 0; }
     _ods_rootless_fix_directory() {
@@ -127,12 +137,34 @@ grep -q '^data/hermes|12001:12002$' "$CALLS" || fail "Hermes ignored UID/GID ove
 pass "compose UID/GID overrides are preserved"
 
 cat > "$INSTALL_DIR/.env" <<'EOF'
+UID=""
+GID=''
+EOF
+: > "$CALLS"
+(
+    source "$LIB"
+    ods_docker_rootless_state() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s|%s\n' "$2" "$3" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f extensions/services/privacy-shield/compose.yaml -f extensions/services/hermes/compose.yaml"
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+)
+grep -q '^data/privacy-shield|1000:1000$' "$CALLS" \
+    || fail "quoted empty UID/GID did not use the compose default"
+grep -q '^data/hermes|10000:10000$' "$CALLS" \
+    || fail "quoted empty UID/GID did not use the Hermes compose default"
+pass "empty UID/GID overrides follow compose default semantics"
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
 UID=not-a-number
 GID=12002
 EOF
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 0; }
+    ods_docker_rootless_state() { return 0; }
     uname() { printf 'Linux\n'; }
     _ods_rootless_ensure_helper_image() { return 0; }
     _ods_rootless_fix_directory() { fail "invalid UID reached mutation"; }
@@ -145,7 +177,7 @@ rm -f "$INSTALL_DIR/.env"
 : > "$CALLS"
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 0; }
+    ods_docker_rootless_state() { return 0; }
     uname() { printf 'Linux\n'; }
     _ods_rootless_ensure_helper_image() { return 0; }
     _ods_rootless_fix_directory() {
@@ -160,11 +192,39 @@ pass "AMD ComfyUI is excluded from the NVIDIA UID contract"
 
 (
     source "$LIB"
-    ods_is_rootless_docker() { return 1; }
+    ods_docker_rootless_state() { return 1; }
     _ods_rootless_ensure_helper_image() { fail "rootful path pulled helper image"; }
     ods_fix_rootless_ownership "$INSTALL_DIR"
 ) || fail "rootful no-op failed"
 pass "rootful Docker is a side-effect-free no-op"
+
+for platform in Darwin MINGW64_NT-10.0; do
+    (
+        source "$LIB"
+        ods_docker_rootless_state() { return 0; }
+        uname() { printf '%s\n' "$platform"; }
+        _ods_rootless_ensure_helper_image() { fail "$platform path pulled helper image"; }
+        ods_fix_rootless_ownership "$INSTALL_DIR"
+    ) || fail "$platform no-op failed"
+done
+pass "macOS and Windows are side-effect-free no-ops"
+
+rm -rf "$INSTALL_DIR/data/comfyui"
+: > "$CALLS"
+(
+    source "$LIB"
+    ods_docker_rootless_state() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s\n' "$2" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f docker-compose.base.yml"
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+)
+[[ ! -e "$INSTALL_DIR/data/comfyui" && ! -s "$CALLS" ]] \
+    || fail "disabled service data was created or repaired"
+pass "disabled services remain untouched"
 
 mkdir -p "$TMP_DIR/outside"
 ln -s "$TMP_DIR/outside" "$INSTALL_DIR/data/escape"
@@ -175,6 +235,40 @@ ln -s "$TMP_DIR/outside" "$INSTALL_DIR/data/escape"
 ) || fail "symlink target was accepted"
 pass "symlink escape is rejected"
 
+ln -s "$TMP_DIR/does-not-exist" "$INSTALL_DIR/data/dangling"
+(
+    source "$LIB"
+    ! _ods_rootless_fix_directory "$INSTALL_DIR" data/dangling 1000:1000 ods-dangling
+) || fail "dangling symlink target was accepted"
+pass "dangling symlink is rejected before creation"
+
+rm -rf "$INSTALL_DIR/data/comfyui"
+CREATE_CALLS="$TMP_DIR/create-calls"
+: > "$CREATE_CALLS"
+(
+    source "$LIB"
+    _ods_rootless_ensure_helper_image() { return 0; }
+    docker() {
+        printf '%s\n' "$*" >> "$CREATE_CALLS"
+        if [[ "$*" == *"mkdir -p /ods-data/comfyui"* ]]; then
+            mkdir -p "$INSTALL_DIR/data/comfyui"
+        fi
+        return 0
+    }
+    _ods_rootless_stat_metadata() {
+        if [[ "$(wc -l < "$CREATE_CALLS" | tr -d ' ')" -le 1 ]]; then
+            printf '0:0:755\n'
+        else
+            printf '1000:1000:755\n'
+        fi
+    }
+    _ods_rootless_container_state() { printf 'absent\n'; }
+    _ods_rootless_fix_directory "$INSTALL_DIR" data/comfyui 1000:1000 ods-comfyui
+) || fail "missing active directory was not created and repaired"
+grep -q 'mkdir -p /ods-data/comfyui' "$CREATE_CALLS" \
+    || fail "missing active directory did not use the rootless helper namespace"
+pass "missing active directory is created before ownership repair"
+
 (
     source "$LIB"
     _ods_rootless_stat_metadata() { printf '1000:1000:755\n'; }
@@ -182,6 +276,15 @@ pass "symlink escape is rejected"
     _ods_rootless_fix_directory "$INSTALL_DIR" data/token-spy 1000:1000 ods-token-spy
 ) || fail "running container with correct ownership was rejected"
 pass "healthy running service is not mutated"
+
+(
+    source "$LIB"
+    _ods_rootless_stat_metadata() { printf '1000:1000:755\n'; }
+    _ods_rootless_container_state() { printf 'stopped\n'; }
+    docker() { fail "idempotent rerun reached mutation"; }
+    _ods_rootless_fix_directory "$INSTALL_DIR" data/token-spy 1000:1000 ods-token-spy
+) || fail "idempotent stopped-service rerun failed"
+pass "second repair skips already-correct stopped services"
 
 (
     source "$LIB"

--- a/ods/tests/test-rootless-docker-ownership.sh
+++ b/ods/tests/test-rootless-docker-ownership.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$ROOT_DIR/lib/rootless-ownership.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+pass_count=0
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+pass() {
+    pass_count=$((pass_count + 1))
+    echo "PASS: $*"
+}
+
+[[ -s "$LIB" ]] || fail "rootless ownership helper is missing"
+bash -n "$LIB"
+pass "helper parses"
+
+(
+    # shellcheck source=../lib/rootless-ownership.sh
+    source "$LIB"
+    ODS_ASSUME_ROOTLESS=1
+    ods_is_rootless_docker
+    ODS_ASSUME_ROOTLESS=0
+    ! ods_is_rootless_docker
+) || fail "rootless detection override"
+pass "rootless detection has deterministic test override"
+
+INSTALL_DIR="$TMP_DIR/ods"
+mkdir -p "$INSTALL_DIR/data"/{ape,privacy-shield,token-spy,n8n,whisper,hermes,comfyui}
+mkdir -p "$INSTALL_DIR/data/langfuse"/{postgres,clickhouse}
+
+CALLS="$TMP_DIR/calls"
+: > "$CALLS"
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s|%s|%s\n' "$2" "$3" "$4" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f docker-compose.base.yml -f extensions/services/token-spy/compose.yaml -f extensions/services/n8n/compose.yaml"
+    GPU_BACKEND=nvidia
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+)
+grep -q '^data/token-spy|1000:1000|ods-token-spy$' "$CALLS" || fail "active core service was skipped"
+grep -q '^data/n8n|1000:1000|ods-n8n$' "$CALLS" || fail "active optional service was skipped"
+[[ "$(wc -l < "$CALLS" | tr -d ' ')" == "2" ]] || fail "disabled service directories were modified"
+pass "only active compose services are repaired"
+
+: > "$CALLS"
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s|%s\n' "$2" "$3" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f extensions/services/token-spy/compose.yaml"
+    ods_fix_rootless_ownership "$INSTALL_DIR" hermes
+)
+grep -q '^data/hermes|10000:10000$' "$CALLS" \
+    || fail "explicitly enabled target was not repaired"
+[[ "$(wc -l < "$CALLS" | tr -d ' ')" == "1" ]] \
+    || fail "targeted repair modified unrelated active services"
+pass "targeted repair covers newly enabled service only"
+
+: > "$CALLS"
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s|%s\n' "$2" "$3" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f extensions/services/comfyui/compose.nvidia.yaml -f extensions/services/langfuse/compose.yaml"
+    GPU_BACKEND=nvidia
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+)
+grep -q '^data/comfyui|1000:1000$' "$CALLS" || fail "NVIDIA ComfyUI ownership missing"
+grep -q '^data/langfuse/postgres|70:70$' "$CALLS" || fail "Langfuse postgres ownership missing"
+grep -q '^data/langfuse/clickhouse|101:101$' "$CALLS" || fail "Langfuse clickhouse ownership missing"
+pass "backend-specific and nested database ownership is mapped"
+
+: > "$CALLS"
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s|%s|%s\n' "$2" "$3" "$5" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f extensions/services/hermes/compose.yaml"
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+)
+grep -q '^data/hermes|10000:10000|700$' "$CALLS" \
+    || fail "Hermes ownership/mode contract is incomplete"
+pass "Hermes keeps UID 10000 and mode 0700"
+
+: > "$CALLS"
+cat > "$INSTALL_DIR/.env" <<'EOF'
+UID=12001
+GID=12002
+EOF
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s|%s\n' "$2" "$3" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f extensions/services/privacy-shield/compose.yaml -f extensions/services/n8n/compose.yaml -f extensions/services/hermes/compose.yaml"
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+)
+grep -q '^data/privacy-shield|12001:12002$' "$CALLS" || fail "Privacy Shield ignored UID/GID override"
+grep -q '^data/n8n|12001:12002$' "$CALLS" || fail "n8n ignored UID/GID override"
+grep -q '^data/hermes|12001:12002$' "$CALLS" || fail "Hermes ignored UID/GID override"
+pass "compose UID/GID overrides are preserved"
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
+UID=not-a-number
+GID=12002
+EOF
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() { fail "invalid UID reached mutation"; }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f extensions/services/n8n/compose.yaml"
+    ! ods_fix_rootless_ownership "$INSTALL_DIR"
+) || fail "invalid UID override was accepted"
+pass "invalid UID/GID override fails before mutation"
+rm -f "$INSTALL_DIR/.env"
+
+: > "$CALLS"
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 0; }
+    uname() { printf 'Linux\n'; }
+    _ods_rootless_ensure_helper_image() { return 0; }
+    _ods_rootless_fix_directory() {
+        printf '%s\n' "$2" >> "$CALLS"
+    }
+    ODS_ROOTLESS_COMPOSE_FLAGS="-f extensions/services/comfyui/compose.amd.yaml"
+    GPU_BACKEND=amd
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+)
+[[ ! -s "$CALLS" ]] || fail "AMD ComfyUI root-owned paths were remapped to UID 1000"
+pass "AMD ComfyUI is excluded from the NVIDIA UID contract"
+
+(
+    source "$LIB"
+    ods_is_rootless_docker() { return 1; }
+    _ods_rootless_ensure_helper_image() { fail "rootful path pulled helper image"; }
+    ods_fix_rootless_ownership "$INSTALL_DIR"
+) || fail "rootful no-op failed"
+pass "rootful Docker is a side-effect-free no-op"
+
+mkdir -p "$TMP_DIR/outside"
+ln -s "$TMP_DIR/outside" "$INSTALL_DIR/data/escape"
+(
+    source "$LIB"
+    _ods_rootless_ensure_helper_image() { return 0; }
+    ! _ods_rootless_fix_directory "$INSTALL_DIR" data/escape 1000:1000 ods-escape
+) || fail "symlink target was accepted"
+pass "symlink escape is rejected"
+
+(
+    source "$LIB"
+    _ods_rootless_stat_metadata() { printf '1000:1000:755\n'; }
+    _ods_rootless_container_state() { printf 'running\n'; }
+    _ods_rootless_fix_directory "$INSTALL_DIR" data/token-spy 1000:1000 ods-token-spy
+) || fail "running container with correct ownership was rejected"
+pass "healthy running service is not mutated"
+
+(
+    source "$LIB"
+    _ods_rootless_stat_metadata() { printf '0:0:755\n'; }
+    _ods_rootless_container_state() { printf 'running\n'; }
+    ! _ods_rootless_fix_directory "$INSTALL_DIR" data/token-spy 1000:1000 ods-token-spy
+) || fail "live recursive chown was allowed"
+pass "mismatched running service fails closed"
+
+(
+    source "$LIB"
+    _ods_rootless_stat_metadata() { printf '10000:10000:755\n'; }
+    _ods_rootless_container_state() { printf 'running\n'; }
+    ! _ods_rootless_fix_directory "$INSTALL_DIR" data/hermes 10000:10000 ods-hermes 700
+) || fail "running Hermes with an unsafe mode was accepted"
+pass "running service mode mismatch fails closed"
+
+(
+    source "$LIB"
+    _ods_rootless_stat_metadata() { printf '0:0:755\n'; }
+    _ods_rootless_container_state() { return 2; }
+    docker() { fail "container-state failure reached mutation"; }
+    ! _ods_rootless_fix_directory "$INSTALL_DIR" data/token-spy 1000:1000 ods-token-spy
+) || fail "container-state query failure was treated as stopped"
+pass "container-state query failure fails closed"
+
+METADATA_CALLS="$TMP_DIR/metadata-calls"
+DOCKER_CALLS="$TMP_DIR/docker-calls"
+: > "$METADATA_CALLS"
+: > "$DOCKER_CALLS"
+(
+    source "$LIB"
+    _ods_rootless_stat_metadata() {
+        local count
+        count=$(wc -l < "$METADATA_CALLS" | tr -d ' ')
+        printf 'called\n' >> "$METADATA_CALLS"
+        if [[ "$count" == "0" ]]; then
+            printf '0:0:755\n'
+        else
+            printf '10000:10000:700\n'
+        fi
+    }
+    _ods_rootless_container_state() { printf 'stopped\n'; }
+    docker() {
+        printf '%s\n' "$*" >> "$DOCKER_CALLS"
+        return 0
+    }
+    _ods_rootless_fix_directory "$INSTALL_DIR" data/hermes 10000:10000 ods-hermes 700
+) || fail "stopped Hermes repair did not complete"
+grep -q 'chown -R 10000:10000 /data' "$DOCKER_CALLS" || fail "stopped repair skipped recursive chown"
+grep -q 'chmod 700 /data' "$DOCKER_CALLS" || fail "stopped repair skipped mode correction"
+[[ "$(wc -l < "$METADATA_CALLS" | tr -d ' ')" == "2" ]] || fail "stopped repair was not verified"
+pass "stopped service repair is applied and verified"
+
+(
+    source "$LIB"
+    _ods_rootless_stat_metadata() { printf '0:0:755\n'; }
+    _ods_rootless_container_state() { printf 'stopped\n'; }
+    docker() { return 1; }
+    ! _ods_rootless_fix_directory "$INSTALL_DIR" data/token-spy 1000:1000 ods-token-spy
+) || fail "chown failure was swallowed"
+pass "helper failure propagates"
+
+grep -q 'ods_fix_rootless_ownership' "$ROOT_DIR/installers/phases/06-directories.sh" \
+    || fail "phase 06 does not invoke ownership repair"
+env_chmod_line=$(grep -n 'chmod 600 "$INSTALL_DIR/.env"' "$ROOT_DIR/installers/phases/06-directories.sh" | cut -d: -f1)
+phase_repair_line=$(grep -n 'ods_fix_rootless_ownership "$INSTALL_DIR"' "$ROOT_DIR/installers/phases/06-directories.sh" | cut -d: -f1)
+[[ -n "$env_chmod_line" && -n "$phase_repair_line" && "$phase_repair_line" -gt "$env_chmod_line" ]] \
+    || fail "phase 06 rootless repair must run after final .env generation"
+grep -q 'rootless-ownership|rootless)' "$ROOT_DIR/ods-cli" \
+    || fail "CLI repair command is missing"
+grep -q '_ods_rootless_fix_directory.*data/langfuse/postgres' \
+    "$ROOT_DIR/extensions/services/langfuse/hooks/post_install.sh" \
+    || fail "Langfuse post-install rootless path is missing"
+grep -q '"DOCKER_HOST", "XDG_RUNTIME_DIR"' "$ROOT_DIR/bin/ods-host-agent.py" \
+    || fail "host-agent hook drops rootless Docker routing variables"
+grep -q '_repair_rootless_data_ownership(service_id)' "$ROOT_DIR/bin/ods-host-agent.py" \
+    || fail "host-agent start path omits rootless ownership repair"
+grep -q '_ods_cli_repair_rootless_ownership "$resolved_service"' "$ROOT_DIR/ods-cli" \
+    || fail "CLI start path omits rootless ownership repair"
+[[ "$(grep -c '_ods_cli_repair_rootless_ownership "$resolved_service"' "$ROOT_DIR/ods-cli")" -eq 2 ]] \
+    || fail "CLI start and restart must both invoke rootless ownership repair"
+pass "installer, CLI, and Langfuse lifecycle hooks are wired"
+
+echo "All $pass_count rootless ownership tests passed."

--- a/ods/tests/test-rootless-docker-ownership.sh
+++ b/ods/tests/test-rootless-docker-ownership.sh
@@ -277,14 +277,21 @@ pass "missing active directory is created before ownership repair"
 ) || fail "running container with correct ownership was rejected"
 pass "healthy running service is not mutated"
 
+RERUN_CALLS="$TMP_DIR/rerun-calls"
+: > "$RERUN_CALLS"
 (
     source "$LIB"
     _ods_rootless_stat_metadata() { printf '1000:1000:755\n'; }
     _ods_rootless_container_state() { printf 'stopped\n'; }
-    docker() { fail "idempotent rerun reached mutation"; }
+    docker() {
+        printf '%s\n' "$*" >> "$RERUN_CALLS"
+        return 0
+    }
     _ods_rootless_fix_directory "$INSTALL_DIR" data/token-spy 1000:1000 ods-token-spy
-) || fail "idempotent stopped-service rerun failed"
-pass "second repair skips already-correct stopped services"
+) || fail "stopped-service rerun failed"
+grep -q 'chown -R 1000:1000 /data' "$RERUN_CALLS" \
+    || fail "stopped-service rerun did not repair potentially stale descendants"
+pass "rerun repairs descendants even when root metadata already matches"
 
 (
     source "$LIB"


### PR DESCRIPTION
Fixes #1702

## Summary

Docker rootless remaps container UIDs into the caller's subordinate-ID namespace. Installer-created bind mounts can therefore be readable by the host while remaining unwritable by non-root container users.

This change adds one fail-closed ownership contract for clean install, rerun, CLI start/restart, dashboard-driven late enable, and Langfuse post-install. It repairs only active, known ODS bind mounts and leaves rootful Docker, macOS, Windows, and unsupported services unchanged.

Supersedes the conflicted approaches in #1708 and #1709 without widening the Host Agent listener.

## Root Cause

Host-side `chown 1000:1000` is not equivalent to container UID `1000` under rootless Docker. Ownership must be applied from inside the rootless user namespace. Broad recursive repair is also unsafe for stacks such as Langfuse, where Postgres and ClickHouse use different UIDs.

## Behavior And Invariants

| Invariant | Implementation |
|---|---|
| Rootful and non-Linux installs do not mutate | Detection returns before image pulls or filesystem mutation |
| Docker detection errors fail closed | An unavailable daemon is not treated as rootful Docker |
| Only enabled built-ins are repaired | Active Compose flags and a fixed service allowlist select targets |
| Missing active directories are safe | They are created inside the rootless namespace before ownership repair |
| Disabled services remain untouched | Their directories are neither created nor repaired |
| Late extension enable is covered | Host Agent invokes a targeted repair before Compose start |
| Start and restart are covered | `ods-cli` verifies ownership before either lifecycle operation |
| Reruns repair stale descendants | Stopped services repeat recursive correction so nested ownership cannot hide behind correct root metadata |
| Running workloads are protected | Correct metadata is a no-op; mismatches fail closed with recovery instructions |
| Paths cannot escape `data/` | Existing and dangling symlinks, traversal, and resolved out-of-tree targets are rejected |
| Results are proven | UID, GID, and required mode are read back after repair |
| User overrides match Compose | Numeric, quoted numeric, empty, and quoted-empty `UID` / `GID` values follow Compose defaults |
| Partial failures remain visible | Installer, CLI, hooks, and Host Agent stop before Compose start |

## Service Contracts

- APE: `100:100`
- Token Spy, Whisper, NVIDIA ComfyUI: `1000:1000`
- n8n and Privacy Shield: `${UID:-1000}:${GID:-1000}`
- Hermes: `${UID:-10000}:${GID:-10000}`, mode `0700`
- Langfuse Postgres: `70:70`
- Langfuse ClickHouse: `101:101`

AMD ComfyUI is intentionally excluded because its persistent paths use a different root-owned runtime contract. OpenClaw, Hermes Proxy, and root-owned services retain their existing in-container setup.

## Security And Compatibility

- Uses the pinned `busybox:1.36.1` helper with `--user 0:0`, `--network none`, and `--pull never` during mutation.
- Pulls the helper only when native Linux rootless Docker is active and the image is absent.
- Restricts directory creation and ownership repair to resolved descendants of `data/`.
- Does not set `ODS_AGENT_BIND=0.0.0.0`, infer a LAN address, alter low-port forwarding, or change Tailscale/proxy behavior.
- Preserves `DOCKER_HOST` and `XDG_RUNTIME_DIR` only for extension hooks that must address the caller's rootless daemon.

## Recovery For Existing Installs

```bash
cd ~/ods
./ods-cli stop
./ods-cli repair rootless-ownership
./ods-cli start
```

No reinstall or data deletion is required.

## Validation

Validated on head `71a1ded3a434744e2fbe9ca0f0b2925b21143557` against `main` `d6b7efdc2f9466ea018a8e41dab55a24115262e6`:

```text
bash ods/tests/test-rootless-docker-ownership.sh
  25 passed

python -m pytest ods/extensions/services/dashboard-api/tests/test_host_agent.py -q
  256 passed

bash ods/tests/test-ods-doctor-rootless-subid.sh
  10 passed

bash ods/tests/contracts/test-installer-hardening.sh
bash ods/tests/test-update-rollback-contract.sh
bash ods/tests/test-rollback-compose-stack.sh
  passed

shellcheck --norc -e SC1090,SC1091 ods/lib/rootless-ownership.sh
python -m ruff check ods/bin/ods-host-agent.py
bash -n <changed shell plus macOS installer scripts>
PowerShell parser <all Windows installer scripts>
python -m py_compile ods/bin/ods-host-agent.py
git diff --check
  passed

Docker Compose render:
  base + NVIDIA: passed
  base + AMD: passed
  base + Apple: passed
  base + CPU: passed
```

The installer environment smoke also passed clean generation, second run, schema, dependency, and NVIDIA Compose checks. Its unrelated `ai_err` function-resolution failure reproduces on current `main`. The broad installer contract's unrelated Hermes template-bound failure also reproduces on a clean `main` worktree.

## Residual Limits

- This Windows workstation cannot provide a physical native-Linux rootless Docker receipt. Hermetic tests cover namespace behavior and lifecycle integration, but a real rootless install/start/restart/late-enable run remains the final release-environment receipt.
- Ownership changes are intentionally persistent filesystem state. If a later service fails, ODS reports the failure but does not reverse a successful ownership correction.
- Arbitrary third-party extensions are not inferred automatically; only built-ins with documented runtime UIDs are repaired.
- Rootless Host Agent networking, privileged ports, Tailscale, and proxy exposure are separate concerns and remain out of scope.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work

## Changed Surface

- [ ] Dashboard UI
- [x] Dashboard API / Host Agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / manifests
- [x] Dependencies / runtime wiring
- [x] Documentation and regression tests
