### PR TITLE
chore(models): pin and score Qwen 3.6 35B-A3B

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1832,17 +1832,37 @@
       "name": "Qwen 3.6 35B-A3B",
       "family": "qwen",
       "gguf_file": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-      "gguf_url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a483e9e6cbd595906af30beda3187c2663a1118c/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
       "gguf_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
+      "size_bytes": 22134528992,
       "size_mb": 21110,
       "vram_required_gb": 24,
       "context_length": 131072,
+      "max_context_length": 262144,
+      "total_params_b": 35,
+      "active_params_b": 3,
+      "architecture": "moe",
       "quantization": "UD-Q4_K_M",
-      "specialty": "Quality",
-      "description": "Current A3B MoE successor for Spark-class unified-memory hosts. Verified on DGX Spark with llama.cpp b9014.",
+      "specialty": "Reasoning, Coding & Agents",
+      "description": "Alibaba's Apache-2.0 Qwen 3.6 MoE activates 3B of 35B parameters per token, combines native 262K context with agentic-coding improvements, and scores 32 on the current Artificial Analysis Intelligence Index. It is the higher-throughput large-model complement to the denser, higher-scoring Qwen 3.6 27B.",
       "tokens_per_sec_estimate": 59,
       "llm_model_name": "qwen3.6-35b-a3b",
-      "llama_server_image": null
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/qwen3-6-35b-a3b/",
+        "score": 32,
+        "assessed_at": "2026-07-28",
+        "note": "Qwen 3.6 27B scores higher at 37; this A3B model is retained for its sparse 3B-active inference profile rather than represented as the absolute quality leader."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
+        "model_revision": "995ad96eacd98c81ed38be0c5b274b04031597b0",
+        "gguf_repository": "unsloth/Qwen3.6-35B-A3B-GGUF",
+        "gguf_revision": "a483e9e6cbd595906af30beda3187c2663a1118c",
+        "license": "apache-2.0"
+      }
     },
     {
       "id": "deepseek-r1-70b-q4",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -863,6 +863,34 @@ def test_jamba_reasoning_3b_records_fleet_compatibility_without_recommendation()
     assert not _agent_viable_for_release(model)
 
 
+def test_qwen36_35b_a3b_records_pinned_artifact_and_current_quality_evidence():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["qwen3.6-35b-a3b-ud-q4"]
+
+    assert model["gguf_url"] == (
+        "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/"
+        "resolve/a483e9e6cbd595906af30beda3187c2663a1118c/"
+        "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+    )
+    assert model["gguf_sha256"] == "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61"
+    assert model["size_bytes"] == 22134528992
+    assert model["context_length"] == 131072
+    assert model["max_context_length"] == 262144
+    assert model["total_params_b"] == 35
+    assert model["active_params_b"] == 3
+    assert model["architecture"] == "moe"
+    assert model["quality_evidence"]["score"] == 32
+    assert "Qwen 3.6 27B scores higher" in model["quality_evidence"]["note"]
+    assert model["source_evidence"]["model_revision"] == (
+        "995ad96eacd98c81ed38be0c5b274b04031597b0"
+    )
+    assert model["source_evidence"]["gguf_revision"] == (
+        "a483e9e6cbd595906af30beda3187c2663a1118c"
+    )
+    assert model["install_recommendation"] is False
+
+
 def test_new_switchboard_models_do_not_change_install_recommendations():
     expected_switchboard_only = {
         "phi3.5-mini-q4",


### PR DESCRIPTION
## Summary

- pin the existing Qwen 3.6 35B-A3B GGUF to an immutable Hugging Face revision
- record its exact byte size, upstream revisions, 35B-total / 3B-active MoE shape, and native context ceiling
- add current independent quality evidence and explicitly compare it with the stronger dense Qwen 3.6 27B
- keep installation recommendation disabled until a fresh exact six-host app rotation passes

## Why this model

This is the next practical quality candidate after Qwen 3.6 27B, not a small-model convenience pick. Artificial Analysis Intelligence Index v4.1 scores the reasoning model at 32. The dense 27B model remains stronger at 37, but this 35B-A3B variant activates only 3B parameters per token and is therefore the better candidate for testing whether a genuinely large model can retain useful throughput across mixed local hardware.

The larger tier was considered too: Qwen 3.5 122B-A10B currently scores 32 versus GPT-OSS 120B at 24, but a Q4 artifact is roughly 75 GB and cannot pass the present 8 GB GPU / 32 GB system-memory fleet floor. That model remains worth catalog and capable-host work, but it is not a plausible six-host promotion candidate. Qwen 3.6 35B-A3B is the highest-quality sparse model near the current universal-memory boundary.

## Artifact

- upstream model: `Qwen/Qwen3.6-35B-A3B`
- upstream revision: `995ad96eacd98c81ed38be0c5b274b04031597b0`
- GGUF repo: `unsloth/Qwen3.6-35B-A3B-GGUF`
- GGUF revision: `a483e9e6cbd595906af30beda3187c2663a1118c`
- file: `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`
- bytes: `22134528992`
- sha256: `ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61`
- license: Apache-2.0

## Evidence handling

- official model card: 35B total, 3B active, 262,144-token native context
- independent Intelligence Index v4.1: 32
- catalog note explicitly preserves Qwen 3.6 27B's higher score of 37
- `install_recommendation: false`; no app-compatibility claim is made before fleet evidence exists

## Validation

- `python3 -m pytest -q ods/tests/test-model-library-coverage.py` — 41 passed
- JSON parse and `git diff --check` — passed

## Promotion gate

This PR is draft. Promotion requires exact commit `6562797a` to pass download/checksum, load, direct inference, ODS Talk, every required deployed LLM consumer, original-model restore, candidate deletion, and clean environment verification on tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy. Any memory or throughput failure remains a real rejection signal rather than being hidden by the model's benchmark score.
