### PR TITLE
fix(windows): tolerate stale Lemonade listener PIDs

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -9721,6 +9721,16 @@ function Stop-ODSProcessId {
         [switch]$AllowStaleReference
     )
     $owned = Get-CimInstance Win32_Process -Filter ("ProcessId = {0}" -f $ProcId) -ErrorAction SilentlyContinue
+    # A Lemonade child can exit after its listening socket is enumerated but
+    # before CIM resolves the PID. Only accept that race when the PID itself
+    # is gone; a live PID without CIM metadata cannot prove ODS ownership.
+    if (-not $owned) {
+        $liveProcess = Get-Process -Id $ProcId -ErrorAction SilentlyContinue
+        if (-not $liveProcess -or $AllowStaleReference) {
+            return
+        }
+        throw "Refusing to stop unowned process $ProcId on configured Lemonade port $port"
+    }
     $portOwners = Get-ODSPortOwners
     if (-not (Test-ODSLemonadeProcess $owned $portOwners)) {
         if ($AllowStaleReference) {

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -1977,6 +1977,11 @@ class TestRestartWindowsLemonade:
         assert "Refusing to stop unowned process" in script
         assert "[switch]$AllowStaleReference" in script
         assert (
+            "$owned = Get-CimInstance Win32_Process" in script
+            and "$liveProcess = Get-Process -Id $ProcId" in script
+            and "if (-not $liveProcess -or $AllowStaleReference)" in script
+        )
+        assert (
             "Stop-ODSProcessId -ProcId ([int]$rawPid) -AllowStaleReference"
             in script
         )
@@ -2000,6 +2005,138 @@ class TestRestartWindowsLemonade:
             "installers/windows/lib/backend-contract.ps1"
         )
         assert captured["env"]["ODS_WIN_ENV_PATH"] == str(tmp_path / ".env")
+
+    def test_restart_ignores_listener_that_exits_before_cim_lookup(
+        self, monkeypatch, tmp_path
+    ):
+        shell = shutil.which("pwsh") or shutil.which("powershell.exe")
+        if not shell:
+            pytest.skip("PowerShell is unavailable")
+
+        local_app_data = tmp_path / "AppData" / "Local"
+        lemonade_exe = (
+            local_app_data / "lemonade_server" / "bin" / "LemonadeServer.exe"
+        )
+        lemonade_exe.parent.mkdir(parents=True)
+        lemonade_exe.write_text("", encoding="utf-8")
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["script"] = cmd[-1]
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+        monkeypatch.delenv("ProgramFiles", raising=False)
+        monkeypatch.delenv("ProgramFiles(x86)", raising=False)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        _restart_windows_lemonade({"AMD_INFERENCE_PORT": "13305"})
+
+        script = captured["script"]
+        function_start = script.index("function Get-ODSPortOwners")
+        invocation_start = script.index("if (Test-Path $pidPath)")
+        function_block = script[function_start:invocation_start]
+        base_harness = (
+            '$port = 13305\n'
+            '$exe = "C:\\ODS\\LemonadeServer.exe"\n'
+            '$modelsDir = "C:\\ODS\\data\\models"\n'
+            "$binPrefix = 'C:\\ODS\\bin\\'\n"
+            '$cachePrefix = $null\n'
+            '$knownProcessNames = @("LemonadeServer.exe", "lemonade-server.exe", '
+            '"lemonade-router.exe", "lemonade.exe")\n'
+            f"{function_block}\n"
+            "function Get-ODSPortOwners { return @{} }\n"
+        )
+        stale_harness = base_harness + (
+            "function Get-CimInstance { return $null }\n"
+            "function Get-Process { return $null }\n"
+            "Stop-ODSProcessId -ProcId 424242\n"
+            'Write-Output "STALE_LISTENER_IGNORED"\n'
+        )
+        unverifiable_live_harness = base_harness + (
+            "function Get-CimInstance { return $null }\n"
+            "function Get-Process { return [pscustomobject]@{ Id = 424243 } }\n"
+            "try {\n"
+            "    Stop-ODSProcessId -ProcId 424243\n"
+            '    Write-Error "UNVERIFIABLE_LIVE_PROCESS_ACCEPTED"\n'
+            "    exit 2\n"
+            "} catch {\n"
+            '    if ($_.Exception.Message -notlike "Refusing to stop unowned process*") {\n'
+            "        throw\n"
+            "    }\n"
+            '    Write-Output "UNVERIFIABLE_LIVE_PROCESS_REJECTED"\n'
+            "}\n"
+        )
+        reused_pid_harness = base_harness + (
+            "function Get-CimInstance { return $null }\n"
+            "function Get-Process { return [pscustomobject]@{ Id = 424244 } }\n"
+            "Stop-ODSProcessId -ProcId 424244 -AllowStaleReference\n"
+            'Write-Output "REUSED_STALE_PID_IGNORED"\n'
+        )
+        unowned_harness = base_harness + (
+            "function Get-CimInstance {\n"
+            "    return [pscustomobject]@{\n"
+            "        ProcessId = 424243\n"
+            '        Name = "unrelated-server.exe"\n'
+            '        ExecutablePath = "C:\\Other\\unrelated-server.exe"\n'
+            '        CommandLine = "unrelated-server.exe --port 13305"\n'
+            "    }\n"
+            "}\n"
+            "try {\n"
+            "    Stop-ODSProcessId -ProcId 424243\n"
+            '    Write-Error "UNOWNED_PROCESS_ACCEPTED"\n'
+            "    exit 2\n"
+            "} catch {\n"
+            '    if ($_.Exception.Message -notlike "Refusing to stop unowned process*") {\n'
+            "        throw\n"
+            "    }\n"
+            '    Write-Output "UNOWNED_PROCESS_REJECTED"\n'
+            "}\n"
+        )
+        stale_result = _real_subprocess_run(
+            [shell, "-NoProfile", "-NonInteractive", "-Command", stale_harness],
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+        unverifiable_live_result = _real_subprocess_run(
+            [
+                shell,
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                unverifiable_live_harness,
+            ],
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+        reused_pid_result = _real_subprocess_run(
+            [shell, "-NoProfile", "-NonInteractive", "-Command", reused_pid_harness],
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+        unowned_result = _real_subprocess_run(
+            [shell, "-NoProfile", "-NonInteractive", "-Command", unowned_harness],
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+
+        assert stale_result.returncode == 0, stale_result.stderr
+        assert "STALE_LISTENER_IGNORED" in stale_result.stdout
+        assert unverifiable_live_result.returncode == 0, unverifiable_live_result.stderr
+        assert (
+            "UNVERIFIABLE_LIVE_PROCESS_REJECTED"
+            in unverifiable_live_result.stdout
+        )
+        assert reused_pid_result.returncode == 0, reused_pid_result.stderr
+        assert "REUSED_STALE_PID_IGNORED" in reused_pid_result.stdout
+        assert unowned_result.returncode == 0, unowned_result.stderr
+        assert "UNOWNED_PROCESS_REJECTED" in unowned_result.stdout
 
     def test_installer_and_cli_lemonade_tasks_are_always_on(self):
         ods_root = Path(__file__).resolve().parents[4]


### PR DESCRIPTION
## Summary

Windows Lemonade model activation can race with the runtime while clearing the old listener. `Get-NetTCPConnection` may return a PID whose process exits before `Get-CimInstance` resolves it. The restart helper treated that missing process as an unowned live process and aborted activation.

This change accepts the race only when the PID is actually gone. If CIM metadata is unavailable while the PID remains alive, cleanup stays fail-closed and refuses to stop it. Existing stale PID-file protection and live-process ownership checks remain intact.

## Failure mode

```text
Model activation failed: Windows Lemonade restart failed with exit code 1:
Refusing to stop unowned process <pid> on configured Lemonade port 13305
```

The reported PID had already exited by the time it was inspected. A replacement `lemonade-router.exe` subsequently listened on the same ODS-configured port.

## Behavior and invariants

| Case | Result |
|---|---|
| Listener PID exits before CIM lookup and no longer exists | Continue cleanup; there is no process left to stop |
| CIM lookup is empty but the PID is still alive | Refuse cleanup because ODS ownership cannot be proved |
| Recorded PID is stale, reused, and marked `AllowStaleReference` | Leave the reused process untouched; the listener/process discovery passes still handle active ODS children |
| PID still exists and matches the Lemonade executable, install directory, known listener name, or ODS models command line | Stop through the existing bounded process-tree cleanup |
| PID still exists but is not proven to be ODS Lemonade | Refuse to stop it |

No ownership matcher, port scope, launch contract, health timeout, model transaction, persistence file, or rollback behavior is relaxed.

## Regression coverage

The PowerShell behavior regression executes the generated restart functions and proves four sides of the contract:

- a vanished listener PID completes without an exception;
- a live PID with unavailable CIM identity is rejected;
- a reused stale PID-file reference is not stopped;
- a live unrelated executable with CIM metadata remains rejected.

## Validation

- `python -m pytest ods/extensions/services/dashboard-api/tests/test_model_activate.py ods/extensions/services/dashboard-api/tests/test_host_agent.py -q` -> `489 passed`
- focused Windows Lemonade tests -> `8 passed`
- `tests/contracts/test-windows-lemonade-swap-wait.sh` -> `12 passed`
- `tests/contracts/test-windows-amd-local-compose.sh` -> passed with real `docker compose config`
- `tests/contracts/test-windows-runtime-recovery.ps1` -> passed
- `tests/contracts/test-windows-lemonade-task-cleanup.ps1` -> passed
- Ruff, Python compile, and `git diff --check` -> passed
- GitHub CI on the prior head was green across Dashboard API/frontend, Linux integration, distro matrix, macOS smoke, PowerShell lint on Windows/Ubuntu, Ruff, mypy, ShellCheck, env validation, and secret scan; the amended head reruns the same matrix.

### Windows runtime receipt

The final guard was applied to an existing Windows AMD/Lemonade installation without reinstalling or replacing data:

1. Host Agent restarted under a new PID and returned `{"status":"ok","version":"1.0.0"}` on port `7710`.
2. Lemonade health on configured port `13305` remained `ok` on version `10.0.0`.
3. The imported `Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M` GGUF remained loaded and `/api/v1/models` listed all three local models.
4. The earlier end-to-end activation receipt proved Dashboard activation, exact GGUF identity, 32K context, consumer synchronization, and a real chat completion returning `ODS_OK`.

## Adversarial audit

The audit traced Dashboard activation and CLI ensure requests through Host Agent mutation, native Lemonade restart, readiness proof, PID persistence, consumer synchronization, and rollback. Clean install, in-place update, repeated activation, empty/stale PID state, external runtime opt-out, partial restart failure, and rollback paths were checked against their existing tests and contracts.

One additional in-scope defect was reproduced during review: an empty CIM result could also mean a transient CIM failure while the PID remained alive. The final patch distinguishes this from a genuinely exited process and adds executable regression coverage. No other reproducible defect remains within this PR's scope.

## Scope

This is limited to the Host Agent's managed Windows Lemonade stop race. Download, Hugging Face import, model metadata, Compose definitions, Linux/macOS runtimes, cloud mode, and non-Lemonade backends are unchanged.