### PR TITLE
models: pin and vet Qwen 3.5 4B candidate

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1557,7 +1557,7 @@
       "tokens_per_sec_estimate": 100,
       "llm_model_name": "qwen3.5-4b",
       "llama_server_image": null,
-      "install_recommendation": true,
+      "install_recommendation": false,
       "quality_evidence": {
         "source": "Artificial Analysis Intelligence Index v4.1",
         "source_url": "https://artificialanalysis.ai/models/qwen3-5-4b/",
@@ -1573,6 +1573,17 @@
         "license": "apache-2.0"
       },
       "app_compatibility": {
+        "litellm": {
+          "status": "unsupported_until_revalidated",
+          "label": "LiteLLM revalidation required on Strixy",
+          "reason": "Fresh exact-commit six-host coverage passed Qwen 3.5 4B load, challenge-bound ODS Talk, Open WebUI, and Perplexica on Strixy, but the direct LiteLLM response spent its output budget on a duplicated reasoning preamble before returning the full verification phrase. A clean targeted Strixy retry reproduced the same LiteLLM-only failure after baseline probes passed. Both runs reached the correct Qwen3.5-4B-Q4_K_M Lemonade route with HTTP 200 and signed route evidence, then restored the original 35B baseline, deleted test-owned artifacts, and finished cleanup. Keep this model out of install recommendations until its Lemonade reasoning-response behavior is fixed and revalidated.",
+          "evidence": "fleet-test/runs/2026-07-28T07-50-30Z-model-ui-product-633151859d49-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-qwen35-4b-six-host-switchboard-r1/cycle-001/strixy; fleet-test/runs/2026-07-28T08-17-40Z-model-ui-product-633151859d49-harness-19d43e6f9f25-hosts-strixy-qwen35-4b-strixy-targeted-r2/cycle-001/strixy",
+          "recordedAt": "2026-07-28T08:23:55Z",
+          "productSha": "633151859d49e686feba4d8f971704a559e20a26",
+          "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
+          "hostScope": ["strixy"],
+          "expiresAt": "2026-08-28T00:00:00Z"
+        },
         "openai_chat": {
           "status": "verified",
           "label": "Direct chat verified on Windows",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1543,18 +1543,35 @@
       "name": "Qwen 3.5 4B",
       "family": "qwen",
       "gguf_file": "Qwen3.5-4B-Q4_K_M.gguf",
-      "gguf_url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/e87f176479d0855a907a41277aca2f8ee7a09523/Qwen3.5-4B-Q4_K_M.gguf",
       "gguf_sha256": "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
       "size_bytes": 2740937888,
       "size_mb": 2741,
       "vram_required_gb": 5,
       "context_length": 262144,
+      "total_params_b": 4.7,
+      "architecture": "dense",
       "quantization": "Q4_K_M",
-      "specialty": "Balanced",
-      "description": "Unsloth's GGUF quant of Qwen3.5 4B with native 262K context metadata. A low-VRAM long-context release candidate for app and Talk validation.",
+      "specialty": "Reasoning, Coding & Agents",
+      "description": "Alibaba's Apache-2.0 Qwen 3.5 4B combines native 262K context with reasoning, coding, and agentic capabilities. Its current Artificial Analysis Intelligence Index score of 20 makes it the leading independently ranked model in ODS's 5GB-class local tier.",
       "tokens_per_sec_estimate": 100,
       "llm_model_name": "qwen3.5-4b",
       "llama_server_image": null,
+      "install_recommendation": true,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/qwen3-5-4b/",
+        "score": 20,
+        "assessed_at": "2026-07-28",
+        "note": "The score is an Artificial Analysis estimate pending an independent provider evaluation; it is still materially above Gemma 4 E2B's score of 9 in the same index."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/Qwen/Qwen3.5-4B",
+        "model_revision": "851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a",
+        "gguf_repository": "unsloth/Qwen3.5-4B-GGUF",
+        "gguf_revision": "e87f176479d0855a907a41277aca2f8ee7a09523",
+        "license": "apache-2.0"
+      },
       "app_compatibility": {
         "openai_chat": {
           "status": "verified",


### PR DESCRIPTION
## What changed

- pins the existing Qwen 3.5 4B Q4_K_M artifact to immutable Hugging Face revision `e87f176479d0855a907a41277aca2f8ee7a09523`
- records the exact 2,740,937,888-byte artifact and existing SHA-256 contract
- adds current model/source provenance and Artificial Analysis v4.1 quality evidence
- records a host-scoped Strixy/LiteLLM compatibility blocker and keeps the model out of install recommendations

## Why

Qwen 3.5 4B currently scores 20 on the Artificial Analysis Intelligence Index v4.1, versus 9 for NVIDIA Nemotron 3 Nano 4B and 9 for Gemma 4 E2B. It is Apache-2.0, has a 262K native context ceiling, and already has a validated NVIDIA 8GB runtime profile. This made it the strongest current quality candidate in ODS's roughly 5GB local tier and worth full fleet evaluation rather than defaulting to a convenient incumbent.

The AA score is explicitly recorded as an estimate pending independent provider evaluation.

## User impact

The model remains available as a curated, reproducible artifact, but is not install-recommended. Users are protected from a reproducible Strixy/Lemonade response failure while the five passing host results and exact blocker evidence remain available for future revalidation.

## Validation

Passed locally:

- `python -m json.tool ods/config/model-library.json`
- `git diff --check`
- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/tests/test-offline-model-validation.py` (40 passed)
- `ods/tests/test-tier-map.sh` (128 passed)
- `ods/tests/test-windows-catalog-selector.ps1`

Known baseline issue:

- `ods/tests/test-model-library-verdicts.py` fails on unchanged `main` because `jamba-reasoning-3b-q4.app_compatibility.opencode` lacks a revalidation trigger. This PR does not touch that record.

## Fleet verdict

- exact candidate SHA `633151859d49e686feba4d8f971704a559e20a26` passed fresh install on all six required hosts
- Tower2, Strix Halo, Spark, M5 MBP, and Windows laptop passed candidate load, challenge-bound Talk, every required deployed app route, original-model restore, repeat probes, deletion, and clean final inventory
- Strixy loaded the candidate and passed Talk, Open WebUI, and Perplexica, but LiteLLM returned HTTP 200 from the correct signed Qwen3.5-4B route while spending the response budget on duplicated reasoning text before the full verification phrase
- a clean targeted Strixy retry reproduced that LiteLLM-only failure
- both Strixy runs restored the original 35B model and deleted test-owned artifacts

Evidence:

- `fleet-test/runs/2026-07-28T07-50-30Z-model-ui-product-633151859d49-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-qwen35-4b-six-host-switchboard-r1`
- `fleet-test/runs/2026-07-28T08-17-40Z-model-ui-product-633151859d49-harness-19d43e6f9f25-hosts-strixy-qwen35-4b-strixy-targeted-r2`
