### PR TITLE
fix(preflight): write preflight report atomically in preflight-engine.sh

### DIFF
--- a/ods/scripts/preflight-engine.sh
+++ b/ods/scripts/preflight-engine.sh
@@ -344,7 +344,19 @@ report = {
 
 report_path = pathlib.Path(report_file)
 report_path.parent.mkdir(parents=True, exist_ok=True)
-report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+import os
+import tempfile
+fd, tmp_str = tempfile.mkstemp(dir=str(report_path.parent), prefix=f".{report_path.name}.", suffix=".tmp")
+tmp_path = pathlib.Path(tmp_str)
+content = json.dumps(report, indent=2) + "\n"
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp_path, report_path)
+except Exception:
+    if tmp_path.exists():
+        tmp_path.unlink(missing_ok=True)
+    raise
 
 if env_mode:
     def out(key, value):


### PR DESCRIPTION
## Problem

In `ods/scripts/preflight-engine.sh`, the JSON preflight report was written directly using `report_path.write_text(json.dumps(...))`. If the script execution is interrupted (e.g. process termination or disk error), the target preflight report file can be left partially written or truncated in place.

## Fix

1. Update `preflight-engine.sh` to write the preflight JSON report to a temporary file using `tempfile.mkstemp` in `report_path.parent`.
2. Use `os.replace` for atomic replacement of the destination preflight report file.

## Verification

Verified syntax with `bash -n ods/scripts/preflight-engine.sh`. `git diff --check` passed cleanly with zero whitespace issues.