### PR TITLE
fix(doctor): write doctor report atomically in ods-doctor.sh

### DIFF
--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -1663,7 +1663,19 @@ report["autofix_hints"] = uniq_hints  # overwrite initial empty list
 
 path = pathlib.Path(report_file)
 path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+import os
+import tempfile
+fd, tmp_str = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+tmp_path = pathlib.Path(tmp_str)
+content = json.dumps(report, indent=2) + "\n"
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp_path, path)
+except Exception:
+    if tmp_path.exists():
+        tmp_path.unlink(missing_ok=True)
+    raise
 PY
 
 echo "ODS Doctor report: $REPORT_FILE"


### PR DESCRIPTION
## Problem

In `ods/scripts/ods-doctor.sh`, the JSON doctor diagnostic report was written directly using `path.write_text(json.dumps(...))`. If the script execution is interrupted (e.g. process termination or disk error), the target doctor report file can be left partially written or truncated in place.

## Fix

1. Update `ods-doctor.sh` to write the JSON doctor report to a temporary file using `tempfile.mkstemp` in `path.parent`.
2. Use `os.replace` for atomic replacement of the destination doctor report file.

## Verification

Verified syntax with `bash -n ods/scripts/ods-doctor.sh`. `git diff --check` passed cleanly with zero whitespace issues.