### PR TITLE
models: stage Gemma 4 12B candidate

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1700,14 +1700,14 @@
       "gguf_sha256": "93567e57a8fe10b23569b9d9ec38cd005deedf71e29477c421a4b83f418a538b",
       "size_bytes": 6975879296,
       "size_mb": 6976,
-      "vram_required_gb": 8,
-      "context_length": 32768,
+      "vram_required_gb": 10,
+      "context_length": 65536,
       "max_context_length": 262144,
       "total_params_b": 12,
       "architecture": "dense",
       "quantization": "Q4_0",
       "specialty": "Reasoning, Coding & Agents",
-      "description": "Google's first-party Apache-2.0 QAT Q4_0 release of Gemma 4 12B. It scores 22 on the independently evaluated Artificial Analysis Intelligence Index, supports a native 256K context ceiling, and is staged at a conservative 32K default for local text and agent workflows.",
+      "description": "Google's first-party Apache-2.0 QAT Q4_0 release of Gemma 4 12B. It scores 22 on the independently evaluated Artificial Analysis Intelligence Index, supports a native 256K context ceiling, and is staged at the 64K minimum required for ODS agent and research workflows.",
       "tokens_per_sec_estimate": 55,
       "llm_model_name": "gemma-4-12b-it",
       "llama_server_image": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014",
@@ -1725,28 +1725,7 @@
         "gguf_repository": "google/gemma-4-12B-it-qat-q4_0-gguf",
         "gguf_revision": "29d097773436b69ff9feafd636ab4cf873786537",
         "license": "apache-2.0"
-      },
-      "runtime_profiles": [
-        {
-          "id": "nvidia-8gb-16k-q4-kv",
-          "label": "NVIDIA 8GB 16K context with Q4 KV cache",
-          "backend": "nvidia",
-          "host_arch": ["amd64"],
-          "memory_type": "discrete",
-          "vram_min_gb": 7.5,
-          "vram_max_gb": 8.5,
-          "system_ram_min_gb": 31,
-          "context_length": 16384,
-          "estimated_required_gb": 7.9,
-          "fit_label": "16K 8GB Q4 KV profile",
-          "env": {
-            "LLAMA_PARALLEL": "1",
-            "LLAMA_ARG_FLASH_ATTN": "on",
-            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
-            "LLAMA_ARG_CACHE_TYPE_V": "q4_0"
-          }
-        }
-      ]
+      }
     },
     {
       "id": "phi4-q4",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1692,6 +1692,63 @@
       "llama_server_image": null
     },
     {
+      "id": "gemma4-12b-qat-q4",
+      "name": "Gemma 4 12B",
+      "family": "gemma4",
+      "gguf_file": "gemma-4-12b-it-qat-q4_0.gguf",
+      "gguf_url": "https://huggingface.co/google/gemma-4-12B-it-qat-q4_0-gguf/resolve/29d097773436b69ff9feafd636ab4cf873786537/gemma-4-12b-it-qat-q4_0.gguf",
+      "gguf_sha256": "93567e57a8fe10b23569b9d9ec38cd005deedf71e29477c421a4b83f418a538b",
+      "size_bytes": 6975879296,
+      "size_mb": 6976,
+      "vram_required_gb": 8,
+      "context_length": 32768,
+      "max_context_length": 262144,
+      "total_params_b": 12,
+      "architecture": "dense",
+      "quantization": "Q4_0",
+      "specialty": "Reasoning, Coding & Agents",
+      "description": "Google's first-party Apache-2.0 QAT Q4_0 release of Gemma 4 12B. It scores 22 on the independently evaluated Artificial Analysis Intelligence Index, supports a native 256K context ceiling, and is staged at a conservative 32K default for local text and agent workflows.",
+      "tokens_per_sec_estimate": 55,
+      "llm_model_name": "gemma-4-12b-it",
+      "llama_server_image": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014",
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/gemma-4-12b/",
+        "score": 22,
+        "assessed_at": "2026-07-28",
+        "note": "Gemma 4 12B is independently evaluated, scores above Qwen 3.5 9B's 21, and provides a current Google-family alternative to the higher-scoring Qwen 3.6 27B large-tier candidate."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/google/gemma-4-12B-it",
+        "model_revision": "707f0a3b8a3c7ad586ed01e27eafbad8a27dd0f7",
+        "gguf_repository": "google/gemma-4-12B-it-qat-q4_0-gguf",
+        "gguf_revision": "29d097773436b69ff9feafd636ab4cf873786537",
+        "license": "apache-2.0"
+      },
+      "runtime_profiles": [
+        {
+          "id": "nvidia-8gb-16k-q4-kv",
+          "label": "NVIDIA 8GB 16K context with Q4 KV cache",
+          "backend": "nvidia",
+          "host_arch": ["amd64"],
+          "memory_type": "discrete",
+          "vram_min_gb": 7.5,
+          "vram_max_gb": 8.5,
+          "system_ram_min_gb": 31,
+          "context_length": 16384,
+          "estimated_required_gb": 7.9,
+          "fit_label": "16K 8GB Q4 KV profile",
+          "env": {
+            "LLAMA_PARALLEL": "1",
+            "LLAMA_ARG_FLASH_ATTN": "on",
+            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q4_0"
+          }
+        }
+      ]
+    },
+    {
       "id": "phi4-q4",
       "name": "Phi-4 14B",
       "family": "phi",


### PR DESCRIPTION
## What changed

- adds Google Gemma 4 12B as a new curated model candidate
- uses Google's first-party QAT Q4_0 GGUF, pinned to immutable revision `29d097773436b69ff9feafd636ab4cf873786537`
- records the exact 6,975,879,296-byte artifact and SHA-256
- records Apache-2.0 source provenance and current Artificial Analysis v4.1 quality evidence
- stages the model at the 64K minimum required for ODS agent and research workflows
- records an honest 10GB fit requirement instead of offering a sub-Hermes-floor 8GB profile
- keeps `install_recommendation` false after exact six-host validation found two platform blockers

## Why

Gemma 4 12B scores 22 on the independently evaluated Artificial Analysis Intelligence Index v4.1, ahead of Qwen 3.5 9B at 21 and well ahead of Gemma 4 E2B/NVIDIA Nemotron 3 Nano 4B at 9. It provides a current Google-family alternative to the higher-scoring Qwen 3.6 27B candidate and broadens ODS beyond one model family.

The catalog exposes a practical 64K local context while preserving the model's native 256K ceiling as metadata. The current text-route candidate intentionally does not claim ODS multimodal support without an mmproj integration.

## User impact

No installer choice changes. The model becomes a reproducible, quality-ranked manual candidate while its Mac runtime and 8GB Windows fit blockers remain explicit.

## Validation

Passed locally:

- `python -m json.tool ods/config/model-library.json`
- `git diff --check`
- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/tests/test-offline-model-validation.py` (40 passed)
- `ods/tests/test-tier-map.sh` (128 passed)
- `ods/tests/test-windows-catalog-selector.ps1`

Exact candidate SHA: `10a80a964a22ee43b587c5dbda74165095c6ea62`

Fresh exact-commit install passed on all six hosts:

- `/home/michael/dream-fleet-test/runs/2026-07-28T09-12-30Z-install-product-10a80a964a22-harness-19d43e6f9f25-hosts-six-gemma4-12b-64k-switchboard-r2`

Browser-driven model lifecycle coverage:

- `/home/michael/dream-fleet-test/runs/2026-07-28T09-43-12Z-model-ui-product-10a80a964a22-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-gemma4-12b-64k-six-host-switchboard-r2`
- Tower2, Strix Halo, Spark, and Strixy passed candidate download, exact load, challenge-bound ODS Talk, every deployed required LLM consumer, original-model restore and repeated probes, candidate deletion, and clean final inventory.
- M5 MBP downloaded the exact artifact but its shipped native llama.cpp build `8210 (2cd20b72e)` rejected `general.architecture=gemma4` as unknown. Failure recovery restored its original model and deleted the candidate.
- Windows Laptop rejected the candidate before download with `fitsVram=false`, consistent with the catalog's 10GB requirement on the 8GB host. Failure recovery preserved its original model.
- The wrapper restored every pre-install baseline and removed its temporary bootstrap model.

Result: 4/6 full lifecycle passes, one native-runtime incompatibility, and one honest hardware-fit block. The model remains non-recommended.

Known baseline issue:

- `ods/tests/test-model-library-verdicts.py` fails on unchanged `main` because `jamba-reasoning-3b-q4.app_compatibility.opencode` lacks a revalidation trigger. This PR does not touch that record.
