### PR TITLE
models: stage Ornith 1.0 35B candidate

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1845,6 +1845,45 @@
       "llama_server_image": null
     },
     {
+      "id": "ornith-1.0-35b-q4",
+      "name": "Ornith 1.0 35B",
+      "family": "ornith",
+      "gguf_file": "ornith-1.0-35b-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B-GGUF/resolve/383064f72a1ef3087b779f268d3ca117eb989aac/ornith-1.0-35b-Q4_K_M.gguf",
+      "gguf_sha256": "ff25291b2599fb927a835e624d2b3540106af61761c3fa57ac4264046dbec002",
+      "size_bytes": 21166757760,
+      "size_mb": 21167,
+      "vram_required_gb": 24,
+      "context_length": 65536,
+      "max_context_length": 262144,
+      "total_params_b": 35,
+      "active_params_b": 3,
+      "architecture": "moe",
+      "quantization": "Q4_K_M",
+      "specialty": "Agentic Coding",
+      "description": "DeepReinforce's MIT-licensed Qwen 3.5 MoE post-training for agentic coding. Its official evaluation reports 75.6% SWE-bench Verified and 64.2% Terminal-Bench 2.1, but ODS keeps it staged pending independent benchmarking and exact six-host app validation.",
+      "tokens_per_sec_estimate": 50,
+      "llm_model_name": "ornith-1.0-35b",
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "DeepReinforce Ornith 1.0 official evaluation",
+        "source_url": "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B",
+        "benchmark": "SWE-bench Verified",
+        "score": 75.6,
+        "assessed_at": "2026-07-28",
+        "independent": false,
+        "note": "Vendor-reported with methodology disclosed on the model card; Artificial Analysis has not yet published an independent Intelligence Index score. The same table reports Terminal-Bench 2.1 at 64.2, SWE-bench Pro at 50.4, SWE-bench Multilingual at 69.3, and NL2Repo at 34.6."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B",
+        "model_revision": "5df2ed3f675c7beaa490328cc70bb573b65fb660",
+        "gguf_repository": "deepreinforce-ai/Ornith-1.0-35B-GGUF",
+        "gguf_revision": "383064f72a1ef3087b779f268d3ca117eb989aac",
+        "license": "mit"
+      }
+    },
+    {
       "id": "deepseek-r1-70b-q4",
       "name": "DeepSeek R1 70B",
       "family": "deepseek",


### PR DESCRIPTION
## What changed

- adds DeepReinforce Ornith 1.0 35B as a new curated agentic-coding candidate
- pins the official first-party Q4_K_M GGUF to immutable revision `383064f72a1ef3087b779f268d3ca117eb989aac`
- records the exact 21,166,757,760-byte artifact and SHA-256
- records MIT source provenance, 35B total / 3B active MoE sizing, and the native 256K context ceiling
- stages a 64K ODS runtime context and an honest 24GB fit requirement
- keeps `install_recommendation` false pending exact six-host validation

## Why

Ornith is a current, highly adopted alternative to the Qwen, Gemma, and Granite catalog lines for agentic coding. Its official evaluation reports:

- 75.6% SWE-bench Verified
- 64.2% Terminal-Bench 2.1
- 50.4% SWE-bench Pro
- 69.3% SWE-bench Multilingual
- 34.6% NL2Repo

Those results are vendor-reported, not an independent Artificial Analysis score. The catalog says so explicitly instead of presenting incomparable benchmark numbers as settled evidence. Among the newly released 33–35B coding candidates reviewed, the disclosed results are stronger than Laguna XS 2.1 and the existing Qwen 3.6 35B baseline on the same headline coding evaluations.

## User impact

No installer choice changes. The model becomes a reproducible manual candidate for fleet testing and remains excluded from recommendations until it passes load, inference, app routing, restore, deletion, and clean-inventory coverage on all six required hosts.

## Artifact provenance

- source model: `deepreinforce-ai/Ornith-1.0-35B`
- source revision: `5df2ed3f675c7beaa490328cc70bb573b65fb660`
- GGUF repository: `deepreinforce-ai/Ornith-1.0-35B-GGUF`
- GGUF revision: `383064f72a1ef3087b779f268d3ca117eb989aac`
- file: `ornith-1.0-35b-Q4_K_M.gguf`
- bytes: `21166757760`
- SHA-256: `ff25291b2599fb927a835e624d2b3540106af61761c3fa57ac4264046dbec002`
- license: MIT

## Validation

Passed locally:

- `python -m json.tool ods/config/model-library.json`
- `git diff --check`
- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/tests/test-offline-model-validation.py` (40 passed)
- `ods/tests/test-tier-map.sh` (128 passed)
- `ods/tests/test-windows-catalog-selector.ps1`
- immutable Hugging Face response headers match the catalog's exact byte count and SHA-256

Known baseline issue:

- `ods/tests/test-model-library-verdicts.py` fails on unchanged `main` because `jamba-reasoning-3b-q4.app_compatibility.opencode` lacks a revalidation trigger. This PR does not touch that record.

Fresh exact-commit fleet install:

- PASS on tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy
- product SHA: `d45c5377571de709e13efe4b6ce92187f653bf4c`
- harness SHA: `19d43e6f9f2533e8768ed85b33de9f4ace232129`
- evidence: `fleet-test/runs/2026-07-28T10-22-02Z-install-product-d45c5377571d-harness-19d43e6f9f25-hosts-six-ornith35-switchboard-r1`

Fresh exact-commit browser-driven model lifecycle:

- PASS: tower2, strix-halo, spark
  - exact artifact downloaded and loaded
  - challenge-bound ODS Talk and every required deployed LLM-consumer probe passed
  - original model restored and re-probed
  - Ornith deleted and final inventory clean
- FAIL: m5-mbp, strixy
  - exact artifact loaded and ODS Talk passed
  - LiteLLM and Open WebUI routed to the exact Ornith runtime but Ornith emitted a long Chinese reasoning/safety preamble instead of the requested verification token
  - Perplexica passed
  - failure recovery restored the controlled baseline and deleted Ornith
- FAIL: windows-laptop
  - rejected before download with `fitsVram=false`, consistent with the catalog's 24GB requirement on an 8GB host
  - failure recovery preserved the controlled baseline
- final cleanup restored every host's pre-test original model, removed temporary baseline artifacts, and restored bootstrap-upgrader state
- verdict: 3/6 full lifecycle passes; keep `install_recommendation` false
- evidence: `fleet-test/runs/2026-07-28T10-52-51Z-model-ui-product-d45c5377571d-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-ornith35-six-host-switchboard-r1`
