### PR TITLE
models: stage G9v3 3B candidate

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -623,6 +623,45 @@
       "install_recommendation": true
     },
     {
+      "id": "g9v3-3b-q4",
+      "name": "G9v3 3B",
+      "family": "g9v3",
+      "gguf_file": "ai9stars_G9v3-3B-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/bartowski/ai9stars_G9v3-3B-GGUF/resolve/11fe5d21c70f1c6f5e66ca433d1a533738998225/ai9stars_G9v3-3B-Q4_K_M.gguf",
+      "gguf_sha256": "0a14c40b1cb02ec21643fb9f080d8bbfea27bb4b6e1f9f6c9ad87db5051af0a1",
+      "size_bytes": 1902590528,
+      "size_mb": 1903,
+      "vram_required_gb": 4,
+      "context_length": 65536,
+      "max_context_length": 131072,
+      "total_params_b": 3,
+      "active_params_b": 3,
+      "architecture": "dense",
+      "quantization": "Q4_K_M",
+      "specialty": "Compact Reasoning",
+      "description": "AI9Stars' July 2026 Apache-2.0 dense Llama model for reasoning, coding, and tool use. Artificial Analysis ranks it first among 44 open-weight models at 4B parameters or less, but ODS keeps this third-party GGUF staged pending exact six-host validation.",
+      "tokens_per_sec_estimate": 150,
+      "llm_model_name": "g9v3-3b",
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/g9v3-3b",
+        "benchmark": "Artificial Analysis Intelligence Index",
+        "score": 16,
+        "assessed_at": "2026-07-28",
+        "independent": true,
+        "note": "Ranked #1 of 44 open-weight models at 4B parameters or less. Artificial Analysis reports an 88M-token evaluation footprint versus a 34M class median, so ODS treats short-response behavior as an explicit fleet-validation risk."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/ai9stars/G9v3-3B",
+        "model_revision": "d9553445ff92dbce667381954c9699fbcbc924f9",
+        "gguf_repository": "bartowski/ai9stars_G9v3-3B-GGUF",
+        "gguf_revision": "11fe5d21c70f1c6f5e66ca433d1a533738998225",
+        "license": "apache-2.0"
+      }
+    },
+    {
       "id": "granite4.1-3b-q4",
       "name": "Granite 4.1 3B",
       "family": "granite",


### PR DESCRIPTION
## What changed

- adds AI9Stars G9v3 3B as a new compact reasoning, coding, and tool-use candidate
- pins the base model and Bartowski Q4_K_M GGUF to immutable revisions
- records the exact 1,902,590,528-byte artifact and SHA-256
- records Apache-2.0 provenance, dense 3B sizing, and the native 131K context ceiling
- stages a 64K ODS runtime context and a 4GB fit requirement
- keeps `install_recommendation` false after exact six-host validation found a deployed-runtime compatibility gap

## Why

Artificial Analysis currently ranks G9v3 3B first among 44 open-weight models with 4B parameters or less:

- Artificial Analysis Intelligence Index v4.1: 16
- tiny-class rank: #1 / 44
- tiny-class median: 3

That independent score is materially stronger than the current scores for MiniCPM5 1B (12), Nanbeige 4.1 3B (11), Nemotron 3 Nano 4B (9), Qwen 3.5 2B (7), and Granite 4.1 3B (5). Artificial Analysis also reports unusually high evaluation verbosity, so this candidate remains unrecommended until the exact-token app routes pass.

The model publisher has not released a first-party GGUF. This PR therefore uses Bartowski's Q4_K_M conversion, records that fact explicitly, and pins the conversion instead of relying on a floating third-party artifact.

## User impact

No installer choice changes. The model becomes a reproducible manual candidate but remains excluded from recommendations because only Strixy's Lemonade backend can load it with the currently deployed runtimes.

## Artifact provenance

- source model: `ai9stars/G9v3-3B`
- source revision: `d9553445ff92dbce667381954c9699fbcbc924f9`
- GGUF repository: `bartowski/ai9stars_G9v3-3B-GGUF`
- GGUF revision: `11fe5d21c70f1c6f5e66ca433d1a533738998225`
- file: `ai9stars_G9v3-3B-Q4_K_M.gguf`
- bytes: `1902590528`
- SHA-256: `0a14c40b1cb02ec21643fb9f080d8bbfea27bb4b6e1f9f6c9ad87db5051af0a1`
- license: Apache-2.0

## Validation

Passed locally:

- JSON parse
- `git diff --check`
- `python -m pytest -q ods/tests/test-model-library-coverage.py ods/tests/test-offline-model-validation.py` (40 passed)
- `python ods/tests/test-model-library-verdicts.py`
- `ods/tests/test-tier-map.sh` (128 passed)
- `ods/tests/test-windows-catalog-selector.ps1`
- immutable Hugging Face response headers match the catalog's exact byte count and SHA-256

Passed fleet setup:

- product commit: `6937fceaa60eab496c7cad7eac4e240c48d4f3aa`
- clean harness commit: `19d43e6f9f2533e8768ed85b33de9f4ace232129`
- fresh exact-commit install passed on tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy
- install evidence: `fleet-test/runs/2026-07-28T11-50-00Z-install-product-6937fceaa60e-harness-19d43e6f9f25-hosts-six-g9v3-switchboard-r1`

Exact model result:

- strixy: **PASS** on the Lemonade backend. Browser-driven download and load, challenge-bound ODS Talk, LiteLLM, Open WebUI, and Perplexica probes, original-model restore, repeated Talk and consumer probes, candidate deletion, and clean final inventory all passed.
- tower2, strix-halo, spark, windows-laptop, and m5-mbp: **FAIL** on the deployed llama.cpp-family runtimes. Each downloaded the exact pinned GGUF, then the native loader rejected `tokenizer.ggml.pre=minicpm5` with `unknown pre-tokenizer type: 'minicpm5'`.
- the focused m5-mbp retry first loaded the already fleet-verified Nemotron control model and passed every baseline app probe, then reproduced the same G9v3 loader error. This separates the candidate failure from baseline or route health.
- all failed hosts restored their original models and deleted the candidate; temporary control models and fleet holds were removed. Final fleet lock state was clean.

Primary run evidence:

- tower2 and strix-halo loader failures: `fleet-test/runs/2026-07-28T12-18-29Z-model-ui-product-6937fceaa60e-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy-g9v3-six-host-switchboard-r1`
- spark and windows-laptop loader failures plus clean recovery: `fleet-test/runs/2026-07-29T01-47-24Z-model-ui-product-6937fceaa60e-harness-19d43e6f9f25-hosts-spark-m5-mbp-windows-laptop-strixy-g9v3-incomplete-four-skipbaseline-r5`
- m5-mbp focused control-baseline pass and loader failure: `fleet-test/runs/2026-07-29T02-10-03Z-model-ui-product-6937fceaa60e-harness-19d43e6f9f25-hosts-m5-mbp-g9v3-m5-tempbaseline-r6`
- strixy full pass: `fleet-test/runs/2026-07-29T02-30-20Z-model-ui-product-6937fceaa60e-harness-19d43e6f9f25-hosts-strixy-g9v3-strixy-tempbaseline-r7`

## Decision

Keep G9v3 staged with `install_recommendation: false`.

The result is a runtime-support gap, not a model-quality, VRAM-fit, artifact-integrity, or GGUF-conversion failure: the same pinned artifact passes the complete Strixy lifecycle. Upstream llama.cpp added MiniCPM5 BPE pre-tokenizer support in [PR #23384](https://github.com/ggml-org/llama.cpp/pull/23384), merged at commit `9777256`, while the five failing deployed runtimes predate that change.

Do not work around this with catalog metadata or an unpinned runtime fork. Promotion requires upgrading the supported runtime lineage to include the upstream tokenizer implementation, then repeating fresh exact-commit six-host validation.
