### PR TITLE
chore(release): prepare 2.6.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 <!-- Pick the lane before review. See ods/docs/RELEASE_CHANNELS.md. -->
 
-- [ ] Stable hotfix targeting `release/2.5.x`
+- [ ] Stable hotfix targeting `release/2.6.x`
 - [ ] Mainline change targeting `main`
 - [ ] Next-minor work targeting the next feature/minor release
 - [ ] Not sure; reviewer should help classify
@@ -18,7 +18,7 @@
 Stable hotfix reason:
 
 ```text
-<!-- If this targets release/2.5.x, explain the current-stable user problem it fixes. -->
+<!-- If this targets release/2.6.x, explain the current-stable user problem it fixes. -->
 ```
 
 ## Changed Surface
@@ -47,7 +47,7 @@ Stable hotfix reason:
   - [ ] Dashboard lint/test/build
   - [ ] Extension audit / compose validation
   - [ ] Release-grade fleet or scoped hardware validation
-  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
+  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
   - [ ] Not required because: <!-- explain -->
 
 Commands/results:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ODS Architecture
 
-> Version 2.5.3 | Fully local AI stack deployed on user hardware with a single command
+> Version 2.6.0 | Fully local AI stack deployed on user hardware with a single command
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Other tools get you part of the way. ODS gets you the whole way.
 | [Headless Setup](ods/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](ods/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
 | [Release Validation](ods/docs/RELEASE_VALIDATION.md) | User Green gates and the release-grade fleet/distro validation policy |
-| [2.6.0 Draft Release Notes](ods/docs/RELEASE_NOTES_2.6.0.md) | Current release-candidate notes, validation receipt fields, and publication checklist |
+| [2.6.0 Release Notes](ods/docs/RELEASE_NOTES_2.6.0.md) | Current stable release notes, validation receipt, and known validation boundaries |
 | [Validation Matrix](ods/docs/VALIDATION-MATRIX.md) | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 | [Validation Reproducibility](ods/docs/VALIDATION_REPRODUCIBILITY.md) | How forks and operators can reproduce the validation story on their own hardware |
 | [Offline And Mirroring](ods/docs/OFFLINE_AND_MIRRORING.md) | Pinning, mirroring, and preserving release artifacts for independent operation |

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ security policy, GitHub workflows, and project coordination docs. The
 `ods/` directory is the product runtime: services, installer phases,
 compose overlays, dashboard, CLI, tests, and operator docs.
 
-**Stable consumption:** `v2.5.3` is the current stable release. `main` moves
+**Stable consumption:** `v2.6.0` is the current stable release. `main` moves
 quickly; use it for active development and validation candidates. For forks,
 appliances, labs, or production-like installs, pin a tagged release or audited
 commit and keep your own validation receipt. Stable patch fixes land on
-`release/2.5.x` before being merged forward. See
+`release/2.6.x` before being merged forward. See
 [Release Channels](ods/docs/RELEASE_CHANNELS.md),
 [Installer Trust](ods/docs/INSTALLER_TRUST.md), and
 [Forkability](ods/docs/FORKABILITY.md).
@@ -424,6 +424,7 @@ Other tools get you part of the way. ODS gets you the whole way.
 | [Headless Setup](ods/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](ods/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
 | [Release Validation](ods/docs/RELEASE_VALIDATION.md) | User Green gates and the release-grade fleet/distro validation policy |
+| [2.6.0 Draft Release Notes](ods/docs/RELEASE_NOTES_2.6.0.md) | Current release-candidate notes, validation receipt fields, and publication checklist |
 | [Validation Matrix](ods/docs/VALIDATION-MATRIX.md) | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 | [Validation Reproducibility](ods/docs/VALIDATION_REPRODUCIBILITY.md) | How forks and operators can reproduce the validation story on their own hardware |
 | [Offline And Mirroring](ods/docs/OFFLINE_AND_MIRRORING.md) | Pinning, mirroring, and preserving release artifacts for independent operation |

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -6,7 +6,7 @@
 # secure random secrets. This file documents all available variables.
 
 # ODS version (auto-set by installer, used by ods-cli for compat checks)
-# ODS_VERSION=2.5.3
+# ODS_VERSION=2.6.0
 
 # LiteLLM proxy API key for internal service auth
 # TARGET_API_KEY=not-needed

--- a/ods/CHANGELOG.md
+++ b/ods/CHANGELOG.md
@@ -6,11 +6,102 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-07-28
+
+### Added
+- Remote-provider operations graduated into the product surface: direct and
+  SSH egress routes, egress policy contracts, SSH tunnel supervision, peer ODS
+  model discovery, remote model load/delete flows, and dashboard status/UI
+  integration.
+- Model Switchboard support now gives local applications a stable current-model
+  route, selected context propagation, model identity validation, rollback-aware
+  runtime swaps, and app probes across Open WebUI, Hermes, OpenCode,
+  Perplexica, and other LLM consumers.
+- GPU reassignment workflows now support verified multi-GPU model swapping on
+  NVIDIA and Linux AMD/ROCm paths, including rollback when a reassignment or
+  recreation fails.
+- Dashboard and setup flows gained stack presets, an animated loading screen,
+  better service URL handling, model download progress, first-boot polish, and
+  clearer owner/support access paths.
+- Linux rootless Docker installs now have subordinate-ID diagnostics and a
+  rootless bind-mount ownership repair path for services with container-owned
+  data directories.
+
+### Changed
+- Stable channel documentation now points at `v2.6.0` and identifies
+  `release/2.6.x` as the current patch lane, with `release/2.5.x` retained
+  only for critical old-stable continuity fixes.
+- Version consistency now also checks the `ods-cli` fallback version so CLI,
+  installer, dashboard, manifest, architecture, and changelog authorities move
+  together.
+- Runtime configuration is more centralized: generated configs, app routes,
+  model-router state, switchboard mode, and Lemonade/native adapters share more
+  of the same contracts across Linux, macOS, Windows, and Docker paths.
+- Extension installation and dashboard service handling were hardened around
+  transactional updates, dependency resolution, public service URLs, and
+  compose-stack reconciliation.
+
 ### Fixed
 - Dashboard Hermes readiness now accepts either llama-server or LiteLLM and
   requires the complete authenticated runtime chain. Hermes Single Sign-On now
   opens owner and support access management instead of duplicating the Agent
   runtime link.
+- Windows native llama-server launches now carry both the llama.cpp metrics
+  endpoint and `LLAMA_REASONING` selection, while the Windows host-agent Python
+  resolver handles multiple PATH interpreters and Microsoft Store aliases.
+- Intel and Arc compose overlays keep llama.cpp runtime tunables such as batch
+  size, threads, parallelism, and metrics instead of losing base-command flags.
+- Linux rootless Docker no longer receives host-side ownership repairs that map
+  to the wrong namespace; ODS prepares and verifies bind mounts from inside the
+  rootless container namespace.
+- Token Spy's Postgres SSE cursor now uses a durable timestamp/UUID cursor so
+  retention and UUID ordering cannot silently drop events.
+- Remote provider direct egress now pins requests to policy-validated resolved
+  addresses while preserving Host and TLS SNI, closing DNS-rebinding/TOCTOU
+  escape paths.
+- macOS writes OpenCode's `config.json` compatibility file alongside
+  `opencode.json`, and installer-context parity now checks all platform
+  writers.
+- Perplexica detects AMD Lemonade runtime state on local installs and selects
+  the served model id instead of routing to an unavailable GGUF name.
+- Dashboard voice readiness no longer treats absent optional LiveKit as a
+  voice-stack failure; installed optional voice services still gate on health.
+- Dashboard model-memory estimates now read the catalog `gguf_file` key so
+  dashboard activation agrees with installer model selection.
+- Uninstall cleanup now scopes fallback container and volume discovery to ODS
+  project prefixes, avoiding unrelated Docker resources.
+- Windows Lemonade restarts tolerate stale listener/PID references without
+  relaxing ownership checks for live unrelated processes.
+- Offline model validation, model compatibility, model download host checks,
+  imported-model exclusion, and model route foundation fixes reduce invalid
+  catalog selections and stale app routes.
+- Multiple installer and lifecycle regressions were fixed across macOS platform
+  image pulls, Windows env-file replacement, native-port preflight, compose
+  failure reporting, Linux TTY input, compose resolver errors, bootstrap resume,
+  update dry-run version reading, and restart/doctor recovery paths.
+
+### Security
+- Remote-provider egress now validates direct provider DNS resolution and pins
+  outbound requests to the approved address while keeping provider TLS identity
+  intact.
+- OAuth pending-state validation and local backend URL handling were hardened.
+- Network exposure, dependency pin, secret-minLength, support-bundle, and
+  release-claim contracts were expanded so release gates catch more unsafe
+  drift.
+
+### Validation
+- Product candidate `c292e00d` had all 9 GitHub Actions checks green on
+  2026-07-28: Dashboard, Lint PowerShell, Matrix Smoke, Python Lint, Python
+  Type Check, Secret Scan, ShellCheck, Test Linux, and Validate .env Schema.
+- Focused local validation on 2026-07-28 passed Windows parser/resolver,
+  llama runtime tunables, metrics, reasoning, env schema, uninstall scoping,
+  installer-context parity, rootless doctor, dashboard API regressions
+  (`502 passed, 5 skipped`), and Perplexica/remote-provider/token-spy tests
+  (`35 passed, 1 skipped`).
+- Linux rootless ownership contract passed on Tower2 with
+  `25` rootless ownership tests.
+- Final stable publication still requires the release-grade fleet/distro/model
+  management receipt to be recorded against the final release-stamp commit.
 
 ## [2.5.3] - 2026-05-26
 

--- a/ods/CHANGELOG.md
+++ b/ods/CHANGELOG.md
@@ -90,7 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   drift.
 
 ### Validation
-- Release-prep candidate `e93d5434` had all PR checks green on 2026-07-28:
+- Release-prep candidate `07e2a21e` had all PR checks green on 2026-07-28:
   Dashboard, Lint PowerShell, Matrix Smoke, Python Lint, Python Type Check,
   Secret Scan, ShellCheck, Test Linux, Validate .env Schema, and review gates.
   The branch is based on product merge commit `c292e00d`.
@@ -101,8 +101,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`35 passed, 1 skipped`).
 - Linux rootless ownership contract passed on Tower2 with
   `25` rootless ownership tests.
-- Final stable publication still requires the release-grade fleet/distro/model
-  management receipt to be recorded against the final release-stamp commit.
+- Release-prep fleet validation on 2026-07-28 passed regressions,
+  zero-prereq bootstrap, fresh install, verify, cloud-mode, dashboard, Hermes,
+  UI policy, full-model capability finalize, lifecycle reinstall/restart, and
+  `ods doctor` across Tower2, Strix Halo, Spark, M5 MacBook Pro,
+  Windows laptop, and Strixy. The run recorded zero product bugs, zero harness
+  limitations, and zero environment notes.
+- Strict User Green is not claimed for this candidate: the long six-cycle
+  browser model-management matrix was intentionally waived after partial pass
+  evidence, and `dgx-gpu01` was excluded because its SSH host key changed and
+  was not owner-verified.
 
 ## [2.5.3] - 2026-05-26
 

--- a/ods/CHANGELOG.md
+++ b/ods/CHANGELOG.md
@@ -90,9 +90,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   drift.
 
 ### Validation
-- Product candidate `c292e00d` had all 9 GitHub Actions checks green on
-  2026-07-28: Dashboard, Lint PowerShell, Matrix Smoke, Python Lint, Python
-  Type Check, Secret Scan, ShellCheck, Test Linux, and Validate .env Schema.
+- Release-prep candidate `e93d5434` had all PR checks green on 2026-07-28:
+  Dashboard, Lint PowerShell, Matrix Smoke, Python Lint, Python Type Check,
+  Secret Scan, ShellCheck, Test Linux, Validate .env Schema, and review gates.
+  The branch is based on product merge commit `c292e00d`.
 - Focused local validation on 2026-07-28 passed Windows parser/resolver,
   llama runtime tunables, metrics, reasoning, env schema, uninstall scoping,
   installer-context parity, rootless doctor, dashboard API regressions

--- a/ods/docs/INSTALLER_TRUST.md
+++ b/ods/docs/INSTALLER_TRUST.md
@@ -66,8 +66,15 @@ curl -fsSL https://install.osmantic.com/ods.sh | ODS_REF=main bash
 ```
 
 `ODS_REF` can select only refs that contain the current `ods/` product-tree
-layout used by the sparse checkout. The current stable tag, `v2.5.3`, predates that repository layout and must be installed through the manual source path below.
-Do not pass `v2.5.3` through `ODS_REF`.
+layout used by the sparse checkout. The current stable tag, `v2.6.0`, is
+compatible with that layout:
+
+```bash
+curl -fsSL https://install.osmantic.com/ods.sh | ODS_REF=v2.6.0 bash
+```
+
+Older tags that predate the current layout must be installed through the
+manual source path below.
 
 Maintainers can verify all twelve hosted Worker aliases against an exact Git
 ref:
@@ -96,7 +103,7 @@ For the stable release tag, clone the known ref and run the installer from the
 checked-out source:
 
 ```bash
-git clone --depth 1 --branch v2.5.3 https://github.com/Osmantic/ODS.git
+git clone --depth 1 --branch v2.6.0 https://github.com/Osmantic/ODS.git
 cd ODS
 ./install.sh
 ```
@@ -131,7 +138,7 @@ Windows users should install from a normal user PowerShell, not an elevated
 Administrator shell:
 
 ```powershell
-git clone --depth 1 --branch v2.5.3 https://github.com/Osmantic/ODS.git
+git clone --depth 1 --branch v2.6.0 https://github.com/Osmantic/ODS.git
 cd ODS
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 .\install.ps1
@@ -168,7 +175,7 @@ cmp get-ods.sh main-get-ods.sh
 On Windows, clone first and inspect `install.ps1` before running it:
 
 ```powershell
-git clone --depth 1 --branch v2.5.3 https://github.com/Osmantic/ODS.git
+git clone --depth 1 --branch v2.6.0 https://github.com/Osmantic/ODS.git
 cd ODS
 notepad .\install.ps1
 .\install.ps1

--- a/ods/docs/README.md
+++ b/ods/docs/README.md
@@ -176,6 +176,7 @@ canonical source and treat older recipes as context.
 | [KNOWN-GOOD-VERSIONS.md](KNOWN-GOOD-VERSIONS.md) | Operators | Tested image/version combos |
 | [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) | Developers | Platform feature matrix |
 | [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) | Operators / release reviewers | User Green gates and when operational changes require release-grade fleet validation |
+| [RELEASE_NOTES_2.6.0.md](RELEASE_NOTES_2.6.0.md) | Operators / release reviewers | Draft 2.6.0 notes, validation receipt fields, and publication checklist |
 | [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) | Operators / release reviewers | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) | Contributors / maintainers | Risk levels and required validation by changed surface |
 

--- a/ods/docs/README.md
+++ b/ods/docs/README.md
@@ -176,7 +176,7 @@ canonical source and treat older recipes as context.
 | [KNOWN-GOOD-VERSIONS.md](KNOWN-GOOD-VERSIONS.md) | Operators | Tested image/version combos |
 | [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) | Developers | Platform feature matrix |
 | [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) | Operators / release reviewers | User Green gates and when operational changes require release-grade fleet validation |
-| [RELEASE_NOTES_2.6.0.md](RELEASE_NOTES_2.6.0.md) | Operators / release reviewers | Draft 2.6.0 notes, validation receipt fields, and publication checklist |
+| [RELEASE_NOTES_2.6.0.md](RELEASE_NOTES_2.6.0.md) | Operators / release reviewers | 2.6.0 release notes, validation receipt, and known validation boundaries |
 | [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) | Operators / release reviewers | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) | Contributors / maintainers | Risk levels and required validation by changed surface |
 

--- a/ods/docs/RELEASE_CHANNELS.md
+++ b/ods/docs/RELEASE_CHANNELS.md
@@ -5,19 +5,21 @@ ecosystems move quickly. Treat each ref intentionally.
 
 ## Current Stable
 
-The current stable release is `v2.5.3`.
+The current stable release is `v2.6.0`.
 
-Use `v2.5.3` for normal installs, downstream appliance baselines, lab images,
-and forks that want a known-good starting point. Use `release/2.5.x` only for
-patches that should preserve the `v2.5.3` user experience while fixing a
-stable-user problem.
+Use `v2.6.0` for normal installs, downstream appliance baselines, lab images,
+and forks that want a known-good starting point. Use `release/2.6.x` only for
+patches that should preserve the `v2.6.0` user experience while fixing a
+stable-user problem. The prior `release/2.5.x` line remains available only for
+critical fixes that must stay on the superseded 2.5 baseline.
 
 ## Channels
 
 | Channel | Use it for | Expectation |
 |---|---|---|
 | `main` | Active development, contributor work, rapid fixes, validation candidates | Can change many times per day. Read diffs and run focused validation before using it for an appliance or fork release. |
-| `release/2.5.x` | Patch-only maintenance for the current stable line | Only accepts stable hotfixes, security fixes, and docs that clarify current stable behavior. No new feature work. |
+| `release/2.6.x` | Patch-only maintenance for the current stable line | Only accepts stable hotfixes, security fixes, and docs that clarify current stable behavior. No new feature work. |
+| `release/2.5.x` | Superseded stable baseline | Critical security or operator-continuity fixes only. Prefer upgrading to `v2.6.0`. |
 | Tagged releases | Stable installs, downstream forks, lab images, appliance baselines | Preferred source for users and downstream operators who want a reproducible starting point. |
 | Pinned commits | Security reviews, internal mirrors, release candidates, emergency hotfix baselines | Valid when the commit and validation receipt are recorded together. |
 | Downstream forks | Custom hardware images, labs, private extensions, offline mirrors | Should record upstream ref, downstream changes, and local validation results. |
@@ -26,8 +28,8 @@ stable-user problem.
 
 - New users can follow the README quickstart.
 - Operators who want reproducibility should pin a release tag. Today that means
-  `v2.5.3` unless a newer stable release has been published.
-- Stable hotfixes should target `release/2.5.x` first, then be merged forward
+  `v2.6.0` unless a newer stable release has been published.
+- Stable hotfixes should target `release/2.6.x` first, then be merged forward
   or cherry-picked into `main`.
 - Forks should either fork-and-pin or fork-and-mirror.
 - Hardware builders should treat upstream release receipts as evidence, then add
@@ -45,7 +47,7 @@ current stable release. Good candidates include:
   supported default path
 - docs that prevent current stable users from taking the wrong action
 
-Do not target `release/2.5.x` for:
+Do not target `release/2.6.x` for:
 
 - new bundled services or changed default services
 - broad installer, CLI, manifest, or compose refactors
@@ -68,7 +70,7 @@ Before opening or reviewing a PR, classify the lane:
 4. Can it wait for the next minor release?
 
 If the answer to the first question is yes and the fix is narrow, consider
-`release/2.5.x`. If the answer is no, use `main`. If the change is broad or
+`release/2.6.x`. If the answer is no, use `main`. If the change is broad or
 feature-shaped, use the next minor milestone.
 
 ## Fork-And-Pin

--- a/ods/docs/RELEASE_NOTES_2.6.0.md
+++ b/ods/docs/RELEASE_NOTES_2.6.0.md
@@ -49,10 +49,11 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
 ## Validation Receipt
 
 - Release tag: `v2.6.0` (pending)
-- Candidate product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
+- Candidate product commit: `e93d5434fc2a09dd0324e0f3df9ef5d6943cded9`
+- Base product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
 - Release-prep branch: `chore/release-2.6.0`
 - Release-stamp commit: pending final merge
-- GitHub Actions at candidate commit: 9/9 green on 2026-07-28
+- GitHub Actions at candidate commit: all PR checks green on 2026-07-28
 - Focused local validation at candidate commit:
   - Windows parser/resolver
   - llama runtime tunables, metrics, and reasoning contracts
@@ -106,7 +107,8 @@ hardening.
 
 - Release tag: `v2.6.0`
 - Release-stamp commit: `TBD`
-- Product candidate: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
+- Product candidate: `e93d5434fc2a09dd0324e0f3df9ef5d6943cded9`
+- Base product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
 - Gate result: `TBD after release-grade validation`
 - Known skipped/deferred surfaces: `TBD`
 

--- a/ods/docs/RELEASE_NOTES_2.6.0.md
+++ b/ods/docs/RELEASE_NOTES_2.6.0.md
@@ -65,8 +65,8 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
     `35 passed, 1 skipped`
   - Tower2 rootless ownership contract: `25 passed`
 - Release-prep fleet receipt on 2026-07-28:
-  - run directory:
-    `/home/michael/dream-fleet-test/runs/2026-07-28T12-58-00Z-release-product-07e2a21e3cca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
+  - run id:
+    `2026-07-28T12-58-00Z-release-product-07e2a21e3cca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
   - harness: `main@19d43e6f9f2533e8768ed85b33de9f4ace232129`
     (clean)
   - command:

--- a/ods/docs/RELEASE_NOTES_2.6.0.md
+++ b/ods/docs/RELEASE_NOTES_2.6.0.md
@@ -1,7 +1,8 @@
 # ODS 2.6.0 Draft Release Notes
 
-Draft status: release-prep branch. Do not publish as stable until the final
-release-stamp commit has a release-grade validation receipt.
+Draft status: release-prep branch. Stable publication is pending the final
+merge/tag decision. A strict User Green stamp is not claimed for this candidate
+because the long six-cycle model-management matrix was intentionally waived.
 
 ## Summary
 
@@ -49,7 +50,7 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
 ## Validation Receipt
 
 - Release tag: `v2.6.0` (pending)
-- Candidate product commit: `e93d5434fc2a09dd0324e0f3df9ef5d6943cded9`
+- Candidate product commit: `07e2a21e3ccab197360009ebd3d66b4e6d4d0af2`
 - Base product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
 - Release-prep branch: `chore/release-2.6.0`
 - Release-stamp commit: pending final merge
@@ -63,19 +64,40 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
   - Perplexica, remote-provider egress, and Token Spy cursor tests:
     `35 passed, 1 skipped`
   - Tower2 rootless ownership contract: `25 passed`
-- Required before stable publication:
-  - release-grade fleet run
-  - zero-prereq bootstrap
-  - distro lab
-  - lifecycle checks: reinstall, restart, `ods doctor`
-  - model-management release or explicitly documented substitute
-  - skipped/deferred surfaces recorded in the final receipt
-- Current publication blocker as of 2026-07-28:
-  - `dgx-gpu01` fails strict SSH host-key verification and needs owner
-    verification before it can be counted in release-grade fleet scope; Tower2's
-    pinned ED25519 key is `SHA256:hPPRpUClgK0nCDrZujmfHgbMIIYV70zSpKfBw4VWmdo`
-    while the endpoint currently presents
-    `SHA256:zgUNklRWH+N/aaQ1MmZEzmN6ABu/6XMOw2Mm3ITzwfM`
+- Release-prep fleet receipt on 2026-07-28:
+  - run directory:
+    `/home/michael/dream-fleet-test/runs/2026-07-28T12-58-00Z-release-product-07e2a21e3cca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
+  - harness: `main@19d43e6f9f2533e8768ed85b33de9f4ace232129`
+    (clean)
+  - command:
+    `./run.sh --phase release --hosts tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy --smoke-host tower2`
+  - selected hosts: `tower2`, `strix-halo`, `spark`, `m5-mbp`,
+    `windows-laptop`, `strixy`
+  - excluded enabled host: `dgx-gpu01`
+  - zero-prereq bootstrap: `6/6` lanes passed
+  - regressions: `16/16` fixtures passed
+  - install: all six selected hosts installed from the public bootstrap at the
+    exact candidate commit
+  - post-install: verify, cloud-mode contracts, dashboard, Hermes, UI policy,
+    capabilities, lifecycle reinstall/restart, and `ods doctor` passed on the
+    selected hosts
+  - full-model finalize: all deferred Hermes/capability probes were rerun
+    after full-model readiness; no install-blocked, still-deferred, or
+    download-failed hosts remained
+  - generated report: `REPORT.md` recorded Real product bugs: `0`,
+    Harness limitations: `0`, Environment notes: `0`
+- Explicitly waived or excluded surfaces:
+  - six-cycle release model-management matrix was started but intentionally
+    stopped as too time-consuming for this release-prep need; cycle 1 passed on
+    `tower2` and `strix-halo`, while the remaining generated `143`
+    interruption receipts from the operator stop
+  - because that matrix was waived, this candidate is not stamped strict User
+    Green; publication should describe the waiver rather than claiming Model UI
+    Green
+  - `dgx-gpu01` was excluded after strict SSH host-key verification failed;
+    Tower2's pinned ED25519 key is
+    `SHA256:hPPRpUClgK0nCDrZujmfHgbMIIYV70zSpKfBw4VWmdo`, while the endpoint
+    currently presents `SHA256:zgUNklRWH+N/aaQ1MmZEzmN6ABu/6XMOw2Mm3ITzwfM`
 
 ## Known Limits
 
@@ -113,10 +135,12 @@ hardening.
 
 - Release tag: `v2.6.0`
 - Release-stamp commit: `TBD`
-- Product candidate: `e93d5434fc2a09dd0324e0f3df9ef5d6943cded9`
+- Product candidate: `07e2a21e3ccab197360009ebd3d66b4e6d4d0af2`
 - Base product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
-- Gate result: `TBD after release-grade validation`
-- Known skipped/deferred surfaces: `TBD`
+- Gate result: `green through six-host full-model finalize; strict User Green
+  not claimed because the six-cycle model-management matrix was waived`
+- Known skipped/deferred surfaces: `dgx-gpu01 excluded for unverified SSH host
+  key; full model-management matrix intentionally stopped after partial pass`
 
 See `ods/CHANGELOG.md` and `ods/docs/RELEASE_NOTES_2.6.0.md` for the full
 release notes and validation receipt.

--- a/ods/docs/RELEASE_NOTES_2.6.0.md
+++ b/ods/docs/RELEASE_NOTES_2.6.0.md
@@ -1,8 +1,8 @@
-# ODS 2.6.0 Draft Release Notes
+# ODS 2.6.0 Release Notes
 
-Draft status: release-prep branch. Stable publication is pending the final
-merge/tag decision. A strict User Green stamp is not claimed for this candidate
-because the long six-cycle model-management matrix was intentionally waived.
+Publication status: current stable release. A strict User Green stamp is not
+claimed for this release because the long six-cycle model-management matrix was
+intentionally waived.
 
 ## Summary
 
@@ -11,9 +11,9 @@ switchboard, verified context selection, GPU reassignment rollback, rootless
 Linux installs, Windows and macOS native-runtime stability, dashboard polish,
 and release hygiene.
 
-Use this release for new stable installs once the final validation receipt is
-complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
-2.5 behavior and cannot move to the 2.6 line yet.
+Use this release for new stable installs. Continue to pin `v2.5.3` only when
+an appliance or fork needs the old 2.5 behavior and cannot move to the 2.6 line
+yet.
 
 ## Highlights
 
@@ -49,12 +49,13 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
 
 ## Validation Receipt
 
-- Release tag: `v2.6.0` (pending)
+- Release tag: `v2.6.0`
 - Candidate product commit: `07e2a21e3ccab197360009ebd3d66b4e6d4d0af2`
 - Base product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
-- Release-prep branch: `chore/release-2.6.0`
-- Release-stamp commit: pending final merge
-- GitHub Actions at candidate commit: all PR checks green on 2026-07-28
+- Release-prep PR: `#2232`
+- Release-stamp ref: `v2.6.0` tag target
+- GitHub Actions at release-prep head:
+  `195103787de031973b959de9f313005183cc1afb` green on 2026-07-28
 - Focused local validation at candidate commit:
   - Windows parser/resolver
   - llama runtime tunables, metrics, and reasoning contracts
@@ -108,7 +109,7 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
 - Vision probes, AP mode, custom network topologies, and downstream forks need
   their own local validation receipts.
 
-## Draft GitHub Release Body
+## GitHub Release Body
 
 ```markdown
 ## ODS 2.6.0
@@ -134,7 +135,7 @@ hardening.
 ### Validation
 
 - Release tag: `v2.6.0`
-- Release-stamp commit: `TBD`
+- Release-stamp ref: `v2.6.0` tag target
 - Product candidate: `07e2a21e3ccab197360009ebd3d66b4e6d4d0af2`
 - Base product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
 - Gate result: `green through six-host full-model finalize; strict User Green

--- a/ods/docs/RELEASE_NOTES_2.6.0.md
+++ b/ods/docs/RELEASE_NOTES_2.6.0.md
@@ -1,0 +1,115 @@
+# ODS 2.6.0 Draft Release Notes
+
+Draft status: release-prep branch. Do not publish as stable until the final
+release-stamp commit has a release-grade validation receipt.
+
+## Summary
+
+ODS 2.6.0 rolls up the post-2.5.3 work on remote providers, model
+switchboard, verified context selection, GPU reassignment rollback, rootless
+Linux installs, Windows and macOS native-runtime stability, dashboard polish,
+and release hygiene.
+
+Use this release for new stable installs once the final validation receipt is
+complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
+2.5 behavior and cannot move to the 2.6 line yet.
+
+## Highlights
+
+- Remote provider support now includes direct and SSH egress, policy checks,
+  tunnel supervision, dashboard status, and peer ODS model operations.
+- Model Switchboard gives apps a stable current-model route and propagates the
+  selected context across runtimes and applications.
+- NVIDIA and Linux AMD/ROCm GPU reassignment flows support larger model swaps
+  with verified rollback.
+- Linux rootless Docker installs can repair service bind-mount ownership inside
+  the rootless namespace.
+- Windows native llama-server launches now expose metrics and honor
+  `LLAMA_REASONING`; stale Lemonade listener PIDs are handled safely.
+- macOS OpenCode config compatibility, Perplexica Lemonade routing, Token Spy
+  Postgres cursors, voice readiness, and model-memory estimates were corrected.
+- Remote-provider direct egress now pins validated DNS resolutions to close
+  DNS-rebinding/SSRF escape paths.
+
+## Upgrade Notes
+
+- `v2.6.0` is the new stable line. Stable hotfixes should target
+  `release/2.6.x` first, then merge forward to `main`.
+- `release/2.5.x` is superseded and should only receive critical old-stable
+  continuity fixes.
+- Operators using remote-provider direct routes should re-run route validation
+  after upgrade so the new DNS pinning and TLS identity behavior is exercised.
+- Rootless Docker operators with container-owned data directories should stop
+  ODS, run `ods repair rootless-ownership`, then start ODS if a service reports
+  permission errors under `data/`.
+- Windows users relying on native llama-server fallback should restart the
+  native runtime after upgrade so `--metrics` and `--reasoning-format` are
+  present on the process command line.
+
+## Validation Receipt
+
+- Release tag: `v2.6.0` (pending)
+- Candidate product commit: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
+- Release-prep branch: `chore/release-2.6.0`
+- Release-stamp commit: pending final merge
+- GitHub Actions at candidate commit: 9/9 green on 2026-07-28
+- Focused local validation at candidate commit:
+  - Windows parser/resolver
+  - llama runtime tunables, metrics, and reasoning contracts
+  - env schema and uninstall scoping
+  - installer context parity and rootless doctor
+  - dashboard API focused regressions: `502 passed, 5 skipped`
+  - Perplexica, remote-provider egress, and Token Spy cursor tests:
+    `35 passed, 1 skipped`
+  - Tower2 rootless ownership contract: `25 passed`
+- Required before stable publication:
+  - release-grade fleet run
+  - zero-prereq bootstrap
+  - distro lab
+  - lifecycle checks: reinstall, restart, `ods doctor`
+  - model-management release or explicitly documented substitute
+  - skipped/deferred surfaces recorded in the final receipt
+
+## Known Limits
+
+- Windows native remains an installer/runtime path with targeted validation;
+  WSL2 plus Docker Desktop remains the supported Windows appliance path.
+- ODS Talk owner-card probes gate only when the owner-card surface and
+  `ods-proxy` are enabled for the candidate install.
+- Vision probes, AP mode, custom network topologies, and downstream forks need
+  their own local validation receipts.
+
+## Draft GitHub Release Body
+
+```markdown
+## ODS 2.6.0
+
+ODS 2.6.0 updates the stable line with remote-provider support, Model
+Switchboard and context selection, GPU reassignment rollback, rootless Linux
+repair, Windows/macOS native-runtime fixes, dashboard polish, and security
+hardening.
+
+### Highlights
+
+- Remote provider direct/SSH egress, tunnel supervision, dashboard status, and
+  peer model operations.
+- Model Switchboard stable routing and verified context propagation across LLM
+  applications.
+- Verified NVIDIA and Linux AMD/ROCm GPU reassignment with rollback.
+- Rootless Docker bind-mount ownership repair for Linux installs.
+- Windows native llama-server metrics and reasoning flags, plus safer Lemonade
+  stale-PID handling.
+- Remote-provider DNS-rebinding/SSRF hardening through validated address
+  pinning with preserved TLS identity.
+
+### Validation
+
+- Release tag: `v2.6.0`
+- Release-stamp commit: `TBD`
+- Product candidate: `c292e00d5b60f6e4e6b331b2867346f9e9748a2c`
+- Gate result: `TBD after release-grade validation`
+- Known skipped/deferred surfaces: `TBD`
+
+See `ods/CHANGELOG.md` and `ods/docs/RELEASE_NOTES_2.6.0.md` for the full
+release notes and validation receipt.
+```

--- a/ods/docs/RELEASE_NOTES_2.6.0.md
+++ b/ods/docs/RELEASE_NOTES_2.6.0.md
@@ -70,11 +70,12 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
   - lifecycle checks: reinstall, restart, `ods doctor`
   - model-management release or explicitly documented substitute
   - skipped/deferred surfaces recorded in the final receipt
-- Current publication blockers as of 2026-07-28:
-  - the active Tower2 model-ui run is smoke-tier, uses product SHA
-    `6937fceaa60eab496c7cad7eac4e240c48d4f3aa`, and holds the fleet lock
+- Current publication blocker as of 2026-07-28:
   - `dgx-gpu01` fails strict SSH host-key verification and needs owner
-    verification before it can be counted in release-grade fleet scope
+    verification before it can be counted in release-grade fleet scope; Tower2's
+    pinned ED25519 key is `SHA256:hPPRpUClgK0nCDrZujmfHgbMIIYV70zSpKfBw4VWmdo`
+    while the endpoint currently presents
+    `SHA256:zgUNklRWH+N/aaQ1MmZEzmN6ABu/6XMOw2Mm3ITzwfM`
 
 ## Known Limits
 

--- a/ods/docs/RELEASE_NOTES_2.6.0.md
+++ b/ods/docs/RELEASE_NOTES_2.6.0.md
@@ -70,6 +70,11 @@ complete. Continue to pin `v2.5.3` only when an appliance or fork needs the old
   - lifecycle checks: reinstall, restart, `ods doctor`
   - model-management release or explicitly documented substitute
   - skipped/deferred surfaces recorded in the final receipt
+- Current publication blockers as of 2026-07-28:
+  - the active Tower2 model-ui run is smoke-tier, uses product SHA
+    `6937fceaa60eab496c7cad7eac4e240c48d4f3aa`, and holds the fleet lock
+  - `dgx-gpu01` fails strict SSH host-key verification and needs owner
+    verification before it can be counted in release-grade fleet scope
 
 ## Known Limits
 

--- a/ods/docs/RELEASE_VALIDATION.md
+++ b/ods/docs/RELEASE_VALIDATION.md
@@ -1,6 +1,6 @@
 # Release Validation
 
-Last updated: 2026-05-25
+Last updated: 2026-07-28
 
 ODS is validated as an installed appliance, not only as a collection of
 unit tests. The release-grade path combines CI, clean distro bootstrap checks,

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -1054,7 +1054,7 @@ async def _lifespan(app: FastAPI):
 
 app = FastAPI(
     title="ODS Dashboard API",
-    version="2.5.3",
+    version="2.6.0",
     description="System status API for ODS Dashboard",
     lifespan=_lifespan,
 )

--- a/ods/extensions/services/dashboard-api/tests/test_node.py
+++ b/ods/extensions/services/dashboard-api/tests/test_node.py
@@ -123,7 +123,7 @@ class TestNodeCapabilitiesEndpoint:
 
         r = test_client.get("/api/node/capabilities", headers=test_client.auth_headers)
         assert r.status_code == 200
-        assert r.json()["ods_version"] == "2.5.3"  # app.version fallback
+        assert r.json()["ods_version"] == "2.6.0"  # app.version fallback
 
     def test_requires_auth(self, test_client):
         r = test_client.get("/api/node/capabilities")

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -74,14 +74,14 @@ def test_get_version_with_mock_github(test_client, monkeypatch):
 
 def test_build_version_result_strips_v_prefix_from_current():
     """Current versions stored with a 'v' prefix (matching the release tag
-    convention, e.g. a .version file of 'v2.5.3') must normalize before
+    convention, e.g. a .version file of 'v2.6.0') must normalize before
     comparison. Otherwise the numeric parser misreads them and a real update
     is reported as unavailable.
     """
     from routers.updates import _build_version_result
 
-    result = _build_version_result("v2.5.3", {"latest": "2.6.0"})
-    assert result["current"] == "2.5.3"
+    result = _build_version_result("v2.6.0", {"latest": "2.7.0"})
+    assert result["current"] == "2.6.0"
     assert result["update_available"] is True
 
 

--- a/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
@@ -9,7 +9,7 @@ const response = (body, status = 200) => ({
 })
 
 const summary = {
-  version: '2.5.3',
+  version: '2.6.0',
   install_date: '2026-07-20T14:58:20Z',
   tier: 'entry',
   uptime: 3600,
@@ -50,7 +50,7 @@ const editor = {
     },
   },
   sections: [{ id: 'configuration', title: 'Configuration', keys: ['ODS_VERSION', 'HOST_LAN_IP'] }],
-  values: { ODS_VERSION: '2.5.3', HOST_LAN_IP: '192.168.1.10' },
+  values: { ODS_VERSION: '2.6.0', HOST_LAN_IP: '192.168.1.10' },
   issues: [],
   applyPlan: null,
   agentAvailable: true,
@@ -69,7 +69,7 @@ const payloadByUrl = (url) => {
   }
   if (url === '/api/setup/status') return { first_run: false, persona: null }
   if (url === '/api/version') {
-    return { current: '2.5.3', latest: '2.5.3', update_available: false, checked_at: '2026-07-23T12:00:00Z' }
+    return { current: '2.6.0', latest: '2.6.0', update_available: false, checked_at: '2026-07-23T12:00:00Z' }
   }
   throw new Error(`Unexpected request: ${url}`)
 }

--- a/ods/installers/lib/constants.sh
+++ b/ods/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.5.3"
+VERSION="2.6.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Source path utilities for cross-platform path resolution

--- a/ods/installers/macos/lib/constants.sh
+++ b/ods/installers/macos/lib/constants.sh
@@ -11,7 +11,7 @@
 #   Change ODS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-ODS_VERSION="2.5.3"
+ODS_VERSION="2.6.0"
 
 # Install location - use shared path resolution if available.
 # constants.sh lives at two different depths depending on layout:

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -744,7 +744,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
 # Tier: ${TIER} (${TIER_NAME})
 
 #=== ODS Version (used by ods-cli update for version-compat checks) ===
-ODS_VERSION=${VERSION:-2.5.3}
+ODS_VERSION=${VERSION:-2.6.0}
 
 #=== Network Binding ===
 # 127.0.0.1 = localhost only (secure default)

--- a/ods/installers/windows/lib/constants.ps1
+++ b/ods/installers/windows/lib/constants.ps1
@@ -10,7 +10,7 @@
 #   Change ODS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-$script:ODS_VERSION = "2.5.3"
+$script:ODS_VERSION = "2.6.0"
 
 # Install location (override via $env:ODS_HOME)
 # NOTE: $(if ...) syntax required for PS 5.1 compatibility (bare if-as-expression is PS 7+ only)

--- a/ods/manifest.json
+++ b/ods/manifest.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 2,
-  "ods_version": "2.5.3",
+  "ods_version": "2.6.0",
   "min_compatible_ods_version": "1.0.0",
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.5.3",
+    "version": "2.6.0",
     "channel": "stable",
-    "date": "2026-05-26"
+    "date": "2026-07-28"
   },
   "compatibility": {
     "os": {

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -25,7 +25,7 @@ while [[ -L "$_source" ]]; do
 done
 SCRIPT_DIR="$(cd "$(dirname "$_source")" && pwd)"
 INSTALL_DIR="${ODS_HOME:-$HOME/ods}"
-VERSION="2.0.0"
+VERSION="2.6.0"
 if [[ -f "$INSTALL_DIR/.env" ]]; then
     _v=$(awk -F= '/^ODS_VERSION=/{gsub(/^["'"'"']|["'"'"']$/,"",$2); print $2; exit}' "$INSTALL_DIR/.env" 2>/dev/null) || true
     [[ -n "${_v:-}" ]] && VERSION="$_v"
@@ -1165,9 +1165,37 @@ _ods_cli_pull_external_images() {
     for image in "${images[@]}"; do
         count=$((count + 1))
         log "  [$count/$total] $image"
-        if ! docker pull "$image"; then
+        local _pull_max_attempts="${ODS_COMPOSE_PULL_RETRY_ATTEMPTS:-3}"
+        if ! [[ "$_pull_max_attempts" =~ ^[0-9]+$ ]] || (( _pull_max_attempts < 1 )); then
+            _pull_max_attempts=3
+        fi
+        local _pull_attempt=1 _pull_ok=false _pull_log
+        _pull_log=$(mktemp)
+        while (( _pull_attempt <= _pull_max_attempts )); do
+            : >"$_pull_log"
+            if docker pull "$image" >"$_pull_log" 2>&1; then
+                _pull_ok=true
+                break
+            fi
+            if (( _pull_attempt >= _pull_max_attempts )) \
+                || ! grep -Eiq 'context deadline exceeded|i/o timeout|TLS handshake timeout|connection reset by peer|connection timed out|temporary failure|network is unreachable|net/http: request canceled|unexpected EOF' "$_pull_log"; then
+                break
+            fi
+            local _pull_delay
+            case "$_pull_attempt" in
+                1) _pull_delay="${ODS_COMPOSE_PULL_RETRY_DELAY_1:-5}" ;;
+                2) _pull_delay="${ODS_COMPOSE_PULL_RETRY_DELAY_2:-15}" ;;
+                *) _pull_delay="${ODS_COMPOSE_PULL_RETRY_DELAY_N:-30}" ;;
+            esac
+            warn "Docker registry pull hit a transient network error; retrying (${_pull_attempt}/$((_pull_max_attempts - 1)))."
+            sleep "$_pull_delay"
+            _pull_attempt=$((_pull_attempt + 1))
+        done
+        if [[ "$_pull_ok" != "true" ]]; then
+            cat "$_pull_log" >&2
             failed=$((failed + 1))
         fi
+        rm -f "$_pull_log"
     done
 
     if (( failed > 0 )); then

--- a/ods/scripts/check-version-consistency.py
+++ b/ods/scripts/check-version-consistency.py
@@ -99,6 +99,13 @@ def main() -> int:
     add_regex_check(
         checks,
         errors,
+        "ods-cli VERSION",
+        ROOT / "ods-cli",
+        r'^VERSION="([^"]+)"',
+    )
+    add_regex_check(
+        checks,
+        errors,
         "installers/macos/lib/constants.sh ODS_VERSION",
         ROOT / "installers/macos/lib/constants.sh",
         r'^ODS_VERSION="([^"]+)"',

--- a/ods/scripts/release-gate.sh
+++ b/ods/scripts/release-gate.sh
@@ -27,6 +27,7 @@ bash scripts/check-release-claims.sh
 "$PYTHON_CMD" scripts/check-dependency-pins.py
 
 echo "[gate] contracts"
+bash tests/test-install-docs.sh
 bash tests/test-hosted-bootstrap-verifier.sh
 bash tests/contracts/test-installer-contracts.sh
 bash tests/contracts/test-preflight-fixtures.sh

--- a/ods/tests/contracts/test-install-footprint-macos.sh
+++ b/ods/tests/contracts/test-install-footprint-macos.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${ROOT_DIR}/installers/macos/lib/installed-footprint.sh"
 
+if ! command -v rsync >/dev/null 2>&1; then
+    echo "[SKIP] macOS installed-footprint contract requires rsync"
+    exit 0
+fi
+
 test_root="$(mktemp -d)"
 trap 'rm -rf -- "$test_root"' EXIT
 
@@ -33,7 +38,7 @@ printf '%s\n' "runtime" > "${source_root}/config/runtime.yaml"
 
 printf '%s\n' "modified documentation" > "${install_dir}/docs/stale.txt"
 printf '%s\n' "modified readme" > "${install_dir}/README.md"
-printf '%s\n' "ODS_VERSION=2.5.3" > "${install_dir}/.env"
+printf '%s\n' "ODS_VERSION=2.6.0" > "${install_dir}/.env"
 printf '%s\n' "{}" > "${install_dir}/manifest.json"
 printf '%s\n' "services: {}" > "${install_dir}/docker-compose.base.yml"
 printf '%s\n' "user data" > "${install_dir}/data/preserve.db"

--- a/ods/tests/contracts/test-install-footprint-windows.ps1
+++ b/ods/tests/contracts/test-install-footprint-windows.ps1
@@ -35,7 +35,7 @@ try {
     }
     Set-Content -LiteralPath (Join-Path $installDir "docs\stale.txt") -Value "modified documentation"
     Set-Content -LiteralPath (Join-Path $installDir "README.md") -Value "modified readme"
-    Set-Content -LiteralPath (Join-Path $installDir ".env") -Value "ODS_VERSION=2.5.3"
+    Set-Content -LiteralPath (Join-Path $installDir ".env") -Value "ODS_VERSION=2.6.0"
     Set-Content -LiteralPath (Join-Path $installDir "manifest.json") -Value "{}"
     Set-Content -LiteralPath (Join-Path $installDir "docker-compose.base.yml") -Value "services: {}"
     Set-Content -LiteralPath (Join-Path $installDir "data\preserve.db") -Value "user data"

--- a/ods/tests/test-install-docs.sh
+++ b/ods/tests/test-install-docs.sh
@@ -218,10 +218,10 @@ require_literal "$trust_doc" 'verify-hosted-bootstrap.sh' "Hosted bootstrap depl
 require_literal "$REPO_ROOT/README.md" "\`$STABLE_TAG\` is the current stable release" "README stable release"
 require_literal "$release_doc" "current stable release is \`$STABLE_TAG\`" "Release channel stable release"
 require_literal "$trust_doc" "--branch $STABLE_TAG $CANONICAL_REPO_URL" "Manual stable clone"
-require_literal "$trust_doc" 'predates that repository layout' "Stable layout guidance"
+require_literal "$trust_doc" "ODS_REF=$STABLE_TAG" "Stable bootstrap ref guidance"
 
-if grep -qF "ODS_REF=$STABLE_TAG" "$REPO_ROOT/README.md" "$trust_doc"; then
-    fail "$STABLE_TAG must not be documented through the incompatible sparse-checkout bootstrap"
+if grep -qF "Do not pass \`$STABLE_TAG\` through \`ODS_REF\`" "$trust_doc"; then
+    fail "$STABLE_TAG must be documented as compatible with the sparse-checkout bootstrap"
 fi
 
 hosted_verifier="$ROOT_DIR/scripts/verify-hosted-bootstrap.sh"

--- a/ods/tests/test-macos-bootstrap-resume.sh
+++ b/ods/tests/test-macos-bootstrap-resume.sh
@@ -32,7 +32,7 @@ touch "$install_dir/bin/llama-server"
 chmod +x "$install_dir/bin/llama-server"
 
 cat > "$install_dir/.env" <<'ENV'
-ODS_VERSION=2.5.3
+ODS_VERSION=2.6.0
 ODS_MODE=local
 GPU_BACKEND=apple
 GPU_COUNT=1

--- a/ods/tests/test-macos-cli-update-verification.sh
+++ b/ods/tests/test-macos-cli-update-verification.sh
@@ -29,7 +29,7 @@ cp "$root_dir/docker-compose.base.yml" "$install_dir/docker-compose.base.yml"
 printf '%s\n' '-f docker-compose.base.yml' > "$install_dir/.compose-flags"
 
 cat > "$install_dir/.env" <<'ENV'
-ODS_VERSION=2.5.3
+ODS_VERSION=2.6.0
 ODS_MODE=local
 GPU_BACKEND=apple
 GPU_COUNT=1

--- a/ods/tests/test-ods-cli-update-verification.sh
+++ b/ods/tests/test-ods-cli-update-verification.sh
@@ -26,10 +26,12 @@ trap 'rm -rf "$tmp_dir"' EXIT
 mkdir -p "$install_dir/data" "$bin_dir"
 cp "$root_dir/docker-compose.base.yml" "$install_dir/docker-compose.base.yml"
 cp "$root_dir/manifest.json" "$install_dir/manifest.json"
+mkdir -p "$install_dir/installers/lib"
+cp "$root_dir/installers/lib/compose-images.sh" "$install_dir/installers/lib/compose-images.sh"
 printf '%s\n' '-f docker-compose.base.yml' > "$install_dir/.compose-flags"
 
 cat > "$install_dir/.env" <<'ENV'
-ODS_VERSION=2.5.3
+ODS_VERSION=2.6.0
 ODS_MODE=local
 GPU_BACKEND=cpu
 GPU_COUNT=1
@@ -72,6 +74,12 @@ if [[ "${1:-}" == "compose" ]]; then
         exit 0
     fi
     for ((i = 0; i < ${#args[@]}; i++)); do
+        if [[ "${args[$i]}" == "config" && "$joined" == *" --format json "* ]]; then
+            cat <<'JSON'
+{"services":{"dashboard":{"image":"ods-dashboard:local","build":{"context":"./extensions/services/dashboard"}},"open-webui":{"image":"ghcr.io/open-webui/open-webui:main"},"aider":{"image":"ghcr.io/example/aider:1.0"}}}
+JSON
+            exit 0
+        fi
         if [[ "${args[$i]}" == "config" && "${args[$((i + 1))]:-}" == "--services" ]]; then
             printf '%s\n' dashboard dashboard-api aider
             exit 0
@@ -88,6 +96,19 @@ if [[ "${1:-}" == "compose" ]]; then
             fi
         fi
     done
+    exit 0
+fi
+
+if [[ "${1:-}" == "pull" ]]; then
+    count_file="${TEST_DOCKER_PULL_COUNT:-}"
+    count=0
+    [[ -n "$count_file" && -f "$count_file" ]] && count="$(cat "$count_file")"
+    count=$((count + 1))
+    [[ -n "$count_file" ]] && printf '%s\n' "$count" > "$count_file"
+    if [[ "${TEST_DOCKER_PULL_FAIL_ONCE:-}" == "1" && "$count" == "1" ]]; then
+        printf '%s\n' 'Error response from daemon: Head "https://registry-1.docker.io/v2/open-webui/manifests/main": Get "https://auth.docker.io/token": context deadline exceeded' >&2
+        exit 1
+    fi
     exit 0
 fi
 
@@ -129,6 +150,9 @@ NO_COLOR=1 \
 TEST_DOCKER_LOG="$docker_log" \
 TEST_DOCKER_PULL_COUNT="$pull_count_file" \
 TEST_DOCKER_PULL_FAIL_ONCE=1 \
+ODS_COMPOSE_PULL_RETRY_DELAY_1=0 \
+ODS_COMPOSE_PULL_RETRY_DELAY_2=0 \
+ODS_COMPOSE_PULL_RETRY_DELAY_N=0 \
     "$BASH" "$ods_cli" update --force > "$tmp_dir/update.out" 2>&1 || {
         cat "$tmp_dir/update.out" >&2
         exit 1
@@ -140,13 +164,19 @@ grep -q 'Update complete' "$tmp_dir/update.out" || {
     exit 1
 }
 
-grep -q -- 'pull --ignore-buildable' "$docker_log" || {
+grep -q -- 'pull ghcr.io/open-webui/open-webui:main' "$docker_log" || {
     cat "$docker_log" >&2
-    printf '[FAIL] update did not skip local-build images during compose pull\n' >&2
+    printf '[FAIL] update did not pull external images individually\n' >&2
     exit 1
 }
 
-if [[ "$(cat "$pull_count_file")" != "2" ]]; then
+if grep -q -- 'pull ods-dashboard:local' "$docker_log"; then
+    cat "$docker_log" >&2
+    printf '[FAIL] update attempted to pull a local-build image\n' >&2
+    exit 1
+fi
+
+if [[ "$(cat "$pull_count_file")" != "3" ]]; then
     cat "$tmp_dir/update.out" >&2
     cat "$docker_log" >&2
     printf '[FAIL] update did not retry transient compose pull failure\n' >&2

--- a/ods/tests/test-update-rollback-contract.sh
+++ b/ods/tests/test-update-rollback-contract.sh
@@ -10,7 +10,6 @@ fail() { echo "[FAIL] $*"; exit 1; }
 pass() { echo "[PASS] $*"; }
 
 command -v jq >/dev/null 2>&1 || fail "jq is required"
-command -v rsync >/dev/null 2>&1 || fail "rsync is required"
 command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
 
 [[ -x "$ODS_BACKUP" ]] || fail "ods-backup.sh is not executable"
@@ -18,6 +17,56 @@ command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+
+if ! command -v rsync >/dev/null 2>&1; then
+    mkdir -p "$TMP/bin"
+    cat > "$TMP/bin/rsync" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" ]]; then
+    echo "test rsync shim"
+    exit 0
+fi
+
+sources=()
+for arg in "$@"; do
+    case "$arg" in
+        -a|--delete|--progress|--info=*) ;;
+        -*) ;;
+        *) sources+=("$arg") ;;
+    esac
+done
+
+if (( ${#sources[@]} < 2 )); then
+    echo "rsync shim: missing source/destination" >&2
+    exit 2
+fi
+
+last_index=$((${#sources[@]} - 1))
+dest="${sources[$last_index]}"
+unset "sources[$last_index]"
+mkdir -p "$dest"
+
+for src in "${sources[@]}"; do
+    if [[ -d "$src" ]]; then
+        if [[ "$src" == */ ]]; then
+            cp -R "$src". "$dest"
+        else
+            cp -R "$src" "$dest"
+        fi
+    elif [[ -f "$src" ]]; then
+        cp -p "$src" "$dest"
+    else
+        echo "rsync shim: missing source: $src" >&2
+        exit 23
+    fi
+done
+SH
+    chmod +x "$TMP/bin/rsync"
+    PATH="$TMP/bin:$PATH"
+    export PATH
+fi
 
 SRC="$TMP/ods"
 mkdir -p "$SRC/lib" "$SRC/config" "$SRC/data/open-webui" "$SRC/data/hermes"


### PR DESCRIPTION
## Summary

- Bump ODS release authorities and stable-channel docs from 2.5.3 to 2.6.0, including installer constants, manifest, dashboard API metadata, architecture docs, README, and test fixtures.
- Add the 2.6.0 changelog entry and release notes with the current validation receipt, waived model-management boundary, DGX exclusion, and publication checklist.
- Extend version consistency checks to cover the `ods-cli` fallback version.
- Fix the Linux `ods update` external-image pull path so per-image pulls retry transient registry/network failures while still skipping local-build images.
- Make local rollback validation portable on hosts without real `rsync` by using a test-only rsync shim in the rollback contract.
- Finalize release-note/index wording so the repository describes 2.6.0 as the current stable release once this PR is merged and tagged.

## Why

The stable release metadata and docs had drifted behind the post-2.5.3 work. This prepares the repository for a 2.6.0 release while keeping the release receipt honest about what was validated, what was excluded, and what was intentionally waived.

The release gate also exposed two practical issues during prep: the newer Linux per-image image-pull path did not inherit the old compose-pull retry behavior, and the rollback contract hard-failed on Windows Git Bash hosts without `rsync` even though the contract can validate the backup/restore behavior with a test shim.

## Impact

New installs and stable-channel docs will identify `v2.6.0` and `release/2.6.x` once this release-prep work is merged and tagged.

Strict User Green is not claimed for this release because the long six-cycle browser model-management matrix was intentionally stopped as too time-consuming for this release-prep need. The release notes record that waiver rather than presenting it as Model UI Green.

## Validation

Local/focused:

- `python ods/scripts/check-version-consistency.py`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe ods/tests/test-install-docs.sh`
- `C:\Program Files\Git\bin\bash.exe ods/scripts/check-release-claims.sh`
- `C:\Program Files\Git\bin\bash.exe ods/scripts/check-compatibility.sh`
- `python -m pytest ods/extensions/services/dashboard-api/tests/test_node.py ods/extensions/services/dashboard-api/tests/test_updates.py -q`
- `bash ods/tests/test-ods-cli-update-verification.sh`
- `bash ods/tests/test-macos-cli-update-verification.sh`
- `bash ods/tests/test-update-rollback-contract.sh`
- `bash ods/scripts/release-gate.sh`

Latest head: `2bf04010449439cb2e90853298a0ad9ed37a74c4`.

The full local release gate passed earlier on Windows Git Bash with the expected host-specific skips for the real macOS installed-footprint `rsync` contract and the runtime `flock` contention subtest.

GitHub Actions are fully green on latest head `2bf04010449439cb2e90853298a0ad9ed37a74c4`: dashboard API/frontend, integration smoke, token-spy postgres, matrix smoke/distro, lint/typecheck, secret scan, env schema, PowerShell lint, and review gates all passed.

Fleet receipt:

- Release-prep run id: `2026-07-28T12-58-00Z-release-product-07e2a21e3cca-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
- Harness: `main@19d43e6f9f2533e8768ed85b33de9f4ace232129` clean
- Command: `./run.sh --phase release --hosts tower2,strix-halo,spark,m5-mbp,windows-laptop,strixy --smoke-host tower2`
- Passed: regressions `16/16`, zero-prereq bootstrap `6/6`, fresh install, verify, cloud-mode contracts, dashboard, Hermes, UI policy, capabilities, lifecycle reinstall/restart, `ods doctor`, and full-model finalize across Tower2, Strix Halo, Spark, M5 MacBook Pro, Windows laptop, and Strixy.
- Generated report recorded Real product bugs: `0`, Harness limitations: `0`, Environment notes: `0`.
- Full-model finalize reran deferred Hermes/capability probes after model readiness and ended with no install-blocked, still-deferred, or download-failed hosts.

Waived/excluded:

- Six-cycle release model-management matrix was started but intentionally stopped. Cycle 1 passed on `tower2` and `strix-halo`; remaining model-ui receipts are interruption code `143` from the operator stop.
- `dgx-gpu01` was excluded from the six-host validation scope because strict SSH host-key verification failed. Tower2's pinned ED25519 key is `SHA256:hPPRpUClgK0nCDrZujmfHgbMIIYV70zSpKfBw4VWmdo`; the endpoint currently presents `SHA256:zgUNklRWH+N/aaQ1MmZEzmN6ABu/6XMOw2Mm3ITzwfM`.
