### PR TITLE
fix(support-bundle): write bundle manifest JSON atomically in ods-support-bundle.sh

### DIFF
--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -571,7 +571,20 @@ manifest = {
     "commands": commands,
 }
 
-(bundle_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+manifest_path = bundle_dir / "manifest.json"
+import os
+import tempfile
+fd, tmp_str = tempfile.mkstemp(dir=str(manifest_path.parent), prefix=f".{manifest_path.name}.", suffix=".tmp")
+tmp_path = pathlib.Path(tmp_str)
+content = json.dumps(manifest, indent=2) + "\n"
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp_path, manifest_path)
+except Exception:
+    if tmp_path.exists():
+        tmp_path.unlink(missing_ok=True)
+    raise
 PY
 }
 


### PR DESCRIPTION
## Problem

In `ods/scripts/ods-support-bundle.sh`, support bundle manifest JSON files were written directly using `(bundle_dir / "manifest.json").write_text(json.dumps(...))`. If support bundle creation is interrupted (e.g. process termination or disk error), the target manifest JSON file can be left partially written or truncated in place.

## Fix

1. Update `ods-support-bundle.sh` to write the support bundle manifest JSON to a temporary file via `tempfile.mkstemp` in `bundle_dir`.
2. Use `os.replace` for atomic replacement of the destination manifest file.

## Verification

Verified syntax with `bash -n ods/scripts/ods-support-bundle.sh`. `git diff --check` passed cleanly with zero whitespace issues.