### PR TITLE
fix(dashboard-api): write extension install progress atomically in extensions.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -261,7 +261,16 @@ def _write_initial_progress(service_id: str) -> None:
         "updated_at": now,
     }
     progress_file = progress_dir / f"{service_id}.json"
-    progress_file.write_text(json.dumps(progress), encoding="utf-8")
+    fd, tmp_str = tempfile.mkstemp(dir=str(progress_dir), prefix=f".{service_id}.json.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(progress))
+        os.replace(tmp_path, progress_file)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def _write_error_progress(service_id: str, error_msg: str) -> None:
@@ -279,7 +288,16 @@ def _write_error_progress(service_id: str, error_msg: str) -> None:
     data["error"] = error_msg
     data["updated_at"] = now
     progress_file.parent.mkdir(parents=True, exist_ok=True)
-    progress_file.write_text(json.dumps(data), encoding="utf-8")
+    fd, tmp_str = tempfile.mkstemp(dir=str(progress_file.parent), prefix=f".{service_id}.json.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data))
+        os.replace(tmp_path, progress_file)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def _has_error_progress(service_id: str) -> bool:


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/extensions.py`, `_write_initial_progress` and `_write_error_progress` updated extension installation status files directly using `progress_file.write_text(json.dumps(...))`. If an interrupted write occurs (e.g. process termination or disk error), progress files can be left truncated or empty, causing the dashboard UI to hang.

## Fix

1. Update `_write_initial_progress` and `_write_error_progress` in `extensions.py` to write progress JSON data to a temporary file via `tempfile.mkstemp` in `progress_file.parent`.
2. Use `os.replace` for atomic replacement of destination progress JSON files.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py`: 54/54 passed. `git diff --check` passed cleanly with zero whitespace issues.