### PR TITLE
fix(setup): make local ODS access frictionless

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,54 @@ commit and keep your own validation receipt. Stable patch fixes land on
 
 ## Get Started
 
-Linux and macOS:
+Choose your system, copy the block, run it in a normal terminal. ODS installs the stack, picks a model for your hardware, starts the services, and gives you the local web UI.
+
+**Linux or macOS**
 
 ```bash
 curl -fsSL https://install.osmantic.com/ods.sh | bash
 ```
 
-The hosted endpoint proxies the current bootstrap from repository `main`.
+**Windows PowerShell**
+
+```powershell
+$ProgressPreference = "SilentlyContinue"
+$odsZip = Join-Path $env:TEMP "ods-main.zip"
+$odsSrc = Join-Path $env:TEMP "ods-main"
+Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
+Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
+cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\install.ps1
+```
+
+Prerequisites: Docker must be installed and running. On Windows, use Docker Desktop with the WSL2 backend enabled and run the block in a normal, non-Administrator PowerShell window.
+
+The hosted Linux/macOS endpoint proxies the current bootstrap from repository `main`.
 Reviewed merges reach it automatically after edge-cache refresh. `ODS_REF` selects a compatible repository checkout. See
 [Installer Trust](ods/docs/INSTALLER_TRUST.md) to inspect the script or install
 a stable release or audited commit manually.
 
-Windows users should use the PowerShell installer shown below or follow the [Windows Quickstart](ods/docs/WINDOWS-QUICKSTART.md).
+Windows users should not run the `curl ... | bash` command from PowerShell. The PowerShell block above downloads the source ZIP and runs the same Windows installer used by the clone-based workflow. For more detail, see the [Windows Quickstart](ods/docs/WINDOWS-QUICKSTART.md).
 
 After install, open **http://localhost:3000** and start chatting.
+
+Uninstall later with the matching platform command:
+
+```bash
+cd ~/ods
+./ods-uninstall.sh --force
+```
+
+```powershell
+$installDir = "$env:USERPROFILE\ods"
+cd $installDir
+.\ods.ps1 uninstall --force
+```
+
+Windows recovery note: if the runtime folder is partial and `.\ods.ps1` is missing, run the same command from a source checkout as `.\ods\installers\windows\ods.ps1 uninstall --force`. It removes Docker resources labelled as the ODS compose project before removing the runtime directory.
 
 > **API endpoint:** Linux Docker installs expose llama-server on **http://localhost:11434** by default (`OLLAMA_PORT`) while containers use `llama-server:8080`. macOS native Metal and Windows native/Lemonade paths use **http://localhost:8080** unless overridden. Open WebUI stays on **http://localhost:3000**.
 
@@ -168,16 +202,22 @@ Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) with 
 Open a normal **PowerShell** session and run:
 
 ```powershell
+$ProgressPreference = "SilentlyContinue"
+$odsZip = Join-Path $env:TEMP "ods-main.zip"
+$odsSrc = Join-Path $env:TEMP "ods-main"
+Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
+Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
+cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-git clone https://github.com/Osmantic/ODS.git
-cd ODS
 .\install.ps1
 ```
 
 > The `Set-ExecutionPolicy` command allows the installer script to run in the current session. It does not change your system-wide policy.
 > Running as Administrator is not recommended for the installer because user-level paths such as `.opencode`, `data/`, and `.env` can be created with admin-owned permissions.
 
-The installer detects your GPU, picks the right model, generates credentials, starts all services, and creates a Desktop shortcut to the Dashboard. Manage with `.\ods\installers\windows\ods.ps1 status`.
+The installer detects your GPU, picks the right model, generates credentials, starts all services, and creates a Desktop shortcut to the Dashboard. Manage from the runtime directory with `.\ods.ps1 status`; uninstall with `.\ods.ps1 uninstall --force`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,9 @@ curl -fsSL https://install.osmantic.com/ods.sh | bash
 
 ```powershell
 $ProgressPreference = "SilentlyContinue"
-$odsZip = Join-Path $env:TEMP "ods-main.zip"
-$odsSrc = Join-Path $env:TEMP "ods-main"
-Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
-Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+$odsSrc = Join-Path $env:TEMP ("ods-install-" + [guid]::NewGuid().ToString("N"))
+$odsZip = Join-Path $odsSrc "ods-main.zip"
+New-Item -ItemType Directory -Path $odsSrc | Out-Null
 Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
 Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
 cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
@@ -203,10 +202,9 @@ Open a normal **PowerShell** session and run:
 
 ```powershell
 $ProgressPreference = "SilentlyContinue"
-$odsZip = Join-Path $env:TEMP "ods-main.zip"
-$odsSrc = Join-Path $env:TEMP "ods-main"
-Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
-Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+$odsSrc = Join-Path $env:TEMP ("ods-install-" + [guid]::NewGuid().ToString("N"))
+$odsZip = Join-Path $odsSrc "ods-main.zip"
+New-Item -ItemType Directory -Path $odsSrc | Out-Null
 Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
 Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
 cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -404,8 +404,9 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # Legacy Kokoro TTS voice name
 # TTS_VOICE=en_US-lessac-medium
 
-# Open WebUI authentication (true/false)
-# WEBUI_AUTH=true
+# Open WebUI authentication (true/false). Installers default this to false for
+# loopback-only ODS and true when services are exposed to the network.
+# WEBUI_AUTH=false
 
 # Open WebUI PWA / branding name. Shown as the app title, page title, and PWA
 # install label (the text next to the icon on a phone's home screen).

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -714,7 +714,7 @@
     },
     "OPENCODE_SERVER_PASSWORD": {
       "type": "string",
-      "description": "OpenCode web UI authentication password",
+      "description": "Optional password for a manually network-exposed OpenCode server. ODS-managed OpenCode is loopback-only and opens without a login.",
       "secret": true,
       "minLength": 10
     },
@@ -725,8 +725,8 @@
     },
     "WEBUI_AUTH": {
       "type": "boolean",
-      "description": "Enable Open WebUI authentication",
-      "default": true
+      "description": "Enable Open WebUI authentication. ODS installers default to false on loopback and true for network-bound installs.",
+      "default": false
     },
     "WEBUI_NAME": {
       "type": "string",

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -726,7 +726,7 @@
     "WEBUI_AUTH": {
       "type": "boolean",
       "description": "Enable Open WebUI authentication. ODS installers default to false on loopback and true for network-bound installs.",
-      "default": false
+      "default": true
     },
     "WEBUI_NAME": {
       "type": "string",

--- a/ods/FAQ.md
+++ b/ods/FAQ.md
@@ -193,12 +193,29 @@ docker compose logs llama-server
 - Restart: `docker compose restart`
 
 ### How do I uninstall?
+**Linux/macOS:**
+
 ```bash
 cd ~/ods
 ./ods-uninstall.sh --force
 ```
 
-This uses ODS's saved `.compose-flags` stack, removes the matching containers and volumes, and then removes the install directory. Use `--keep-data` or `--keep-models` if you want to preserve local state.
+**Windows:**
+
+```powershell
+$installDir = "$env:USERPROFILE\ods"
+cd $installDir
+.\ods.ps1 uninstall --force
+```
+
+These use ODS's saved compose stack when available, remove the matching containers and volumes, and then remove the install directory. Use `--keep-data` or `--keep-models` if you want to preserve local state.
+
+On Windows, if the runtime folder is partial and `.\ods.ps1` is missing, run the cleanup from a source checkout:
+
+```powershell
+cd ODS
+.\ods\installers\windows\ods.ps1 uninstall --force
+```
 
 If you need to run Docker Compose manually, do not use bare `docker compose down`: ODS does not use a top-level `docker-compose.yml`. Use the saved flags instead:
 

--- a/ods/QUICKSTART.md
+++ b/ods/QUICKSTART.md
@@ -36,7 +36,7 @@ see [MACOS-QUICKSTART.md](docs/MACOS-QUICKSTART.md),
 
 ## Install
 
-### Linux One-Liner
+### Linux/macOS One-Liner
 
 ```bash
 curl -fsSL https://install.osmantic.com/ods.sh | bash
@@ -46,6 +46,8 @@ The hosted endpoint proxies the current bootstrap from repository `main`.
 Reviewed merges reach it automatically after edge-cache refresh. `ODS_REF` selects a compatible repository checkout. See
 [Installer Trust](docs/INSTALLER_TRUST.md) to inspect the script or install a
 stable release or audited commit manually.
+
+Do not run this command from Windows PowerShell; use the Windows installer below.
 
 ### Manual Clone
 
@@ -58,9 +60,15 @@ cd ODS
 ### Windows
 
 ```powershell
+$ProgressPreference = "SilentlyContinue"
+$odsZip = Join-Path $env:TEMP "ods-main.zip"
+$odsSrc = Join-Path $env:TEMP "ods-main"
+Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
+Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
+cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-git clone https://github.com/Osmantic/ODS.git
-cd ODS
 .\install.ps1
 ```
 
@@ -75,6 +83,27 @@ Useful install flags:
 | `--no-hermes` | `-NoHermes` | Disable the default Hermes agent |
 | `--no-bootstrap` | `-NoBootstrap` | Wait for the full model instead of fast-start |
 | `--tier 3` | `-Tier 3` | Force a hardware/model tier |
+
+## Uninstall
+
+Linux/macOS:
+
+```bash
+cd ~/ods
+./ods-uninstall.sh --force
+```
+
+Windows:
+
+```powershell
+$installDir = "$env:USERPROFILE\ods"
+cd $installDir
+.\ods.ps1 uninstall --force
+```
+
+Use `--keep-data` or `--keep-models` to preserve local state. If the Windows
+runtime folder is partial and `.\ods.ps1` is missing, run
+`.\ods\installers\windows\ods.ps1 uninstall --force` from a source checkout.
 
 ## What Happens First
 
@@ -218,6 +247,7 @@ ods stop
 ods restart
 ods logs llm
 ods update
+./ods-uninstall.sh --force
 ```
 
 Windows:
@@ -230,6 +260,7 @@ cd $env:USERPROFILE\ods
 .\ods.ps1 restart
 .\ods.ps1 logs llm
 .\ods.ps1 update
+.\ods.ps1 uninstall --force
 ```
 
 ## Next Steps

--- a/ods/QUICKSTART.md
+++ b/ods/QUICKSTART.md
@@ -61,10 +61,9 @@ cd ODS
 
 ```powershell
 $ProgressPreference = "SilentlyContinue"
-$odsZip = Join-Path $env:TEMP "ods-main.zip"
-$odsSrc = Join-Path $env:TEMP "ods-main"
-Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
-Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+$odsSrc = Join-Path $env:TEMP ("ods-install-" + [guid]::NewGuid().ToString("N"))
+$odsZip = Join-Path $odsSrc "ods-main.zip"
+New-Item -ItemType Directory -Path $odsSrc | Out-Null
 Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
 Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
 cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
@@ -136,7 +135,9 @@ Get-Content .\logs\model-upgrade.log -Wait
 - Dashboard: http://localhost:3001
 - OpenCode IDE, when enabled: http://localhost:3003
 
-The first Chat UI user becomes admin.
+Loopback-only installs open the Chat UI directly without an account. A
+network-bound or ODS proxy install keeps authentication enabled and prompts the
+first user to create the admin account.
 
 ## Validate The Install
 

--- a/ods/README.md
+++ b/ods/README.md
@@ -113,10 +113,9 @@ llama-server runs natively with Metal GPU acceleration; all other services run i
 
 ```powershell
 $ProgressPreference = "SilentlyContinue"
-$odsZip = Join-Path $env:TEMP "ods-main.zip"
-$odsSrc = Join-Path $env:TEMP "ods-main"
-Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
-Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+$odsSrc = Join-Path $env:TEMP ("ods-install-" + [guid]::NewGuid().ToString("N"))
+$odsZip = Join-Path $odsSrc "ods-main.zip"
+New-Item -ItemType Directory -Path $odsSrc | Out-Null
 Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
 Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
 cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName

--- a/ods/README.md
+++ b/ods/README.md
@@ -37,12 +37,12 @@ Known-good version baselines: [`docs/KNOWN-GOOD-VERSIONS.md`](docs/KNOWN-GOOD-VE
 
 ---
 
-## 5-Minute Quickstart (Linux)
+## 5-Minute Quickstart
 
 > **Prerequisites:** `curl` and `jq` must be installed. The installer will auto-install `jq` if missing, but `curl` is required to fetch the installer itself.
 
 ```bash
-# One-line install (Linux — NVIDIA, AMD, Intel Arc, or CPU/cloud fallback)
+# One-line install for Linux/macOS shells
 curl -fsSL https://install.osmantic.com/ods.sh | bash
 ```
 
@@ -50,6 +50,9 @@ The hosted endpoint proxies the current bootstrap from repository `main`.
 Reviewed merges reach it automatically after edge-cache refresh. `ODS_REF` selects a compatible repository checkout. See
 [Installer Trust](docs/INSTALLER_TRUST.md) to inspect the script or install a
 stable release or audited commit manually.
+
+Do not run the `curl ... | bash` installer from Windows PowerShell. Use the
+Windows PowerShell installer below.
 
 Or manually:
 
@@ -109,7 +112,16 @@ llama-server runs natively with Metal GPU acceleration; all other services run i
 > **Prerequisite:** Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) with WSL2 backend and make sure it is running before you start.
 
 ```powershell
-.\install.ps1   # Auto-detects GPU, launches all services via Docker Desktop + WSL2
+$ProgressPreference = "SilentlyContinue"
+$odsZip = Join-Path $env:TEMP "ods-main.zip"
+$odsSrc = Join-Path $env:TEMP "ods-main"
+Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
+Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
+cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\install.ps1
 ```
 
 Windows installs keep the cloned repo separate from the runtime directory. The
@@ -119,6 +131,27 @@ installing, run `.\ods.ps1` or manual `docker compose` commands from that
 runtime directory, not from the source checkout.
 
 See [`docs/WINDOWS-QUICKSTART.md`](docs/WINDOWS-QUICKSTART.md) for details.
+
+### Uninstall
+
+Linux/macOS:
+
+```bash
+cd ~/ods
+./ods-uninstall.sh --force
+```
+
+Windows:
+
+```powershell
+$installDir = "$env:USERPROFILE\ods"
+cd $installDir
+.\ods.ps1 uninstall --force
+```
+
+Use `--keep-data` or `--keep-models` if you want to preserve local state. If a
+Windows runtime is partial and `.\ods.ps1` is missing, run the cleanup from a
+source checkout with `.\ods\installers\windows\ods.ps1 uninstall --force`.
 
 ---
 

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -2624,15 +2624,15 @@ def _assert_text_file_matches_snapshot(path: Path, snapshot: dict) -> None:
         raise RuntimeError(f"Configuration changed during model activation: {path}")
 
 
-def _upsert_env_value(env_path: Path, key: str, value: str) -> None:
-    """Persist one simple ``KEY=value`` entry without disturbing other lines."""
+def _upsert_env_text(raw_text: str, key: str, value: str) -> str:
+    """Return env text with one canonical ``KEY=value`` entry."""
     if any(character in value for character in "\r\n\x00"):
         raise ValueError(f"Invalid newline or NUL in {key}")
-    lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
     output = []
     written = False
-    for line in lines:
-        line_key = line.split("=", 1)[0] if "=" in line and not line.startswith("#") else None
+    for line in raw_text.splitlines():
+        left, separator, _ = line.partition("=")
+        line_key = left.strip() if separator and not line.lstrip().startswith("#") else None
         if line_key == key:
             if not written:
                 output.append(f"{key}={value}")
@@ -2641,7 +2641,13 @@ def _upsert_env_value(env_path: Path, key: str, value: str) -> None:
         output.append(line)
     if not written:
         output.append(f"{key}={value}")
-    _atomic_write_text(env_path, "\n".join(output) + "\n")
+    return "\n".join(output) + "\n"
+
+
+def _upsert_env_value(env_path: Path, key: str, value: str) -> None:
+    """Persist one simple ``KEY=value`` entry without disturbing other lines."""
+    raw_text = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    _atomic_write_text(env_path, _upsert_env_text(raw_text, key, value))
 
 
 def _write_activation_config_file(path: Path, content: str) -> None:
@@ -3152,7 +3158,17 @@ def _repair_rootless_data_ownership(service_id: str) -> None:
 
 def docker_compose_action(service_id: str, action: str) -> tuple:
     flags = resolve_compose_flags()
+    compose_env = os.environ.copy()
     if action == "start":
+        if service_id == "ods-proxy":
+            ok, error = _prepare_proxy_auth_start(flags)
+            if not ok:
+                return False, error
+        elif service_id == "open-webui" and _proxy_compose_enabled():
+            ok, error = _persist_proxy_auth_required()
+            if not ok:
+                return False, error
+            compose_env["WEBUI_AUTH"] = "true"
         _precreate_data_dirs(service_id)
         try:
             _repair_rootless_data_ownership(service_id)
@@ -3167,11 +3183,68 @@ def docker_compose_action(service_id: str, action: str) -> tuple:
     try:
         result = subprocess.run(
             cmd, cwd=str(INSTALL_DIR),
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True, text=True, timeout=timeout, env=compose_env,
         )
         return (True, "") if result.returncode == 0 else (False, result.stderr[:500])
     except subprocess.TimeoutExpired:
         return False, f"Docker compose operation timed out ({timeout}s)"
+
+
+def _proxy_compose_enabled() -> bool:
+    """Return whether the current compose stack includes ods-proxy."""
+    return any(
+        root != Path() and (root / "ods-proxy" / "compose.yaml").is_file()
+        for root in (EXTENSIONS_DIR, USER_EXTENSIONS_DIR)
+    )
+
+
+def _persist_proxy_auth_required() -> tuple[bool, str]:
+    """Persist network-safe Open WebUI auth while serializing .env writers."""
+    env_path = INSTALL_DIR / ".env"
+    if not env_path.is_file():
+        return False, f"Cannot enable network access without {env_path}"
+
+    try:
+        with _model_activate_lock:
+            raw_text = env_path.read_text(encoding="utf-8")
+            new_text = _upsert_env_text(raw_text, "WEBUI_AUTH", "true")
+            if new_text != raw_text:
+                _atomic_write_text(env_path, new_text)
+                logger.info("Enforced WEBUI_AUTH=true for network-accessible ODS")
+    except (OSError, UnicodeError, RuntimeError) as exc:
+        return False, f"Could not enforce proxy authentication: {exc}"
+    return True, ""
+
+
+def _prepare_proxy_auth_start(flags: list[str]) -> tuple[bool, str]:
+    """Persist network-safe auth and apply it before exposing ods-proxy."""
+    ok, error = _persist_proxy_auth_required()
+    if not ok:
+        return False, error
+
+    compose_env = os.environ.copy()
+    compose_env["WEBUI_AUTH"] = "true"
+    try:
+        result = subprocess.run(
+            ["docker", "compose"] + flags
+            + ["up", "-d", "--no-deps", "--force-recreate", "open-webui"],
+            cwd=str(INSTALL_DIR),
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_START,
+            env=compose_env,
+        )
+    except subprocess.TimeoutExpired:
+        return False, (
+            "Open WebUI authentication preflight timed out; ods-proxy was not started"
+        )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "unknown error").strip()
+        return False, (
+            "Could not recreate Open WebUI with authentication; "
+            f"ods-proxy was not started: {detail[-500:]}"
+        )
+    return True, ""
 
 
 def validate_core_recreate_ids(service_ids: list[str]) -> tuple[bool, str]:
@@ -3201,6 +3274,8 @@ def docker_compose_recreate(service_ids: list[str]) -> tuple:
     compose_env = os.environ.copy()
     for key in ("GGUF_FILE", "LLM_MODEL", "LEMONADE_MODEL", "MAX_CONTEXT", "CTX_SIZE"):
         compose_env.pop(key, None)
+    if "open-webui" in service_ids and _proxy_compose_enabled():
+        compose_env["WEBUI_AUTH"] = "true"
     try:
         result = subprocess.run(
             cmd, cwd=str(INSTALL_DIR),
@@ -5511,6 +5586,10 @@ class AgentHandler(BaseHTTPRequestHandler):
             logger.warning("env_update rejected: raw_text missing/empty from %s", client_ip)
             json_response(self, 400, {"error": "raw_text required"})
             return
+        enforced_values = {}
+        if _proxy_compose_enabled():
+            raw_text = _upsert_env_text(raw_text, "WEBUI_AUTH", "true")
+            enforced_values["WEBUI_AUTH"] = "true"
         backup = body.get("backup", True)
 
         schema_path = INSTALL_DIR / ".env.schema.json"
@@ -5590,7 +5669,11 @@ class AgentHandler(BaseHTTPRequestHandler):
             _model_activate_lock.release()
 
         logger.info(".env updated via host agent from %s (backup=%s)", client_ip, backup_relative_path or "none")
-        json_response(self, 200, {"status": "ok", "backup_path": backup_relative_path})
+        json_response(self, 200, {
+            "status": "ok",
+            "backup_path": backup_relative_path,
+            "enforced_values": enforced_values,
+        })
 
     def _handle_core_recreate(self):
         if not check_auth(self):

--- a/ods/docs/FAQ.md
+++ b/ods/docs/FAQ.md
@@ -174,6 +174,8 @@ Yes. Common use cases:
 
 **With install wizard:** Under 1 hour for someone comfortable with terminal.
 
+Linux/macOS:
+
 ```bash
 curl -fsSL https://install.osmantic.com/ods.sh | bash
 ```
@@ -182,6 +184,23 @@ The hosted endpoint proxies the current bootstrap from repository `main`.
 Reviewed merges reach it automatically after edge-cache refresh. `ODS_REF` selects a compatible repository checkout. See
 [Installer Trust](INSTALLER_TRUST.md) to inspect the script or install a stable
 release or audited commit manually.
+
+Windows:
+
+```powershell
+$ProgressPreference = "SilentlyContinue"
+$odsZip = Join-Path $env:TEMP "ods-main.zip"
+$odsSrc = Join-Path $env:TEMP "ods-main"
+Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
+Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
+cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\install.ps1
+```
+
+Do not run the `curl ... | bash` installer from Windows PowerShell.
 
 The wizard:
 1. Detects your hardware

--- a/ods/docs/FAQ.md
+++ b/ods/docs/FAQ.md
@@ -189,10 +189,9 @@ Windows:
 
 ```powershell
 $ProgressPreference = "SilentlyContinue"
-$odsZip = Join-Path $env:TEMP "ods-main.zip"
-$odsSrc = Join-Path $env:TEMP "ods-main"
-Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
-Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+$odsSrc = Join-Path $env:TEMP ("ods-install-" + [guid]::NewGuid().ToString("N"))
+$odsZip = Join-Path $odsSrc "ods-main.zip"
+New-Item -ItemType Directory -Path $odsSrc | Out-Null
 Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
 Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
 cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName

--- a/ods/docs/INTEGRATION-GUIDE.md
+++ b/ods/docs/INTEGRATION-GUIDE.md
@@ -239,10 +239,12 @@ client = OpenAI(
 
 ### Open WebUI Auth
 
-WebUI has built-in user management:
-1. First user becomes admin
-2. Configure auth in WebUI settings
-3. Set `WEBUI_AUTH=true` in `.env`
+Loopback-only ODS installs open directly. For a network deployment, Open WebUI
+has built-in user management:
+
+1. Set `WEBUI_AUTH=true` in `.env`
+2. Restart Open WebUI
+3. The first user becomes admin and can configure auth in Open WebUI settings
 
 ---
 

--- a/ods/docs/MACOS-QUICKSTART.md
+++ b/ods/docs/MACOS-QUICKSTART.md
@@ -42,7 +42,9 @@ The installer will:
 - **Dashboard:** http://localhost:3001
 - **OpenCode (IDE):** http://localhost:3003
 
-First user on the Chat UI becomes admin. Start chatting immediately.
+The normal loopback-only install opens the Chat UI directly without an account.
+A network-bound or ODS proxy install keeps authentication enabled and prompts
+the first user to create the admin account.
 
 ---
 

--- a/ods/docs/MULTI-USER-SETUP.md
+++ b/ods/docs/MULTI-USER-SETUP.md
@@ -175,7 +175,7 @@ Run through this before declaring multi-user ready:
 - [ ] `BIND_ADDRESS` set appropriately; `ods restart` run after the change.
 - [ ] Firewall rules limit each open port to the intended subnet or VPN interface.
 - [ ] Dashboard, dashboard-api, n8n, opencode are *not* reachable from the user-facing network.
-- [ ] open-webui has `WEBUI_AUTH=true` (the default) and a strong `WEBUI_SECRET`.
+- [ ] open-webui has `WEBUI_AUTH=true` (the network-deployment default) and a strong `WEBUI_SECRET`.
 - [ ] Inference backend matches user count: llama-server up to ~10–15, vLLM beyond.
 - [ ] Reverse proxy or VPN in place for any remote access.
 - [ ] Capacity claim from `HARDWARE-GUIDE.md` reality-checked under load before announcing.

--- a/ods/docs/ODS-PROXY.md
+++ b/ods/docs/ODS-PROXY.md
@@ -64,7 +64,7 @@ The installer's first-boot flow handles both. If you're not using the installer,
 **The proxy is the trusted gate.** Behind it, each service's own auth applies:
 
 - `dashboard-api`: API key (`DASHBOARD_API_KEY`)
-- Open WebUI: its own auth (`WEBUI_AUTH=true` by default — users sign up / sign in)
+- Open WebUI: its own auth (`WEBUI_AUTH=true` is selected when the installer enables this LAN proxy)
 - Dashboard SPA: the React app shows admin features only when the API call succeeds
 - ODS Talk: signed `ods-session` cookie from owner-card redemption; no dashboard admin API control
 - `hermes-proxy`: Caddy `forward_auth` against `dashboard-api/api/auth/verify-session` (signed-cookie check)

--- a/ods/docs/WINDOWS-INSTALL-WALKTHROUGH.md
+++ b/ods/docs/WINDOWS-INSTALL-WALKTHROUGH.md
@@ -81,8 +81,14 @@ Skip this NVIDIA CUDA container check on AMD systems.
 Open **PowerShell** (not as admin) and run:
 
 ```powershell
-git clone https://github.com/Osmantic/ODS.git
-cd ODS
+$ProgressPreference = "SilentlyContinue"
+$odsZip = Join-Path $env:TEMP "ods-main.zip"
+$odsSrc = Join-Path $env:TEMP "ods-main"
+Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
+Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
+cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 .\install.ps1
 ```
@@ -272,17 +278,25 @@ docker compose up -d
 
 ## Uninstall
 
+Start Docker Desktop first so ODS can remove the Docker side of the install.
+
 ```powershell
-# Stop and remove containers
 $installDir = "$env:USERPROFILE\ods"
 # If you installed with -InstallDir, use that same path instead.
 cd $installDir
-$composeFlags = (Get-Content .compose-flags -Raw).Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
-docker compose @composeFlags down -v --remove-orphans
-
-# Remove installation directory
-Remove-Item -Recurse -Force $installDir
+.\ods.ps1 uninstall --force
 ```
+
+Use `--keep-data` or `--keep-models` if you want to preserve local state.
+
+If the runtime folder is partial and `.\ods.ps1` is missing, run the same cleanup from a source checkout:
+
+```powershell
+cd ODS
+.\ods\installers\windows\ods.ps1 uninstall --force
+```
+
+The fallback path removes Docker containers, networks, and volumes labelled as the ODS compose project, so it still works when `.compose-flags` or the compose files were deleted before uninstall.
 
 ---
 

--- a/ods/docs/WINDOWS-INSTALL-WALKTHROUGH.md
+++ b/ods/docs/WINDOWS-INSTALL-WALKTHROUGH.md
@@ -82,10 +82,9 @@ Open **PowerShell** (not as admin) and run:
 
 ```powershell
 $ProgressPreference = "SilentlyContinue"
-$odsZip = Join-Path $env:TEMP "ods-main.zip"
-$odsSrc = Join-Path $env:TEMP "ods-main"
-Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
-Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+$odsSrc = Join-Path $env:TEMP ("ods-install-" + [guid]::NewGuid().ToString("N"))
+$odsZip = Join-Path $odsSrc "ods-main.zip"
+New-Item -ItemType Directory -Path $odsSrc | Out-Null
 Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
 Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
 cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName

--- a/ods/docs/WINDOWS-QUICKSTART.md
+++ b/ods/docs/WINDOWS-QUICKSTART.md
@@ -9,9 +9,15 @@ ODS is fully supported on Windows 10 2004+ and Windows 11 (NVIDIA and AMD). The 
 Open a normal **PowerShell** session and run:
 
 ```powershell
+$ProgressPreference = "SilentlyContinue"
+$odsZip = Join-Path $env:TEMP "ods-main.zip"
+$odsSrc = Join-Path $env:TEMP "ods-main"
+Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
+Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
+cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-git clone https://github.com/Osmantic/ODS.git
-cd ODS
 .\install.ps1
 ```
 
@@ -23,11 +29,10 @@ The installer will:
 
 ### Source checkout vs runtime directory
 
-The cloned `ODS` folder is only the installer/source checkout. The
-Windows runtime is created under `$env:USERPROFILE\ods` by default
-(or `$env:ODS_HOME` if you set it before installing). That runtime directory
-contains `.env`, generated secrets, model files, logs, data, and the compose
-state.
+The downloaded source folder is only the installer/source checkout. The Windows
+runtime is created under `$env:USERPROFILE\ods` by default (or `$env:ODS_HOME`
+if you set it before installing). That runtime directory contains `.env`,
+generated secrets, model files, logs, data, and the compose state.
 
 If your `C:` drive is tight, choose the runtime location explicitly. Running
 the installer from `G:\ODS` does not automatically install the runtime
@@ -68,6 +73,7 @@ cd $installDir
 .\ods.ps1 logs llama-server   # Tail logs (any service name)
 .\ods.ps1 update              # Pull latest images and restart
 .\ods.ps1 report              # Generate diagnostics bundle
+.\ods.ps1 uninstall --force   # Remove ODS containers, volumes, and files
 ```
 
 For development installs where you intentionally want the runtime files inside
@@ -190,6 +196,35 @@ $installDir = "$env:USERPROFILE\ods"
 cd $installDir
 .\ods.ps1 update
 ```
+
+---
+
+## Uninstalling
+
+Start Docker Desktop first so ODS can remove its containers and volumes, then run:
+
+```powershell
+$installDir = "$env:USERPROFILE\ods"
+# If you installed with -InstallDir, use that same path instead.
+cd $installDir
+.\ods.ps1 uninstall --force
+```
+
+To preserve local state:
+
+```powershell
+.\ods.ps1 uninstall --force --keep-data
+.\ods.ps1 uninstall --force --keep-models
+```
+
+If the runtime folder is partial and `.\ods.ps1` is missing, run the cleanup command from a source checkout:
+
+```powershell
+cd ODS
+.\ods\installers\windows\ods.ps1 uninstall --force
+```
+
+That fallback removes Docker resources labelled as the ODS compose project before removing the runtime directory.
 
 ---
 

--- a/ods/docs/WINDOWS-QUICKSTART.md
+++ b/ods/docs/WINDOWS-QUICKSTART.md
@@ -10,10 +10,9 @@ Open a normal **PowerShell** session and run:
 
 ```powershell
 $ProgressPreference = "SilentlyContinue"
-$odsZip = Join-Path $env:TEMP "ods-main.zip"
-$odsSrc = Join-Path $env:TEMP "ods-main"
-Remove-Item -LiteralPath $odsZip -Force -ErrorAction SilentlyContinue
-Remove-Item -LiteralPath $odsSrc -Recurse -Force -ErrorAction SilentlyContinue
+$odsSrc = Join-Path $env:TEMP ("ods-install-" + [guid]::NewGuid().ToString("N"))
+$odsZip = Join-Path $odsSrc "ods-main.zip"
+New-Item -ItemType Directory -Path $odsSrc | Out-Null
 Invoke-WebRequest "https://github.com/Osmantic/ODS/archive/refs/heads/main.zip" -OutFile $odsZip
 Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force
 cd (Get-ChildItem -LiteralPath $odsSrc -Directory | Select-Object -First 1).FullName
@@ -93,7 +92,9 @@ models to live inside that checkout.
 
 Visit **http://localhost:3000** — the chat interface is ready after the installer completes.
 
-First user becomes admin. Start chatting immediately.
+The normal loopback-only install opens directly without an account. A
+network-bound or ODS proxy install keeps authentication enabled and prompts the
+first user to create the admin account.
 
 ---
 

--- a/ods/extensions/library/schema/service-manifest.v1.json
+++ b/ods/extensions/library/schema/service-manifest.v1.json
@@ -90,6 +90,10 @@
           "type": "boolean",
           "description": "When false, omit this service from dashboard external quicklinks while keeping it in health/status APIs."
         },
+        "macos_host_supported": {
+          "type": "boolean",
+          "description": "True when a host-systemd service has an equivalent macOS LaunchAgent and should remain in the Apple service registry."
+        },
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
         "startup_check": {
           "type": "boolean",

--- a/ods/extensions/schema/service-manifest.v1.json
+++ b/ods/extensions/schema/service-manifest.v1.json
@@ -90,6 +90,10 @@
           "type": "boolean",
           "description": "When false, omit this service from dashboard external quicklinks while keeping it in health/status APIs."
         },
+        "macos_host_supported": {
+          "type": "boolean",
+          "description": "True when a host-systemd service has an equivalent macOS LaunchAgent and should remain in the Apple service registry."
+        },
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
         "startup_check": {
           "type": "boolean",

--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -353,7 +353,10 @@ def load_extension_manifests(
                         continue
                 supported = service.get("gpu_backends", ["amd", "nvidia", "apple"])
                 if gpu_backend == "apple":
-                    if service.get("type") == "host-systemd":
+                    if (
+                        service.get("type") == "host-systemd"
+                        and not service.get("macos_host_supported", False)
+                    ):
                         continue  # Linux-only service, not available on macOS
                     # All docker services run on macOS regardless of gpu_backends declaration
                 elif gpu_backend not in supported and "all" not in supported:
@@ -381,6 +384,7 @@ def load_extension_manifests(
                     "ui_path": service.get("ui_path", "/"),
                     "public_url": public_url,
                     "external_link": bool(service.get("external_link", True)),
+                    "macos_host_supported": bool(service.get("macos_host_supported", False)),
                     "container_name": service.get("container_name", f"ods-{service_id}"),
                     "depends_on": service.get("depends_on", []),
                     "category": service.get("category", "optional"),

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -1629,11 +1629,19 @@ async def api_settings_env_save(
             detail={"message": "Could not contact host agent to write environment file."},
         ) from exc
     backup_relative = agent_resp.get("backup_path")
+    saved_raw_text = raw_text
+    enforced_values = agent_resp.get("enforced_values")
+    if isinstance(enforced_values, dict):
+        saved_values, _ = _parse_env_text(raw_text)
+        for key, value in enforced_values.items():
+            if isinstance(key, str) and isinstance(value, str):
+                saved_values[key] = value
+        saved_raw_text = _render_env_from_values(saved_values)
 
     _clear_settings_caches()
     result = await asyncio.to_thread(
         _build_settings_env_payload,
-        raw_text=raw_text,
+        raw_text=saved_raw_text,
         backup_path=backup_relative,
         apply_plan=apply_plan,
     )

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -518,6 +518,21 @@ class TestLoadExtensionManifests:
         services, _, _ = load_extension_manifests(tmp_path, "apple")
         assert "systemd-svc" not in services
 
+    def test_apple_backend_includes_explicitly_supported_host_service(self, tmp_path):
+        """A cross-platform host service may declare a macOS LaunchAgent."""
+        svc_dir = tmp_path / "host-svc"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: ods.services.v1\n"
+            "service:\n  id: host-svc\n  name: Host Svc\n  port: 3003\n"
+            "  type: host-systemd\n"
+            "  macos_host_supported: true\n"
+            "  gpu_backends: [all]\n"
+        )
+
+        services, _, _ = load_extension_manifests(tmp_path, "apple")
+        assert services["host-svc"]["macos_host_supported"] is True
+
     def test_apple_backend_loads_all_features(self, tmp_path):
         """Features with gpu_backends: [amd, nvidia] are loaded for apple backend."""
         svc_dir = tmp_path / "svc-with-gpu-feature"

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2844,6 +2844,8 @@ def env_update_env(tmp_path, monkeypatch):
 
     monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
     monkeypatch.setattr(_mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(_mod, "EXTENSIONS_DIR", install_dir / "extensions" / "services")
+    monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", data_dir / "user-extensions")
     monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
     return install_dir, data_dir
 
@@ -2871,6 +2873,26 @@ class TestHandleEnvUpdate:
         # backup file actually exists where the response says it does
         backup_files = list((data_dir / "config-backups").glob(".env.backup.*"))
         assert len(backup_files) == 1
+
+    def test_proxy_enabled_forces_auth_and_reports_saved_value(self, env_update_env):
+        install_dir, _ = env_update_env
+        proxy_dir = _mod.EXTENSIONS_DIR / "ods-proxy"
+        proxy_dir.mkdir(parents=True)
+        (proxy_dir / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
+        body = _make_body(
+            "ODS_AGENT_KEY=newvalue\n WEBUI_AUTH = false\nWEBUI_AUTH=false\n"
+        )
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 200
+        env_text = (install_dir / ".env").read_text(encoding="utf-8")
+        assert env_text.count("WEBUI_AUTH=true") == 1
+        assert "WEBUI_AUTH=false" not in env_text
+        response = handler.parse_response()
+        assert response["enforced_values"] == {"WEBUI_AUTH": "true"}
+        assert "raw_text" not in response
 
     def test_413_oversize_body(self, env_update_env):
         # Construct headers claiming body is too large; rfile content is irrelevant.
@@ -4150,6 +4172,144 @@ class TestRootlessDataOwnershipRepair:
         assert ok is False
         assert error == "ownership mismatch"
         assert compose_calls == []
+
+
+class TestProxyAuthStart:
+    def test_auth_is_persisted_and_applied_before_proxy_start(
+        self, tmp_path, monkeypatch,
+    ):
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "BIND_ADDRESS=127.0.0.1\nWEBUI_AUTH=false\nWEBUI_AUTH=false\n",
+            encoding="utf-8",
+        )
+        calls = []
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(
+            _mod, "resolve_compose_flags", lambda: ["-f", "base.yml"],
+        )
+        monkeypatch.setattr(_mod, "_precreate_data_dirs", lambda _sid: None)
+        monkeypatch.setattr(
+            _mod, "_repair_rootless_data_ownership", lambda _sid: None,
+        )
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        ok, error = _mod.docker_compose_action("ods-proxy", "start")
+
+        assert ok is True
+        assert error == ""
+        assert env_path.read_text(encoding="utf-8").count("WEBUI_AUTH=true") == 1
+        assert "WEBUI_AUTH=false" not in env_path.read_text(encoding="utf-8")
+        assert calls[0][0][-5:] == [
+            "up", "-d", "--no-deps", "--force-recreate", "open-webui",
+        ]
+        assert calls[0][1]["env"]["WEBUI_AUTH"] == "true"
+        assert calls[1][0][-3:] == ["up", "-d", "ods-proxy"]
+
+    def test_proxy_does_not_start_when_auth_recreate_fails(
+        self, tmp_path, monkeypatch,
+    ):
+        (tmp_path / ".env").write_text(
+            "WEBUI_AUTH=false\n",
+            encoding="utf-8",
+        )
+        calls = []
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(
+            _mod, "resolve_compose_flags", lambda: ["-f", "base.yml"],
+        )
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 1, "", "recreate failed")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        ok, error = _mod.docker_compose_action("ods-proxy", "start")
+
+        assert ok is False
+        assert "ods-proxy was not started" in error
+        assert len(calls) == 1
+        assert calls[0][-1] == "open-webui"
+        assert (tmp_path / ".env").read_text(encoding="utf-8") == (
+            "WEBUI_AUTH=true\n"
+        )
+
+    def test_open_webui_start_keeps_auth_on_when_proxy_is_enabled(
+        self, tmp_path, monkeypatch,
+    ):
+        env_path = tmp_path / ".env"
+        env_path.write_text("WEBUI_AUTH=false\n", encoding="utf-8")
+        extensions_dir = tmp_path / "extensions" / "services"
+        proxy_dir = extensions_dir / "ods-proxy"
+        proxy_dir.mkdir(parents=True)
+        (proxy_dir / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
+        calls = []
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", extensions_dir)
+        monkeypatch.setattr(
+            _mod, "USER_EXTENSIONS_DIR", tmp_path / "data" / "user-extensions",
+        )
+        monkeypatch.setattr(
+            _mod, "resolve_compose_flags", lambda: ["-f", "base.yml"],
+        )
+        monkeypatch.setattr(_mod, "_precreate_data_dirs", lambda _sid: None)
+        monkeypatch.setattr(
+            _mod, "_repair_rootless_data_ownership", lambda _sid: None,
+        )
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        ok, error = _mod.docker_compose_action("open-webui", "start")
+
+        assert ok is True
+        assert error == ""
+        assert env_path.read_text(encoding="utf-8") == "WEBUI_AUTH=true\n"
+        assert calls[0][0][-3:] == ["up", "-d", "open-webui"]
+        assert calls[0][1]["env"]["WEBUI_AUTH"] == "true"
+
+    def test_core_recreate_keeps_auth_on_when_proxy_is_enabled(
+        self, tmp_path, monkeypatch,
+    ):
+        extensions_dir = tmp_path / "extensions" / "services"
+        proxy_dir = extensions_dir / "ods-proxy"
+        proxy_dir.mkdir(parents=True)
+        (proxy_dir / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
+        calls = []
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", extensions_dir)
+        monkeypatch.setattr(
+            _mod, "USER_EXTENSIONS_DIR", tmp_path / "data" / "user-extensions",
+        )
+        monkeypatch.setattr(_mod, "CORE_SERVICE_IDS", {"open-webui"})
+        monkeypatch.setattr(
+            _mod, "resolve_compose_flags", lambda: ["-f", "base.yml"],
+        )
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        ok, error = _mod.docker_compose_recreate(["open-webui"])
+
+        assert ok is True
+        assert error == ""
+        assert calls[0][1]["env"]["WEBUI_AUTH"] == "true"
 
 
 class TestInstallRunningStateVerification:

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -578,6 +578,34 @@ def test_api_settings_env_save_returns_llama_apply_plan(test_client, settings_en
     assert "llama-server" in payload["applyPlan"]["summary"]
 
 
+def test_api_settings_env_save_uses_host_agent_canonical_value(
+    test_client, settings_env_fixture, monkeypatch,
+):
+    def fake_env_update(raw_text):
+        return {
+            "backup_path": "data/config-backups/.env.backup.test",
+            "enforced_values": {"WEBUI_AUTH": "true"},
+        }
+
+    monkeypatch.setattr("main._call_agent_env_update", fake_env_update)
+
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {
+                "WEBUI_AUTH": "false",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["values"]["WEBUI_AUTH"] == "true"
+    assert payload["fields"]["WEBUI_AUTH"]["value"] == "true"
+
+
 def test_api_settings_env_preserves_commented_empty_llama_args(test_client, settings_env_fixture):
     env_path = settings_env_fixture["env_path"]
 

--- a/ods/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/ods/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -60,7 +60,9 @@ export default function Sidebar({ status, collapsed, onToggle }) {
   }, [status, serviceTokens, apiLinks])
 
   const visibleExternalLinks = useMemo(() => {
-    return showAllQuickLinks ? externalLinks : externalLinks.filter(link => link.healthy)
+    return showAllQuickLinks
+      ? externalLinks
+      : externalLinks.filter(link => link.healthy || link.alwaysVisible)
   }, [externalLinks, showAllQuickLinks])
 
   // Service counts with degraded nuance
@@ -213,7 +215,7 @@ export default function Sidebar({ status, collapsed, onToggle }) {
                       className="ml-auto text-[9px] font-mono uppercase tracking-[0.18em]"
                       style={{ color: healthy ? 'var(--sidebar-accent-soft)' : 'var(--sidebar-inactive)' }}
                     >
-                      {healthy ? 'OPEN' : '—'}
+                      {healthy ? 'OPEN' : 'OFFLINE'}
                     </span>
                   </a>
                 </li>

--- a/ods/extensions/services/dashboard/src/components/__tests__/Sidebar.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/Sidebar.test.jsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import { render } from '../../test/test-utils'
 import Sidebar from '../Sidebar' // eslint-disable-line no-unused-vars
+import { getSidebarExternalLinks } from '../../plugins/registry'
 
 vi.mock('../../plugins/registry', () => ({
   getSidebarNavItems: vi.fn(() => [
@@ -65,5 +66,24 @@ describe('Sidebar', () => {
   test('shows version in header', () => {
     render(<Sidebar status={defaultStatus} collapsed={false} onToggle={() => {}} />)
     expect(screen.getAllByText(/v1\.0\.0/)).toHaveLength(2)
+  })
+
+  test('keeps an always-visible OpenCode launcher in the default application list', () => {
+    getSidebarExternalLinks.mockReturnValueOnce([
+      {
+        key: 'opencode',
+        url: 'http://localhost:3003',
+        icon: () => <span data-testid="opencode-icon">OC</span>,
+        label: 'OpenCode',
+        healthy: false,
+        alwaysVisible: true,
+      },
+    ])
+
+    render(<Sidebar status={defaultStatus} collapsed={false} onToggle={() => {}} />)
+
+    expect(screen.getByText('OpenCode')).toBeInTheDocument()
+    expect(screen.getByText('OFFLINE')).toBeInTheDocument()
+    expect(screen.getByText('OpenCode').closest('a')).not.toHaveAttribute('href')
   })
 })

--- a/ods/extensions/services/dashboard/src/plugins/core.js
+++ b/ods/extensions/services/dashboard/src/plugins/core.js
@@ -9,6 +9,7 @@ import {
   Cloud,
   UserPlus,
   CreditCard,
+  Code,
 } from 'lucide-react'
 
 const Dashboard = lazy(() => import('../pages/Dashboard'))
@@ -119,4 +120,17 @@ export const coreRoutes = [
   },
 ]
 
-export const coreExternalLinks = []
+// OpenCode is an ODS application on every platform, even though its process is
+// host-managed rather than part of the Docker stack. Keep the launcher present
+// while health data is loading or the host service needs attention.
+export const coreExternalLinks = [
+  {
+    id: 'opencode',
+    label: 'OpenCode',
+    icon: Code,
+    port: 3003,
+    ui_path: '/',
+    healthNeedles: ['opencode', 'OpenCode (IDE)'],
+    alwaysVisible: true,
+  },
+]

--- a/ods/extensions/services/dashboard/src/plugins/registry.js
+++ b/ods/extensions/services/dashboard/src/plugins/registry.js
@@ -1,11 +1,11 @@
 import { coreRoutes, coreExternalLinks } from './core'
 import { appendPath } from '../lib/serviceUrls'
 import {
-  MessageSquare, Network, Bot, Terminal, Search, Image, ExternalLink
+  MessageSquare, Network, Bot, Terminal, Search, Image, Code, ExternalLink
 } from 'lucide-react'
 
 const ICON_MAP = {
-  MessageSquare, Network, Bot, Terminal, Search, Image, ExternalLink,
+  MessageSquare, Network, Bot, Terminal, Search, Image, Code, ExternalLink,
 }
 
 const routeExtensions = []
@@ -51,22 +51,20 @@ export function getSidebarExternalLinks(context = {}) {
   const { status, getExternalUrl, apiLinks = [] } = context
   // Merge static plugin links with API-fetched links
   const allLinks = [...coreExternalLinks, ...externalLinkExtensions, ...apiLinks]
-  // Deduplicate by id (API links take priority)
-  const seen = new Set()
-  const deduped = []
-  for (const link of allLinks.reverse()) {
-    if (!seen.has(link.id)) {
-      seen.add(link.id)
-      deduped.unshift(link)
-    }
+  // Merge by id so API values take priority without discarding static launcher
+  // behavior such as OpenCode's always-visible application entry.
+  const linksById = new Map()
+  for (const link of allLinks) {
+    linksById.set(link.id, { ...(linksById.get(link.id) || {}), ...link })
   }
-  return deduped.map(link => {
+  return [...linksById.values()].map(link => {
     const healthy = link.alwaysHealthy ? true : isServiceHealthy(status, link.healthNeedles || [])
     return {
       key: link.id,
       label: link.label,
       icon: typeof link.icon === 'string' ? (ICON_MAP[link.icon] || ExternalLink) : (link.icon || ExternalLink),
       healthy,
+      alwaysVisible: Boolean(link.alwaysVisible),
       url: link.public_url || appendPath(
         typeof getExternalUrl === 'function' ? getExternalUrl(link.port) : `http://localhost:${link.port}`,
         link.ui_path,

--- a/ods/extensions/services/dashboard/src/plugins/registry.test.js
+++ b/ods/extensions/services/dashboard/src/plugins/registry.test.js
@@ -18,7 +18,7 @@ describe('getSidebarExternalLinks', () => {
       ],
     })
 
-    expect(links[0].url).toBe('https://chat.example.test')
+    expect(links.find(link => link.key === 'open-webui').url).toBe('https://chat.example.test')
   })
 
   it('keeps the existing host-port plus ui_path fallback', () => {
@@ -36,6 +36,31 @@ describe('getSidebarExternalLinks', () => {
       ],
     })
 
-    expect(links[0].url).toBe('http://localhost:3005/dashboard')
+    expect(links.find(link => link.key === 'token-spy').url).toBe('http://localhost:3005/dashboard')
+  })
+
+  it('keeps the core OpenCode launcher visible when API metadata overrides it', () => {
+    const links = getSidebarExternalLinks({
+      status: { services: [{ id: 'opencode', name: 'OpenCode (IDE)', status: 'not_deployed' }] },
+      getExternalUrl: port => `http://localhost:${port}`,
+      apiLinks: [
+        {
+          id: 'opencode',
+          label: 'OpenCode (IDE)',
+          port: 3003,
+          ui_path: '/',
+          icon: 'Code',
+          healthNeedles: ['opencode', 'opencode (ide)'],
+        },
+      ],
+    })
+
+    const openCode = links.find(link => link.key === 'opencode')
+    expect(openCode).toMatchObject({
+      label: 'OpenCode (IDE)',
+      url: 'http://localhost:3003',
+      healthy: false,
+      alwaysVisible: true,
+    })
   })
 })

--- a/ods/extensions/services/open-webui/README.md
+++ b/ods/extensions/services/open-webui/README.md
@@ -15,7 +15,7 @@ Open WebUI is served at `http://localhost:3000` and communicates with llama-serv
 - **Image generation**: ComfyUI backend using SDXL Lightning 4-step (1024×1024)
 - **Voice input**: Speech-to-text via Whisper (`/v1/audio/transcriptions`)
 - **Voice output**: Text-to-speech via Kokoro (`/v1/audio/speech`)
-- **User authentication**: Optional login system (enabled by default)
+- **User authentication**: Opens directly on loopback; enabled by default for LAN/network deployments
 - **Document Q&A**: Upload files and chat with their contents (requires Qdrant)
 - **Model selection**: Switch between models at runtime
 
@@ -27,7 +27,7 @@ Environment variables (set in `.env`):
 |----------|---------|-------------|
 | `WEBUI_SECRET` | *(required)* | Session signing key — generate with `openssl rand -hex 32` |
 | `WEBUI_PORT` | `3000` | External port (maps to internal 8080) |
-| `WEBUI_AUTH` | `true` | Enable user authentication (`true`/`false`) |
+| `WEBUI_AUTH` | conditional | `false` for loopback-only installs; `true` for LAN-bound or ODS proxy installs |
 | `TIMEZONE` | `UTC` | System timezone for timestamps |
 | `LLM_API_URL` | `http://llama-server:8080` | LLM backend URL (internal Docker hostname) |
 
@@ -62,8 +62,8 @@ User accounts, chat history, and uploaded documents are stored in `data/open-web
 ## First Use
 
 1. Open `http://localhost:3000` in your browser
-2. Create an admin account (first user automatically becomes admin)
-3. Start chatting — the LLM is ready when llama-server reports healthy
+2. Start chatting; a normal loopback-only ODS install does not require an account
+3. On a LAN/network deployment, create the first admin account when prompted
 
 ## Troubleshooting
 
@@ -86,7 +86,9 @@ docker compose logs open-webui
 - Enable via `ods enable comfyui`
 
 **Authentication issues:**
-- To disable auth (local use only): set `WEBUI_AUTH=false` in `.env` and restart
+- Local-only installs should have `BIND_ADDRESS=127.0.0.1` and `WEBUI_AUTH=false`
+- LAN, ODS proxy, VPN, and public deployments should set `WEBUI_AUTH=true`
+- After changing `WEBUI_AUTH`, recreate Open WebUI with `ods restart open-webui`
 - To reset admin password: remove `data/open-webui/` (loses all chat history)
 
 ## Files

--- a/ods/extensions/services/opencode/README.md
+++ b/ods/extensions/services/opencode/README.md
@@ -38,7 +38,7 @@ login on Linux, macOS, and Windows. It is not exposed through the LAN proxy.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENCODE_PORT` | `3003` | OpenCode web interface port |
+| `OPENCODE_PORT` | `3003` | Dashboard metadata for the managed OpenCode web interface; host launchers currently use port 3003 |
 | `OPENCODE_SERVER_PASSWORD` | generated | Optional password for a separately managed, network-exposed OpenCode server; ignored by the ODS loopback launcher |
 
 ODS regenerates the managed OpenCode provider/model route during install,
@@ -75,8 +75,8 @@ Get-ScheduledTask -TaskName ODSOpenCodeWeb
 .\ods.ps1 restart opencode
 ```
 
-If the service is absent, rerun the ODS installer. If the port is occupied by
-another process, stop that process or change `OPENCODE_PORT` before reinstalling.
+If the service is absent, rerun the ODS installer. If port 3003 is occupied by
+another process, stop that process before reinstalling.
 
 ## Files
 

--- a/ods/extensions/services/opencode/README.md
+++ b/ods/extensions/services/opencode/README.md
@@ -1,90 +1,84 @@
 # OpenCode
 
-AI-powered coding assistant accessible via browser in ODS
+Browser-based AI coding assistant connected to the active ODS model.
 
 ## Overview
 
-OpenCode provides a browser-based AI coding environment that integrates with your local LLM. It gives you code completion, explanation, refactoring, and generation capabilities through a web interface — no IDE plugin required. Unlike other ODS services, OpenCode runs directly on the host system (not in Docker) as a systemd-managed process.
+OpenCode runs directly on the host rather than in Docker. ODS installs it,
+configures its local model route, starts its web interface on loopback, and
+keeps an OpenCode entry in the dashboard application menu even while the host
+process is starting or needs attention.
 
-## Features
+## Deployment
 
-- **Browser-based IDE**: Access your AI coding assistant from any browser on your local network
-- **Local LLM backend**: All code and queries stay on your machine — connects to llama-server for inference when available
-- **Code completion**: Context-aware completions for multiple languages
-- **Explanation and refactoring**: Ask the LLM to explain, refactor, or debug your code
-- **No IDE installation required**: Works entirely in the browser
+ODS manages the host process with the native user service for each platform:
 
-## Deployment Type
+| Platform | Service manager | Service |
+|----------|-----------------|---------|
+| Linux | systemd user service | `opencode-web.service` |
+| macOS | LaunchAgent | `com.ods.opencode-web` |
+| Windows | Task Scheduler | `ODSOpenCodeWeb` |
 
-OpenCode runs as a **host-level systemd service** (`type: host-systemd`), not as a Docker container. This means:
+The manifest retains `type: host-systemd` for compatibility with the existing
+host-service health path. `macos_host_supported: true` tells the dashboard that
+the equivalent macOS LaunchAgent is available.
 
-- It is managed by systemd on the host, not by Docker Compose
-- There is no `container_name` — use systemd commands to manage the process
-- LLM features require either OpenCode's own backend or llama-server to be running (either satisfies the requirement)
+## Access
+
+Open the **OpenCode** entry in the dashboard or browse directly to:
+
+```text
+http://localhost:3003
+```
+
+ODS-managed OpenCode binds only to `127.0.0.1` and opens without a separate
+login on Linux, macOS, and Windows. It is not exposed through the LAN proxy.
 
 ## Configuration
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENCODE_PORT` | 3003 | Port for the OpenCode web interface |
+| `OPENCODE_PORT` | `3003` | OpenCode web interface port |
+| `OPENCODE_SERVER_PASSWORD` | generated | Optional password for a separately managed, network-exposed OpenCode server; ignored by the ODS loopback launcher |
 
-> **Note:** LLM-powered features (completion, explanation) need either OpenCode's own backend or `llama-server` running. OpenCode itself starts independently.
-
-## Accessing OpenCode
-
-Once running, open your browser and navigate to:
-
-```
-http://localhost:3003
-```
+ODS regenerates the managed OpenCode provider/model route during install,
+upgrade, and model activation. The route follows `ods/current` when the model
+switchboard is enabled.
 
 ## Requirements
 
-| Requirement | Details |
-|-------------|---------|
-| GPU VRAM | 8 GB minimum (for LLM inference via llama-server) |
-| LLM service | `llama-server` must be running |
-| GPU backends | NVIDIA, AMD |
-
-## Architecture
-
-```
-┌──────────┐  HTTP :3003   ┌──────────────┐
-│ Browser  │──────────────▶│  OpenCode    │
-│          │◀──────────────│ (host daemon)│
-└──────────┘               └──────┬───────┘
-                                  │ LLM inference
-                                  ▼
-                           ┌──────────────┐
-                           │ llama-server │
-                           │   (Docker)   │
-                           └──────────────┘
-```
-
-## Files
-
-- `manifest.yaml` — Service metadata (port, health endpoint, GPU backends, feature definition)
+- A supported ODS host on Linux, macOS, or Windows
+- An active ODS local or remote model route for inference
+- Enough memory for the selected model; OpenCode itself does not require 8 GB
+  of VRAM
 
 ## Troubleshooting
 
-**OpenCode not accessible on port 3003:**
+First check whether port 3003 is listening and whether the platform service is
+running:
 
-Since OpenCode is a host systemd service, check its status with systemd:
 ```bash
-# Check service status
-systemctl status opencode
-
-# View logs
-journalctl -u opencode --follow
-
-# Restart the service
-systemctl restart opencode
+# Linux
+systemctl --user status opencode-web.service
+journalctl --user -u opencode-web.service --follow
 ```
 
-**LLM inference not working:**
-- Verify llama-server is running: `docker compose -f ods/docker-compose.base.yml ps llama-server`
-- Ensure sufficient VRAM (minimum 8 GB) is available
+```bash
+# macOS
+launchctl print "gui/$(id -u)/com.ods.opencode-web"
+tail -f "$HOME/Library/Logs/ODS/opencode-web.log"
+```
 
-**Port 3003 already in use:**
-- Check what is using the port: `lsof -i :3003`
-- Update the port in your ODS configuration and restart the service
+```powershell
+# Windows
+Get-ScheduledTask -TaskName ODSOpenCodeWeb
+.\ods.ps1 restart opencode
+```
+
+If the service is absent, rerun the ODS installer. If the port is occupied by
+another process, stop that process or change `OPENCODE_PORT` before reinstalling.
+
+## Files
+
+- `manifest.yaml`: service metadata, health route, and dashboard feature
+- `opencode-web.service`: Linux user service template

--- a/ods/extensions/services/opencode/manifest.yaml
+++ b/ods/extensions/services/opencode/manifest.yaml
@@ -14,6 +14,7 @@ service:
   external_port_default: 3003
   health: /
   type: host-systemd
+  macos_host_supported: true
   gpu_backends: [all]
   category: optional
   depends_on: []
@@ -26,7 +27,6 @@ service:
     probe:
       kind: custom
       path: /
-      auth: env:OPENCODE_SERVER_PASSWORD
 
 features:
   - id: coding

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -320,6 +320,19 @@ generate_ods_env() {
                 upsert_env_value "$env_path" "HOST_LAN_IP" "$_host_lan_ip"
             fi
         fi
+
+        # A local install may later be exposed by editing BIND_ADDRESS or
+        # enabling the ODS proxy. Do not preserve an authless localhost value
+        # across that transition.
+        local _existing_proxy
+        _existing_proxy="$(read_env_value "$env_path" "ENABLE_ODS_PROXY")"
+        if [[ "${ENABLE_ODS_PROXY:-false}" == "true" ]] \
+            || [[ "${_existing_proxy:-false}" == "true" ]] \
+            || [[ "$_existing_bind" != "127.0.0.1" && "$_existing_bind" != "::1" && "$_existing_bind" != "localhost" ]]; then
+            upsert_env_value "$env_path" "WEBUI_AUTH" "true"
+        elif ! env_key_exists "$env_path" "WEBUI_AUTH"; then
+            upsert_env_value "$env_path" "WEBUI_AUTH" "false"
+        fi
         return 0
     fi
 
@@ -444,12 +457,12 @@ generate_ods_env() {
     local rag_openai_api_key="${RAG_OPENAI_API_KEY:-}"
     local embeddings_memory_limit="${EMBEDDINGS_MEMORY_LIMIT:-4G}"
     local bind_address="${BIND_ADDRESS:-127.0.0.1}"
-    local webui_auth="${WEBUI_AUTH:-}"
-    if [[ -z "$webui_auth" && "${ENABLE_ODS_PROXY:-false}" == "true" ]]; then
+    local webui_auth
+    if [[ "${ENABLE_ODS_PROXY:-false}" == "true" ]]; then
         webui_auth="true"
-    elif [[ -z "$webui_auth" ]]; then
+    else
         case "$bind_address" in
-            127.0.0.1|::1|localhost) webui_auth="false" ;;
+            127.0.0.1|::1|localhost) webui_auth="${WEBUI_AUTH:-false}" ;;
             *) webui_auth="true" ;;
         esac
     fi

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -443,6 +443,16 @@ generate_ods_env() {
     local rag_openai_api_base_url="${RAG_OPENAI_API_BASE_URL:-}"
     local rag_openai_api_key="${RAG_OPENAI_API_KEY:-}"
     local embeddings_memory_limit="${EMBEDDINGS_MEMORY_LIMIT:-4G}"
+    local bind_address="${BIND_ADDRESS:-127.0.0.1}"
+    local webui_auth="${WEBUI_AUTH:-}"
+    if [[ -z "$webui_auth" && "${ENABLE_ODS_PROXY:-false}" == "true" ]]; then
+        webui_auth="true"
+    elif [[ -z "$webui_auth" ]]; then
+        case "$bind_address" in
+            127.0.0.1|::1|localhost) webui_auth="false" ;;
+            *) webui_auth="true" ;;
+        esac
+    fi
 
     # Build .env content (matches Phase 06 format)
     cat > "$env_path" << ENVEOF
@@ -453,6 +463,7 @@ generate_ods_env() {
 #=== Network Binding ===
 # macOS has no --lan flag; operators opt in by setting BIND_ADDRESS=0.0.0.0
 # manually. HOST_LAN_IP is only populated when that pre-existed at install time.
+BIND_ADDRESS=${bind_address}
 HOST_LAN_IP=${host_lan_ip}
 # Device name used by ods-mdns/ods-proxy hostnames and magic-link URLs.
 # Derived from the macOS LocalHostName/hostname so multiple installs on one LAN
@@ -582,7 +593,8 @@ RAG_OPENAI_API_KEY=${rag_openai_api_key}
 EMBEDDINGS_MEMORY_LIMIT=${embeddings_memory_limit}
 
 #=== Web UI Settings ===
-WEBUI_AUTH=true
+# Loopback installs open directly. Network-bound installs require a login.
+WEBUI_AUTH=${webui_auth}
 ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
 OPEN_WEBUI_LLM_BASE_URL=${open_webui_llm_base_url}

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -400,6 +400,32 @@ upsert_env_value() {
     fi
 }
 
+proxy_is_enabled() {
+    [[ -f "${INSTALL_DIR}/extensions/services/ods-proxy/compose.yaml" ]] \
+        || [[ -f "${INSTALL_DIR}/data/user-extensions/ods-proxy/compose.yaml" ]]
+}
+
+require_proxy_auth() {
+    local env_file="${INSTALL_DIR}/.env"
+    [[ -f "$env_file" ]] || {
+        ai_err "Cannot enable network access without ${env_file}."
+        return 1
+    }
+    if [[ "$(read_env_value "$env_file" "WEBUI_AUTH")" != "true" ]]; then
+        upsert_env_value "$env_file" "WEBUI_AUTH" "true"
+        ai "Network access requires sign-in; set WEBUI_AUTH=true."
+    fi
+    export WEBUI_AUTH=true
+}
+
+prepare_proxy_start() {
+    local flags="$1"
+    require_proxy_auth || return 1
+    ai "Applying authenticated Open WebUI configuration..."
+    # shellcheck disable=SC2086
+    docker compose $flags up -d --no-deps --force-recreate open-webui
+}
+
 select_auto_cpu_value() {
     local existing="$1"
     local detected="$2"
@@ -731,6 +757,12 @@ cmd_start() {
     local flags
     flags=$(get_compose_flags)
 
+    if [[ "$service" == "ods-proxy" ]]; then
+        prepare_proxy_start "$flags" || return 1
+    elif [[ -z "$service" || "$service" == "open-webui" ]] && proxy_is_enabled; then
+        require_proxy_auth || return 1
+    fi
+
     if [[ "$service" == "llama-server" || "$service" == "llama" ]]; then
         macos_wait_for_bootstrap_compose_safe "start" || return 1
         start_native_llama
@@ -788,6 +820,12 @@ cmd_restart() {
 
     local flags
     flags=$(get_compose_flags)
+
+    if [[ "$service" == "ods-proxy" ]]; then
+        prepare_proxy_start "$flags" || return 1
+    elif [[ -z "$service" || "$service" == "open-webui" ]] && proxy_is_enabled; then
+        require_proxy_auth || return 1
+    fi
 
     if [[ "$service" == "llama-server" || "$service" == "llama" ]]; then
         macos_wait_for_bootstrap_compose_safe "restart" || return 1

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -629,11 +629,13 @@ raise SystemExit(1)' 2>/dev/null && return 0
     else
         BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
     fi
-    if [[ "${ENABLE_ODS_PROXY:-false}" != "true" ]] \
-        && [[ "$BIND_ADDRESS" == "127.0.0.1" || "$BIND_ADDRESS" == "::1" || "$BIND_ADDRESS" == "localhost" ]]; then
-        WEBUI_AUTH=$(_env_get WEBUI_AUTH "false")
+    if [[ "${ENABLE_ODS_PROXY:-false}" == "true" ]] \
+        || [[ "$BIND_ADDRESS" != "127.0.0.1" && "$BIND_ADDRESS" != "::1" && "$BIND_ADDRESS" != "localhost" ]]; then
+        # Never carry an authless localhost value into a network-exposed rerun.
+        WEBUI_AUTH="true"
     else
-        WEBUI_AUTH=$(_env_get WEBUI_AUTH "true")
+        # On loopback, preserve an operator's explicit opt-in to authentication.
+        WEBUI_AUTH=$(_env_get WEBUI_AUTH "false")
     fi
 
     # Host LAN IP — only meaningful when BIND_ADDRESS=0.0.0.0. Some services

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -629,6 +629,12 @@ raise SystemExit(1)' 2>/dev/null && return 0
     else
         BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
     fi
+    if [[ "${ENABLE_ODS_PROXY:-false}" != "true" ]] \
+        && [[ "$BIND_ADDRESS" == "127.0.0.1" || "$BIND_ADDRESS" == "::1" || "$BIND_ADDRESS" == "localhost" ]]; then
+        WEBUI_AUTH=$(_env_get WEBUI_AUTH "false")
+    else
+        WEBUI_AUTH=$(_env_get WEBUI_AUTH "true")
+    fi
 
     # Host LAN IP — only meaningful when BIND_ADDRESS=0.0.0.0. Some services
     # (e.g. openclaw) need to know the host's LAN address so the Control UI
@@ -972,7 +978,8 @@ EMBEDDINGS_MEMORY_LIMIT=${EMBEDDINGS_MEMORY_LIMIT_VALUE}
 ODS_DEVICE_NAME=${ODS_DEVICE_NAME}
 
 #=== Web UI Settings ===
-WEBUI_AUTH=true
+# Loopback installs open directly. Network-bound installs require a login.
+WEBUI_AUTH=${WEBUI_AUTH}
 ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
 

--- a/ods/installers/windows/lib/constants.ps1
+++ b/ods/installers/windows/lib/constants.ps1
@@ -63,6 +63,7 @@ $script:OPENCODE_BIN = Join-Path (Join-Path $env:USERPROFILE ".opencode") "bin"
 $script:OPENCODE_EXE = Join-Path (Join-Path $env:USERPROFILE ".opencode") "bin\opencode.exe"
 $script:OPENCODE_CONFIG_DIR = Join-Path (Join-Path $env:USERPROFILE ".config") "opencode"
 $script:OPENCODE_PORT = 3003
+$script:OPENCODE_TASK_NAME = "ODSOpenCodeWeb"
 
 # ODS Host Agent (host-level extension lifecycle manager)
 $script:ODS_AGENT_PORT       = 7710

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -490,12 +490,23 @@ function New-ODSEnv {
     }
 
     $bindAddressDefault = if ($EnableLan) { "0.0.0.0" } else { "127.0.0.1" }
-    $bindAddress = Get-EnvOrNew "BIND_ADDRESS" $bindAddressDefault
-    $webuiAuthDefault = if (
-        $bindAddress -in @("127.0.0.1", "::1", "localhost") -and
-        -not $EnableODSProxy
-    ) { "false" } else { "true" }
-    $webuiAuth = Get-EnvOrNew "WEBUI_AUTH" $webuiAuthDefault
+    $bindAddress = if ($EnableLan) {
+        # An explicit -Lan rerun must override a stale loopback-only .env.
+        $bindAddressDefault
+    } else {
+        Get-EnvOrNew "BIND_ADDRESS" $bindAddressDefault
+    }
+    $networkExposed = (
+        $bindAddress -notin @("127.0.0.1", "::1", "localhost") -or
+        $EnableODSProxy
+    )
+    if ($networkExposed) {
+        # Never carry an authless localhost value into a network-exposed rerun.
+        $webuiAuth = "true"
+    } else {
+        # On loopback, preserve an operator's explicit opt-in to authentication.
+        $webuiAuth = Get-EnvOrNew "WEBUI_AUTH" "false"
+    }
 
     $webuiPort = Resolve-WindowsODSPort `
         -Name "WEBUI_PORT" -DefaultPort 3000 `

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -457,7 +457,8 @@ function New-ODSEnv {
         # user already had in .env (via Get-EnvOrNew), so manual
         # `ods enable langfuse` edits survive.
         [bool]$EnableLangfuse = $false,
-        [bool]$EnableLan = $false
+        [bool]$EnableLan = $false,
+        [bool]$EnableODSProxy = $false
     )
 
     # Preserve existing secrets on re-install (mirrors Linux _env_get logic)
@@ -487,6 +488,14 @@ function New-ODSEnv {
         }
         return $Default
     }
+
+    $bindAddressDefault = if ($EnableLan) { "0.0.0.0" } else { "127.0.0.1" }
+    $bindAddress = Get-EnvOrNew "BIND_ADDRESS" $bindAddressDefault
+    $webuiAuthDefault = if (
+        $bindAddress -in @("127.0.0.1", "::1", "localhost") -and
+        -not $EnableODSProxy
+    ) { "false" } else { "true" }
+    $webuiAuth = Get-EnvOrNew "WEBUI_AUTH" $webuiAuthDefault
 
     $webuiPort = Resolve-WindowsODSPort `
         -Name "WEBUI_PORT" -DefaultPort 3000 `
@@ -809,7 +818,7 @@ function New-ODSEnv {
 #=== Network Binding ===
 # 127.0.0.1 = localhost only (secure default)
 # 0.0.0.0   = accessible from LAN (install with -Lan or set manually)
-BIND_ADDRESS=$(Get-EnvOrNew "BIND_ADDRESS" "$(if ($EnableLan) { "0.0.0.0" } else { "127.0.0.1" })")
+BIND_ADDRESS=$bindAddress
 # Docker Desktop containers reach loopback-only host services through this name.
 ODS_AGENT_HOST=$(Get-EnvOrNew "ODS_AGENT_HOST" "host.docker.internal")
 # The dashboard-api container must call the host agent over Docker Desktop's
@@ -950,7 +959,8 @@ RAG_OPENAI_API_KEY=$ragOpenAiApiKey
 EMBEDDINGS_MEMORY_LIMIT=$embeddingsMemoryLimit
 
 #=== Web UI Settings ===
-WEBUI_AUTH=true
+# Loopback installs open directly. LAN installs require a login by default.
+WEBUI_AUTH=$webuiAuth
 ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
 

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -303,6 +303,38 @@ function Assert-ODSInstallDirSafeForRemoval {
     if ($fullPath.TrimEnd("\") -eq $userProfile.TrimEnd("\")) {
         throw "Install directory resolves to the user profile ($fullPath); refusing to remove files."
     }
+
+    $primaryMarkers = @(
+        "manifest.json",
+        "ods.ps1",
+        "docker-compose.base.yml",
+        "docker-compose.yml"
+    )
+    $primaryMarkerCount = @($primaryMarkers | Where-Object {
+        Test-Path -LiteralPath (Join-Path $fullPath $_) -PathType Leaf
+    }).Count
+
+    $supportingMarkerCount = 0
+    if (Test-Path -LiteralPath (Join-Path $fullPath ".compose-flags") -PathType Leaf) {
+        $supportingMarkerCount++
+    }
+    $envPath = Join-Path $fullPath ".env"
+    if (Test-Path -LiteralPath $envPath -PathType Leaf) {
+        $envText = Get-Content -LiteralPath $envPath -Raw -ErrorAction SilentlyContinue
+        if (
+            $envText -match '(?m)^WEBUI_SECRET=' -and
+            $envText -match '(?m)^DASHBOARD_API_KEY='
+        ) {
+            $supportingMarkerCount++
+        }
+    }
+
+    if (
+        $primaryMarkerCount -lt 2 -and
+        -not ($primaryMarkerCount -ge 1 -and $supportingMarkerCount -ge 1)
+    ) {
+        throw "Install directory does not contain enough ODS runtime markers ($fullPath); refusing to remove files."
+    }
 }
 
 function Remove-ODSInstallDirectory {
@@ -364,9 +396,19 @@ function Invoke-Uninstall {
         $hasProjectContainers = ((Get-ODSDockerProjectResourceNames -Kind "container").Count -gt 0)
     }
 
+    if (-not $dockerAvailable) {
+        Write-AIError "Docker Desktop is not running, so ODS containers and volumes cannot be removed safely."
+        Write-AI "Start Docker Desktop and rerun the uninstall command. Runtime files were left unchanged."
+        throw "ODS_UNINSTALL_DOCKER_UNAVAILABLE"
+    }
+
     if (-not $hasInstallDir -and -not $hasProjectContainers) {
         Write-AISuccess "No ODS install found at $InstallDir"
         return
+    }
+
+    if ($hasInstallDir) {
+        Assert-ODSInstallDirSafeForRemoval
     }
 
     if (-not $force) {
@@ -397,37 +439,48 @@ function Invoke-Uninstall {
         try { Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue } catch { }
     }
 
-    if ($dockerAvailable) {
-        $composeDownSucceeded = $false
-        if ($hasInstallDir) {
-            try {
-                Push-Location $InstallDir
-                $flags = Get-ComposeFlags
-                if (Test-ODSComposeFlagsFilesAvailable -ComposeFlags $flags) {
-                    $downArgs = @("down", "--remove-orphans")
-                    if ($removeVolumes) { $downArgs += "-v" }
-                    Write-AI "Removing ODS Docker stack with saved compose flags..."
-                    $composeArgs = $flags + $downArgs
-                    & docker compose @composeArgs
-                    $composeDownSucceeded = ($LASTEXITCODE -eq 0)
-                    if (-not $composeDownSucceeded) {
-                        Write-AIWarn "docker compose down failed; falling back to label-based cleanup."
-                    }
+    $composeDownSucceeded = $false
+    if ($hasInstallDir) {
+        try {
+            Push-Location $InstallDir
+            $flags = Get-ComposeFlags
+            if (Test-ODSComposeFlagsFilesAvailable -ComposeFlags $flags) {
+                $downArgs = @("down", "--remove-orphans")
+                if ($removeVolumes) { $downArgs += "-v" }
+                Write-AI "Removing ODS Docker stack with saved compose flags..."
+                $composeArgs = $flags + $downArgs
+                & docker compose @composeArgs
+                $composeDownSucceeded = ($LASTEXITCODE -eq 0)
+                if (-not $composeDownSucceeded) {
+                    Write-AIWarn "docker compose down failed; falling back to label-based cleanup."
                 } else {
-                    Write-AIWarn "Compose files are unavailable; falling back to label-based cleanup."
+                    Write-AISuccess "Removed ODS Docker stack"
                 }
-            } catch {
-                Write-AIWarn "docker compose cleanup failed: $_"
-            } finally {
-                try { Pop-Location } catch { }
+            } else {
+                Write-AIWarn "Compose files are unavailable; falling back to label-based cleanup."
             }
+        } catch {
+            Write-AIWarn "docker compose cleanup failed: $_"
+        } finally {
+            try { Pop-Location } catch { }
         }
+    }
 
-        if (-not $composeDownSucceeded -or (Get-ODSDockerProjectResourceNames -Kind "container").Count -gt 0) {
-            Remove-ODSDockerProjectByLabel -RemoveVolumes:$removeVolumes
-        }
+    if (-not $composeDownSucceeded -or (Get-ODSDockerProjectResourceNames -Kind "container").Count -gt 0) {
+        Remove-ODSDockerProjectByLabel -RemoveVolumes:$removeVolumes
+    }
+
+    $remainingContainers = (Get-ODSDockerProjectResourceNames -Kind "container").Count
+    $remainingNetworks = (Get-ODSDockerProjectResourceNames -Kind "network").Count
+    $remainingVolumes = if ($removeVolumes) {
+        (Get-ODSDockerProjectResourceNames -Kind "volume").Count
     } else {
-        Write-AIWarn "Docker Desktop is not running; Docker containers and volumes were not removed."
+        0
+    }
+    if ($remainingContainers -gt 0 -or $remainingNetworks -gt 0 -or $remainingVolumes -gt 0) {
+        Write-AIError "Docker cleanup is incomplete; runtime files were left in place for recovery."
+        Write-AI "Remaining resources: containers=$remainingContainers networks=$remainingNetworks volumes=$remainingVolumes"
+        throw "ODS_UNINSTALL_DOCKER_CLEANUP_INCOMPLETE"
     }
 
     Remove-ODSInstallDirectory -KeepData:$keepData -KeepModels:$keepModels
@@ -887,15 +940,16 @@ function Set-ODSEnvValue {
     if (-not (Test-Path $envFile)) { return }
 
     $lines = New-Object 'System.Collections.Generic.List[string]'
-    Get-Content $envFile | ForEach-Object { [void]$lines.Add($_) }
-
     $escapedKey = [regex]::Escape($Key)
     $updated = $false
-    for ($i = 0; $i -lt $lines.Count; $i++) {
-        if ($lines[$i] -match "^${escapedKey}=") {
-            $lines[$i] = "${Key}=${Value}"
-            $updated = $true
-            break
+    foreach ($line in @(Get-Content $envFile)) {
+        if ($line -match "^${escapedKey}=") {
+            if (-not $updated) {
+                [void]$lines.Add("${Key}=${Value}")
+                $updated = $true
+            }
+        } else {
+            [void]$lines.Add($line)
         }
     }
 
@@ -905,6 +959,35 @@ function Set-ODSEnvValue {
 
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     [System.IO.File]::WriteAllLines($envFile, $lines.ToArray(), $utf8NoBom)
+}
+
+function Set-ODSProxyAuthRequired {
+    $envFile = Join-Path $InstallDir ".env"
+    if (-not (Test-Path -LiteralPath $envFile -PathType Leaf)) {
+        throw "Cannot enable network access without $envFile."
+    }
+
+    $current = Get-ODSEnvValue -Name "WEBUI_AUTH"
+    if ($current -ne "true") {
+        Set-ODSEnvValue -Key "WEBUI_AUTH" -Value "true"
+        Write-AI "Network access requires sign-in; set WEBUI_AUTH=true."
+    }
+    $env:WEBUI_AUTH = "true"
+}
+
+function Invoke-ODSProxyAuthPreflight {
+    param([Parameter(Mandatory = $true)][string[]]$ComposeFlags)
+
+    Set-ODSProxyAuthRequired
+    Write-AI "Applying authenticated Open WebUI configuration..."
+    $composeExit = Invoke-ODSDockerCompose -InstallDir $InstallDir -ComposeFlags $ComposeFlags `
+        -ComposeArgs @("up", "-d", "--no-deps", "--force-recreate", "open-webui")
+    if ($composeExit -ne 0) {
+        Write-AIError "Could not recreate Open WebUI with authentication; ods-proxy was not started."
+        Write-ODSComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $ComposeFlags `
+            -Phase "ods.ps1 proxy auth preflight"
+        throw "ODS_PROXY_AUTH_PREFLIGHT_FAILED"
+    }
 }
 
 function Select-AutoCpuValue {
@@ -1297,15 +1380,60 @@ function Stop-ODSOpenCodeRuntime {
     Write-AISuccess "OpenCode stopped ($($pidsToStop.Count) process(es))"
 }
 
+function Get-ODSOpenCodePortState {
+    $listeners = @(
+        Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT `
+            -State Listen -ErrorAction SilentlyContinue
+    )
+    if ($listeners.Count -eq 0) {
+        return [pscustomobject]@{ InUse = $false; OwnedByODS = $false; ProcessIds = @() }
+    }
+
+    $listenerPids = @(
+        $listeners |
+            Select-Object -ExpandProperty OwningProcess -Unique |
+            Where-Object { [int]$_ -gt 0 }
+    )
+    $expectedExe = [System.IO.Path]::GetFullPath($script:OPENCODE_EXE)
+    $ownedPids = @()
+    foreach ($processId in $listenerPids) {
+        $process = Get-CimInstance Win32_Process `
+            -Filter "ProcessId = $([int]$processId)" -ErrorAction SilentlyContinue
+        if (-not $process -or [string]::IsNullOrWhiteSpace($process.ExecutablePath)) {
+            continue
+        }
+        try {
+            $actualExe = [System.IO.Path]::GetFullPath([string]$process.ExecutablePath)
+        } catch {
+            continue
+        }
+        if ($actualExe.Equals($expectedExe, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $ownedPids += [int]$processId
+        }
+    }
+
+    return [pscustomobject]@{
+        InUse = $true
+        OwnedByODS = ($ownedPids.Count -gt 0)
+        ProcessIds = $listenerPids
+    }
+}
+
 function Start-ODSOpenCodeRuntime {
     if (-not (Test-Path -LiteralPath $script:OPENCODE_EXE)) {
         Write-AIWarn "OpenCode is not installed. Re-run the ODS installer to restore it."
-        return
+        return $false
     }
 
-    if (@(Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT -State Listen -ErrorAction SilentlyContinue).Count -gt 0) {
-        Write-AISuccess "OpenCode already running (http://localhost:$($script:OPENCODE_PORT))"
-        return
+    $portState = Get-ODSOpenCodePortState
+    if ($portState.InUse) {
+        if ($portState.OwnedByODS) {
+            Write-AISuccess "OpenCode already running (http://localhost:$($script:OPENCODE_PORT))"
+            return $true
+        }
+        Write-AIError "Port $($script:OPENCODE_PORT) is used by another process (PID: $($portState.ProcessIds -join ', '))."
+        Write-AI "Stop that process or move it to another port, then start OpenCode again."
+        return $false
     }
 
     $started = $false
@@ -1329,15 +1457,21 @@ function Start-ODSOpenCodeRuntime {
         }
     }
 
-    if (-not $started) { return }
+    if (-not $started) { return $false }
     for ($attempt = 0; $attempt -lt 15; $attempt++) {
         Start-Sleep -Seconds 1
-        if (@(Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT -State Listen -ErrorAction SilentlyContinue).Count -gt 0) {
+        $portState = Get-ODSOpenCodePortState
+        if ($portState.OwnedByODS) {
             Write-AISuccess "OpenCode started (http://localhost:$($script:OPENCODE_PORT))"
-            return
+            return $true
+        }
+        if ($portState.InUse) {
+            Write-AIError "OpenCode could not start because another process took port $($script:OPENCODE_PORT)."
+            return $false
         }
     }
     Write-AIWarn "OpenCode did not become reachable on port $($script:OPENCODE_PORT)."
+    return $false
 }
 
 function Stop-ODSLemonadeRuntime {
@@ -1951,7 +2085,7 @@ function Invoke-Start {
     param([string]$Service)
     Test-Install
     if ($Service -in @("opencode", "opencode-web")) {
-        Start-ODSOpenCodeRuntime
+        if (-not (Start-ODSOpenCodeRuntime)) { exit 1 }
         return
     }
     Push-Location $InstallDir
@@ -1966,11 +2100,17 @@ function Invoke-Start {
         # Start host agent (if not already running)
         if (-not $Service) {
             Invoke-Agent -Action "start"
-            Start-ODSOpenCodeRuntime
+            $null = Start-ODSOpenCodeRuntime
         }
 
         $flags = Get-ComposeFlags
         $hermesInStack = Test-ODSComposeServiceAvailable -ComposeFlags $flags -Service "hermes"
+        if ($Service -eq "ods-proxy") {
+            Invoke-ODSProxyAuthPreflight -ComposeFlags $flags
+        } elseif ((-not $Service -or $Service -eq "open-webui") -and
+            (Test-ODSComposeServiceAvailable -ComposeFlags $flags -Service "ods-proxy")) {
+            Set-ODSProxyAuthRequired
+        }
         if ($Service) {
             if (-not (Test-ODSComposeServiceAvailable -ComposeFlags $flags -Service $Service)) {
                 Write-ODSMissingComposeServiceHint -ComposeFlags $flags -Service $Service
@@ -2084,7 +2224,7 @@ function Invoke-Restart {
     Test-Install
     if ($Service -in @("opencode", "opencode-web")) {
         Stop-ODSOpenCodeRuntime
-        Start-ODSOpenCodeRuntime
+        if (-not (Start-ODSOpenCodeRuntime)) { exit 1 }
         return
     }
     Push-Location $InstallDir
@@ -2093,6 +2233,12 @@ function Invoke-Restart {
 
         $flags = Get-ComposeFlags
         $hermesInStack = Test-ODSComposeServiceAvailable -ComposeFlags $flags -Service "hermes"
+        if ($Service -eq "ods-proxy") {
+            Invoke-ODSProxyAuthPreflight -ComposeFlags $flags
+        } elseif ((-not $Service -or $Service -eq "open-webui") -and
+            (Test-ODSComposeServiceAvailable -ComposeFlags $flags -Service "ods-proxy")) {
+            Set-ODSProxyAuthRequired
+        }
         if ($Service) {
             if (-not (Test-ODSComposeServiceAvailable -ComposeFlags $flags -Service $Service)) {
                 Write-ODSMissingComposeServiceHint -ComposeFlags $flags -Service $Service
@@ -2156,7 +2302,7 @@ function Invoke-Restart {
                 exit 1
             }
             Write-AISuccess "All services restarted"
-            Start-ODSOpenCodeRuntime
+            $null = Start-ODSOpenCodeRuntime
             if ($hermesInStack) {
                 Invoke-HermesSoulRefresh -SyncContainer
             }
@@ -3052,6 +3198,10 @@ function Invoke-Enable {
     if ($category -eq "core") {
         Write-AISuccess "$ServiceId is a core service (always enabled)."
         return
+    }
+
+    if ($ServiceId -eq "ods-proxy") {
+        Set-ODSProxyAuthRequired
     }
 
     # Pull in disabled dependencies before touching this service's fragment.

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -19,6 +19,7 @@
 #   .\ods.ps1 enable <service>    # Enable an extension service (+ its dependencies)
 #   .\ods.ps1 disable <service>   # Disable an extension service
 #   .\ods.ps1 disable <svc> -Force # Disable even when other extensions depend on it
+#   .\ods.ps1 uninstall --force    # Remove ODS containers, volumes, and files
 #   .\ods.ps1 report              # Generate Windows diagnostics bundle
 #   .\ods.ps1 version             # Show version
 #   .\ods.ps1 help                # Show help
@@ -162,6 +163,282 @@ function Get-ComposeFlags {
     }
 
     return $flags
+}
+
+function Test-ODSArgumentPresent {
+    param(
+        [string[]]$Arguments,
+        [string[]]$Names
+    )
+
+    if (-not $Arguments) { return $false }
+    foreach ($arg in $Arguments) {
+        foreach ($name in $Names) {
+            if ($arg -eq $name) { return $true }
+        }
+    }
+    return $false
+}
+
+function Test-ODSDockerRunningQuiet {
+    try {
+        $null = & docker info 2>$null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+function Get-ODSDockerProjectResourceNames {
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("container", "network", "volume")]
+        [string]$Kind
+    )
+
+    $filter = "label=com.docker.compose.project=ods"
+    try {
+        switch ($Kind) {
+            "container" {
+                return @(& docker ps -aq --filter $filter 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+            }
+            "network" {
+                return @(& docker network ls -q --filter $filter 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+            }
+            "volume" {
+                return @(& docker volume ls -q --filter $filter 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+            }
+        }
+    } catch {
+        return @()
+    }
+}
+
+function Test-ODSComposeFlagsFilesAvailable {
+    param([string[]]$ComposeFlags)
+
+    if (-not $ComposeFlags -or $ComposeFlags.Count -eq 0) { return $false }
+
+    $hasComposeFile = $false
+    for ($i = 0; $i -lt $ComposeFlags.Count; $i++) {
+        $token = [string]$ComposeFlags[$i]
+        $path = $null
+        $isComposeFile = $false
+
+        if (($token -eq "-f" -or $token -eq "--file" -or $token -eq "--env-file") -and ($i + 1) -lt $ComposeFlags.Count) {
+            $path = [string]$ComposeFlags[$i + 1]
+            $isComposeFile = ($token -ne "--env-file")
+            $i++
+        } elseif ($token -like "--file=*") {
+            $path = $token.Substring("--file=".Length)
+            $isComposeFile = $true
+        } elseif ($token -like "--env-file=*") {
+            $path = $token.Substring("--env-file=".Length)
+        }
+
+        if ($path) {
+            if ([System.IO.Path]::IsPathRooted($path)) {
+                $fullPath = $path
+            } else {
+                $fullPath = Join-Path $InstallDir $path
+            }
+            if (-not (Test-Path -LiteralPath $fullPath)) {
+                Write-AIWarn "Compose receipt references missing file: $path"
+                return $false
+            }
+            if ($isComposeFile) {
+                $hasComposeFile = $true
+            }
+        }
+    }
+
+    return $hasComposeFile
+}
+
+function Remove-ODSDockerProjectByLabel {
+    param([switch]$RemoveVolumes)
+
+    $containers = Get-ODSDockerProjectResourceNames -Kind "container"
+    if ($containers.Count -gt 0) {
+        Write-AI "Removing ODS containers by Docker label..."
+        & docker rm -f @containers | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            Write-AIWarn "Some ODS containers could not be removed."
+        }
+    }
+
+    $networks = Get-ODSDockerProjectResourceNames -Kind "network"
+    if ($networks.Count -gt 0) {
+        Write-AI "Removing ODS Docker networks by label..."
+        & docker network rm @networks | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            Write-AIWarn "Some ODS networks could not be removed."
+        }
+    }
+
+    if ($RemoveVolumes) {
+        $volumes = Get-ODSDockerProjectResourceNames -Kind "volume"
+        if ($volumes.Count -gt 0) {
+            Write-AI "Removing ODS Docker volumes by label..."
+            & docker volume rm @volumes | Out-Host
+            if ($LASTEXITCODE -ne 0) {
+                Write-AIWarn "Some ODS volumes could not be removed."
+            }
+        }
+    }
+}
+
+function Assert-ODSInstallDirSafeForRemoval {
+    if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+        throw "Install directory is empty; refusing to remove files."
+    }
+
+    $fullPath = [System.IO.Path]::GetFullPath($InstallDir)
+    $rootPath = [System.IO.Path]::GetPathRoot($fullPath)
+    $userProfile = [System.IO.Path]::GetFullPath($env:USERPROFILE)
+
+    if ($fullPath.TrimEnd("\") -eq $rootPath.TrimEnd("\")) {
+        throw "Install directory resolves to a drive root ($fullPath); refusing to remove files."
+    }
+    if ($fullPath.TrimEnd("\") -eq $userProfile.TrimEnd("\")) {
+        throw "Install directory resolves to the user profile ($fullPath); refusing to remove files."
+    }
+}
+
+function Remove-ODSInstallDirectory {
+    param(
+        [switch]$KeepData,
+        [switch]$KeepModels
+    )
+
+    if (-not (Test-Path -LiteralPath $InstallDir)) { return }
+
+    Assert-ODSInstallDirSafeForRemoval
+
+    try {
+        $currentLocation = (Get-Location).ProviderPath
+        if ($currentLocation -and $currentLocation.StartsWith($InstallDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $parent = Split-Path -Parent $InstallDir
+            if (-not $parent) { $parent = $env:USERPROFILE }
+            Set-Location $parent
+        }
+    } catch { }
+
+    if ($KeepData) {
+        Write-AI "Preserving data under $InstallDir\data"
+        Get-ChildItem -LiteralPath $InstallDir -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ne "data" } |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    if ($KeepModels) {
+        Write-AI "Preserving downloaded models under $InstallDir\data\models"
+        $dataDir = Join-Path $InstallDir "data"
+        if (Test-Path -LiteralPath $dataDir) {
+            Get-ChildItem -LiteralPath $dataDir -Force -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -ne "models" } |
+                Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        Get-ChildItem -LiteralPath $InstallDir -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ne "data" } |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    Remove-Item -LiteralPath $InstallDir -Recurse -Force
+}
+
+function Invoke-Uninstall {
+    param([string[]]$UninstallArgs)
+
+    $force = Test-ODSArgumentPresent -Arguments $UninstallArgs -Names @("-Force", "--force")
+    $keepData = Test-ODSArgumentPresent -Arguments $UninstallArgs -Names @("-KeepData", "--keep-data")
+    $keepModels = Test-ODSArgumentPresent -Arguments $UninstallArgs -Names @("-KeepModels", "--keep-models")
+    $removeVolumes = (-not $keepData -and -not $keepModels)
+
+    $dockerAvailable = Test-ODSDockerRunningQuiet
+    $hasInstallDir = Test-Path -LiteralPath $InstallDir
+    $hasProjectContainers = $false
+    if ($dockerAvailable) {
+        $hasProjectContainers = ((Get-ODSDockerProjectResourceNames -Kind "container").Count -gt 0)
+    }
+
+    if (-not $hasInstallDir -and -not $hasProjectContainers) {
+        Write-AISuccess "No ODS install found at $InstallDir"
+        return
+    }
+
+    if (-not $force) {
+        Write-AIWarn "This will stop ODS and remove the Windows runtime at $InstallDir."
+        if ($removeVolumes) {
+            Write-AIWarn "Docker volumes for the ods project will also be removed."
+        }
+        $answer = Read-Host "Type uninstall to continue"
+        if ($answer -ne "uninstall") {
+            Write-AI "Uninstall cancelled."
+            return
+        }
+    }
+
+    Write-AI "Stopping ODS host-side helpers..."
+    try { Invoke-Agent -Action "stop" } catch { Write-AIWarn "Host agent stop skipped: $_" }
+    try { Stop-ODSOpenCodeRuntime } catch { Write-AIWarn "OpenCode stop skipped: $_" }
+    try {
+        if ((Get-NativeInferenceBackend) -ne "none") {
+            Stop-NativeInferenceServer
+        }
+    } catch {
+        Write-AIWarn "Native inference stop skipped: $_"
+    }
+
+    foreach ($taskName in @($script:ODS_AGENT_TASK_NAME, $script:ODS_MODEL_UPGRADE_TASK_NAME, $script:LEMONADE_TASK_NAME, $script:OPENCODE_TASK_NAME)) {
+        try { Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue } catch { }
+        try { Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue } catch { }
+    }
+
+    if ($dockerAvailable) {
+        $composeDownSucceeded = $false
+        if ($hasInstallDir) {
+            try {
+                Push-Location $InstallDir
+                $flags = Get-ComposeFlags
+                if (Test-ODSComposeFlagsFilesAvailable -ComposeFlags $flags) {
+                    $downArgs = @("down", "--remove-orphans")
+                    if ($removeVolumes) { $downArgs += "-v" }
+                    Write-AI "Removing ODS Docker stack with saved compose flags..."
+                    $composeArgs = $flags + $downArgs
+                    & docker compose @composeArgs
+                    $composeDownSucceeded = ($LASTEXITCODE -eq 0)
+                    if (-not $composeDownSucceeded) {
+                        Write-AIWarn "docker compose down failed; falling back to label-based cleanup."
+                    }
+                } else {
+                    Write-AIWarn "Compose files are unavailable; falling back to label-based cleanup."
+                }
+            } catch {
+                Write-AIWarn "docker compose cleanup failed: $_"
+            } finally {
+                try { Pop-Location } catch { }
+            }
+        }
+
+        if (-not $composeDownSucceeded -or (Get-ODSDockerProjectResourceNames -Kind "container").Count -gt 0) {
+            Remove-ODSDockerProjectByLabel -RemoveVolumes:$removeVolumes
+        }
+    } else {
+        Write-AIWarn "Docker Desktop is not running; Docker containers and volumes were not removed."
+    }
+
+    Remove-ODSInstallDirectory -KeepData:$keepData -KeepModels:$keepModels
+
+    if ($keepData) {
+        Write-AISuccess "ODS uninstalled; data was preserved at $InstallDir\data"
+    } elseif ($keepModels) {
+        Write-AISuccess "ODS uninstalled; models were preserved at $InstallDir\data\models"
+    } else {
+        Write-AISuccess "ODS uninstalled from $InstallDir"
+    }
 }
 
 function Read-ODSEnv {
@@ -954,6 +1231,8 @@ function Stop-ODSNativeProcessId {
 }
 
 function Stop-ODSOpenCodeRuntime {
+    try { Stop-ScheduledTask -TaskName $script:OPENCODE_TASK_NAME -ErrorAction SilentlyContinue } catch { }
+
     $opencodeExe = $script:OPENCODE_EXE
     $opencodePort = [string]$script:OPENCODE_PORT
     $processes = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)
@@ -1016,6 +1295,49 @@ function Stop-ODSOpenCodeRuntime {
         Stop-ODSNativeProcessId -ProcessId ([int]$pidValue)
     }
     Write-AISuccess "OpenCode stopped ($($pidsToStop.Count) process(es))"
+}
+
+function Start-ODSOpenCodeRuntime {
+    if (-not (Test-Path -LiteralPath $script:OPENCODE_EXE)) {
+        Write-AIWarn "OpenCode is not installed. Re-run the ODS installer to restore it."
+        return
+    }
+
+    if (@(Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT -State Listen -ErrorAction SilentlyContinue).Count -gt 0) {
+        Write-AISuccess "OpenCode already running (http://localhost:$($script:OPENCODE_PORT))"
+        return
+    }
+
+    $started = $false
+    try {
+        $task = Get-ScheduledTask -TaskName $script:OPENCODE_TASK_NAME -ErrorAction Stop
+        Start-ScheduledTask -TaskName $task.TaskName -ErrorAction Stop
+        $started = $true
+    } catch {
+        $launcher = Join-Path $script:OPENCODE_DIR "start-opencode.ps1"
+        if (Test-Path -LiteralPath $launcher) {
+            $argument = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$launcher`""
+            try {
+                Start-Process -FilePath "powershell.exe" -ArgumentList $argument `
+                    -WorkingDirectory $script:OPENCODE_DIR -WindowStyle Hidden -ErrorAction Stop | Out-Null
+                $started = $true
+            } catch {
+                Write-AIWarn "Could not start OpenCode: $_"
+            }
+        } else {
+            Write-AIWarn "OpenCode launcher is missing. Re-run the ODS installer to repair it."
+        }
+    }
+
+    if (-not $started) { return }
+    for ($attempt = 0; $attempt -lt 15; $attempt++) {
+        Start-Sleep -Seconds 1
+        if (@(Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT -State Listen -ErrorAction SilentlyContinue).Count -gt 0) {
+            Write-AISuccess "OpenCode started (http://localhost:$($script:OPENCODE_PORT))"
+            return
+        }
+    }
+    Write-AIWarn "OpenCode did not become reachable on port $($script:OPENCODE_PORT)."
 }
 
 function Stop-ODSLemonadeRuntime {
@@ -1628,6 +1950,10 @@ function Invoke-BootstrapUpgradeResume {
 function Invoke-Start {
     param([string]$Service)
     Test-Install
+    if ($Service -in @("opencode", "opencode-web")) {
+        Start-ODSOpenCodeRuntime
+        return
+    }
     Push-Location $InstallDir
     try {
         Ensure-LlamaCpuBudget
@@ -1640,6 +1966,7 @@ function Invoke-Start {
         # Start host agent (if not already running)
         if (-not $Service) {
             Invoke-Agent -Action "start"
+            Start-ODSOpenCodeRuntime
         }
 
         $flags = Get-ComposeFlags
@@ -1692,6 +2019,11 @@ function Invoke-Start {
 
 function Invoke-Stop {
     param([string]$Service)
+
+    if ($Service -in @("opencode", "opencode-web")) {
+        Stop-ODSOpenCodeRuntime
+        return
+    }
 
     if (-not $Service) {
         if (-not (Test-Path $InstallDir)) {
@@ -1750,6 +2082,11 @@ function Invoke-Stop {
 function Invoke-Restart {
     param([string]$Service)
     Test-Install
+    if ($Service -in @("opencode", "opencode-web")) {
+        Stop-ODSOpenCodeRuntime
+        Start-ODSOpenCodeRuntime
+        return
+    }
     Push-Location $InstallDir
     try {
         Ensure-LlamaCpuBudget
@@ -1786,6 +2123,7 @@ function Invoke-Restart {
                 Invoke-HermesSoulRefresh -SyncContainer
             }
         } else {
+            Stop-ODSOpenCodeRuntime
             # For AMD, also restart native inference server
             if ((Get-NativeInferenceBackend) -ne "none") {
                 Stop-NativeInferenceServer
@@ -1818,6 +2156,7 @@ function Invoke-Restart {
                 exit 1
             }
             Write-AISuccess "All services restarted"
+            Start-ODSOpenCodeRuntime
             if ($hermesInStack) {
                 Invoke-HermesSoulRefresh -SyncContainer
             }
@@ -3014,6 +3353,8 @@ function Show-Help {
     Write-Host "Enable an extension service and its dependencies" -ForegroundColor DarkGray
     Write-Host "    disable <service>   " -ForegroundColor Cyan -NoNewline
     Write-Host "Disable an extension service (-Force skips the dependent check)" -ForegroundColor DarkGray
+    Write-Host "    uninstall [options] " -ForegroundColor Cyan -NoNewline
+    Write-Host "Remove ODS containers, volumes, and runtime files" -ForegroundColor DarkGray
     Write-Host "    agent [action]      " -ForegroundColor Cyan -NoNewline
     Write-Host "Host agent: status|start|stop|restart|logs" -ForegroundColor DarkGray
     Write-Host "    report              " -ForegroundColor Cyan -NoNewline
@@ -3031,6 +3372,8 @@ function Show-Help {
     Write-Host "    .\ods.ps1 enable comfyui" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 disable langfuse" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 disable hermes -Force" -ForegroundColor DarkGray
+    Write-Host "    .\ods.ps1 uninstall --force" -ForegroundColor DarkGray
+    Write-Host "    .\ods.ps1 uninstall --force --keep-data" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 chat `"What is quantum computing?`"" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 model swap T1" -ForegroundColor DarkGray
     Write-Host ""
@@ -3112,6 +3455,7 @@ switch ($Command.ToLower()) {
     "repair"  { Invoke-Repair -Target ($Arguments | Select-Object -First 1) }
     "enable"  { Invoke-Enable -ServiceId (Get-ServiceIdArgument -Arguments $Arguments) }
     "disable" { Invoke-Disable -ServiceId (Get-ServiceIdArgument -Arguments $Arguments) -Force:(Test-ForceArgument -Arguments $Arguments) }
+    "uninstall" { Invoke-Uninstall -UninstallArgs $Arguments }
     "report"  { Invoke-Report }
     "agent"   {
         $action = ($Arguments | Select-Object -First 1)

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -338,7 +338,8 @@ $envResult = New-ODSEnv `
     -WhisperCudaEnabled $whisperCudaSupported `
     -EnableLangfuse $enableLangfuse `
     -SwitchboardMode $env:ODS_MODEL_SWITCHBOARD `
-    -EnableLan      $lanFlag
+    -EnableLan      $lanFlag `
+    -EnableODSProxy $enableODSProxy
 Write-AISuccess "Generated .env with secure secrets"
 
 # ── Post-generation validation: verify all required keys are present with values ──

--- a/ods/installers/windows/phases/07-devtools.ps1
+++ b/ods/installers/windows/phases/07-devtools.ps1
@@ -26,7 +26,7 @@ Write-Phase -Phase 7 -Total 13 -Name "DEVELOPER TOOLS" -Estimate "~2-5 minutes"
 if ($dryRun) {
     Write-AI "[DRY RUN] Would install OpenCode v$($script:OPENCODE_VERSION) to $($script:OPENCODE_EXE)"
     Write-AI "[DRY RUN] Would configure OpenCode for local llama-server (model: $($tierConfig.LlmModel))"
-    Write-AI "[DRY RUN] Would create a manual OpenCode launcher"
+    Write-AI "[DRY RUN] Would register and start $($script:OPENCODE_TASK_NAME) for the OpenCode web app"
     if (-not $cloudMode) {
         Write-AI "[DRY RUN] Would check for Node.js and install Claude Code + Codex CLI via npm"
     }
@@ -109,20 +109,83 @@ if (Test-Path $script:OPENCODE_EXE) {
     }
 
     # ── VBS launcher (available for manual startup) ──────────────────────────
-    # Creates a VBS script users can run to start OpenCode without a console
-    # window. NOT added to Windows Startup -- OpenCode is a developer tool,
-    # not a core service, so it should be opt-in.
+    # OpenCode is bound to loopback, so match the Linux and macOS launchers:
+    # clear any inherited password and open directly from the ODS app menu.
+    $_ocLauncherPath = Join-Path $script:OPENCODE_DIR "start-opencode.ps1"
+    $_ocExeLiteral = $script:OPENCODE_EXE.Replace("'", "''")
+    $_ocDirLiteral = $script:OPENCODE_DIR.Replace("'", "''")
+    $_ocLauncherContent = @"
+`$ErrorActionPreference = "Stop"
+Remove-Item Env:OPENCODE_SERVER_PASSWORD -ErrorAction SilentlyContinue
+Set-Location -LiteralPath '$_ocDirLiteral'
+& '$_ocExeLiteral' web --port $($script:OPENCODE_PORT) --hostname 127.0.0.1
+exit `$LASTEXITCODE
+"@
+    Write-Utf8NoBom -Path $_ocLauncherPath -Content $_ocLauncherContent
+
+    $_ocTaskArgument = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$($_ocLauncherPath)`""
+    $_ocStarted = $false
+    try {
+        try { Stop-ScheduledTask -TaskName $script:OPENCODE_TASK_NAME -ErrorAction SilentlyContinue } catch { }
+        try { Unregister-ScheduledTask -TaskName $script:OPENCODE_TASK_NAME -Confirm:$false -ErrorAction SilentlyContinue } catch { }
+
+        $_ocTaskAction = New-ScheduledTaskAction -Execute "powershell.exe" `
+            -Argument $_ocTaskArgument -WorkingDirectory $script:OPENCODE_DIR
+        $_ocTaskTrigger = New-ScheduledTaskTrigger -AtLogOn
+        $_ocTaskSettings = New-ScheduledTaskSettingsSet `
+            -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+            -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero)
+        $_ocTaskPrincipal = New-ODSInteractiveScheduledTaskPrincipal -RunLevel Limited
+
+        Register-ScheduledTask -TaskName $script:OPENCODE_TASK_NAME `
+            -Action $_ocTaskAction -Trigger $_ocTaskTrigger `
+            -Settings $_ocTaskSettings -Principal $_ocTaskPrincipal `
+            -Description "ODS OpenCode browser application" `
+            -Force -ErrorAction Stop | Out-Null
+        Start-ScheduledTask -TaskName $script:OPENCODE_TASK_NAME -ErrorAction Stop
+        $_ocStarted = $true
+    } catch {
+        Write-AIWarn "Could not register the OpenCode login task: $_"
+        Write-AI "Starting OpenCode for this session..."
+        try {
+            Start-Process -FilePath "powershell.exe" -ArgumentList $_ocTaskArgument `
+                -WorkingDirectory $script:OPENCODE_DIR -WindowStyle Hidden -ErrorAction Stop | Out-Null
+            $_ocStarted = $true
+        } catch {
+            Write-AIWarn "Could not start OpenCode: $_"
+        }
+    }
+
+    $_ocHealthy = $false
+    if ($_ocStarted) {
+        for ($_ocAttempt = 0; $_ocAttempt -lt 15; $_ocAttempt++) {
+            Start-Sleep -Seconds 1
+            if (@(Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT `
+                    -State Listen -ErrorAction SilentlyContinue).Count -gt 0) {
+                $_ocHealthy = $true
+                break
+            }
+        }
+    }
+
+    if ($_ocHealthy) {
+        Write-AISuccess "OpenCode web app started (http://localhost:$($script:OPENCODE_PORT))"
+    } elseif ($_ocStarted) {
+        Write-AIWarn "OpenCode was launched but did not become reachable on port $($script:OPENCODE_PORT)."
+    }
+
+    # Retain the familiar double-click launcher as a recovery path.
     $_vbsContent = @"
 ' ODS -- OpenCode Web Server (silent launcher)
 ' Run this script to start OpenCode without a visible console window.
 Set WshShell = CreateObject("WScript.Shell")
-WshShell.CurrentDirectory = WshShell.ExpandEnvironmentStrings("%USERPROFILE%\.opencode")
-WshShell.Run """%USERPROFILE%\.opencode\bin\opencode.exe"" web --port $($script:OPENCODE_PORT) --hostname 127.0.0.1", 0, False
+WshShell.Run "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""$_ocLauncherPath""", 0, False
 "@
     $_vbsPath = Join-Path $script:OPENCODE_DIR "start-opencode.vbs"
     Write-Utf8NoBom -Path $_vbsPath -Content $_vbsContent
-    Write-AISuccess "OpenCode ready -- start manually: $($script:OPENCODE_EXE) web --port $($script:OPENCODE_PORT)"
-    Write-AI "  Or run: $($_vbsPath) (silent, no console window)"
+    if (-not $_ocStarted) {
+        Write-AI "  Recovery launcher: $($_vbsPath)"
+    }
 }
 
 # ── Node.js / npm tools (Claude Code + Codex CLI) ────────────────────────────

--- a/ods/installers/windows/phases/07-devtools.ps1
+++ b/ods/installers/windows/phases/07-devtools.ps1
@@ -123,6 +123,32 @@ exit `$LASTEXITCODE
 "@
     Write-Utf8NoBom -Path $_ocLauncherPath -Content $_ocLauncherContent
 
+    function Test-ODSOpenCodePortOwned {
+        $listeners = @(
+            Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT `
+                -State Listen -ErrorAction SilentlyContinue
+        )
+        if ($listeners.Count -eq 0) { return $false }
+
+        $expectedExe = [System.IO.Path]::GetFullPath($script:OPENCODE_EXE)
+        foreach ($processId in @($listeners | Select-Object -ExpandProperty OwningProcess -Unique)) {
+            $process = Get-CimInstance Win32_Process `
+                -Filter "ProcessId = $([int]$processId)" -ErrorAction SilentlyContinue
+            if (-not $process -or [string]::IsNullOrWhiteSpace($process.ExecutablePath)) {
+                continue
+            }
+            try {
+                $actualExe = [System.IO.Path]::GetFullPath([string]$process.ExecutablePath)
+            } catch {
+                continue
+            }
+            if ($actualExe.Equals($expectedExe, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $true
+            }
+        }
+        return $false
+    }
+
     $_ocTaskArgument = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$($_ocLauncherPath)`""
     $_ocStarted = $false
     try {
@@ -160,8 +186,7 @@ exit `$LASTEXITCODE
     if ($_ocStarted) {
         for ($_ocAttempt = 0; $_ocAttempt -lt 15; $_ocAttempt++) {
             Start-Sleep -Seconds 1
-            if (@(Get-NetTCPConnection -LocalPort $script:OPENCODE_PORT `
-                    -State Listen -ErrorAction SilentlyContinue).Count -gt 0) {
+            if (Test-ODSOpenCodePortOwned) {
                 $_ocHealthy = $true
                 break
             }

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -125,6 +125,30 @@ _env_get_raw() {
     ' "$file" 2>/dev/null | tr -d '\r' || true
 }
 
+_ods_cli_proxy_enabled() {
+    [[ -f "$INSTALL_DIR/extensions/services/ods-proxy/compose.yaml" ]] \
+        || [[ -f "$INSTALL_DIR/data/user-extensions/ods-proxy/compose.yaml" ]]
+}
+
+_ods_cli_require_proxy_auth() {
+    [[ -f "$INSTALL_DIR/.env" ]] \
+        || error "Cannot enable network access without $INSTALL_DIR/.env."
+    if [[ "$(_env_get_raw WEBUI_AUTH)" != "true" ]]; then
+        _env_set "WEBUI_AUTH" "true" \
+            || error "Could not enforce WEBUI_AUTH=true before enabling network access."
+        log "  Network access requires sign-in; set WEBUI_AUTH=true."
+    fi
+    export WEBUI_AUTH=true
+}
+
+_ods_cli_prepare_proxy_start() {
+    local -a compose_flags=("$@")
+    _ods_cli_require_proxy_auth
+    _compose_run_with_summary \
+        "Applying authenticated Open WebUI configuration" \
+        "${compose_flags[@]}" up -d --no-deps --force-recreate open-webui
+}
+
 _ods_cli_bootstrap_status() {
     local status_file="$INSTALL_DIR/data/bootstrap-status.json"
     [[ -f "$status_file" ]] || return 0
@@ -1508,6 +1532,13 @@ cmd_restart() {
         resolved_service=$(resolve_service "$resolved_service")
     fi
 
+    if [[ "$resolved_service" == "ods-proxy" ]]; then
+        _ods_cli_prepare_proxy_start "${flags[@]}"
+    elif [[ -z "$resolved_service" || "$resolved_service" == "open-webui" ]] \
+        && _ods_cli_proxy_enabled; then
+        _ods_cli_require_proxy_auth
+    fi
+
     if ! _ods_cli_repair_rootless_ownership "$resolved_service"; then
         error "Rootless bind-mount ownership is not ready; service restart was cancelled."
     fi
@@ -1705,6 +1736,13 @@ cmd_start() {
     local resolved_service="$service"
     if [[ -n "$resolved_service" ]]; then
         resolved_service=$(resolve_service "$resolved_service")
+    fi
+
+    if [[ "$resolved_service" == "ods-proxy" ]]; then
+        _ods_cli_prepare_proxy_start "${flags[@]}"
+    elif [[ -z "$resolved_service" || "$resolved_service" == "open-webui" ]] \
+        && _ods_cli_proxy_enabled; then
+        _ods_cli_require_proxy_auth
     fi
 
     local refresh_soul="false"
@@ -2684,6 +2722,10 @@ cmd_enable() {
     # Check it's not a core service
     local cat="${SERVICE_CATEGORIES[$service_id]:-optional}"
     [[ "$cat" == "core" ]] && { success "$service_id is a core service (always enabled)."; return 0; }
+
+    if [[ "$service_id" == "ods-proxy" ]]; then
+        _ods_cli_require_proxy_auth
+    fi
 
     # Check GPU backend compatibility
     local gpu_backends="${SERVICE_GPU_BACKENDS[$service_id]:-}"

--- a/ods/tests/test-install-docs.sh
+++ b/ods/tests/test-install-docs.sh
@@ -8,6 +8,7 @@ REPO_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
 
 CANONICAL_ENDPOINT="https://install.osmantic.com/ods.sh"
 CANONICAL_REPO_URL="https://github.com/Osmantic/ODS.git"
+WINDOWS_SOURCE_ZIP_URL="https://github.com/Osmantic/ODS/archive/refs/heads/main.zip"
 STABLE_VERSION="$(
     python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["release"]["version"])' \
         "$ROOT_DIR/manifest.json"
@@ -179,6 +180,15 @@ clone_docs=(
     "$ROOT_DIR/docs/INSTALLER_TRUST.md"
 )
 
+windows_copy_paste_docs=(
+    "$REPO_ROOT/README.md"
+    "$ROOT_DIR/README.md"
+    "$ROOT_DIR/QUICKSTART.md"
+    "$ROOT_DIR/docs/FAQ.md"
+    "$ROOT_DIR/docs/WINDOWS-QUICKSTART.md"
+    "$ROOT_DIR/docs/WINDOWS-INSTALL-WALKTHROUGH.md"
+)
+
 for file in "${install_docs[@]}"; do
     [[ -f "$file" ]] || fail "Expected install document missing: $file"
     require_literal "$file" "$CANONICAL_ENDPOINT" "Canonical install endpoint"
@@ -186,6 +196,17 @@ done
 
 for file in "${clone_docs[@]}"; do
     require_literal "$file" "$CANONICAL_REPO_URL" "Canonical clone URL"
+done
+
+require_literal "$REPO_ROOT/README.md" 'Choose your system, copy the block' "Front-page copy/paste install guidance"
+require_literal "$REPO_ROOT/README.md" '**Linux or macOS**' "Front-page Linux/macOS install label"
+require_literal "$REPO_ROOT/README.md" '**Windows PowerShell**' "Front-page Windows install label"
+require_literal "$REPO_ROOT/README.md" 'Docker must be installed and running' "Front-page Docker prerequisite"
+
+for file in "${windows_copy_paste_docs[@]}"; do
+    require_literal "$file" "$WINDOWS_SOURCE_ZIP_URL" "Windows no-Git source ZIP install"
+    require_literal "$file" 'Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force' "Windows source ZIP expansion"
+    require_literal "$file" '.\install.ps1' "Windows installer invocation"
 done
 
 compatible_ref_docs=(

--- a/ods/tests/test-install-docs.sh
+++ b/ods/tests/test-install-docs.sh
@@ -205,8 +205,12 @@ require_literal "$REPO_ROOT/README.md" 'Docker must be installed and running' "F
 
 for file in "${windows_copy_paste_docs[@]}"; do
     require_literal "$file" "$WINDOWS_SOURCE_ZIP_URL" "Windows no-Git source ZIP install"
+    require_literal "$file" '[guid]::NewGuid().ToString("N")' "Windows collision-free temporary source directory"
     require_literal "$file" 'Expand-Archive -LiteralPath $odsZip -DestinationPath $odsSrc -Force' "Windows source ZIP expansion"
     require_literal "$file" '.\install.ps1' "Windows installer invocation"
+    if grep -qF 'Remove-Item -LiteralPath $odsSrc -Recurse' "$file"; then
+        fail "Windows copy/paste install must not recursively delete a reusable temporary path in ${file#"$REPO_ROOT"/}"
+    fi
 done
 
 compatible_ref_docs=(

--- a/ods/tests/test-local-app-auth-defaults.sh
+++ b/ods/tests/test-local-app-auth-defaults.sh
@@ -5,8 +5,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LINUX_ENV="$ROOT_DIR/installers/phases/06-directories.sh"
 MACOS_ENV="$ROOT_DIR/installers/macos/lib/env-generator.sh"
 WINDOWS_ENV="$ROOT_DIR/installers/windows/lib/env-generator.ps1"
+WINDOWS_CLI="$ROOT_DIR/installers/windows/ods.ps1"
 WINDOWS_OPENCODE="$ROOT_DIR/installers/windows/phases/07-devtools.ps1"
 LINUX_OPENCODE="$ROOT_DIR/opencode/opencode-web.service"
+LINUX_CLI="$ROOT_DIR/ods-cli"
+MACOS_CLI="$ROOT_DIR/installers/macos/ods-macos.sh"
 
 require() {
     local pattern="$1" file="$2" message="$3"
@@ -18,22 +21,43 @@ require() {
 
 require '_env_get WEBUI_AUTH "false"' "$LINUX_ENV" \
     "Linux loopback installs must default Open WebUI auth off"
-require '_env_get WEBUI_AUTH "true"' "$LINUX_ENV" \
-    "Linux network installs must default Open WebUI auth on"
+require 'WEBUI_AUTH="true"' "$LINUX_ENV" \
+    "Linux network installs must force Open WebUI auth on"
 require 'ENABLE_ODS_PROXY.*false' "$LINUX_ENV" \
     "Linux LAN proxy installs must keep Open WebUI auth on"
 
-require '127\.0\.0\.1\|::1\|localhost.*webui_auth="false"' "$MACOS_ENV" \
+require '127\.0\.0\.1\|::1\|localhost.*webui_auth=.*false' "$MACOS_ENV" \
     "macOS loopback installs must default Open WebUI auth off"
-require 'ENABLE_ODS_PROXY.*true' "$MACOS_ENV" \
-    "macOS LAN proxy installs must keep Open WebUI auth on"
+require 'upsert_env_value.*WEBUI_AUTH.*true' "$MACOS_ENV" \
+    "macOS network transitions must force Open WebUI auth on"
 
-require 'webuiAuthDefault = if' "$WINDOWS_ENV" \
+require 'networkExposed = ' "$WINDOWS_ENV" \
     "Windows loopback auth policy is missing"
 require '127\.0\.0\.1", "::1", "localhost' "$WINDOWS_ENV" \
     "Windows loopback host allowlist is missing"
 require 'EnableODSProxy' "$WINDOWS_ENV" \
     "Windows LAN proxy auth policy is missing"
+require 'webuiAuth = "true"' "$WINDOWS_ENV" \
+    "Windows network transitions must force Open WebUI auth on"
+
+require '_ods_cli_require_proxy_auth' "$LINUX_CLI" \
+    "Linux extension management must enforce proxy authentication"
+require 'force-recreate open-webui' "$LINUX_CLI" \
+    "Linux must apply authentication before starting the proxy"
+require 'resolved_service.*open-webui' "$LINUX_CLI" \
+    "Linux Open WebUI-only lifecycle commands must preserve proxy authentication"
+require 'require_proxy_auth' "$MACOS_CLI" \
+    "macOS service management must enforce proxy authentication"
+require 'force-recreate open-webui' "$MACOS_CLI" \
+    "macOS must apply authentication before starting the proxy"
+require 'service.*open-webui.*proxy_is_enabled' "$MACOS_CLI" \
+    "macOS Open WebUI-only lifecycle commands must preserve proxy authentication"
+require 'Set-ODSProxyAuthRequired' "$WINDOWS_CLI" \
+    "Windows extension management must enforce proxy authentication"
+require 'ODS_PROXY_AUTH_PREFLIGHT_FAILED' "$WINDOWS_CLI" \
+    "Windows must fail closed when authenticated Open WebUI recreation fails"
+require 'Service -eq "open-webui"' "$WINDOWS_CLI" \
+    "Windows Open WebUI-only lifecycle commands must preserve proxy authentication"
 
 require 'UnsetEnvironment=OPENCODE_SERVER_PASSWORD' "$LINUX_OPENCODE" \
     "Linux OpenCode must clear inherited browser auth"

--- a/ods/tests/test-local-app-auth-defaults.sh
+++ b/ods/tests/test-local-app-auth-defaults.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LINUX_ENV="$ROOT_DIR/installers/phases/06-directories.sh"
+MACOS_ENV="$ROOT_DIR/installers/macos/lib/env-generator.sh"
+WINDOWS_ENV="$ROOT_DIR/installers/windows/lib/env-generator.ps1"
+WINDOWS_OPENCODE="$ROOT_DIR/installers/windows/phases/07-devtools.ps1"
+LINUX_OPENCODE="$ROOT_DIR/opencode/opencode-web.service"
+
+require() {
+    local pattern="$1" file="$2" message="$3"
+    if ! grep -Eq -- "$pattern" "$file"; then
+        printf 'FAIL: %s\n' "$message" >&2
+        exit 1
+    fi
+}
+
+require '_env_get WEBUI_AUTH "false"' "$LINUX_ENV" \
+    "Linux loopback installs must default Open WebUI auth off"
+require '_env_get WEBUI_AUTH "true"' "$LINUX_ENV" \
+    "Linux network installs must default Open WebUI auth on"
+require 'ENABLE_ODS_PROXY.*false' "$LINUX_ENV" \
+    "Linux LAN proxy installs must keep Open WebUI auth on"
+
+require '127\.0\.0\.1\|::1\|localhost.*webui_auth="false"' "$MACOS_ENV" \
+    "macOS loopback installs must default Open WebUI auth off"
+require 'ENABLE_ODS_PROXY.*true' "$MACOS_ENV" \
+    "macOS LAN proxy installs must keep Open WebUI auth on"
+
+require 'webuiAuthDefault = if' "$WINDOWS_ENV" \
+    "Windows loopback auth policy is missing"
+require '127\.0\.0\.1", "::1", "localhost' "$WINDOWS_ENV" \
+    "Windows loopback host allowlist is missing"
+require 'EnableODSProxy' "$WINDOWS_ENV" \
+    "Windows LAN proxy auth policy is missing"
+
+require 'UnsetEnvironment=OPENCODE_SERVER_PASSWORD' "$LINUX_OPENCODE" \
+    "Linux OpenCode must clear inherited browser auth"
+require 'Remove-Item Env:OPENCODE_SERVER_PASSWORD' "$WINDOWS_OPENCODE" \
+    "Windows OpenCode must clear inherited browser auth"
+require '--hostname 127\.0\.0\.1' "$WINDOWS_OPENCODE" \
+    "Passwordless Windows OpenCode must remain loopback-only"
+
+printf 'PASS: local app authentication defaults\n'

--- a/ods/tests/test-windows-cli-enable-disable.sh
+++ b/ods/tests/test-windows-cli-enable-disable.sh
@@ -550,9 +550,12 @@ else
         echo 'function Write-AIError { param($Message) Write-Host "ERROR: $Message" }'
         echo 'function Write-AISuccess { param($Message) Write-Host "OK: $Message" }'
         echo 'function Test-ODSInstallFiles { }'
+        echo 'function Get-ODSEnvValue { param($Name, $Default = ""); $match = Get-Content (Join-Path $InstallDir ".env") | Where-Object { $_ -like "${Name}=*" } | Select-Object -Last 1; if ($match) { return ($match -split "=", 2)[1] }; return $Default }'
         # Exercise the real reconciliation logic against each temporary install.
         extract_fn Get-ComposeFlags
         extract_fn Update-ComposeFlags
+        extract_fn Set-ODSEnvValue
+        extract_fn Set-ODSProxyAuthRequired
         # Keep Docker out of the test: force the offline branch of Invoke-Disable.
         echo 'function docker { $global:LASTEXITCODE = 1 }'
         echo '$script:_EnableVisited = @()'
@@ -579,6 +582,9 @@ else
         mkdir -p "$dir"
         if [[ ! -e "$root/.compose-flags" ]]; then
             printf '%s' '--env-file .env -f docker-compose.base.yml' > "$root/.compose-flags"
+        fi
+        if [[ ! -e "$root/.env" ]]; then
+            printf '%s\n' 'WEBUI_AUTH=false' > "$root/.env"
         fi
         cat > "$dir/manifest.yaml" <<EOF
 schema_version: ods.services.v1
@@ -672,6 +678,8 @@ EOF
         || fail "enable did not repair stale compose flags; output: $out3b; flags: $flags3b"
     [[ $(grep -o 'extensions/services/ods-proxy/compose.yaml' "$C3B/.compose-flags" | wc -l) -eq 1 ]] \
         || fail "enable duplicated the ods-proxy compose fragment; flags: $flags3b"
+    [[ "$(grep '^WEBUI_AUTH=' "$C3B/.env")" == "WEBUI_AUTH=true" ]] \
+        || fail "enable did not force network-safe Open WebUI auth; output: $out3b"
     pass "enable repairs stale compose flags without duplicate entries"
 
     # ── Case 3c: empty/missing caches recover before reconciliation ───────────

--- a/ods/tests/test-windows-opencode-config.sh
+++ b/ods/tests/test-windows-opencode-config.sh
@@ -63,6 +63,13 @@ grep -q 'function Start-ODSOpenCodeRuntime' "$ODS_PS1" \
     && grep -q 'Start-ODSOpenCodeRuntime' "$ODS_PS1" \
     && pass "Windows CLI manages the OpenCode host app" \
     || fail "Windows CLI must manage the OpenCode host app"
+grep -q 'function Get-ODSOpenCodePortState' "$ODS_PS1" \
+    && grep -q 'OwnedByODS' "$ODS_PS1" \
+    && pass "Windows CLI rejects foreign OpenCode port listeners" \
+    || fail "Windows CLI must verify OpenCode port ownership"
+grep -q 'function Test-ODSOpenCodePortOwned' "$DEVTOOLS_PS1" \
+    && pass "installer verifies the OpenCode listener belongs to ODS" \
+    || fail "installer must not accept a foreign listener as OpenCode"
 grep -q '\$script:OPENCODE_TASK_NAME' "$ODS_PS1" \
     && pass "OpenCode task participates in runtime cleanup" \
     || fail "OpenCode scheduled task cleanup missing"

--- a/ods/tests/test-windows-opencode-config.sh
+++ b/ods/tests/test-windows-opencode-config.sh
@@ -14,6 +14,8 @@ OPENCODE_LIB="$ROOT_DIR/installers/windows/lib/opencode-config.ps1"
 INSTALLER_PS1="$ROOT_DIR/installers/windows/install-windows.ps1"
 BOOTSTRAP_UPGRADE="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
 UPDATE_SCRIPT="$ROOT_DIR/scripts/update-windows-opencode-config.ps1"
+CONSTANTS_PS1="$ROOT_DIR/installers/windows/lib/constants.ps1"
+ODS_PS1="$ROOT_DIR/installers/windows/ods.ps1"
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -42,6 +44,28 @@ grep -q 'ODS_MODEL_SWITCHBOARD' "$OPENCODE_LIB" && pass "switchboard mode is rea
 grep -q 'ods/current' "$OPENCODE_LIB" && pass "switchboard alias is written to OpenCode config" || fail "switchboard alias missing from OpenCode helper"
 grep -q 'LITELLM_KEY' "$OPENCODE_LIB" && pass "switchboard OpenCode route uses LiteLLM key" || fail "switchboard LiteLLM key missing from OpenCode helper"
 grep -q 'ODS switchboard' "$OPENCODE_LIB" && pass "switchboard provider is labelled" || fail "switchboard provider label missing"
+grep -q 'OPENCODE_TASK_NAME = "ODSOpenCodeWeb"' "$CONSTANTS_PS1" \
+    && pass "OpenCode scheduled task has a stable name" \
+    || fail "OpenCode scheduled task name missing"
+grep -q 'Register-ScheduledTask -TaskName \$script:OPENCODE_TASK_NAME' "$DEVTOOLS_PS1" \
+    && pass "installer registers OpenCode for login persistence" \
+    || fail "installer must register the OpenCode login task"
+grep -q 'Start-ScheduledTask -TaskName \$script:OPENCODE_TASK_NAME' "$DEVTOOLS_PS1" \
+    && pass "installer starts OpenCode immediately" \
+    || fail "installer must start OpenCode immediately"
+grep -q 'Remove-Item Env:OPENCODE_SERVER_PASSWORD' "$DEVTOOLS_PS1" \
+    && pass "OpenCode launcher clears inherited browser authentication" \
+    || fail "OpenCode launcher must open directly on loopback"
+grep -q -- '--hostname 127.0.0.1' "$DEVTOOLS_PS1" \
+    && pass "passwordless OpenCode remains loopback-only" \
+    || fail "passwordless OpenCode must remain loopback-only"
+grep -q 'function Start-ODSOpenCodeRuntime' "$ODS_PS1" \
+    && grep -q 'Start-ODSOpenCodeRuntime' "$ODS_PS1" \
+    && pass "Windows CLI manages the OpenCode host app" \
+    || fail "Windows CLI must manage the OpenCode host app"
+grep -q '\$script:OPENCODE_TASK_NAME' "$ODS_PS1" \
+    && pass "OpenCode task participates in runtime cleanup" \
+    || fail "OpenCode scheduled task cleanup missing"
 
 if grep -q 'preserving existing configuration' "$DEVTOOLS_PS1"; then
     fail "existing configs are still preserved without migration"

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -151,8 +151,56 @@ try {
         if ($defaultEnv -notmatch "(?m)^WEBUI_PORT=3000\r?$") {
             throw "Default Windows env generation no longer writes WEBUI_PORT=3000"
         }
+        if ($defaultEnv -notmatch "(?m)^WEBUI_AUTH=false\r?$") {
+            throw "Loopback Windows installs must open Open WebUI without a login"
+        }
     } finally {
         Remove-Item -LiteralPath $defaultDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    $lanDir = Join-Path ([IO.Path]::GetTempPath()) "ods-webui-auth-lan-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $lanDir | Out-Null
+    try {
+        New-ODSEnv -InstallDir $lanDir -TierConfig $tierConfig `
+            -Tier "3" -GpuBackend "nvidia" -EnableLan $true | Out-Null
+        $lanEnv = Get-Content -LiteralPath (Join-Path $lanDir ".env") -Raw
+        if ($lanEnv -notmatch "(?m)^BIND_ADDRESS=0\.0\.0\.0\r?$" -or
+            $lanEnv -notmatch "(?m)^WEBUI_AUTH=true\r?$") {
+            throw "LAN-bound Windows installs must keep Open WebUI authentication enabled"
+        }
+    } finally {
+        Remove-Item -LiteralPath $lanDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    $proxyDir = Join-Path ([IO.Path]::GetTempPath()) "ods-webui-auth-proxy-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $proxyDir | Out-Null
+    try {
+        New-ODSEnv -InstallDir $proxyDir -TierConfig $tierConfig `
+            -Tier "3" -GpuBackend "nvidia" -EnableODSProxy $true | Out-Null
+        $proxyEnv = Get-Content -LiteralPath (Join-Path $proxyDir ".env") -Raw
+        if ($proxyEnv -notmatch "(?m)^BIND_ADDRESS=127\.0\.0\.1\r?$" -or
+            $proxyEnv -notmatch "(?m)^WEBUI_AUTH=true\r?$") {
+            throw "LAN proxy installs must keep Open WebUI authentication enabled"
+        }
+    } finally {
+        Remove-Item -LiteralPath $proxyDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    $explicitAuthDir = Join-Path ([IO.Path]::GetTempPath()) "ods-webui-auth-explicit-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $explicitAuthDir | Out-Null
+    try {
+        Set-Content -LiteralPath (Join-Path $explicitAuthDir ".env") -Value @(
+            "BIND_ADDRESS=127.0.0.1",
+            "WEBUI_AUTH=true"
+        )
+        New-ODSEnv -InstallDir $explicitAuthDir -TierConfig $tierConfig `
+            -Tier "3" -GpuBackend "nvidia" | Out-Null
+        $explicitAuthEnv = Get-Content -LiteralPath (Join-Path $explicitAuthDir ".env") -Raw
+        if ($explicitAuthEnv -notmatch "(?m)^WEBUI_AUTH=true\r?$") {
+            throw "Windows env regeneration must preserve an explicit WEBUI_AUTH choice"
+        }
+    } finally {
+        Remove-Item -LiteralPath $explicitAuthDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     $installDir = Join-Path ([IO.Path]::GetTempPath()) "ods-port-preflight-$([Guid]::NewGuid().ToString('N'))"

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -172,15 +172,37 @@ try {
         Remove-Item -LiteralPath $lanDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 
+    $lanTransitionDir = Join-Path ([IO.Path]::GetTempPath()) "ods-webui-auth-lan-transition-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $lanTransitionDir | Out-Null
+    try {
+        Set-Content -LiteralPath (Join-Path $lanTransitionDir ".env") -Value @(
+            "BIND_ADDRESS=127.0.0.1",
+            "WEBUI_AUTH=false"
+        )
+        New-ODSEnv -InstallDir $lanTransitionDir -TierConfig $tierConfig `
+            -Tier "3" -GpuBackend "nvidia" -EnableLan $true | Out-Null
+        $lanTransitionEnv = Get-Content -LiteralPath (Join-Path $lanTransitionDir ".env") -Raw
+        if ($lanTransitionEnv -notmatch "(?m)^BIND_ADDRESS=0\.0\.0\.0\r?$" -or
+            $lanTransitionEnv -notmatch "(?m)^WEBUI_AUTH=true\r?$") {
+            throw "A Windows -Lan rerun must replace stale loopback/authless settings"
+        }
+    } finally {
+        Remove-Item -LiteralPath $lanTransitionDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     $proxyDir = Join-Path ([IO.Path]::GetTempPath()) "ods-webui-auth-proxy-$([Guid]::NewGuid().ToString('N'))"
     New-Item -ItemType Directory -Path $proxyDir | Out-Null
     try {
+        Set-Content -LiteralPath (Join-Path $proxyDir ".env") -Value @(
+            "BIND_ADDRESS=127.0.0.1",
+            "WEBUI_AUTH=false"
+        )
         New-ODSEnv -InstallDir $proxyDir -TierConfig $tierConfig `
             -Tier "3" -GpuBackend "nvidia" -EnableODSProxy $true | Out-Null
         $proxyEnv = Get-Content -LiteralPath (Join-Path $proxyDir ".env") -Raw
         if ($proxyEnv -notmatch "(?m)^BIND_ADDRESS=127\.0\.0\.1\r?$" -or
             $proxyEnv -notmatch "(?m)^WEBUI_AUTH=true\r?$") {
-            throw "LAN proxy installs must keep Open WebUI authentication enabled"
+            throw "A Windows proxy rerun must replace stale authless settings"
         }
     } finally {
         Remove-Item -LiteralPath $proxyDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/ods/tests/test-windows-uninstall-command.sh
+++ b/ods/tests/test-windows-uninstall-command.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Static regression checks for the Windows ods.ps1 uninstall command.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
+ODS_PS1="$ROOT_DIR/installers/windows/ods.ps1"
+
+fail() { echo "[FAIL] $1"; exit 1; }
+pass() { echo "[PASS] $1"; }
+
+[[ -f "$ODS_PS1" ]] || fail "Windows ods.ps1 missing"
+
+grep -q 'uninstall.*Remove ODS containers' "$ODS_PS1" \
+    || fail "Header/help must document uninstall"
+grep -q 'function Invoke-Uninstall' "$ODS_PS1" \
+    || fail "Invoke-Uninstall function missing"
+grep -q '"uninstall" { Invoke-Uninstall' "$ODS_PS1" \
+    || fail "Command dispatcher must route uninstall"
+
+grep -q 'com.docker.compose.project=ods' "$ODS_PS1" \
+    || fail "Uninstall must have Docker label fallback for broken compose receipts"
+grep -q 'docker rm -f @containers' "$ODS_PS1" \
+    || fail "Uninstall fallback must remove labelled containers"
+grep -q 'docker network rm @networks' "$ODS_PS1" \
+    || fail "Uninstall fallback must remove labelled networks"
+grep -q 'docker volume rm @volumes' "$ODS_PS1" \
+    || fail "Uninstall fallback must remove labelled volumes"
+grep -q 'function Test-ODSComposeFlagsFilesAvailable' "$ODS_PS1" \
+    || fail "Uninstall must validate compose receipt files before compose down"
+grep -q 'Assert-ODSInstallDirSafeForRemoval' "$ODS_PS1" \
+    || fail "Uninstall must guard recursive removal target"
+
+for doc in \
+    "$REPO_ROOT/README.md" \
+    "$ROOT_DIR/README.md" \
+    "$ROOT_DIR/QUICKSTART.md" \
+    "$ROOT_DIR/FAQ.md" \
+    "$ROOT_DIR/docs/WINDOWS-QUICKSTART.md" \
+    "$ROOT_DIR/docs/WINDOWS-INSTALL-WALKTHROUGH.md"; do
+    [[ -f "$doc" ]] || fail "Expected doc missing: $doc"
+    grep -q '.\\ods.ps1 uninstall --force' "$doc" \
+        || fail "Doc must show Windows uninstall command: $doc"
+done
+
+pass "Windows uninstall command and docs are wired"

--- a/ods/tests/test-windows-uninstall-command.sh
+++ b/ods/tests/test-windows-uninstall-command.sh
@@ -32,6 +32,12 @@ grep -q 'function Test-ODSComposeFlagsFilesAvailable' "$ODS_PS1" \
     || fail "Uninstall must validate compose receipt files before compose down"
 grep -q 'Assert-ODSInstallDirSafeForRemoval' "$ODS_PS1" \
     || fail "Uninstall must guard recursive removal target"
+grep -q 'does not contain enough ODS runtime markers' "$ODS_PS1" \
+    || fail "Uninstall must refuse arbitrary ODS_HOME directories"
+grep -q 'ODS_UNINSTALL_DOCKER_UNAVAILABLE' "$ODS_PS1" \
+    || fail "Uninstall must keep runtime files when Docker cleanup cannot run"
+grep -q 'ODS_UNINSTALL_DOCKER_CLEANUP_INCOMPLETE' "$ODS_PS1" \
+    || fail "Uninstall must keep runtime files when Docker resources remain"
 
 for doc in \
     "$REPO_ROOT/README.md" \


### PR DESCRIPTION
## Summary

- Put copy-and-paste install and uninstall commands for Windows, Linux, and macOS prominently in the README and align the quickstarts, FAQs, and Windows walkthrough.
- Install and persist OpenCode as an ODS host application on Windows and macOS, expose it through the ODS lifecycle commands, and keep it visible in the dashboard application menu.
- Open loopback-only Open WebUI and OpenCode deployments directly without a login while retaining authentication for every network-accessible deployment.
- Harden Windows uninstall so files are removed only after the target is verified as an ODS runtime and Docker cleanup is proven complete.

## Why

A normal local ODS deployment could still present a login prompt, OpenCode was not reliably available after installation or restart, and the repository front page did not provide one obvious proven command per operating system. The previous Windows install and uninstall guidance also failed in common partial-install states.

## Behavior and safety

- Fresh loopback-only installs default to `WEBUI_AUTH=false`.
- Non-loopback binds and ODS proxy installs force `WEBUI_AUTH=true`.
- Proxy authentication is enforced across installer upgrades, CLI start/restart/enable, dashboard settings saves, host-agent starts, and core-service recreation. A failed authenticated Open WebUI recreation prevents the proxy from starting.
- Existing explicit `WEBUI_AUTH=true` is preserved. An explicit false value is preserved only while the deployment remains loopback-only.
- Passwordless OpenCode is bound to `127.0.0.1`, clears inherited browser authentication, and verifies that its listener belongs to the managed OpenCode executable.
- Windows uninstall refuses arbitrary `ODS_HOME` targets, refuses file removal when Docker is unavailable, and verifies that labelled containers, networks, and removable volumes are gone first.
- Windows copy/paste installation uses a unique temporary source directory and does not recursively delete a reusable temp path.
- Existing Open WebUI data and chat ownership are unaffected.

## Validation

- Dashboard API host-agent tests: 257 passed, 4 skipped
- Dashboard API settings tests: 76 passed
- Dashboard API config tests: 53 passed
- Dashboard Vitest suite: 258 passed; build and lint passed
- Windows OpenCode tests: 24 passed
- Windows CLI enable/disable behavior suite: passed
- Windows port preflight, uninstall, local-auth, install-doc, Linux reconciliation, macOS transition, env-schema, manifest-schema, and network contract suites: passed
- PowerShell parser and error-severity PSScriptAnalyzer: passed
- Bash/Python syntax and `git diff --check`: passed
- Current GitHub `main.zip` download expanded successfully and its `install.ps1` parsed without errors
- Live Windows smoke test: Open WebUI, dashboard, and OpenCode returned HTTP 200; Open WebUI and OpenCode listened only on `127.0.0.1`; both host tasks remained running