### PR TITLE
fix: lower VRAM CPU-fallback threshold from 4096 to 3584 MB for 4GB card tolerance

### DIFF
--- a/ods/installers/phases/02-detection.sh
+++ b/ods/installers/phases/02-detection.sh
@@ -177,8 +177,8 @@ else
         && "${GPU_BACKEND:-}" == "nvidia" \
         && "${GPU_MEMORY_TYPE:-discrete}" == "discrete" \
         && "${GPU_VRAM:-0}" -gt 0 \
-        && "${GPU_VRAM:-0}" -lt 4096 ]]; then
-        apply_cpu_gpu_fallback "Detected NVIDIA GPU has only ${GPU_VRAM}MB VRAM; using CPU/Tier 0 fallback to avoid CUDA OOM loops."
+        && "${GPU_VRAM:-0}" -lt 3584 ]]; then
+        apply_cpu_gpu_fallback "Detected NVIDIA GPU has only ${GPU_VRAM}MB VRAM (< 3.5 GB); using CPU/Tier 0 fallback to avoid CUDA OOM loops."
     fi
 fi
 
@@ -482,7 +482,7 @@ if [[ -z "$TIER" ]]; then
         TIER=3
     elif [[ $GPU_VRAM -ge 12000 ]] || [[ $RAM_GB -ge 48 ]]; then
         TIER=2
-    elif [[ $GPU_VRAM -lt 4000 ]] && [[ $RAM_GB -lt 12 ]]; then
+    elif [[ $GPU_VRAM -lt 3584 ]] && [[ $RAM_GB -lt 12 ]]; then
         TIER=0
     else
         TIER=1

--- a/ods/installers/windows/lib/tier-map.ps1
+++ b/ods/installers/windows/lib/tier-map.ps1
@@ -772,6 +772,7 @@ function ConvertTo-TierFromGpu {
     if ($vramGB -ge 20) { return "3" }
     if ($vramGB -ge 12) { return "2" }
     if ($vramGB -lt 4 -and $SystemRamGB -lt 12) { return "0" }
+    if ($vramMB -gt 0 -and $vramMB -lt 3584) { return "0" }
     return "1"
 }
 

--- a/ods/scripts/detect-hardware.sh
+++ b/ods/scripts/detect-hardware.sh
@@ -682,7 +682,7 @@ main() {
     # Determine tier
     # For unified memory AMD APUs, use system RAM — VRAM reports only carve-out, not usable UMA.
     local tier tier_desc recommended_model
-    if [[ "$memory_type" == "discrete" && "$gpu_type" == "nvidia" && "$gpu_vram_mb" -gt 0 && "$gpu_vram_mb" -lt 4096 ]]; then
+    if [[ "$memory_type" == "discrete" && "$gpu_type" == "nvidia" && "$gpu_vram_mb" -gt 0 && "$gpu_vram_mb" -lt 3584 ]]; then
         tier="T0"
     elif [[ "$memory_type" == "unified" && "$gpu_type" == "amd" ]]; then
         tier=$(get_strix_halo_tier "$ram")


### PR DESCRIPTION
## Problem
The VRAM CPU-fallback threshold at `< 4096` MB is a knife-edge boundary. Many laptop GPUs (e.g., GTX 1650 4GB, RTX 3050 4GB, RTX 4050 4GB) report slightly less than 4096 MB due to firmware VRAM reservations. A card reporting 4095, 4032, or 3840 MB incorrectly triggers CPU-only fallback (Tier 0) and the tiny Qwen3.5-2B model.

## Fix
Lower the threshold from `< 4096` to `< 3584` MB (3.5 GB) across all detection paths:

1. `ods/installers/phases/02-detection.sh:180` - CPU fallback guard
2. `ods/installers/phases/02-detection.sh:485` - Tier 0 auto-assignment
3. `ods/scripts/detect-hardware.sh:685` - Standalone hardware detection
4. `ods/installers/windows/lib/tier-map.ps1:775` - Windows tier mapping

A card with < 3.5 GB VRAM genuinely cannot run CUDA inference without OOM, while cards reporting 3584-4095 MB can still run with partial CPU offload via llama.cpp's `--n-gpu-layers` mechanism.