### PR TITLE
models: stage Nemotron 3 Super 120B candidate

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1979,7 +1979,7 @@
       "architecture": "hybrid-moe",
       "quantization": "UD-Q4_K_M",
       "specialty": "Large-Scale Agentic Reasoning",
-      "description": "NVIDIA's March 2026 hybrid Mamba-2, latent-MoE, attention, and MTP model for reasoning, coding, tool use, RAG, and long-context agents. Artificial Analysis ranks it fourth among 62 comparable open-weight models; ODS stages a practical 64K profile for 96GB-class systems.",
+      "description": "NVIDIA's March 2026 hybrid Mamba-2, latent-MoE, attention, and MTP model for reasoning, coding, tool use, RAG, and long-context agents. Its independent Artificial Analysis score of 25 is above the comparable open-weight size-class median of 9; ODS stages a practical 64K profile for 96GB-class systems.",
       "tokens_per_sec_estimate": 12,
       "llm_model_name": "Nvidia-Nemotron-3-Super-120B-A12B",
       "llama_server_image": null,
@@ -1991,8 +1991,47 @@
         "score": 25,
         "assessed_at": "2026-07-29",
         "independent": true,
-        "note": "Ranked #4 of 62 comparable open-weight models with a class median of 9. Artificial Analysis reports 110M evaluation output tokens versus a 53M class median, so ODS treats exact-response behavior as an explicit fleet-validation risk."
+        "note": "The score of 25 is above the comparable open-weight size-class median of 9. Artificial Analysis reports 110M evaluation output tokens versus a 53M class median, so ODS treats exact-response behavior as an explicit fleet-validation risk."
       },
+      "publisher_evidence": {
+        "source_url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+        "mmlu_pro": 83.73,
+        "aime_2025": 90.21,
+        "gpqa_diamond": 79.23,
+        "gpqa_diamond_with_tools": 82.7,
+        "livecodebench": 81.19,
+        "scicode": 42.05,
+        "terminal_bench_2_hard": 25.78,
+        "swe_bench_verified_openhands": 60.47,
+        "swe_bench_verified_opencode": 59.2,
+        "ruler_256k": 96.3,
+        "ruler_512k": 95.67,
+        "ruler_1m": 91.75,
+        "independent": false,
+        "note": "Publisher-reported results span reasoning, coding-agent, tool-use, and long-context evaluations. NVIDIA discloses evaluation configurations for most results but labels some configurations internal; these numbers are supporting evidence, not independent validation."
+      },
+      "deployment_evidence": [
+        {
+          "source": "LocalLLaMA community deployment report",
+          "source_url": "https://www.reddit.com/r/LocalLLaMA/comments/1s10kug/nemotron_super_120b_on_strix_halo/",
+          "artifact": "unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF UD-Q4_K_M, three shards",
+          "hardware": "AMD Strix Halo unified memory",
+          "runtime": "llama.cpp ROCm",
+          "reported_result": "The exact three-shard quant was reported loading and generating at roughly 14-17 tokens/s; the first roughly 7.6MB shard was correctly identified as metadata rather than a complete model.",
+          "independent": true,
+          "controlled": false
+        },
+        {
+          "source": "LocalLLaMA community long-context deployment report",
+          "source_url": "https://www.reddit.com/r/LocalLLaMA/comments/1ugj1sf/nemotron3super120ba12b_hybrid_mambamoe_holds/",
+          "artifact": "mradermacher i1 Q4_K_S sibling quant",
+          "hardware": "4x RTX 3090",
+          "runtime": "llama.cpp",
+          "reported_result": "A sibling Q4 quant was reported retaining full needle-retrieval recall through a 504,482-token prompt.",
+          "independent": true,
+          "controlled": false
+        }
+      ],
       "source_evidence": {
         "model_card": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
         "model_revision": "d51eab0d1f979ebc26b546e634a04f450d99158e",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1940,6 +1940,67 @@
       "tokens_per_sec_estimate": 15,
       "llm_model_name": "qwen3.5-122b-a10b",
       "llama_server_image": null
+    },
+    {
+      "id": "nvidia-nemotron3-super-120b-a12b-ud-q4",
+      "name": "NVIDIA Nemotron 3 Super 120B-A12B",
+      "family": "nemotron",
+      "gguf_file": "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00001-of-00003.gguf",
+      "gguf_url": "",
+      "gguf_sha256": "",
+      "gguf_parts": [
+        {
+          "file": "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00001-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF/resolve/036038fb30334a2d56a146c6f0d4871ab5edccbb/UD-Q4_K_M/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00001-of-00003.gguf",
+          "sha256": "f22083eb6b15acb52905308ab083e8b0cc38897005cc45e8881abd164580aac2",
+          "size_bytes": 7872576
+        },
+        {
+          "file": "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00002-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF/resolve/036038fb30334a2d56a146c6f0d4871ab5edccbb/UD-Q4_K_M/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00002-of-00003.gguf",
+          "sha256": "6d65adda88759f1bcea714e4da09dab8ecc42265a57b87f9bf7fe3cb7f53b889",
+          "size_bytes": 49932117344
+        },
+        {
+          "file": "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00003-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF/resolve/036038fb30334a2d56a146c6f0d4871ab5edccbb/UD-Q4_K_M/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00003-of-00003.gguf",
+          "sha256": "2b126c51396dd31fbb1273fb2b28d0c8502bab5e357a852f67af7a4b6f5ba79c",
+          "size_bytes": 32601178560
+        }
+      ],
+      "size_bytes": 82541168480,
+      "size_mb": 82542,
+      "vram_required_gb": 96,
+      "context_length": 65536,
+      "max_context_length": 1048576,
+      "total_params_b": 120.6,
+      "active_params_b": 12.7,
+      "architecture": "hybrid-moe",
+      "quantization": "UD-Q4_K_M",
+      "specialty": "Large-Scale Agentic Reasoning",
+      "description": "NVIDIA's March 2026 hybrid Mamba-2, latent-MoE, attention, and MTP model for reasoning, coding, tool use, RAG, and long-context agents. Artificial Analysis ranks it fourth among 62 comparable open-weight models; ODS stages a practical 64K profile for 96GB-class systems.",
+      "tokens_per_sec_estimate": 12,
+      "llm_model_name": "Nvidia-Nemotron-3-Super-120B-A12B",
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/nvidia-nemotron-3-super-120b-a12b/",
+        "benchmark": "Artificial Analysis Intelligence Index",
+        "score": 25,
+        "assessed_at": "2026-07-29",
+        "independent": true,
+        "note": "Ranked #4 of 62 comparable open-weight models with a class median of 9. Artificial Analysis reports 110M evaluation output tokens versus a 53M class median, so ODS treats exact-response behavior as an explicit fleet-validation risk."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+        "model_revision": "d51eab0d1f979ebc26b546e634a04f450d99158e",
+        "gguf_repository": "unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF",
+        "gguf_revision": "036038fb30334a2d56a146c6f0d4871ab5edccbb",
+        "license": "nvidia-nemotron-open-model-license",
+        "license_url": "https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-nemotron-open-model-license/",
+        "license_note": "Commercial use and derivative distribution are allowed. Redistribution requires a license copy, retained notices, and the NVIDIA NOTICE attribution when applicable."
+      }
     }
   ]
 }

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -106,7 +106,8 @@
           "recordedAt": "2026-07-27T11:12:30Z",
           "productSha": "ca730791cacaadb0280f63f3fc9f8b8ef70e4ebb",
           "harnessSha": "19d43e6f9f2533e8768ed85b33de9f4ace232129",
-          "hostScope": ["tower2", "strix-halo"]
+          "hostScope": ["tower2", "strix-halo"],
+          "expiresAt": "2026-08-27T11:12:30Z"
         },
         "agent_viability": {
           "status": "not_agent_viable",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -863,6 +863,74 @@ def test_jamba_reasoning_3b_records_fleet_compatibility_without_recommendation()
     assert not _agent_viable_for_release(model)
 
 
+def test_nemotron3_super_120b_stages_exact_multipart_artifact_and_evidence():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["nvidia-nemotron3-super-120b-a12b-ud-q4"]
+
+    assert model["gguf_file"] == (
+        "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00001-of-00003.gguf"
+    )
+    assert model["gguf_url"] == ""
+    assert model["gguf_sha256"] == ""
+    assert model["size_bytes"] == 82541168480
+    assert model["size_mb"] == 82542
+    assert model["vram_required_gb"] == 96
+    assert model["context_length"] == HERMES_CONTEXT_FLOOR
+    assert model["max_context_length"] == 1048576
+    assert model["total_params_b"] == 120.6
+    assert model["active_params_b"] == 12.7
+    assert model["architecture"] == "hybrid-moe"
+    assert model["quantization"] == "UD-Q4_K_M"
+    assert model["install_recommendation"] is False
+
+    parts = model["gguf_parts"]
+    assert [part["file"] for part in parts] == [
+        "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00001-of-00003.gguf",
+        "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00002-of-00003.gguf",
+        "NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00003-of-00003.gguf",
+    ]
+    assert [part["sha256"] for part in parts] == [
+        "f22083eb6b15acb52905308ab083e8b0cc38897005cc45e8881abd164580aac2",
+        "6d65adda88759f1bcea714e4da09dab8ecc42265a57b87f9bf7fe3cb7f53b889",
+        "2b126c51396dd31fbb1273fb2b28d0c8502bab5e357a852f67af7a4b6f5ba79c",
+    ]
+    assert [part["size_bytes"] for part in parts] == [
+        7872576,
+        49932117344,
+        32601178560,
+    ]
+    assert sum(part["size_bytes"] for part in parts) == model["size_bytes"]
+    assert all(
+        "/resolve/036038fb30334a2d56a146c6f0d4871ab5edccbb/"
+        in part["url"]
+        for part in parts
+    )
+
+    quality = model["quality_evidence"]
+    assert quality["independent"] is True
+    assert quality["score"] == 25
+    assert "median of 9" in quality["note"]
+    assert "Ranked" not in quality["note"]
+    publisher = model["publisher_evidence"]
+    assert publisher["independent"] is False
+    assert publisher["swe_bench_verified_openhands"] == 60.47
+    assert publisher["ruler_1m"] == 91.75
+    deployment = model["deployment_evidence"]
+    assert deployment[0]["independent"] is True
+    assert deployment[0]["controlled"] is False
+    assert "exact three-shard quant" in deployment[0]["reported_result"]
+
+    source = model["source_evidence"]
+    assert source["model_revision"] == (
+        "d51eab0d1f979ebc26b546e634a04f450d99158e"
+    )
+    assert source["gguf_revision"] == (
+        "036038fb30334a2d56a146c6f0d4871ab5edccbb"
+    )
+    assert source["license"] == "nvidia-nemotron-open-model-license"
+
+
 def test_new_switchboard_models_do_not_change_install_recommendations():
     expected_switchboard_only = {
         "phi3.5-mini-q4",
@@ -891,6 +959,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "llama3.1-8b-instruct-q4",
         "granite3.3-8b-instruct-q4",
         "mistral-nemo-12b-instruct-q4",
+        "nvidia-nemotron3-super-120b-a12b-ud-q4",
     }
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}


### PR DESCRIPTION
## What changed

- adds NVIDIA Nemotron 3 Super 120B-A12B as a large-tier agentic reasoning candidate
- pins the official BF16 source model and Unsloth UD-Q4_K_M GGUF to immutable revisions
- records all three GGUF shards with exact byte counts and SHA-256 values
- records the 82,541,168,480-byte aggregate artifact, 120.6B total / 12.7B active sizing, and hybrid Mamba-2 + latent-MoE + attention + MTP architecture
- stages a practical 64K ODS context for 96GB-class systems while recording the native 1M context ceiling
- separates independent quality and community-deployment evidence from NVIDIA's publisher-reported benchmark results
- regression-tests the exact multipart artifact, revisions, evidence provenance, and non-recommended state
- records the NVIDIA Nemotron Open Model License and its redistribution obligations
- keeps `install_recommendation` false pending exact fleet validation

## Why

This candidate deliberately expands the evaluation pipeline beyond small and mid-size models.

Artificial Analysis provides current independent evidence for the reasoning configuration:

- Artificial Analysis Intelligence Index v4.1: 25
- comparable-class median: 9
- total / active parameters: 120.6B / 12.7B

It scores slightly above GPT-OSS 120B in the same independent comparison. Artificial Analysis also reports 110M evaluation output tokens versus a 53M class median, so exact-response behavior remains an explicit fleet-validation risk rather than an assumed strength.

The official model card positions Nemotron 3 Super for agentic workflows, reasoning, coding, tool use, RAG, and long-context workloads. Its hybrid architecture and 12.7B active footprint make it a materially different candidate from the dense and transformer-MoE families already evaluated.

## User impact

No installer choice changes. The model becomes a reproducible manual candidate for appropriately sized systems and remains excluded from recommendations until the required fleet lifecycle passes.

## Artifact provenance

- source model: `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16`
- source revision: `d51eab0d1f979ebc26b546e634a04f450d99158e`
- GGUF repository: `unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF`
- GGUF revision: `036038fb30334a2d56a146c6f0d4871ab5edccbb`
- quantization: `UD-Q4_K_M`
- aggregate bytes: `82541168480`
- license: NVIDIA Nemotron Open Model License
- license terms: commercial use and derivatives are allowed; redistribution requires a license copy, retained notices, and the NVIDIA NOTICE attribution when applicable

GGUF shards:

1. `NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00001-of-00003.gguf`
   - bytes: `7872576`
   - SHA-256: `f22083eb6b15acb52905308ab083e8b0cc38897005cc45e8881abd164580aac2`
2. `NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00002-of-00003.gguf`
   - bytes: `49932117344`
   - SHA-256: `6d65adda88759f1bcea714e4da09dab8ecc42265a57b87f9bf7fe3cb7f53b889`
3. `NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_M-00003-of-00003.gguf`
   - bytes: `32601178560`
   - SHA-256: `2b126c51396dd31fbb1273fb2b28d0c8502bab5e357a852f67af7a4b6f5ba79c`

## Validation

Passed locally:

- JSON parse
- `git diff --check`
- `pytest -q ods/tests/test-model-library-coverage.py ods/tests/test-model-library-verdicts.py` (43 passed)
- `ods/tests/test-tier-map.sh` (128 passed)
- `ods/tests/test-windows-catalog-selector.ps1`
- immutable Hugging Face headers match all three catalog byte counts and SHA-256 values
- GGUF metadata reports `general.architecture=nemotron_h_moe`, `general.size_label=120B-A12B`, and `tokenizer.ggml.pre=pixtral`
- the deployed llama.cpp lineage is newer than public `nemotron_h_moe` execution evidence, so architecture support is plausible but not treated as a fleet pass

Current candidate head: `d9ce2c44e956f7468eb0f38b06c9714e27fb7476`.
The evidence-hardening commit does not alter the artifact, but its exact six-host
install rerun remains required before any further lifecycle work.

Exact-commit install:

- product SHA: `bea70e167ed80fd644c914112c6c84d362691a8a`
- harness SHA: `19d43e6f9f2533e8768ed85b33de9f4ace232129`
- tower2, strix-halo, spark, and m5-mbp passed in:
  - `/home/michael/dream-fleet-test/runs/2026-07-29T02-50-08Z-install-product-bea70e167ed8-harness-19d43e6f9f25-hosts-six-nemotron3-super-r1`
- windows-laptop and strixy passed after prefetching the exact candidate branch into their existing product caches:
  - `/home/michael/dream-fleet-test/runs/2026-07-29T03-06-20Z-install-product-bea70e167ed8-harness-19d43e6f9f25-hosts-windows-two-nemotron3-super-r2`
- combined exact-install verdict: 6 / 6 hosts passed

Fit contract:

- tower2: accepted; 191.2 GB aggregate NVIDIA VRAM
- spark: accepted; 121.7 GB unified GPU memory
- strix-halo: rejected by the ODS unified-memory reserve policy
- m5-mbp: rejected by the ODS unified-memory reserve policy
- windows-laptop: rejected; 8 GB VRAM
- strixy: rejected; 31.8 GB GPU memory

The catalog's 96 GB requirement is intentionally conservative. The runtime
calculation is approximately 87.61 GB including weights and KV cache. ODS
reserves 45% of unified memory on Apple and Strix Halo systems, so their
128 GB physical capacity does not satisfy this candidate's usable-memory
contract.

First fit-host model lifecycle:

- run:
  - `/home/michael/dream-fleet-test/runs/2026-07-29T03-16-54Z-model-ui-product-bea70e167ed8-harness-19d43e6f9f25-hosts-tower2-spark-nemotron3-super-fit-two-r1`
- both hosts completed the exact three-shard browser download
- spark parsed the GGUF as `nemotron_h_moe`, identified 120.67B total
  parameters, offloaded 89 / 89 layers, allocated a 78,165.87 MiB CUDA model
  buffer, and reached a listening llama.cpp server
- spark's dashboard activation request timed out at 120 seconds immediately
  before the server became healthy, so the UI lifecycle returned to
  `downloaded`; this is a response-window failure, not model incompatibility
- tower2 failed before model parsing because its x86 multi-GPU container
  received an empty `LLAMA_ARG_TENSOR_SPLIT` value and llama.cpp rejected it
  with `stof`; this is a product configuration failure, not a GGUF failure
- failure recovery, original-model restore, temporary-model deletion, and
  candidate deletion passed on both hosts; the fleet lock was released

Second Spark-only lifecycle:

- run:
  - `/home/michael/dream-fleet-test/runs/2026-07-29T04-53-07Z-model-ui-product-bea70e167ed8-harness-19d43e6f9f25-hosts-spark-nemotron3-super-spark-longresponse-r2`
- all three exact shards downloaded and finalized; the browser download wait
  completed in 2,940,419 ms
- llama.cpp parsed the candidate as `nemotron_h_moe`, identified 120.67B
  parameters, offloaded 89 / 89 layers, and allocated a 78,165.87 MiB CUDA
  model buffer; this rules out an architecture or GGUF parse rejection
- an unrelated, pre-existing Qwen3.6 27B llama-server process retained
  18,704 MiB of GPU memory throughout the run; with the candidate retaining
  approximately 78.3 GiB, Spark was under severe unified-memory pressure and
  the dashboard subsequently reported `fitsCurrentVram=false`
- the host agent's fixed readiness verifier remained
  `identity=False` through attempt 55 and exhausted its 60 attempts at
  five-second intervals; at `05:51:30Z` it reported
  `verify_identity: runtime did not report the staged model` and safely
  rolled back
- rollback restored the temporary NVIDIA Nemotron 3 Nano 4B baseline, which
  became healthy at `05:52:31Z`; the activation endpoint returned 500 and the
  dashboard load route returned the authoritative 502
- the browser harness captured that 502 in `test.load.click.run` but does not
  currently treat a non-2xx observed response as terminal, so it spent the
  configured 1,204,443 ms waiting for a loaded state that could no longer
  occur; this is a harness latency issue, not a second product failure
- no candidate inference or challenge-bound consumer probe ran because the
  candidate never passed runtime identity
- failure recovery restored the temporary baseline and deleted the candidate
  through a confirmed HTTP 200; wrapper recovery then restored the original
  Qwen baseline, removed the temporary Nano artifact, restored the held
  bootstrap-upgrade state, and released the fleet lock
- the restored upgrader resumed the pre-existing Qwen3.6 35B download from
  byte 17,412,698,112, verified the 22,134,528,992-byte artifact, loaded and
  pre-warmed it, reconciled Hermes and Perplexica, and recorded bootstrap
  status `complete` at `06:16:41Z`
- final live inventory contained only the restored Qwen3.6 35B model; all
  Nemotron Super shards and the temporary Nano model were absent, `/health`
  and `/v1/models` named the restored model, and the fleet lock was free

## Remaining blockers

- challenge-bound ODS Talk and every deployed LLM-consumer probe after a
  successful candidate load
- tower2 multi-GPU tensor-split configuration correction and exact lifecycle
  retry
- a contention-free Spark retry that can pass the product's fixed five-minute
  identity window
- required fit policy still rejects strix-halo, m5-mbp, windows-laptop, and
  strixy, so strict six-host load coverage is not currently achievable

Promotion remains blocked. The catalog entry stays staged with
`install_recommendation=false`.
