### PR TITLE
models: stage Qwen 3.6 27B candidate

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1845,6 +1845,48 @@
       "llama_server_image": null
     },
     {
+      "id": "qwen3.6-27b-q4",
+      "name": "Qwen 3.6 27B",
+      "family": "qwen",
+      "gguf_file": "Qwen3.6-27B-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/82d411acf4a06cfb8d9b073a5211bf410bfc29bf/Qwen3.6-27B-Q4_K_M.gguf",
+      "gguf_sha256": "5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0",
+      "size_bytes": 16817244384,
+      "size_mb": 16818,
+      "vram_required_gb": 32,
+      "context_length": 131072,
+      "max_context_length": 1010000,
+      "total_params_b": 26.9,
+      "active_params_b": 26.9,
+      "architecture": "hybrid-dense",
+      "quantization": "Q4_K_M",
+      "specialty": "Agentic Coding and Reasoning",
+      "description": "Alibaba's April 2026 dense hybrid DeltaNet and attention model for coding, tool use, reasoning, and long-context work. Artificial Analysis ranks its reasoning configuration first among 130 comparable open-weight models.",
+      "tokens_per_sec_estimate": 25,
+      "llm_model_name": "qwen3.6-27b",
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/qwen3-6-27b/",
+        "benchmark": "Artificial Analysis Intelligence Index",
+        "score": 37,
+        "assessed_at": "2026-07-29",
+        "independent": true,
+        "note": "Ranked #1 of 130 comparable open-weight models in the 4B-40B class with a class median of 9. Artificial Analysis reports 140M evaluation output tokens versus a 37M class median, so exact-response and latency behavior remain explicit fleet-validation risks."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/Qwen/Qwen3.6-27B",
+        "model_revision": "6a9e13bd6fc8f0983b9b99948120bc37f49c13e9",
+        "gguf_repository": "unsloth/Qwen3.6-27B-GGUF",
+        "gguf_revision": "82d411acf4a06cfb8d9b073a5211bf410bfc29bf",
+        "license": "apache-2.0",
+        "license_url": "https://www.apache.org/licenses/LICENSE-2.0",
+        "license_note": "Commercial use, modification, and redistribution are permitted subject to the Apache 2.0 license notice and attribution requirements.",
+        "gguf_metadata_note": "The selected language GGUF reports architecture qwen35, 26.90B parameters, 64 layers, native 262K context, and Q4_K_M at 15.65 GiB. The deployed llama.cpp b9014 lineage parses it and offloads 65 of 65 layers on DGX Spark."
+      }
+    },
+    {
       "id": "deepseek-r1-70b-q4",
       "name": "DeepSeek R1 70B",
       "family": "deepseek",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -863,6 +863,44 @@ def test_jamba_reasoning_3b_records_fleet_compatibility_without_recommendation()
     assert not _agent_viable_for_release(model)
 
 
+def test_qwen36_27b_records_pinned_candidate_evidence_without_recommendation():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["qwen3.6-27b-q4"]
+
+    assert model["gguf_url"] == (
+        "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/"
+        "resolve/82d411acf4a06cfb8d9b073a5211bf410bfc29bf/"
+        "Qwen3.6-27B-Q4_K_M.gguf"
+    )
+    assert model["gguf_sha256"] == (
+        "5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0"
+    )
+    assert model["size_bytes"] == 16817244384
+    assert model["size_mb"] == 16818
+    assert model["vram_required_gb"] == 32
+    assert model["context_length"] == 131072
+    assert model["max_context_length"] == 1010000
+    assert model["total_params_b"] == 26.9
+    assert model["active_params_b"] == 26.9
+    assert model["architecture"] == "hybrid-dense"
+    assert model["install_recommendation"] is False
+
+    quality = model["quality_evidence"]
+    assert quality["independent"] is True
+    assert quality["score"] == 37
+    assert "#1 of 130" in quality["note"]
+
+    source = model["source_evidence"]
+    assert source["model_revision"] == (
+        "6a9e13bd6fc8f0983b9b99948120bc37f49c13e9"
+    )
+    assert source["gguf_revision"] == (
+        "82d411acf4a06cfb8d9b073a5211bf410bfc29bf"
+    )
+    assert source["license"] == "apache-2.0"
+
+
 def test_new_switchboard_models_do_not_change_install_recommendations():
     expected_switchboard_only = {
         "phi3.5-mini-q4",
@@ -891,6 +929,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "llama3.1-8b-instruct-q4",
         "granite3.3-8b-instruct-q4",
         "mistral-nemo-12b-instruct-q4",
+        "qwen3.6-27b-q4",
     }
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}


### PR DESCRIPTION
## What changed

- adds Qwen3.6 27B as a 32GB-tier agentic coding and reasoning candidate
- pins the official source model and Unsloth Q4_K_M GGUF to immutable revisions
- records the exact 16,817,244,384-byte artifact and SHA-256
- records the selected language GGUF's 26.90B dense parameter count and hybrid DeltaNet / attention architecture
- stages a practical 128K ODS context while retaining the 1.01M extended ceiling
- records independent quality evidence and Apache 2.0 licensing
- keeps `install_recommendation` false pending exact fleet validation

## Why this candidate

This is a current quality leader, not a small-model or incumbent-family convenience pick.

Artificial Analysis currently ranks the reasoning configuration first among
130 comparable open-weight models in the 4B-40B class:

- Artificial Analysis Intelligence Index v4.1: 37
- comparable-class rank: #1 / 130
- comparable-class median: 9
- source-model parameters: 27.8B
- native context: 262K

The same evaluation reports 140M output tokens versus a 37M class median.
That makes instruction-following, exact-response behavior, latency, and agent
loop termination explicit fleet risks rather than assumed strengths.

The official model card describes the first open Qwen3.6 variant as a
stability and real-world-utility release with specific gains in agentic
coding, repository-level reasoning, and thinking preservation. It uses 64
layers arranged as repeating Gated DeltaNet and full-attention blocks, with
262,144 native context and extension to 1,010,000 tokens.

Current alternatives were checked:

- GLM-4.7-Flash is an attractive MIT 30B-A3B model, but its current
  independent Intelligence Index is materially lower and its deployed
  llama.cpp compatibility is less established
- Qwen3.6 35B-A3B is already represented as the efficient Spark-class MoE;
  this dense 27B candidate tests a different quality / memory / latency point
- NVIDIA Nemotron 3 Super 120B-A12B remains separately staged in the 96GB
  tier, so this entry does not substitute a mid-size model for large-model
  evaluation

## Quant selection

The quant source was compared rather than selected by habit:

- selected: `unsloth/Qwen3.6-27B-GGUF` Q4_K_M
  - exact bytes: `16817244384`
  - exact SHA-256: `5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0`
  - Hugging Face snapshot at assessment: 725,170 downloads / 906 likes
  - deployed llama.cpp b9014 on DGX Spark parses the same artifact shape as
    `qwen35`, reports 26.90B parameters, and offloads 65 / 65 layers
- compared: `ggml-org/Qwen3.6-27B-GGUF` Q4_K_M
  - exact bytes: `19095766304`
  - exact SHA-256: `65b753ea835627f7b511143c6ceb976525c7f21f5df8c664bc0a9c23d1c49921`
  - Hugging Face snapshot at assessment: 23,292 downloads / 16 likes

The selected artifact is smaller, has substantially broader observed use,
and already has deployed-runtime parse evidence. Promotion still requires the
full exact-commit lifecycle; parse evidence alone is not a recommendation.

## Artifact provenance

- source model: `Qwen/Qwen3.6-27B`
- source revision: `6a9e13bd6fc8f0983b9b99948120bc37f49c13e9`
- GGUF repository: `unsloth/Qwen3.6-27B-GGUF`
- GGUF revision: `82d411acf4a06cfb8d9b073a5211bf410bfc29bf`
- GGUF file: `Qwen3.6-27B-Q4_K_M.gguf`
- bytes: `16817244384`
- SHA-256: `5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0`
- quantization: `Q4_K_M`
- license: Apache 2.0

The text GGUF is staged without a multimodal projector, so this entry does
not claim image or video support even though the full source model includes a
vision encoder.

## Memory contract

The deployed runtime projects approximately 18,487 MiB of device memory at
32K context: 15,345.66 MiB model, 2,646 MiB context, and 495 MiB compute.
ODS stages 128K context because the official card advises at least 128K for
thinking quality. The 32GB requirement is therefore intentionally
conservative and must be confirmed by the switchboard fit contract on every
fleet host.

## Validation

Passed locally:

- JSON parse
- `git diff --check`
- model-library coverage and offline validator pytest: 41 passed
- tier-map contract: 128 passed
- Windows catalog selector
- immutable Hugging Face headers match the catalog byte count, SHA-256, and
  GGUF revision
- deployed llama.cpp b9014 metadata reports GGUF V3, `qwen35`, Q4_K_M,
  26.90B parameters, 64 layers, 262K native context, and 65 / 65 layers
  offloaded on DGX Spark

Running the verdict lifecycle module through pytest also exposes one
pre-existing baseline failure:
`jamba-reasoning-3b-q4.app_compatibility.opencode` has lifecycle metadata but
no `revalidateAgainstSha` or `expiresAt`. This candidate does not touch that
record; it should be corrected in a separate scoped change.

## Exact fleet evidence

Exact product commit:
`dd62ac821db261015f136623837a73b6bdeb601d`.

Install passed on all six fleet hosts at:

`/home/michael/dream-fleet-test/runs/2026-07-29T06-25-15Z-install-product-dd62ac821db2-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`

The switchboard fit contract then classified:

- fitting: tower2, strix-halo, spark, m5-mbp, and strixy
- static rejection: windows-laptop, because its available memory cannot
  satisfy the candidate's 32GB / 128K contract

The first five-host lifecycle run passed the complete candidate and restore
sequence on tower2, strix-halo, spark, and m5-mbp:

`/home/michael/dream-fleet-test/runs/2026-07-29T06-55-32Z-model-ui-product-dd62ac821db2-harness-19d43e6f9f25-hosts-tower2-strix-halo-spark-m5-mbp-strixy-qwen36-27b-fit-five-r1`

Strixy stopped before candidate download because long synchronous OpenCode
responses reset through its Windows SSH forward. The host-local probe repair
is isolated in draft DS-Fleet-Test PR
https://github.com/Osmantic/DS-Fleet-Test/pull/38.

With exact harness commit
`65a24267982811bc72e45db219e09e6e547c9628`, Strixy passed the full lifecycle:

`/home/michael/dream-fleet-test/runs/2026-07-29T08-28-58Z-model-ui-product-dd62ac821db2-harness-65a242679828-hosts-strixy-qwen36-27b-strixy-r7`

That run passed:

- candidate download and artifact verification
- exact candidate load and runtime identity
- challenge-bound ODS Talk
- every required deployed LLM consumer, including host-local OpenCode with an
  assistant-role exact-token response through `llama-server/ods/current`
- original-model restore followed by Talk and every required consumer again
- candidate deletion, clean final inventory, artifact-integrity validation,
  updater restoration, and lock release

The final Strixy state was download idle, original Qwen 3.6 35B loaded, and
both the temporary Nano and 27B candidate absent.

## Promotion decision

The model has complete lifecycle evidence on all five fitting hosts and a
correct static fit rejection on windows-laptop. It remains staged with
`install_recommendation=false`: the initiative's deliberately stricter
six-host promotion rule cannot be satisfied by a 32GB-tier model on the
Windows laptop. This is a hardware-fit limitation, not a model-quality or
runtime-compatibility failure.
