### PR TITLE
models: stage Mistral Small 4 119B candidate

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1940,6 +1940,105 @@
       "tokens_per_sec_estimate": 15,
       "llm_model_name": "qwen3.5-122b-a10b",
       "llama_server_image": null
+    },
+    {
+      "id": "mistral-small-4-119b-a6b-ud-q4",
+      "name": "Mistral Small 4 119B-A6.5B",
+      "family": "mistral",
+      "gguf_file": "Mistral-Small-4-119B-2603-UD-Q4_K_M-00001-of-00003.gguf",
+      "gguf_url": "",
+      "gguf_sha256": "",
+      "gguf_parts": [
+        {
+          "file": "Mistral-Small-4-119B-2603-UD-Q4_K_M-00001-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/Mistral-Small-4-119B-2603-GGUF/resolve/bd93c721735aa32c035c0f19e738cb3371fd56ff/UD-Q4_K_M/Mistral-Small-4-119B-2603-UD-Q4_K_M-00001-of-00003.gguf",
+          "sha256": "fd3cc46082e4e64eb623eea4611b02583d1de4c20a59411bf1820925d5117dfe",
+          "size_bytes": 7875616
+        },
+        {
+          "file": "Mistral-Small-4-119B-2603-UD-Q4_K_M-00002-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/Mistral-Small-4-119B-2603-GGUF/resolve/bd93c721735aa32c035c0f19e738cb3371fd56ff/UD-Q4_K_M/Mistral-Small-4-119B-2603-UD-Q4_K_M-00002-of-00003.gguf",
+          "sha256": "f357d8dc029824fa4515ae60d7a8b7e108546763614f16c00a1b4ea0cd94145c",
+          "size_bytes": 49299298464
+        },
+        {
+          "file": "Mistral-Small-4-119B-2603-UD-Q4_K_M-00003-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/Mistral-Small-4-119B-2603-GGUF/resolve/bd93c721735aa32c035c0f19e738cb3371fd56ff/UD-Q4_K_M/Mistral-Small-4-119B-2603-UD-Q4_K_M-00003-of-00003.gguf",
+          "sha256": "9dc960d67fb1ef23029d24878b4cf6c63b743ab26cf9137402549591bd770c50",
+          "size_bytes": 24456006464
+        }
+      ],
+      "size_bytes": 73763180544,
+      "size_mb": 73764,
+      "vram_required_gb": 80,
+      "context_length": 65536,
+      "max_context_length": 262144,
+      "total_params_b": 119,
+      "active_params_b": 6.5,
+      "architecture": "mistral4-moe",
+      "quantization": "UD-Q4_K_M",
+      "specialty": "Multimodal Agentic Reasoning",
+      "description": "Mistral's March 2026 Apache-2.0 MoE unifies instruct, reasoning, coding-agent, tool-call, and vision behavior with 6.5B active parameters. Its independent score of 20 is above the comparable open-weight size-class median of 9, but community reports favor Qwen 3.6 on some real workloads. ODS therefore stages it as a non-default 64K candidate pending exact fleet validation.",
+      "tokens_per_sec_estimate": 15,
+      "llm_model_name": "Mistral-Small-4-119B-2603",
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/mistral-small-4",
+        "benchmark": "Artificial Analysis Intelligence Index",
+        "score": 20,
+        "assessed_at": "2026-07-29",
+        "independent": true,
+        "note": "The reasoning profile scores 20, above the comparable open-weight size-class median of 9. Artificial Analysis reports 53M evaluation output tokens, equal to the class median; the score is materially below Qwen 3.6 27B's 37, so this candidate broadens architecture and licensing coverage rather than replacing the current quality leader."
+      },
+      "publisher_evidence": {
+        "source_url": "https://huggingface.co/mistralai/Mistral-Small-4-119B-2603",
+        "aa_lcr": 0.72,
+        "aa_lcr_output_characters": 1600,
+        "livecodebench_output_reduction_vs_gpt_oss_120b_pct": 20,
+        "independent": false,
+        "note": "Mistral reports 119B total and 6.5B active parameters, 256K context, configurable reasoning effort, native function calling, JSON output, vision, and multilingual support. Its comparative benchmark charts are publisher evidence and do not substitute for fleet validation."
+      },
+      "deployment_evidence": [
+        {
+          "source": "llama.cpp CUDA deployment issue",
+          "source_url": "https://github.com/ggml-org/llama.cpp/issues/20710",
+          "artifact": "Unsloth Mistral Small 4 GGUF sibling quants",
+          "hardware": "RTX 4090 with 128GB system RAM",
+          "runtime": "llama.cpp b8400 CUDA",
+          "reported_result": "The model loaded and decoded, but enabling flash attention produced poor prefill GPU utilization and roughly 8 tokens/s versus an expected 16 tokens/s for the MXFP4_MOE sibling quant.",
+          "independent": true,
+          "controlled": false
+        },
+        {
+          "source": "LocalLLaMA post-fix user report",
+          "source_url": "https://www.reddit.com/r/LocalLLaMA/comments/1sq01bj/unsloth_fix_on_mistral_small_4/",
+          "artifact": "Unsloth updated UD-Q4 family and Mistral API",
+          "hardware": "not reported",
+          "runtime": "local GGUF and OpenRouter",
+          "reported_result": "A user described the model as janky outside web-development work and preferred Qwen 3.6; the similar API result suggests the concern was not solely quantization. This is anecdotal negative evidence, retained to prevent benchmark-only promotion.",
+          "independent": true,
+          "controlled": false
+        }
+      ],
+      "runtime_evidence": {
+        "llama_cpp_support_pr": "https://github.com/ggml-org/llama.cpp/pull/20649",
+        "llama_cpp_merge_commit": "d34ff7e",
+        "llama_cpp_merged_at": "2026-03-16",
+        "chat_template_source": "https://huggingface.co/unsloth/Mistral-Small-4-119B-2603-GGUF",
+        "chat_template_requirement": "The selected repository includes Unsloth chat-template fixes and explicitly instructs llama.cpp users to enable --jinja.",
+        "validation_risk": "Exact ODS fleet validation must prove chat-template rendering and compare flash-attention behavior on each supported backend before any recommendation."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/mistralai/Mistral-Small-4-119B-2603",
+        "model_revision": "a11f36bebf709121056b1dbcc943d1c6afbe494d",
+        "gguf_repository": "unsloth/Mistral-Small-4-119B-2603-GGUF",
+        "gguf_revision": "bd93c721735aa32c035c0f19e738cb3371fd56ff",
+        "license": "apache-2.0",
+        "license_url": "https://www.apache.org/licenses/LICENSE-2.0",
+        "license_note": "Apache 2.0 permits commercial use, modification, and redistribution subject to its notice and license terms."
+      }
     }
   ]
 }

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -863,6 +863,77 @@ def test_jamba_reasoning_3b_records_fleet_compatibility_without_recommendation()
     assert not _agent_viable_for_release(model)
 
 
+def test_mistral_small_4_stages_exact_multipart_artifact_and_balanced_evidence():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["mistral-small-4-119b-a6b-ud-q4"]
+
+    assert model["gguf_file"] == (
+        "Mistral-Small-4-119B-2603-UD-Q4_K_M-00001-of-00003.gguf"
+    )
+    assert model["gguf_url"] == ""
+    assert model["gguf_sha256"] == ""
+    assert model["size_bytes"] == 73763180544
+    assert model["size_mb"] == 73764
+    assert model["vram_required_gb"] == 80
+    assert model["context_length"] == HERMES_CONTEXT_FLOOR
+    assert model["max_context_length"] == 262144
+    assert model["total_params_b"] == 119
+    assert model["active_params_b"] == 6.5
+    assert model["architecture"] == "mistral4-moe"
+    assert model["quantization"] == "UD-Q4_K_M"
+    assert model["install_recommendation"] is False
+
+    parts = model["gguf_parts"]
+    assert [part["file"] for part in parts] == [
+        "Mistral-Small-4-119B-2603-UD-Q4_K_M-00001-of-00003.gguf",
+        "Mistral-Small-4-119B-2603-UD-Q4_K_M-00002-of-00003.gguf",
+        "Mistral-Small-4-119B-2603-UD-Q4_K_M-00003-of-00003.gguf",
+    ]
+    assert [part["sha256"] for part in parts] == [
+        "fd3cc46082e4e64eb623eea4611b02583d1de4c20a59411bf1820925d5117dfe",
+        "f357d8dc029824fa4515ae60d7a8b7e108546763614f16c00a1b4ea0cd94145c",
+        "9dc960d67fb1ef23029d24878b4cf6c63b743ab26cf9137402549591bd770c50",
+    ]
+    assert [part["size_bytes"] for part in parts] == [
+        7875616,
+        49299298464,
+        24456006464,
+    ]
+    assert sum(part["size_bytes"] for part in parts) == model["size_bytes"]
+    assert all(
+        "/resolve/bd93c721735aa32c035c0f19e738cb3371fd56ff/"
+        in part["url"]
+        for part in parts
+    )
+
+    quality = model["quality_evidence"]
+    assert quality["independent"] is True
+    assert quality["score"] == 20
+    assert "median of 9" in quality["note"]
+    assert "Qwen 3.6 27B's 37" in quality["note"]
+
+    deployment = model["deployment_evidence"]
+    assert all(item["independent"] is True for item in deployment)
+    assert all(item["controlled"] is False for item in deployment)
+    assert "poor prefill GPU utilization" in deployment[0]["reported_result"]
+    assert "preferred Qwen 3.6" in deployment[1]["reported_result"]
+
+    runtime = model["runtime_evidence"]
+    assert runtime["llama_cpp_merge_commit"] == "d34ff7e"
+    assert "--jinja" in runtime["chat_template_requirement"]
+    assert "fleet validation" in runtime["validation_risk"]
+
+    source = model["source_evidence"]
+    assert source["model_revision"] == (
+        "a11f36bebf709121056b1dbcc943d1c6afbe494d"
+    )
+    assert source["gguf_revision"] == (
+        "bd93c721735aa32c035c0f19e738cb3371fd56ff"
+    )
+    assert source["license"] == "apache-2.0"
+
+
 def test_new_switchboard_models_do_not_change_install_recommendations():
     expected_switchboard_only = {
         "phi3.5-mini-q4",
@@ -891,6 +962,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "llama3.1-8b-instruct-q4",
         "granite3.3-8b-instruct-q4",
         "mistral-nemo-12b-instruct-q4",
+        "mistral-small-4-119b-a6b-ud-q4",
     }
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}


### PR DESCRIPTION
## Summary

- stage Mistral Small 4 119B-A6.5B as a switchboard-only, non-default candidate
- pin the exact three-part Unsloth UD-Q4_K_M artifact by repository revision, SHA-256, and byte size
- record independent quality evidence alongside negative community/runtime evidence
- keep the production context profile at 64K while preserving the model's 256K maximum

## Why this model

Mistral Small 4 is an Apache-2.0 MoE with 119B total parameters and 6.5B active per token. It covers general instruction following, reasoning, coding agents, tool calls, and multimodal input. Artificial Analysis scores its reasoning profile at 20, above the comparable open-weight size-class median of 9.

This is not presented as the current overall quality leader: Qwen 3.6 27B scores materially higher, and community feedback on Mistral Small 4 is mixed. The catalog preserves that negative evidence and the known llama.cpp flash-attention and `--jinja` risks so fleet validation, not publisher benchmarks, determines any later promotion.

Mistral Medium 3.5 128B was also reviewed rather than omitted for convenience. It scores higher at 30, but it is a dense 128B model and its modified MIT license requires a separate commercial arrangement for companies above $20M monthly revenue. The existing Qwen 3.5 122B-A10B candidate scores higher still, is sparse, and is Apache-2.0. Small 4 is therefore staged for its distinct sparse Mistral/Apache profile, while Qwen 122B remains the higher-priority medium-class candidate.

## Artifact

- source revision: `a11f36bebf709121056b1dbcc943d1c6afbe494d`
- GGUF revision: `bd93c721735aa32c035c0f19e738cb3371fd56ff`
- quant: `UD-Q4_K_M`
- shards: 3
- exact bytes: `73,763,180,544`
- staged VRAM class: 80 GB
- license: Apache-2.0

## Validation

- `41 passed` — `ods/tests/test-model-library-coverage.py`
- `50 passed` — dashboard performance-oracle suite
- `git diff --check`

The broader verdict/offline pair currently has one pre-existing failure on `origin/main`: the Jamba OpenCode blocking verdict lacks a revalidation trigger. The offline validation test itself passes, and this change does not modify verdict data.

## Promotion gate

`install_recommendation` remains `false`. Promotion requires exact-commit install and model/UI lifecycle validation, including chat-template rendering, signed switchboard routes, all required LLM consumers, restoration, candidate deletion, and clean final inventory.
