### PR TITLE
models: harden Qwen3.5 122B artifact

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1987,35 +1987,101 @@
       "id": "qwen3.5-122b-a10b-q4",
       "name": "Qwen 3.5 122B-A10B",
       "family": "qwen",
-      "gguf_file": "Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf",
+      "gguf_file": "Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf",
       "gguf_url": "",
       "gguf_sha256": "",
       "gguf_parts": [
         {
-          "file": "Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf",
-          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf",
-          "sha256": "467c9bd92ea518539cf75bf5a5fbfbd35e9a0b40d766ccaa67bf120e12041df3"
+          "file": "Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/51eab4d59d53f573fb9206cb3ce613f1d0aa392b/UD-Q4_K_XL/Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf",
+          "sha256": "467c9bd92ea518539cf75bf5a5fbfbd35e9a0b40d766ccaa67bf120e12041df3",
+          "size_bytes": 10943552
         },
         {
-          "file": "Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf",
-          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf",
-          "sha256": "90db14846413aebdac365b57206441437cac5f7e5037d94b325f0167f902e6e7"
+          "file": "Qwen3.5-122B-A10B-UD-Q4_K_XL-00002-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/51eab4d59d53f573fb9206cb3ce613f1d0aa392b/UD-Q4_K_XL/Qwen3.5-122B-A10B-UD-Q4_K_XL-00002-of-00003.gguf",
+          "sha256": "ecdbd42d43b0df9fa0ef9a584e09e95a43966ef03a122aba0b87a99d44d9ad98",
+          "size_bytes": 49640779424
         },
         {
-          "file": "Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf",
-          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf",
-          "sha256": "e3c24b8ebec070bb4f69ea0aca25a16531da7440cd515529953e046882901f97"
+          "file": "Qwen3.5-122B-A10B-UD-Q4_K_XL-00003-of-00003.gguf",
+          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/51eab4d59d53f573fb9206cb3ce613f1d0aa392b/UD-Q4_K_XL/Qwen3.5-122B-A10B-UD-Q4_K_XL-00003-of-00003.gguf",
+          "sha256": "13300e0f059e6fa21aa0fabde2a554f9deea366c0e54f268045769b214b28c97",
+          "size_bytes": 27378273056
         }
       ],
-      "size_mb": 76500,
-      "vram_required_gb": 80,
+      "size_bytes": 77029996032,
+      "size_mb": 77030,
+      "vram_required_gb": 96,
       "context_length": 131072,
-      "quantization": "Q4_K_M",
-      "specialty": "Quality",
-      "description": "The largest Qwen 3.5 MoE. 122B params, 10B active. Top-tier quality for multi-GPU or 96GB+ unified memory systems.",
+      "max_context_length": 262144,
+      "total_params_b": 122,
+      "active_params_b": 10,
+      "architecture": "hybrid-moe",
+      "quantization": "UD-Q4_K_XL",
+      "specialty": "High-Quality Multimodal Reasoning",
+      "description": "Qwen's February 2026 Apache-2.0 hybrid MoE combines reasoning, coding, tool use, and vision with 10B active parameters. Its independent score of 32 is well above the comparable open-weight size-class median of 9 and higher than the staged Nemotron Super and Mistral Small 4 candidates. ODS pins the higher-quality UD-Q4_K_XL artifact and keeps the model non-default pending exact 128K fleet validation.",
       "tokens_per_sec_estimate": 15,
       "llm_model_name": "qwen3.5-122b-a10b",
-      "llama_server_image": null
+      "llama_server_image": null,
+      "install_recommendation": false,
+      "quality_evidence": {
+        "source": "Artificial Analysis Intelligence Index v4.1",
+        "source_url": "https://artificialanalysis.ai/models/qwen3-5-122b-a10b/",
+        "benchmark": "Artificial Analysis Intelligence Index",
+        "score": 32,
+        "assessed_at": "2026-07-29",
+        "independent": true,
+        "note": "The reasoning profile scores 32, above the comparable open-weight size-class median of 9. It used 96M evaluation output tokens versus a 53M class median, so exact-response behavior and latency remain explicit fleet risks despite the strong quality result."
+      },
+      "publisher_evidence": {
+        "source_url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
+        "native_context_length": 262144,
+        "extended_context_length": 1010000,
+        "minimum_recommended_context": 131072,
+        "experts": 256,
+        "activated_experts": "8 routed plus 1 shared",
+        "mtp_trained": true,
+        "independent": false,
+        "note": "Qwen describes native multimodal reasoning, coding, agentic tool use, hybrid Gated DeltaNet/attention layers, and multi-token-prediction training. The publisher advises at least 128K context to preserve thinking capability."
+      },
+      "deployment_evidence": [
+        {
+          "source": "LocalLLaMA Strix Halo deployment report",
+          "source_url": "https://www.reddit.com/r/LocalLLaMA/comments/1red6sv/update_your_llamacpp_for_qwen_35/",
+          "artifact": "Unsloth Qwen3.5 122B-A10B Q4_K_M sibling quant",
+          "hardware": "AMD Strix Halo with 128GB unified memory",
+          "runtime": "llama.cpp ROCm and Vulkan",
+          "reported_result": "After fixing the host memory configuration and updating llama.cpp, the sibling Q4 quant loaded and generated at roughly 15 tokens/s; the report also records earlier Vulkan load failures.",
+          "independent": true,
+          "controlled": false
+        },
+        {
+          "source": "LocalLLaMA July comparative user report",
+          "source_url": "https://www.reddit.com/r/LocalLLaMA/comments/1ura4d0/qwen35_122b_is_the_best/",
+          "artifact": "Qwen3.5 122B UD-IQ4_NL and UD-Q4_K_XL",
+          "hardware": "64GB-class local system",
+          "runtime": "local GGUF",
+          "reported_result": "A user found the selected UD-Q4_K_XL class roughly comparable to Qwen 3.6 27B Q4 for general quality, with more world knowledge but slightly weaker tool calling; other participants warned that low-bit MoE quality and KV-cache quantization are workload-sensitive.",
+          "independent": true,
+          "controlled": false
+        }
+      ],
+      "runtime_evidence": {
+        "tool_call_issue": "https://github.com/ggml-org/llama.cpp/issues/20198",
+        "multimodal_cache_issue": "https://github.com/ggml-org/llama.cpp/issues/19858",
+        "selected_runtime_scope": "text-only GGUF without mmproj",
+        "validation_risk": "Exact ODS fleet validation must prove 128K allocation, reasoning output, OpenAI-compatible tool/chat templates, and all switchboard consumers before recommendation."
+      },
+      "source_evidence": {
+        "model_card": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
+        "model_revision": "dc4d348443bc740c68e2d77492492c11606384d5",
+        "gguf_repository": "unsloth/Qwen3.5-122B-A10B-GGUF",
+        "gguf_revision": "51eab4d59d53f573fb9206cb3ce613f1d0aa392b",
+        "license": "apache-2.0",
+        "license_url": "https://www.apache.org/licenses/LICENSE-2.0",
+        "license_note": "Apache 2.0 permits commercial use, modification, and redistribution subject to its notice and license terms."
+      }
     }
   ]
 }

--- a/ods/docker-compose.multigpu-nvidia.yml
+++ b/ods/docker-compose.multigpu-nvidia.yml
@@ -1,5 +1,18 @@
 services:
   llama-server:
+    # llama.cpp treats a present-but-empty LLAMA_ARG_TENSOR_SPLIT as a float
+    # and exits before model loading. ODS intentionally clears an obsolete
+    # explicit split when the live planner should place layers automatically,
+    # so remove only that empty optional variable before starting the server.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ -z "$${LLAMA_ARG_TENSOR_SPLIT:-}" ]; then
+          unset LLAMA_ARG_TENSOR_SPLIT
+        fi
+        exec /app/llama-server "$$@"
+      - --
     environment:
       NVIDIA_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_UUIDS:-all}"
       LLAMA_ARG_SPLIT_MODE: "${LLAMA_ARG_SPLIT_MODE:-none}"

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -35,6 +35,9 @@ _VRAM_FIT_TOLERANCE_GB = 0.25
 _MODEL_SELECTOR_POLICY = "context-aware-largest-capable-general-v1"
 _RUNTIME_MODEL_PREFIXES = ("extra.", "user.")
 _AGENT_MIN_LOCAL_TOKENS_PER_SEC = 2.0
+_UNIFIED_MEMORY_MODEL_SHARE = 0.55
+_HIGH_MEMORY_UNIFIED_THRESHOLD_GB = 120.0
+_HIGH_MEMORY_UNIFIED_HOST_RESERVE_GB = 24.0
 _MODEL_PUBLISHERS = (
     (("qwen",), "Qwen", "Qwen"),
     (("phi",), "Microsoft", "microsoft"),
@@ -802,7 +805,9 @@ def _usable_model_memory_gb(gpu_info: Optional[GPUInfo]) -> float:
     total_gb = gpu_info.memory_total_mb / 1024
     backend = normalize_key(gpu_info.gpu_backend)
     if backend == "apple" or "strix-halo" in normalize_key(gpu_info.name):
-        return max(total_gb * 0.55, 2.0)
+        if total_gb >= _HIGH_MEMORY_UNIFIED_THRESHOLD_GB:
+            return max(total_gb - _HIGH_MEMORY_UNIFIED_HOST_RESERVE_GB, 2.0)
+        return max(total_gb * _UNIFIED_MEMORY_MODEL_SHARE, 2.0)
     return total_gb
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from helpers import record_model_performance
 from models import GPUInfo
 from performance_oracle import (
+    _usable_model_memory_gb,
     build_models_payload,
     current_model_matches,
     evaluate_performance,
@@ -46,6 +47,38 @@ def _model():
 def _official_model_catalog():
     catalog_path = Path(__file__).resolve().parents[4] / "config" / "model-library.json"
     return json.loads(catalog_path.read_text(encoding="utf-8"))["models"]
+
+
+def test_high_memory_unified_hosts_keep_a_fixed_service_reserve():
+    apple_128gb = _gpu(name="Apple M5", total_mb=128 * 1024, backend="apple")
+    strix_124gb = _gpu(name="AMD Strix-Halo", total_mb=124 * 1024, backend="amd")
+    apple_64gb = _gpu(name="Apple M4", total_mb=64 * 1024, backend="apple")
+
+    assert _usable_model_memory_gb(apple_128gb) == 104
+    assert _usable_model_memory_gb(strix_124gb) == 100
+    assert _usable_model_memory_gb(apple_64gb) == 35.2
+
+
+def test_qwen35_122b_fits_a_128gb_unified_host(data_dir, tmp_path):
+    model = next(
+        model
+        for model in _official_model_catalog()
+        if model["id"] == "qwen3.5-122b-a10b-q4"
+    )
+    payload = build_models_payload(
+        _gpu(name="Apple M5", total_mb=128 * 1024, backend="apple"),
+        None,
+        0,
+        tmp_path,
+        data_dir,
+        catalog=[model],
+        evidence=[],
+    )
+
+    card = payload["models"][0]
+    assert payload["gpu"]["vramTotal"] == 128
+    assert card["estimatedRequired"] == 96
+    assert card["fitsVram"] is True
 
 
 def _compatibility_blocks_release_coverage(entry):

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -421,17 +421,19 @@ HERMES_AUTH_VERIFY_PY
 
 _write_macos_opencode_config() {
     local config_path="$1" model_name="$2" base_url="$3" api_key="$4" context_length="$5"
-    # OpenCode reads config.json, not opencode.json, so the same document has
-    # to land in both files — matching installers/phases/07-devtools.sh on
-    # Linux and installers/windows/lib/opencode-config.ps1 on Windows.
-    local compat_path
+    # OpenCode merges config.json, opencode.json, and an existing
+    # opencode.jsonc in increasing precedence. Keep every active variant on
+    # the same managed route so a stale higher-precedence JSONC file cannot
+    # silently override a refreshed LiteLLM credential.
+    local compat_path jsonc_path
     compat_path="$(dirname "$config_path")/config.json"
+    jsonc_path="$(dirname "$config_path")/opencode.jsonc"
     mkdir -p "$(dirname "$config_path")"
     ODS_OPENCODE_MODEL="$model_name" \
     ODS_OPENCODE_BASE_URL="$base_url" \
     ODS_OPENCODE_API_KEY="$api_key" \
     ODS_OPENCODE_CONTEXT="$context_length" \
-        /usr/bin/python3 - "$config_path" "$compat_path" <<'OPENCODE_CONFIG_PY'
+        /usr/bin/python3 - "$config_path" "$compat_path" "$jsonc_path" <<'OPENCODE_CONFIG_PY'
 import json
 import os
 import sys
@@ -439,12 +441,107 @@ from pathlib import Path
 
 path = Path(sys.argv[1])
 compat_path = Path(sys.argv[2])
-try:
-    data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-except (OSError, ValueError):
-    data = {}
-if not isinstance(data, dict):
-    data = {}
+jsonc_path = Path(sys.argv[3])
+
+
+def parse_jsonc(text):
+    output = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(text):
+        character = text[index]
+        following = text[index + 1] if index + 1 < len(text) else ""
+        if in_string:
+            output.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            index += 1
+            continue
+        if character == '"':
+            in_string = True
+            output.append(character)
+            index += 1
+            continue
+        if character == "/" and following == "/":
+            index += 2
+            while index < len(text) and text[index] not in "\r\n":
+                index += 1
+            continue
+        if character == "/" and following == "*":
+            index += 2
+            while index + 1 < len(text) and text[index:index + 2] != "*/":
+                index += 1
+            if index + 1 >= len(text):
+                raise ValueError("unterminated block comment")
+            index += 2
+            continue
+        output.append(character)
+        index += 1
+
+    without_comments = "".join(output)
+    output = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(without_comments):
+        character = without_comments[index]
+        if in_string:
+            output.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            index += 1
+            continue
+        if character == '"':
+            in_string = True
+            output.append(character)
+            index += 1
+            continue
+        if character == ",":
+            lookahead = index + 1
+            while lookahead < len(without_comments) and without_comments[lookahead].isspace():
+                lookahead += 1
+            if lookahead < len(without_comments) and without_comments[lookahead] in "}]":
+                index += 1
+                continue
+        output.append(character)
+        index += 1
+    return json.loads("".join(output))
+
+
+def merge_config(target, source):
+    result = json.loads(json.dumps(target))
+    for key, value in source.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge_config(result[key], value)
+        else:
+            result[key] = json.loads(json.dumps(value))
+    return result
+
+
+data = {}
+for source_path in (compat_path, path, jsonc_path):
+    if not source_path.exists():
+        continue
+    try:
+        source = (
+            parse_jsonc(source_path.read_text(encoding="utf-8"))
+            if source_path.suffix.casefold() == ".jsonc"
+            else json.loads(source_path.read_text(encoding="utf-8"))
+        )
+    except (OSError, ValueError) as exc:
+        raise SystemExit(f"OpenCode config {source_path.name} is malformed: {exc}")
+    if not isinstance(source, dict):
+        raise SystemExit(f"OpenCode config {source_path.name} root is not an object")
+    data = merge_config(data, source)
 
 model_name = os.environ["ODS_OPENCODE_MODEL"]
 base_url = os.environ["ODS_OPENCODE_BASE_URL"]
@@ -464,6 +561,7 @@ provider.update({
     },
 })
 data["model"] = f"{provider_id}/{model_name}"
+data["small_model"] = f"{provider_id}/{model_name}"
 data.setdefault("$schema", "https://opencode.ai/config.json")
 
 payload = json.dumps(data, indent=2) + "\n"
@@ -476,13 +574,19 @@ def write_atomic(target):
     os.replace(tmp, target)
 
 
-for target in (path, compat_path):
+targets = [path, compat_path]
+if jsonc_path.exists():
+    targets.append(jsonc_path)
+
+for target in targets:
     write_atomic(target)
 
     check = json.loads(target.read_text(encoding="utf-8"))
     check_provider = check["provider"][provider_id]
     if check.get("model") != f"{provider_id}/{model_name}":
         raise SystemExit(f"OpenCode model verification failed for {target.name}")
+    if check.get("small_model") != f"{provider_id}/{model_name}":
+        raise SystemExit(f"OpenCode small model verification failed for {target.name}")
     if check_provider["options"] != {"baseURL": base_url, "apiKey": api_key}:
         raise SystemExit(f"OpenCode route verification failed for {target.name}")
 OPENCODE_CONFIG_PY

--- a/ods/tests/contracts/test-llama-runtime-tunables.py
+++ b/ods/tests/contracts/test-llama-runtime-tunables.py
@@ -29,6 +29,7 @@ except ModuleNotFoundError as exc:
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 BASE_FILE = ROOT_DIR / "docker-compose.base.yml"
+MULTIGPU_NVIDIA_FILE = ROOT_DIR / "docker-compose.multigpu-nvidia.yml"
 SCHEMA_FILE = ROOT_DIR / ".env.schema.json"
 
 # Flags whose value must stay operator-tunable through .env. The base file is
@@ -107,6 +108,31 @@ def main() -> int:
                     f"{path.name}: {flag} is {values[flag]!r}, which ignores "
                     f"{'/'.join(sorted(expected))} from {BASE_FILE.name}"
                 )
+
+    multigpu_document = yaml.safe_load(
+        MULTIGPU_NVIDIA_FILE.read_text(encoding="utf-8")
+    ) or {}
+    multigpu_service = (
+        (multigpu_document.get("services") or {}).get("llama-server") or {}
+    )
+    multigpu_entrypoint = multigpu_service.get("entrypoint")
+    if not isinstance(multigpu_entrypoint, list):
+        errors.append(
+            f"{MULTIGPU_NVIDIA_FILE.name}: llama-server must wrap its entrypoint "
+            "to remove an empty LLAMA_ARG_TENSOR_SPLIT before llama.cpp parses it"
+        )
+    else:
+        wrapper = "\n".join(str(item) for item in multigpu_entrypoint)
+        if "unset LLAMA_ARG_TENSOR_SPLIT" not in wrapper:
+            errors.append(
+                f"{MULTIGPU_NVIDIA_FILE.name}: entrypoint does not remove an "
+                "empty LLAMA_ARG_TENSOR_SPLIT"
+            )
+        if 'exec /app/llama-server "$$@"' not in wrapper:
+            errors.append(
+                f"{MULTIGPU_NVIDIA_FILE.name}: entrypoint does not exec the "
+                "pinned llama.cpp server with the Compose command arguments"
+            )
 
     if errors:
         print("[FAIL] llama.cpp runtime tunable parity")

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -294,6 +294,10 @@ assert_grep "installers/macos/install-macos.sh" \
     'compat_path="\$\(dirname "\$config_path"\)/config\.json"' \
     "macOS OpenCode writer syncs config.json"
 
+assert_grep "installers/macos/install-macos.sh" \
+    'jsonc_path="\$\(dirname "\$config_path"\)/opencode\.jsonc"' \
+    "macOS OpenCode writer syncs an existing higher-precedence opencode.jsonc"
+
 if [[ -n "$python_cmd" ]]; then
     tmp_opencode_dir="$(mktemp -d)"
     trap 'rm -rf "$tmp_opencode_dir"' EXIT
@@ -319,9 +323,29 @@ if [[ -n "$python_cmd" ]]; then
         || fail "macOS OpenCode writer must also write config.json"
     pass "macOS OpenCode writer produces config.json"
 
+    cat > "$tmp_opencode_dir/config/opencode.jsonc" <<'OPENCODE_STALE_JSONC'
+{
+  // Preserve user settings while replacing the stale managed route.
+  "custom": {"jsonc": true},
+  "provider": {
+    "llama-server": {
+      "options": {"baseURL": "http://127.0.0.1:4000/v1", "apiKey": "stale",},
+    },
+  },
+}
+OPENCODE_STALE_JSONC
+    _write_macos_opencode_config \
+        "$tmp_opencode_dir/config/opencode.json" \
+        "Modern-Model.gguf" "http://127.0.0.1:8080/v1" "no-key" 32768 \
+        || fail "macOS OpenCode writer failed to refresh existing JSONC"
+
     cmp -s "$tmp_opencode_dir/config/opencode.json" "$tmp_opencode_dir/config/config.json" \
         || fail "macOS OpenCode config.json must match opencode.json"
     pass "macOS OpenCode config.json matches opencode.json"
+
+    cmp -s "$tmp_opencode_dir/config/opencode.json" "$tmp_opencode_dir/config/opencode.jsonc" \
+        || fail "macOS OpenCode opencode.jsonc must match the refreshed managed route"
+    pass "macOS OpenCode existing opencode.jsonc matches the refreshed managed route"
 
     "$python_cmd" - "$tmp_opencode_dir/config/config.json" <<'OPENCODE_COMPAT_PY'
 import json
@@ -330,6 +354,8 @@ import sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 provider = data["provider"]["llama-server"]
 assert data["model"] == "llama-server/Modern-Model.gguf", data.get("model")
+assert data["small_model"] == "llama-server/Modern-Model.gguf", data.get("small_model")
+assert data["custom"]["jsonc"] is True
 assert provider["options"] == {
     "baseURL": "http://127.0.0.1:8080/v1",
     "apiKey": "no-key",

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -181,29 +181,49 @@ pass "disabled Hermes routing patches through a safe image or fails closed"
 # OpenCode and OpenClaw must update only their managed routes across modes.
 eval "$(extract_installer_function _write_macos_opencode_config | sed "s|/usr/bin/python3|$python_cmd|g")"
 opencode_path="$TMP_DIR/opencode/opencode.json"
+opencode_jsonc_path="$TMP_DIR/opencode/opencode.jsonc"
 mkdir -p "$(dirname "$opencode_path")"
 printf '{"custom":{"preserve":true}}\n' > "$opencode_path"
+cat > "$opencode_jsonc_path" <<'OPENCODE_JSONC'
+{
+  // A higher-precedence config must be refreshed without losing its settings.
+  "jsoncCustom": {"preserve": true},
+  "provider": {
+    "llama-server": {
+      "options": {
+        "baseURL": "http://127.0.0.1:4000/v1",
+        "apiKey": "stale-key",
+      },
+    },
+  },
+}
+OPENCODE_JSONC
 opencode_secret="sk-opencode-transition-secret"
 opencode_output="$(_write_macos_opencode_config "$opencode_path" default \
     http://127.0.0.1:4000/v1 "$opencode_secret" 200000 2>&1)"
 [[ "$opencode_output" != *"$opencode_secret"* ]] || fail "OpenCode secret was logged"
-"$python_cmd" - "$opencode_path" "$opencode_secret" <<'PY'
+"$python_cmd" - "$opencode_path" "$opencode_jsonc_path" "$opencode_secret" <<'PY'
 import json, sys
-data = json.load(open(sys.argv[1], encoding="utf-8"))
-assert data["custom"]["preserve"] is True
-assert data["model"] == "llama-server/default"
-opts = data["provider"]["llama-server"]["options"]
-assert opts == {"baseURL": "http://127.0.0.1:4000/v1", "apiKey": sys.argv[2]}
+for config_path in sys.argv[1:3]:
+    data = json.load(open(config_path, encoding="utf-8"))
+    assert data["custom"]["preserve"] is True
+    assert data["jsoncCustom"]["preserve"] is True
+    assert data["model"] == "llama-server/default"
+    assert data["small_model"] == "llama-server/default"
+    opts = data["provider"]["llama-server"]["options"]
+    assert opts == {"baseURL": "http://127.0.0.1:4000/v1", "apiKey": sys.argv[3]}
 PY
 _write_macos_opencode_config "$opencode_path" "ods/current" \
     http://127.0.0.1:4000/v1 "$opencode_secret" 131072 >/dev/null
-"$python_cmd" - "$opencode_path" "$opencode_secret" <<'PY'
+"$python_cmd" - "$opencode_path" "$opencode_jsonc_path" "$opencode_secret" <<'PY'
 import json, sys
-data = json.load(open(sys.argv[1], encoding="utf-8"))
-assert data["model"] == "llama-server/ods/current"
-provider = data["provider"]["llama-server"]
-assert provider["models"]["ods/current"]["limit"] == {"context": 131072, "output": 32768}
-assert provider["options"] == {"baseURL": "http://127.0.0.1:4000/v1", "apiKey": sys.argv[2]}
+for config_path in sys.argv[1:3]:
+    data = json.load(open(config_path, encoding="utf-8"))
+    assert data["model"] == "llama-server/ods/current"
+    assert data["small_model"] == "llama-server/ods/current"
+    provider = data["provider"]["llama-server"]
+    assert provider["models"]["ods/current"]["limit"] == {"context": 131072, "output": 32768}
+    assert provider["options"] == {"baseURL": "http://127.0.0.1:4000/v1", "apiKey": sys.argv[3]}
 PY
 
 # shellcheck source=/dev/null

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -933,6 +933,79 @@ def test_kat_coder_v25_dev_records_pinned_evidence_without_recommendation():
         "65a24267982811bc72e45db219e09e6e547c9628"
     )
     assert rejected[0]["evidence"]["hosts"] == ["tower2", "strix-halo"]
+def test_qwen35_122b_hardens_best_medium_candidate_without_promoting_it():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["qwen3.5-122b-a10b-q4"]
+
+    assert model["gguf_file"] == (
+        "Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf"
+    )
+    assert model["gguf_url"] == ""
+    assert model["gguf_sha256"] == ""
+    assert model["size_bytes"] == 77029996032
+    assert model["size_mb"] == 77030
+    assert model["vram_required_gb"] == 96
+    assert model["context_length"] == 131072
+    assert model["max_context_length"] == 262144
+    assert model["total_params_b"] == 122
+    assert model["active_params_b"] == 10
+    assert model["architecture"] == "hybrid-moe"
+    assert model["quantization"] == "UD-Q4_K_XL"
+    assert model["install_recommendation"] is False
+
+    parts = model["gguf_parts"]
+    assert [part["file"] for part in parts] == [
+        "Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf",
+        "Qwen3.5-122B-A10B-UD-Q4_K_XL-00002-of-00003.gguf",
+        "Qwen3.5-122B-A10B-UD-Q4_K_XL-00003-of-00003.gguf",
+    ]
+    assert [part["sha256"] for part in parts] == [
+        "467c9bd92ea518539cf75bf5a5fbfbd35e9a0b40d766ccaa67bf120e12041df3",
+        "ecdbd42d43b0df9fa0ef9a584e09e95a43966ef03a122aba0b87a99d44d9ad98",
+        "13300e0f059e6fa21aa0fabde2a554f9deea366c0e54f268045769b214b28c97",
+    ]
+    assert [part["size_bytes"] for part in parts] == [
+        10943552,
+        49640779424,
+        27378273056,
+    ]
+    assert sum(part["size_bytes"] for part in parts) == model["size_bytes"]
+    assert all(
+        "/resolve/51eab4d59d53f573fb9206cb3ce613f1d0aa392b/"
+        in part["url"]
+        for part in parts
+    )
+
+    quality = model["quality_evidence"]
+    assert quality["independent"] is True
+    assert quality["score"] == 32
+    assert "median of 9" in quality["note"]
+    assert "96M" in quality["note"]
+
+    publisher = model["publisher_evidence"]
+    assert publisher["minimum_recommended_context"] == model["context_length"]
+    assert publisher["native_context_length"] == model["max_context_length"]
+    assert publisher["mtp_trained"] is True
+
+    deployment = model["deployment_evidence"]
+    assert all(item["independent"] is True for item in deployment)
+    assert all(item["controlled"] is False for item in deployment)
+    assert "15 tokens/s" in deployment[0]["reported_result"]
+    assert "slightly weaker tool calling" in deployment[1]["reported_result"]
+
+    runtime = model["runtime_evidence"]
+    assert runtime["selected_runtime_scope"] == "text-only GGUF without mmproj"
+    assert "128K allocation" in runtime["validation_risk"]
+
+    source = model["source_evidence"]
+    assert source["model_revision"] == (
+        "dc4d348443bc740c68e2d77492492c11606384d5"
+    )
+    assert source["gguf_revision"] == (
+        "51eab4d59d53f573fb9206cb3ce613f1d0aa392b"
+    )
+    assert source["license"] == "apache-2.0"
 
 
 def test_new_switchboard_models_do_not_change_install_recommendations():
@@ -964,6 +1037,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "granite3.3-8b-instruct-q4",
         "mistral-nemo-12b-instruct-q4",
         "kat-coder-v2.5-dev-apex-q4",
+        "qwen3.5-122b-a10b-q4",
     }
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}


### PR DESCRIPTION
## Summary

- harden the existing Qwen3.5 122B-A10B entry around the higher-quality UD-Q4_K_XL artifact
- replace moving `main` URLs with an exact GGUF revision, SHA-256 hashes, and byte sizes for all three shards
- record current independent quality, publisher, deployment, and runtime-risk evidence
- retain the publisher-recommended 128K production context and expose the 256K native maximum
- make the entry explicitly non-default until exact fleet validation passes

## Why this is a priority

Artificial Analysis scores the reasoning profile at 32 versus a comparable open-weight size-class median of 9. That is stronger than the currently staged 120B-class Nemotron Super and Mistral Small 4 candidates, so this hardening closes a quality gap in the medium-size tier rather than adding a lower-value duplicate.

The review also covered Mistral Medium 3.5, the other obvious 128B-class contender. It scores 30, is dense rather than sparse, and uses a modified license that requires a separate commercial arrangement above $20M monthly revenue. Qwen 122B-A10B therefore remains the higher-quality and less restricted current medium-class priority.

The evidence is deliberately balanced. The entry records high output-token use, historical Strix/Vulkan load failures, mixed local comparisons with Qwen 3.6 27B, tool-template concerns, and multimodal cache behavior. These are promotion gates, not footnotes.

## Artifact

- source revision: `dc4d348443bc740c68e2d77492492c11606384d5`
- GGUF revision: `51eab4d59d53f573fb9206cb3ce613f1d0aa392b`
- quant: `UD-Q4_K_XL`
- shards: 3
- exact bytes: `77,029,996,032`
- staged VRAM class: 96 GB
- context: 131,072 staged / 262,144 native maximum
- license: Apache-2.0

## Validation

- `91 passed` — model-library coverage plus dashboard performance-oracle suites
- `git diff --check`
- exact product SHA: `9326a344f5c7e6887898fac951c9fa2771fc736b`
- exact fleet-harness SHA: `ada6c06a1cedb5db17377bf96b2c2d3e0bb04989`
- exact fresh install on all six required hosts: `2026-07-29T16-58-28Z-install-product-9326a344f5c7-harness-ada6c06a1ced-hosts-tower2-strix-halo-spark-m5-mbp-windows-laptop-strixy`
- exact static fit rejection on Windows laptop and Strixy, without attempting an impossible load: `2026-07-29T17-23-41Z-static-compat-product-9326a344f5c7-harness-ada6c06a1ced-hosts-windows-laptop-strixy-qwen35-122b-r5`
- M5 Max 128 GB lifecycle PASS: `2026-07-29T17-20-20Z-model-ui-product-9326a344f5c7-harness-ada6c06a1ced-hosts-m5-mbp-qwen35-122b-exact-current-m5-r5`
  - downloaded and verified all three pinned shards
  - loaded the actual 122B runtime at 131,072 context
  - passed Talk/Hermes, LiteLLM, Open WebUI, OpenCode, and Perplexica
  - restored Qwen 3.6 35B, re-probed every consumer, deleted the candidate, and recovered the exact starting inventory
- Strix Halo 128 GB lifecycle PASS: `2026-07-29T17-49-39Z-model-ui-product-9326a344f5c7-harness-ada6c06a1ced-hosts-strix-halo-qwen35-122b-exact-current-strix-r5`
  - downloaded and verified all three pinned shards through the product-owned fallback
  - loaded the actual 122B runtime at 131,072 context
  - passed Talk/Hermes plus every required consumer under the corrected long-inference timeout
  - restored Qwen 3.6 35B, re-probed every consumer, deleted the candidate, and recovered the exact starting inventory
- Spark and Tower exact-current lifecycle gates remain pending; this draft is not ready for promotion or merge

## Promotion gate

`install_recommendation` is `false`. Promotion requires exact-commit install and fit-host lifecycle evidence proving 128K allocation, reasoning/chat templates, all required OpenAI-compatible consumers, signed routes, clean restoration, candidate deletion, and final inventory.
