### PR TITLE
fix(upgrade): avoid shell parsing Hermes live patches

### DIFF
--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -1301,6 +1301,47 @@ patch_hermes_yaml_with_sed() {
         && { [[ -z "$base_url" ]] || grep -Fq "  base_url: \"${base_url}\"" "$path"; }
 }
 
+patch_hermes_yaml_in_container() {
+    local model="$1" context_length="$2" base_url="${3:-}" request_timeout_seconds="${4:-180}"
+    local normalize_compression="${5:-false}"
+
+    [[ -n "${DOCKER_CMD:-}" ]] || return 1
+    [[ "$context_length" =~ ^[0-9]+$ ]] || return 1
+    [[ "$request_timeout_seconds" =~ ^[0-9]+$ ]] || return 1
+    [[ "$normalize_compression" == "true" || "$normalize_compression" == "false" ]] || return 1
+    case "${model}${base_url}" in
+        *$'\n'*|*$'\r'*) return 1 ;;
+    esac
+
+    local model_sed base_url_sed
+    model_sed="$(printf '%s' "$model" | sed 's/[\\&|]/\\&/g')" || return 1
+    base_url_sed="$(printf '%s' "$base_url" | sed 's/[\\&|]/\\&/g')" || return 1
+
+    local sed_args=(
+        -e "s|^  default: \".*\"[[:space:]]*$|  default: \"${model_sed}\"|"
+        -e "s|^  context_length: .*|  context_length: ${context_length}|"
+        -e "s|^    context_length: .*|    context_length: ${context_length}|"
+    )
+    if [[ -n "$base_url" ]]; then
+        sed_args+=(-e "s|^  base_url: \".*\"|  base_url: \"${base_url_sed}\"|")
+    fi
+    if [[ "$request_timeout_seconds" != "180" ]]; then
+        sed_args+=(-e "s|^    request_timeout_seconds: 180[[:space:]]*$|    request_timeout_seconds: ${request_timeout_seconds}|")
+    fi
+    if [[ "$normalize_compression" == "true" ]]; then
+        sed_args+=(
+            -e 's|^  enabled: .*|  enabled: true|'
+            -e 's|^  threshold: .*|  threshold: 0.75|'
+            -e 's|^  target_ratio: .*|  target_ratio: 0.50|'
+            -e 's|^  protect_last_n: .*|  protect_last_n: 40|'
+        )
+    fi
+
+    $DOCKER_CMD exec ods-hermes sed -i \
+        "${sed_args[@]}" \
+        /opt/data/config.yaml
+}
+
 patch_hermes_model_after_swap() {
     local runtime llm_backend switchboard_mode hermes_base_url old_model new_model tpl live live_host_patch_failed hermes_request_timeout
     runtime="$(read_env_value AMD_INFERENCE_RUNTIME | tr '[:upper:]' '[:lower:]')"
@@ -1343,19 +1384,9 @@ patch_hermes_model_after_swap() {
     fi
 
     if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-hermes --format '{{.Names}}' 2>/dev/null | grep -q ods-hermes; then
-        local live_patch new_model_sed hermes_base_url_sed
-        new_model_sed="$(printf '%s' "$new_model" | sed 's/[\\&|]/\\&/g')"
-        hermes_base_url_sed="$(printf '%s' "$hermes_base_url" | sed 's/[\\&|]/\\&/g')"
-        live_patch="sed -i -e 's|^  default: \".*\"[[:space:]]*$|  default: \"${new_model_sed}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|'"
-        if [[ -n "$hermes_base_url" ]]; then
-            live_patch="${live_patch} -e 's|^  base_url: \".*\"|  base_url: \"${hermes_base_url_sed}\"|'"
-        fi
-        if [[ "$hermes_request_timeout" != "180" ]]; then
-            live_patch="${live_patch} -e 's|^    request_timeout_seconds: 180[[:space:]]*$|    request_timeout_seconds: ${hermes_request_timeout}|'"
-        fi
-        live_patch="${live_patch} /opt/data/config.yaml"
-        $DOCKER_CMD exec ods-hermes sh -c \
-            "$live_patch" 2>&1 || {
+        patch_hermes_yaml_in_container \
+            "$new_model" "$FULL_MAX_CONTEXT" "$hermes_base_url" "$hermes_request_timeout" false \
+            2>&1 || {
                 log "ERROR: Could not patch Hermes live config after full-model swap."
                 return 1
             }
@@ -2812,18 +2843,9 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
 
         if $DOCKER_CMD ps --filter name=ods-hermes --format '{{.Names}}' 2>/dev/null | grep -q ods-hermes; then
             # Live config inside the running container (owned by container UID).
-            _hermes_new_model_sed="$(printf '%s' "$_hermes_new_model" | sed 's/[\\&|]/\\&/g')"
-            _hermes_base_url_sed="$(printf '%s' "$_hermes_base_url" | sed 's/[\\&|]/\\&/g')"
-            _hermes_live_patch="sed -i -e 's|^  default: \".*\"[[:space:]]*$|  default: \"${_hermes_new_model_sed}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|'"
-            if [[ -n "$_hermes_base_url" ]]; then
-                _hermes_live_patch="${_hermes_live_patch} -e 's|^  base_url: \".*\"|  base_url: \"${_hermes_base_url_sed}\"|'"
-            fi
-            if [[ "$_hermes_request_timeout" != "180" ]]; then
-                _hermes_live_patch="${_hermes_live_patch} -e 's|^    request_timeout_seconds: 180[[:space:]]*$|    request_timeout_seconds: ${_hermes_request_timeout}|'"
-            fi
-            _hermes_live_patch="${_hermes_live_patch} -e 's|^  enabled: .*|  enabled: true|' -e 's|^  threshold: .*|  threshold: 0.75|' -e 's|^  target_ratio: .*|  target_ratio: 0.50|' -e 's|^  protect_last_n: .*|  protect_last_n: 40|' /opt/data/config.yaml"
-            $DOCKER_CMD exec ods-hermes sh -c \
-                "$_hermes_live_patch" 2>&1 || \
+            patch_hermes_yaml_in_container \
+                "$_hermes_new_model" "$FULL_MAX_CONTEXT" "$_hermes_base_url" "$_hermes_request_timeout" true \
+                2>&1 || \
                 log "WARNING: Could not patch Hermes /opt/data/config.yaml (non-fatal — operator can hand-edit and 'docker restart ods-hermes')"
             log "Restarting Hermes to pick up model change..."
             $DOCKER_CMD restart ods-hermes 2>&1 || log "WARNING: Hermes restart failed (non-fatal — hand-restart with 'docker restart ods-hermes')"

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -1267,20 +1267,36 @@ restart_windows_native_llama_server_with_full_model() {
     return 0
 }
 
+yaml_double_quoted_scalar_content() {
+    local value="$1"
+    case "$value" in
+        *$'\n'*|*$'\r'*) return 1 ;;
+    esac
+    printf '%s' "$value" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+sed_replacement_escape() {
+    printf '%s' "$1" | sed 's/[\\&|]/\\&/g'
+}
+
 patch_hermes_yaml_with_sed() {
     local path="$1" model="$2" context_length="$3" base_url="${4:-}" request_timeout_seconds="${5:-180}"
     [[ -f "$path" ]] || return 1
+    [[ "$context_length" =~ ^[0-9]+$ ]] || return 1
+    [[ "$request_timeout_seconds" =~ ^[0-9]+$ ]] || return 1
 
-    local model_sed base_url_sed
-    model_sed="$(printf '%s' "$model" | sed 's/[\\&|]/\\&/g')"
-    base_url_sed="$(printf '%s' "$base_url" | sed 's/[\\&|]/\\&/g')"
+    local model_yaml base_url_yaml model_sed base_url_sed
+    model_yaml="$(yaml_double_quoted_scalar_content "$model")" || return 1
+    base_url_yaml="$(yaml_double_quoted_scalar_content "$base_url")" || return 1
+    model_sed="$(sed_replacement_escape "$model_yaml")" || return 1
+    base_url_sed="$(sed_replacement_escape "$base_url_yaml")" || return 1
 
     local sed_args=(
         -e "s|^  default: \".*\"[[:space:]]*$|  default: \"${model_sed}\"|"
         -e "s|^  context_length: .*|  context_length: ${context_length}|"
         -e "s|^    context_length: .*|    context_length: ${context_length}|"
     )
-    if [[ "$request_timeout_seconds" =~ ^[0-9]+$ && "$request_timeout_seconds" != "180" ]]; then
+    if [[ "$request_timeout_seconds" != "180" ]]; then
         sed_args+=(-e "s|^    request_timeout_seconds: 180[[:space:]]*$|    request_timeout_seconds: ${request_timeout_seconds}|")
     fi
     if [[ -n "$base_url" ]]; then
@@ -1296,9 +1312,9 @@ patch_hermes_yaml_with_sed() {
         return 1
     fi
 
-    grep -Fq "  default: \"${model}\"" "$path" \
+    grep -Fq "  default: \"${model_yaml}\"" "$path" \
         && grep -Fq "  context_length: ${context_length}" "$path" \
-        && { [[ -z "$base_url" ]] || grep -Fq "  base_url: \"${base_url}\"" "$path"; }
+        && { [[ -z "$base_url" ]] || grep -Fq "  base_url: \"${base_url_yaml}\"" "$path"; }
 }
 
 patch_hermes_yaml_in_container() {
@@ -1309,13 +1325,11 @@ patch_hermes_yaml_in_container() {
     [[ "$context_length" =~ ^[0-9]+$ ]] || return 1
     [[ "$request_timeout_seconds" =~ ^[0-9]+$ ]] || return 1
     [[ "$normalize_compression" == "true" || "$normalize_compression" == "false" ]] || return 1
-    case "${model}${base_url}" in
-        *$'\n'*|*$'\r'*) return 1 ;;
-    esac
-
-    local model_sed base_url_sed
-    model_sed="$(printf '%s' "$model" | sed 's/[\\&|]/\\&/g')" || return 1
-    base_url_sed="$(printf '%s' "$base_url" | sed 's/[\\&|]/\\&/g')" || return 1
+    local model_yaml base_url_yaml model_sed base_url_sed
+    model_yaml="$(yaml_double_quoted_scalar_content "$model")" || return 1
+    base_url_yaml="$(yaml_double_quoted_scalar_content "$base_url")" || return 1
+    model_sed="$(sed_replacement_escape "$model_yaml")" || return 1
+    base_url_sed="$(sed_replacement_escape "$base_url_yaml")" || return 1
 
     local sed_args=(
         -e "s|^  default: \".*\"[[:space:]]*$|  default: \"${model_sed}\"|"

--- a/ods/tests/contracts/test-windows-lemonade-swap-wait.sh
+++ b/ods/tests/contracts/test-windows-lemonade-swap-wait.sh
@@ -189,8 +189,8 @@ fi
 #    Git Bash, and it must verify the YAML before returning success.
 # ---------------------------------------------------------------------------
 if grep -q 'patch_hermes_yaml_with_sed' "$SCRIPT" \
-   && grep -Fq 'grep -Fq "  default: \"${model}\""' "$SCRIPT" \
-   && grep -Fq 'grep -Fq "  base_url: \"${base_url}\""' "$SCRIPT" \
+   && grep -Fq 'grep -Fq "  default: \"${model_yaml}\""' "$SCRIPT" \
+   && grep -Fq 'grep -Fq "  base_url: \"${base_url_yaml}\""' "$SCRIPT" \
    && grep -q 'ERROR: Could not patch ${tpl} after full-model swap.' "$SCRIPT" \
    && grep -q 'return 1' "$SCRIPT"; then
     pass "post-swap Hermes patch is dependency-free, verifies model/base_url, and is fail-loud"
@@ -208,8 +208,8 @@ if grep -q 'hermes_base_url="$(read_env_value HERMES_LLM_BASE_URL)"' "$SCRIPT" \
    && grep -q 'patch_hermes_yaml_with_sed "$tpl" "$new_model" "$FULL_MAX_CONTEXT" "$hermes_base_url"' "$SCRIPT" \
    && grep -q 'patch_hermes_yaml_with_sed "$live" "$new_model" "$FULL_MAX_CONTEXT" "$hermes_base_url"' "$SCRIPT" \
    && grep -q 'patch_hermes_yaml_with_sed "$_hermes_live" "$_hermes_new_model" "$FULL_MAX_CONTEXT" "$_hermes_base_url"' "$SCRIPT" \
-   && grep -q 'hermes_base_url_sed="$(printf' "$SCRIPT" \
-   && grep -q 'base_url: \\"${hermes_base_url_sed}\\"' "$SCRIPT"; then
+   && grep -q 'patch_hermes_yaml_in_container.*' "$SCRIPT" \
+   && grep -q 'base_url: \\"${base_url_sed}\\"' "$SCRIPT"; then
     pass "post-swap Hermes patch preserves HERMES_LLM_BASE_URL in template and live config"
 else
     fail "post-swap Hermes patch must carry HERMES_LLM_BASE_URL into persisted Hermes config"

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -41,6 +41,49 @@ assert_in_order() {
 # Strip comments so explanatory text cannot satisfy or fail the checks.
 active_code="$(grep -v '^[[:space:]]*#' "$TARGET")"
 
+hermes_container_patch_block="$(function_block patch_hermes_yaml_in_container | grep -v '^[[:space:]]*#')"
+grep -qF '$DOCKER_CMD exec ods-hermes sed -i' <<<"$hermes_container_patch_block" \
+    || fail "Hermes live config patching must pass sed arguments directly to docker exec"
+if grep -qF 'exec ods-hermes sh -c' <<<"$active_code"; then
+    fail "Hermes live config patching must not reparse generated commands through sh -c"
+fi
+
+eval "$hermes_container_patch_block"
+hermes_patch_tmp="$(mktemp -d "${TMPDIR:-/tmp}/ods-hermes-patch.XXXXXX")"
+hermes_patch_marker="$hermes_patch_tmp/injected"
+hermes_docker_calls=0
+hermes_docker_args=()
+docker() {
+    hermes_docker_calls=$((hermes_docker_calls + 1))
+    hermes_docker_args=("$@")
+}
+DOCKER_CMD=docker
+hermes_malicious_model="model&branch|tag\\path' ; touch ${hermes_patch_marker} ; #"
+hermes_malicious_url="http://example.invalid/v1' ; touch ${hermes_patch_marker}.url ; #"
+patch_hermes_yaml_in_container \
+    "$hermes_malicious_model" 65536 "$hermes_malicious_url" 900 true \
+    || fail "Hermes live patch helper rejected metacharacters that should remain data"
+[[ ! -e "$hermes_patch_marker" && ! -e "${hermes_patch_marker}.url" ]] \
+    || fail "Hermes live patch helper executed config values as shell input"
+[[ "${hermes_docker_args[0]:-}" == "exec" \
+    && "${hermes_docker_args[1]:-}" == "ods-hermes" \
+    && "${hermes_docker_args[2]:-}" == "sed" \
+    && "${hermes_docker_args[3]:-}" == "-i" \
+    && "${hermes_docker_args[${#hermes_docker_args[@]}-1]:-}" == "/opt/data/config.yaml" ]] \
+    || fail "Hermes live patch helper did not preserve the expected docker/sed argv boundary"
+for hermes_arg in "${hermes_docker_args[@]}"; do
+    [[ "$hermes_arg" != "sh" && "$hermes_arg" != "-c" ]] \
+        || fail "Hermes live patch helper reintroduced a container shell"
+done
+if patch_hermes_yaml_in_container "safe-model" "65536; touch ${hermes_patch_marker}" "" 180 false; then
+    fail "Hermes live patch helper accepted a non-numeric context"
+fi
+[[ "$hermes_docker_calls" -eq 1 && ! -e "$hermes_patch_marker" ]] \
+    || fail "Hermes live patch helper invoked docker for invalid numeric input"
+rm -rf -- "$hermes_patch_tmp"
+unset -f docker patch_hermes_yaml_in_container
+pass "Hermes live patch values stay inside explicit docker exec arguments"
+
 grep -qF 'up -d --force-recreate --no-deps llama-server' <<<"$active_code" \
     || fail "llama-server hot-swap must force-recreate llama-server without deps"
 pass "llama-server hot-swap uses force-recreate/no-deps"

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -41,6 +41,9 @@ assert_in_order() {
 # Strip comments so explanatory text cannot satisfy or fail the checks.
 active_code="$(grep -v '^[[:space:]]*#' "$TARGET")"
 
+yaml_scalar_block="$(function_block yaml_double_quoted_scalar_content | grep -v '^[[:space:]]*#')"
+sed_escape_block="$(function_block sed_replacement_escape | grep -v '^[[:space:]]*#')"
+hermes_host_patch_block="$(function_block patch_hermes_yaml_with_sed | grep -v '^[[:space:]]*#')"
 hermes_container_patch_block="$(function_block patch_hermes_yaml_in_container | grep -v '^[[:space:]]*#')"
 grep -qF '$DOCKER_CMD exec ods-hermes sed -i' <<<"$hermes_container_patch_block" \
     || fail "Hermes live config patching must pass sed arguments directly to docker exec"
@@ -48,18 +51,40 @@ if grep -qF 'exec ods-hermes sh -c' <<<"$active_code"; then
     fail "Hermes live config patching must not reparse generated commands through sh -c"
 fi
 
+eval "$yaml_scalar_block"
+eval "$sed_escape_block"
+eval "$hermes_host_patch_block"
 eval "$hermes_container_patch_block"
 hermes_patch_tmp="$(mktemp -d "${TMPDIR:-/tmp}/ods-hermes-patch.XXXXXX")"
 hermes_patch_marker="$hermes_patch_tmp/injected"
+hermes_config="$hermes_patch_tmp/config.yaml"
+cat >"$hermes_config" <<'YAML'
+model:
+  default: "old-model"
+  context_length: 8192
+provider:
+  base_url: "http://old.invalid/v1"
+  context_length: 8192
+compression:
+  enabled: false
+  threshold: 0.50
+  target_ratio: 0.25
+  protect_last_n: 20
+request:
+    request_timeout_seconds: 180
+YAML
 hermes_docker_calls=0
 hermes_docker_args=()
 docker() {
     hermes_docker_calls=$((hermes_docker_calls + 1))
     hermes_docker_args=("$@")
+    local arg_count=${#hermes_docker_args[@]}
+    local sed_arg_count=$((arg_count - 4))
+    command sed "${hermes_docker_args[@]:3:$sed_arg_count}" "$hermes_config"
 }
 DOCKER_CMD=docker
-hermes_malicious_model="model&branch|tag\\path' ; touch ${hermes_patch_marker} ; #"
-hermes_malicious_url="http://example.invalid/v1' ; touch ${hermes_patch_marker}.url ; #"
+hermes_malicious_model="model&branch|tag\\path\"quoted' ; touch ${hermes_patch_marker} ; #"
+hermes_malicious_url="http://example.invalid/v1\\path\"quoted' ; touch ${hermes_patch_marker}.url ; #"
 patch_hermes_yaml_in_container \
     "$hermes_malicious_model" 65536 "$hermes_malicious_url" 900 true \
     || fail "Hermes live patch helper rejected metacharacters that should remain data"
@@ -80,8 +105,25 @@ if patch_hermes_yaml_in_container "safe-model" "65536; touch ${hermes_patch_mark
 fi
 [[ "$hermes_docker_calls" -eq 1 && ! -e "$hermes_patch_marker" ]] \
     || fail "Hermes live patch helper invoked docker for invalid numeric input"
+hermes_expected_model="$(yaml_double_quoted_scalar_content "$hermes_malicious_model")"
+hermes_expected_url="$(yaml_double_quoted_scalar_content "$hermes_malicious_url")"
+grep -Fq "  default: \"${hermes_expected_model}\"" "$hermes_config" \
+    || fail "Hermes live patch helper did not persist a valid double-quoted model scalar"
+grep -Fq "  base_url: \"${hermes_expected_url}\"" "$hermes_config" \
+    || fail "Hermes live patch helper did not persist a valid double-quoted base URL scalar"
+
+hermes_host_config="$hermes_patch_tmp/host-config.yaml"
+cp "$hermes_config" "$hermes_host_config"
+patch_hermes_yaml_with_sed \
+    "$hermes_host_config" "$hermes_malicious_model" 131072 "$hermes_malicious_url" 900 \
+    || fail "Hermes host patch helper rejected safe scalar metacharacters"
+grep -Fq "  default: \"${hermes_expected_model}\"" "$hermes_host_config" \
+    || fail "Hermes host patch helper did not persist a valid double-quoted model scalar"
+grep -Fq "  base_url: \"${hermes_expected_url}\"" "$hermes_host_config" \
+    || fail "Hermes host patch helper did not persist a valid double-quoted base URL scalar"
 rm -rf -- "$hermes_patch_tmp"
-unset -f docker patch_hermes_yaml_in_container
+unset -f docker patch_hermes_yaml_in_container patch_hermes_yaml_with_sed \
+    yaml_double_quoted_scalar_content sed_replacement_escape
 pass "Hermes live patch values stay inside explicit docker exec arguments"
 
 grep -qF 'up -d --force-recreate --no-deps llama-server' <<<"$active_code" \


### PR DESCRIPTION
Fixes #2238

## Summary

Hermes live config updates now pass `sed` and each expression directly to `docker exec` instead of assembling a command string for `sh -c`.

The affected inputs come from local model and routing configuration. This removes the command reinterpretation boundary without claiming an unauthenticated remote exploit.

## Changes

- Add one container patch helper shared by both full-model swap paths.
- Pass model, context, base URL, timeout, and compression updates as discrete sed arguments.
- Reject nonnumeric context and timeout values and multiline model or URL input before invoking Docker.
- Preserve the existing strict and best-effort failure behavior at the two call sites.
- Add executable regression coverage with quotes, semicolons, ampersands, pipes, and backslashes in configuration values.

## Validation

- `bash -n ods/scripts/bootstrap-upgrade.sh ods/tests/test-bootstrap-upgrade-hotswap-contract.sh` - passed.
- `bash ods/tests/test-bootstrap-upgrade-hotswap-contract.sh` - passed.
- `(cd ods && bash tests/test-installer-context-parity.sh)` - 73 passed.
- `(cd ods && make lint)` - passed.
- `(cd ods && make smoke)` - passed.
- `git diff --check origin/main...HEAD` - passed.
