### PR TITLE
fix(installer): escape Hermes fallback substitutions

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -204,7 +204,7 @@ _phase11_model_file_valid() {
 
 _phase11_patch_hermes_with_sed() {
     local template_path="$1" model="$2" context_length="$3" request_timeout_seconds="$4"
-    local model_sed backup_path
+    local model_yaml model_sed backup_path
 
     [[ -f "$template_path" ]] || return 1
     [[ "$context_length" =~ ^[0-9]+$ ]] || return 1
@@ -213,7 +213,10 @@ _phase11_patch_hermes_with_sed() {
         *$'\n'*|*$'\r'*) return 1 ;;
     esac
 
-    model_sed="$(printf '%s' "$model" | sed 's/[\\&|]/\\&/g')" || return 1
+    # The replacement is parsed twice: first by sed, then as a YAML
+    # double-quoted scalar. Serialize for YAML before escaping sed metacharacters.
+    model_yaml="$(printf '%s' "$model" | sed 's/\\/\\\\/g; s/"/\\"/g')" || return 1
+    model_sed="$(printf '%s' "$model_yaml" | sed 's/[\\&|]/\\&/g')" || return 1
     backup_path="${template_path}.bak.$$"
 
     if sed -i".bak.$$" \
@@ -228,7 +231,7 @@ _phase11_patch_hermes_with_sed() {
         return 1
     fi
 
-    grep -Fqx "  default: \"${model}\"" "$template_path" \
+    grep -Fqx "  default: \"${model_yaml}\"" "$template_path" \
         && grep -Fqx "  context_length: ${context_length}" "$template_path"
 }
 

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -202,6 +202,14 @@ _phase11_model_file_valid() {
     return 0
 }
 
+_phase11_yaml_double_quoted_scalar_content() {
+    local value="$1"
+    case "$value" in
+        *$'\n'*|*$'\r'*) return 1 ;;
+    esac
+    printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
 _phase11_patch_hermes_with_sed() {
     local template_path="$1" model="$2" context_length="$3" request_timeout_seconds="$4"
     local model_yaml model_sed backup_path
@@ -209,13 +217,10 @@ _phase11_patch_hermes_with_sed() {
     [[ -f "$template_path" ]] || return 1
     [[ "$context_length" =~ ^[0-9]+$ ]] || return 1
     [[ "$request_timeout_seconds" =~ ^[0-9]+$ ]] || return 1
-    case "$model" in
-        *$'\n'*|*$'\r'*) return 1 ;;
-    esac
 
     # The replacement is parsed twice: first by sed, then as a YAML
     # double-quoted scalar. Serialize for YAML before escaping sed metacharacters.
-    model_yaml="$(printf '%s' "$model" | sed 's/\\/\\\\/g; s/"/\\"/g')" || return 1
+    model_yaml="$(_phase11_yaml_double_quoted_scalar_content "$model")" || return 1
     model_sed="$(printf '%s' "$model_yaml" | sed 's/[\\&|]/\\&/g')" || return 1
     backup_path="${template_path}.bak.$$"
 
@@ -1074,7 +1079,12 @@ MODELS_INI_EOF
                     "$_hermes_tpl" "$_hermes_model" "$_hermes_context" "$_hermes_request_timeout" \
                     2>>"$LOG_FILE" || warn "Hermes fallback config patcher failed for $_hermes_tpl"
             fi
-            if grep -Fqx "  default: \"$_hermes_model\"" "$_hermes_tpl" && \
+            _hermes_model_yaml_valid=false
+            if _hermes_model_yaml="$(_phase11_yaml_double_quoted_scalar_content "$_hermes_model")"; then
+                _hermes_model_yaml_valid=true
+            fi
+            if $_hermes_model_yaml_valid && \
+               grep -Fqx "  default: \"$_hermes_model_yaml\"" "$_hermes_tpl" && \
                grep -Fqx "  context_length: ${_hermes_context}" "$_hermes_tpl"; then
                 ai_ok "Patched Hermes template: model.default=$_hermes_model, context=$_hermes_context"
             else

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -202,6 +202,36 @@ _phase11_model_file_valid() {
     return 0
 }
 
+_phase11_patch_hermes_with_sed() {
+    local template_path="$1" model="$2" context_length="$3" request_timeout_seconds="$4"
+    local model_sed backup_path
+
+    [[ -f "$template_path" ]] || return 1
+    [[ "$context_length" =~ ^[0-9]+$ ]] || return 1
+    [[ "$request_timeout_seconds" =~ ^[0-9]+$ ]] || return 1
+    case "$model" in
+        *$'\n'*|*$'\r'*) return 1 ;;
+    esac
+
+    model_sed="$(printf '%s' "$model" | sed 's/[\\&|]/\\&/g')" || return 1
+    backup_path="${template_path}.bak.$$"
+
+    if sed -i".bak.$$" \
+        -e "s|^  default: \"qwen3.5-9b\"|  default: \"${model_sed}\"|" \
+        -e "s|^  context_length: .*|  context_length: ${context_length}|" \
+        -e "s|^    context_length: .*|    context_length: ${context_length}|" \
+        -e "s|^    request_timeout_seconds: 180[[:space:]]*$|    request_timeout_seconds: ${request_timeout_seconds}|" \
+        "$template_path"; then
+        rm -f "$backup_path"
+    else
+        [[ -f "$backup_path" ]] && mv -f "$backup_path" "$template_path"
+        return 1
+    fi
+
+    grep -Fqx "  default: \"${model}\"" "$template_path" \
+        && grep -Fqx "  context_length: ${context_length}" "$template_path"
+}
+
 ods_progress 75 "services" "Starting services"
 show_phase 5 6 "Starting Services" "~2-3 minutes"
 
@@ -1037,15 +1067,12 @@ MODELS_INI_EOF
                 "$_python_cmd" "$_hermes_patcher" "${_hermes_patcher_args[@]}" >>"$LOG_FILE" 2>&1 || \
                     warn "Hermes config patcher failed for $_hermes_tpl"
             else
-                sed -i.bak \
-                    -e "s|^  default: \"qwen3.5-9b\"|  default: \"$_hermes_model\"|" \
-                    -e "s|^  context_length: .*|  context_length: ${_hermes_context}|" \
-                    -e "s|^    context_length: .*|    context_length: ${_hermes_context}|" \
-                    -e "s|^    request_timeout_seconds: 180[[:space:]]*$|    request_timeout_seconds: ${_hermes_request_timeout}|" \
-                    "$_hermes_tpl" 2>>"$LOG_FILE" && rm -f "${_hermes_tpl}.bak"
+                _phase11_patch_hermes_with_sed \
+                    "$_hermes_tpl" "$_hermes_model" "$_hermes_context" "$_hermes_request_timeout" \
+                    2>>"$LOG_FILE" || warn "Hermes fallback config patcher failed for $_hermes_tpl"
             fi
-            if grep -q "^  default: \"$_hermes_model\"$" "$_hermes_tpl" && \
-               grep -q "^  context_length: ${_hermes_context}$" "$_hermes_tpl"; then
+            if grep -Fqx "  default: \"$_hermes_model\"" "$_hermes_tpl" && \
+               grep -Fqx "  context_length: ${_hermes_context}" "$_hermes_tpl"; then
                 ai_ok "Patched Hermes template: model.default=$_hermes_model, context=$_hermes_context"
             else
                 warn "Hermes template substitution didn't take effect — Hermes may 404 every chat completion. Hand-edit $_hermes_tpl after install if Hermes prompts hang."

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -148,9 +148,9 @@ auxiliary:
 HERMES_FALLBACK_EOF
 
     eval "$fallback_patch_block"
-    fallback_model='model&branch|tag\path'
+    fallback_model='model"branch&tag|path\leaf'
     _phase11_patch_hermes_with_sed "$fallback_template" "$fallback_model" 65536 900
-    grep -Fqx '  default: "model&branch|tag\path"' "$fallback_template"
+    grep -Fqx '  default: "model\"branch&tag|path\\leaf"' "$fallback_template"
     grep -Fqx '  context_length: 65536' "$fallback_template"
     grep -Fqx '    context_length: 65536' "$fallback_template"
     grep -Fqx '    request_timeout_seconds: 900' "$fallback_template"

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -49,6 +49,15 @@ assert_not_grep() {
     fi
 }
 
+function_block() {
+    local function_name="$1"
+    awk -v signature="^${function_name}[(][)]" '
+        $0 ~ signature { in_block=1 }
+        in_block { print }
+        in_block && /^}/ { exit }
+    ' "installers/phases/11-services.sh"
+}
+
 echo "=== Installer context parity ==="
 
 echo ""
@@ -119,6 +128,48 @@ assert_grep "installers/phases/11-services.sh" '_hermes_model="ods/current"' \
     "Linux Hermes patcher uses the stable switchboard model alias"
 assert_grep "installers/phases/11-services.sh" '_hermes_base_url=.*http://litellm:4000/v1' \
     "Linux Hermes patcher routes switchboard mode through LiteLLM"
+
+fallback_patch_block="$(function_block _phase11_patch_hermes_with_sed)"
+[[ -n "$fallback_patch_block" ]] || fail "could not extract the Linux Hermes fallback patcher"
+(
+    fallback_tmp="$(mktemp -d "${TMPDIR:-/tmp}/ods-hermes-fallback.XXXXXX")"
+    trap 'rm -rf -- "$fallback_tmp"' EXIT
+    fallback_template="$fallback_tmp/config.yaml"
+    cat >"$fallback_template" <<'HERMES_FALLBACK_EOF'
+model:
+  default: "qwen3.5-9b"
+  context_length: 131072
+providers:
+  custom:
+    request_timeout_seconds: 180
+auxiliary:
+  compression:
+    context_length: 131072
+HERMES_FALLBACK_EOF
+
+    eval "$fallback_patch_block"
+    fallback_model='model&branch|tag\path'
+    _phase11_patch_hermes_with_sed "$fallback_template" "$fallback_model" 65536 900
+    grep -Fqx '  default: "model&branch|tag\path"' "$fallback_template"
+    grep -Fqx '  context_length: 65536' "$fallback_template"
+    grep -Fqx '    context_length: 65536' "$fallback_template"
+    grep -Fqx '    request_timeout_seconds: 900' "$fallback_template"
+    if compgen -G "${fallback_template}.bak.*" >/dev/null; then
+        exit 1
+    fi
+
+    cp "$fallback_template" "$fallback_tmp/before-invalid"
+    if _phase11_patch_hermes_with_sed "$fallback_template" "safe-model" '65536|e touch /tmp/invalid' 900; then
+        exit 1
+    fi
+    cmp -s "$fallback_template" "$fallback_tmp/before-invalid"
+    if _phase11_patch_hermes_with_sed "$fallback_template" $'line1\nline2' 65536 900; then
+        exit 1
+    fi
+    cmp -s "$fallback_template" "$fallback_tmp/before-invalid"
+) || fail "Linux Hermes fallback patcher did not preserve metacharacters or reject unsafe structure"
+pass "Linux Hermes fallback patcher treats sed metacharacters as data"
+
 assert_grep "installers/macos/install-macos.sh" '--context-length "\$MAX_CONTEXT"' \
     "macOS Hermes patcher receives context length"
 assert_grep "installers/macos/ods-macos.sh" 'ENV_CTX_SIZE:-65536' \

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -128,8 +128,14 @@ assert_grep "installers/phases/11-services.sh" '_hermes_model="ods/current"' \
     "Linux Hermes patcher uses the stable switchboard model alias"
 assert_grep "installers/phases/11-services.sh" '_hermes_base_url=.*http://litellm:4000/v1' \
     "Linux Hermes patcher routes switchboard mode through LiteLLM"
+assert_grep "installers/phases/11-services.sh" '_hermes_model_yaml=.*_phase11_yaml_double_quoted_scalar_content' \
+    "Linux Hermes verification serializes the selected model as YAML"
+assert_grep "installers/phases/11-services.sh" 'grep -Fqx "  default: \\"\$_hermes_model_yaml\\""' \
+    "Linux Hermes verification compares the serialized model"
 
+fallback_yaml_block="$(function_block _phase11_yaml_double_quoted_scalar_content)"
 fallback_patch_block="$(function_block _phase11_patch_hermes_with_sed)"
+[[ -n "$fallback_yaml_block" ]] || fail "could not extract the Linux YAML scalar serializer"
 [[ -n "$fallback_patch_block" ]] || fail "could not extract the Linux Hermes fallback patcher"
 (
     fallback_tmp="$(mktemp -d "${TMPDIR:-/tmp}/ods-hermes-fallback.XXXXXX")"
@@ -147,10 +153,12 @@ auxiliary:
     context_length: 131072
 HERMES_FALLBACK_EOF
 
+    eval "$fallback_yaml_block"
     eval "$fallback_patch_block"
     fallback_model='model"branch&tag|path\leaf'
     _phase11_patch_hermes_with_sed "$fallback_template" "$fallback_model" 65536 900
-    grep -Fqx '  default: "model\"branch&tag|path\\leaf"' "$fallback_template"
+    fallback_model_yaml="$(_phase11_yaml_double_quoted_scalar_content "$fallback_model")"
+    grep -Fqx "  default: \"${fallback_model_yaml}\"" "$fallback_template"
     grep -Fqx '  context_length: 65536' "$fallback_template"
     grep -Fqx '    context_length: 65536' "$fallback_template"
     grep -Fqx '    request_timeout_seconds: 900' "$fallback_template"


### PR DESCRIPTION
Fixes #2243

## Summary

Harden the non-Python Hermes template fallback so model names containing sed replacement characters remain data instead of breaking or altering the generated config.

Supported installs normally use the structured Python patcher. When that helper is unavailable, the degraded fallback now either produces the intended values or leaves the original template intact.

## Changes

- Escape backslashes, ampersands, and the sed delimiter in model substitutions.
- Reject nonnumeric context and timeout values and multiline model input before editing.
- Use a per-process backup and restore it if sed fails.
- Verify the resulting model and context with fixed-string, whole-line matching.
- Add executable regression coverage for metacharacter preservation, invalid structure rejection, and backup cleanup.

## Validation

- `bash -n ods/installers/phases/11-services.sh ods/tests/test-installer-context-parity.sh` - passed.
- `(cd ods && bash tests/test-installer-context-parity.sh)` - 74 passed.
- `(cd ods && make lint)` - passed.
- `(cd ods && make smoke)` - passed.
- `git diff --check origin/main...HEAD` - passed.
