### PR TITLE
fix(compose): resolve stack from script root

### DIFF
--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TIER="1"
 GPU_BACKEND="nvidia"
 PROFILE_OVERLAYS=""

--- a/ods/tests/test-resolve-compose-resilient.sh
+++ b/ods/tests/test-resolve-compose-resilient.sh
@@ -55,6 +55,26 @@ fi
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
+# The resolver must remain anchored to the ODS root when invoked directly from
+# an arbitrary working directory. Installers may still override it explicitly.
+mkdir -p "$TEMP_DIR/unrelated-cwd"
+default_root_output=$(
+    cd "$TEMP_DIR/unrelated-cwd"
+    ODS_MODE=local \
+        EXTERNAL_LLM_URL="" \
+        LEMONADE_EXTERNAL=false \
+        AMD_INFERENCE_RUNTIME="" \
+        AMD_INFERENCE_MANAGED="" \
+        bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+            --tier 1 --gpu-backend cpu 2>/dev/null
+)
+if contains_path "$default_root_output" "docker-compose.base.yml" \
+    && contains_path "$default_root_output" "docker-compose.cpu.yml"; then
+    pass "Direct invocation resolves compose files from the ODS root"
+else
+    fail "Direct invocation used the caller working directory instead of the ODS root"
+fi
+
 # Create minimal directory structure
 mkdir -p "$TEMP_DIR/extensions/services/broken-ext"
 mkdir -p "$TEMP_DIR/extensions/services/good-ext"


### PR DESCRIPTION
## Summary

`resolve-compose-stack.sh` used the caller's current working directory as the ODS root. Direct or absolute-path invocation from another directory therefore emitted a fallback such as `-f docker-compose.yml` for files that did not exist there.

This change derives the default root from the resolver's own location while preserving the existing explicit `--script-dir` override used by installers and tests. The official resilient-resolver suite now invokes the script from an unrelated working directory and verifies that the base and CPU overlays are resolved from the ODS installation.

Fixes #2278.

## AI Assistance

AI-assisted issue triage, reproduction, edge-case review, and regression-test drafting were used. The author reviewed the final diff and validation scope.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Behavior And Invariants

| Invariant | Evidence |
|---|---|
| Direct invocation is independent of the caller's working directory | New unrelated-CWD regression |
| The default root is the ODS directory, not `ods/scripts` | Test requires root-level base and CPU overlays |
| `--script-dir` remains authoritative | Existing suite exercises explicit fixture roots throughout |
| Overlay selection and manifest hardening remain unchanged | Full focused resolver suite passes |

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
bash tests/test-resolve-compose-resilient.sh
36 passed, 0 failed; real Docker Compose render skipped because Compose is unavailable in the WSL test shell

bash -n scripts/resolve-compose-stack.sh tests/test-resolve-compose-resilient.sh
passed

git diff --check
passed
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Independent Review

Reviewed without assuming the patch was correct. The reproduction was run from an unrelated directory before the change and returned only `-f docker-compose.yml`. The new regression proves the corrected root, while the existing fixture calls prove explicit overrides still work. Paths with spaces remain quoted. No remaining reproducible defect was found within this scope.

## Notes For Reviewers

This deliberately excludes unrelated parser, schema, workflow, and test-portability changes proposed in broader PRs. Symlink canonicalization is not changed; normal direct, relative, and absolute invocation are covered by the existing Bash script-location convention used by ODS.