### PR TITLE
test(macos): use BSD-compatible mktemp templates

### DIFF
--- a/ods/tests/test-bootstrap-upgrade-close-inherited-fds.sh
+++ b/ods/tests/test-bootstrap-upgrade-close-inherited-fds.sh
@@ -43,9 +43,9 @@ assert_fd_close_spawn() {
 assert_runtime_lock_release() {
     local fd="$1"
     local lock_file pid_file log_file
-    lock_file="$(mktemp "${TMPDIR:-/tmp}/ods-fd-${fd}.XXXXXX.lock")"
-    pid_file="$(mktemp "${TMPDIR:-/tmp}/ods-fd-${fd}.XXXXXX.pid")"
-    log_file="$(mktemp "${TMPDIR:-/tmp}/ods-fd-${fd}.XXXXXX.log")"
+    lock_file="$(mktemp "${TMPDIR:-/tmp}/ods-fd-${fd}.lock.XXXXXX")"
+    pid_file="$(mktemp "${TMPDIR:-/tmp}/ods-fd-${fd}.pid.XXXXXX")"
+    log_file="$(mktemp "${TMPDIR:-/tmp}/ods-fd-${fd}.log.XXXXXX")"
 
     _test_close_inherited_fds_for_daemon() {
         local fd_path fd_dir fd_name


### PR DESCRIPTION
## Summary

The inherited-file-descriptor regression test created temporary paths with characters after `XXXXXX`. GNU `mktemp` accepts that form, but BSD/macOS `mktemp` requires the replacement template at the end and aborted before the macOS assertions ran.

Move the semantic labels before `XXXXXX` for the lock, PID, and log paths. The returned paths remain opaque to the test, so runtime behavior and cleanup are unchanged.

Fixes #2282.

## AI Assistance

AI-assisted triage, portability analysis, test design, and independent review were used. The author reviewed the final one-file diff and validation evidence.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
passed: both static spawn checks and FD 9/200 runtime lock-release checks

same test with a BSD-contract mktemp wrapper that rejects suffixes after XXXXXX
passed

bash -n tests/test-bootstrap-upgrade-close-inherited-fds.sh
passed

git diff --check
passed
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Independent Review

Reviewed from the current main branch without assuming the proposed form was correct. The three paths are used only as opaque lock, PID, and log files and are removed using the exact values returned by `mktemp`; no code depends on a final filename extension. GNU execution and strict BSD-template simulation both pass. No remaining reproducible defect was found within this scope.

## Notes For Reviewers

This intentionally changes only the failing cross-platform test. It does not rewrite unrelated temporary-file templates in Linux-only or other independently tested scripts.