### PR TITLE
test(desktop): report host-agent contract failures

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -212,6 +212,7 @@ jobs:
           bash tests/test-phase03-multigpu-tty.sh
           bash tests/contracts/test-preflight-fixtures.sh
           bash tests/test-preflight-resolver-bug.sh
+          bash tests/test-desktop-agent-host-env.sh
           python3 tests/contracts/test-network-exposure-contracts.py
           python3 tests/contracts/test-remote-provider-egress-policy.py
           python3 tests/contracts/test-remote-provider-egress-service.py

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -122,6 +122,9 @@ test: ## Run unit and contract tests
 	@echo "=== macOS ods-host-agent bootstrap verification ==="
 	@bash tests/test-macos-host-agent-verification.sh
 	@echo ""
+	@echo "=== desktop host-agent environment contract ==="
+	@bash tests/test-desktop-agent-host-env.sh
+	@echo ""
 	@echo "=== macOS model download retry contract ==="
 	@bash tests/test-macos-download-retries.sh
 	@echo ""

--- a/ods/tests/test-desktop-agent-host-env.sh
+++ b/ods/tests/test-desktop-agent-host-env.sh
@@ -3,17 +3,47 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-grep -F 'ODS_AGENT_HOST=$(Get-EnvOrNew "ODS_AGENT_HOST" "host.docker.internal")' \
-    "$ROOT_DIR/installers/windows/lib/env-generator.ps1" >/dev/null
-grep -F 'local agent_host="host.docker.internal"' \
-    "$ROOT_DIR/installers/macos/lib/env-generator.sh" >/dev/null
-grep -F 'agent_host="$macos_host_gateway"' \
-    "$ROOT_DIR/installers/macos/lib/env-generator.sh" >/dev/null
-grep -F 'ODS_AGENT_HOST=${ODS_AGENT_HOST:-${agent_host}}' \
-    "$ROOT_DIR/installers/macos/lib/env-generator.sh" >/dev/null
-grep -F 'ODS_AGENT_HOST=${ODS_AGENT_HOST:-}' \
-    "$ROOT_DIR/docker-compose.base.yml" >/dev/null
-grep -F '"ODS_AGENT_HOST"' "$ROOT_DIR/.env.schema.json" >/dev/null
-grep -F '# ODS_AGENT_HOST=host.docker.internal' "$ROOT_DIR/.env.example" >/dev/null
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+require_literal() {
+    local path="$1"
+    local pattern="$2"
+    local contract="$3"
+
+    grep -Fq -- "$pattern" "$path" \
+        || fail "$contract (${path#"$ROOT_DIR/"})"
+}
+
+require_literal \
+    "$ROOT_DIR/installers/windows/lib/env-generator.ps1" \
+    'ODS_AGENT_HOST=$(Get-EnvOrNew "ODS_AGENT_HOST" "host.docker.internal")' \
+    "Windows env generator is missing the host-agent default"
+require_literal \
+    "$ROOT_DIR/installers/macos/lib/env-generator.sh" \
+    'local agent_host="host.docker.internal"' \
+    "macOS env generator is missing the Docker Desktop fallback"
+require_literal \
+    "$ROOT_DIR/installers/macos/lib/env-generator.sh" \
+    'agent_host="$macos_host_gateway"' \
+    "macOS env generator is missing the direct-bind gateway override"
+require_literal \
+    "$ROOT_DIR/installers/macos/lib/env-generator.sh" \
+    'ODS_AGENT_HOST=${ODS_AGENT_HOST:-${agent_host}}' \
+    "macOS env generator is missing the ODS_AGENT_HOST export"
+require_literal \
+    "$ROOT_DIR/docker-compose.base.yml" \
+    'ODS_AGENT_HOST=${ODS_AGENT_HOST:-}' \
+    "Dashboard API Compose wiring is missing ODS_AGENT_HOST"
+require_literal \
+    "$ROOT_DIR/.env.schema.json" \
+    '"ODS_AGENT_HOST"' \
+    "Environment schema is missing ODS_AGENT_HOST"
+require_literal \
+    "$ROOT_DIR/.env.example" \
+    '# ODS_AGENT_HOST=host.docker.internal' \
+    "Example environment is missing the desktop host-agent override"
 
 echo "[PASS] desktop installers route dashboard-api to the platform-safe host-agent endpoint"


### PR DESCRIPTION
## Summary

`test-desktop-agent-host-env.sh` exited on the first missing literal under `set -e` without identifying the failed platform contract. It was also not registered in `make test` or the Linux CI test lane, so improving its output alone would not provide regression protection.

This change:

- reports the missing Windows, macOS, Compose, schema, or example contract and its source file;
- registers the test in the developer test target;
- runs it in the official Linux installer-contract lane, where the cross-platform files can be validated statically.

Fixes #2284.

## AI Assistance

AI-assisted issue triage, test-registration audit, negative-path reproduction, and independent review were used. The author reviewed the final diff and validation scope.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Invariants

| Contract | Result |
|---|---|
| Windows keeps the Docker Desktop host-agent default | Checked with a named failure |
| macOS keeps fallback, direct-bind override, and exported value | Checked independently with named failures |
| Dashboard API receives `ODS_AGENT_HOST` through Compose | Checked with a named failure |
| Schema and example retain the operator-facing key | Checked with named failures |
| The test runs in local and CI suites | Registered in `Makefile` and `test-linux.yml` |

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
bash tests/test-desktop-agent-host-env.sh
[PASS] desktop installers route dashboard-api to the platform-safe host-agent endpoint

negative-path run with grep forced to miss the first contract
[FAIL] Windows env generator is missing the host-agent default (installers/windows/lib/env-generator.ps1)

bash -n tests/test-desktop-agent-host-env.sh
passed

make -n test | grep -F test-desktop-agent-host-env.sh
registration found

python -c 'import yaml; ... safe_load(test-linux.yml)'
passed

git diff --check
passed
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Independent Review

Reviewed without assuming the diagnostics-only patch was sufficient. The test was proven to be orphaned, so the fix includes both local and CI registration. A forced miss verifies that failure is nonzero and names the first broken contract. Success, shell syntax, Makefile scheduling, and workflow parsing all pass. No remaining reproducible defect was found within this scope.

## Notes For Reviewers

The product configuration is unchanged. This PR only makes an existing cross-platform contract observable and enforceable.