### PR TITLE
fix(config): preserve unmatched env quotes

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -10,6 +10,8 @@ from urllib.parse import urlparse
 
 import yaml
 
+from env_values import strip_matching_quotes
+
 logger = logging.getLogger(__name__)
 
 # --- Paths ---
@@ -98,7 +100,7 @@ def _find_env_file_value(key: str) -> tuple[bool, str]:
         for line in env_path.read_text(encoding="utf-8").splitlines():
             if line.startswith(f"{key}="):
                 found = True
-                value = line.split("=", 1)[1].strip().strip("\"'")
+                value = strip_matching_quotes(line.split("=", 1)[1])
     except (OSError, UnicodeError):
         pass
     return found, value

--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -1,0 +1,14 @@
+"""Small, dependency-free helpers for values read from ODS ``.env`` files."""
+
+
+def strip_matching_quotes(value: str) -> str:
+    """Trim whitespace and remove exactly one matching outer quote pair.
+
+    ODS writes shell-compatible values that may be wrapped in single or
+    double quotes. Unmatched or mixed quotes are data, not delimiters, and
+    must survive reads unchanged.
+    """
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value

--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -9,6 +9,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+from env_values import strip_matching_quotes
 from models import GPUInfo, IndividualGPU
 from host_agent_client import AgentClientError, request_json as request_agent_json
 
@@ -547,7 +548,7 @@ def _read_env_var_from_file_state(key: str) -> tuple[bool, str]:
     try:
         for line in env_path.read_text().splitlines():
             if line.startswith(f"{key}="):
-                return True, line[len(key) + 1:].strip().strip("\"'")
+                return True, strip_matching_quotes(line[len(key) + 1:])
     except OSError:
         pass
     return False, ""

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -18,6 +18,7 @@ import aiohttp
 import httpx
 
 from config import SERVICES, INSTALL_DIR, DATA_DIR, LLM_BACKEND, read_live_env_value
+from env_values import strip_matching_quotes
 from host_agent_client import AgentClientError, async_request_json as request_agent_json
 from models import ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus
 
@@ -826,14 +827,7 @@ def get_model_info() -> Optional[ModelInfo]:
                     key = key.strip()
                     if not key:
                         continue
-                    value = value.strip()
-                    # Strip exactly one matching pair of surrounding quotes.
-                    # str.strip("\"'") removes any run of either quote from
-                    # both ends, so a value legitimately ending in a quote is
-                    # truncated and "'literal'" loses its inner quotes. Keep
-                    # mismatched quotes verbatim, matching lib/safe-env.sh.
-                    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-                        value = value[1:-1]
+                    value = strip_matching_quotes(value)
                     env_values[key] = value
 
             model_name = env_values.get("LLM_MODEL")

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -32,6 +32,7 @@ from fastapi import FastAPI, Depends, HTTPException, Body
 from fastapi.middleware.cors import CORSMiddleware
 
 # --- Local modules ---
+from env_values import strip_matching_quotes
 from config import (
     SERVICES, DATA_DIR, INSTALL_DIR, SIDEBAR_ICONS, MANIFEST_ERRORS, ALWAYS_ON_SERVICES,
     AGENT_HOST, AGENT_PORT, AGENT_URL, ODS_AGENT_KEY,
@@ -149,7 +150,7 @@ def _read_installed_version() -> str:
         try:
             for line in env_file.read_text().splitlines():
                 if line.startswith("ODS_VERSION="):
-                    env_version = line.split("=", 1)[1].strip().strip("\"'")
+                    env_version = strip_matching_quotes(line.split("=", 1)[1])
                     if env_version:
                         return env_version
         except OSError:

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -18,6 +18,7 @@ import re
 from pathlib import Path
 from typing import Any, Optional
 
+from env_values import strip_matching_quotes
 from gguf_inspector import inspect_gguf
 from context_policy import HERMES_MIN_CONTEXT, HERMES_TARGET_CONTEXT
 from helpers import (
@@ -133,7 +134,7 @@ def _system_ram_gb() -> int:
 def read_env_value(key: str, install_dir: str | Path) -> str:
     value = os.environ.get(key, "")
     if value:
-        return value.strip().strip("\"'")
+        return strip_matching_quotes(value)
     return read_env_file_value(key, install_dir)
 
 
@@ -142,7 +143,7 @@ def read_env_file_value(key: str, install_dir: str | Path) -> str:
     try:
         for line in env_path.read_text(encoding="utf-8").splitlines():
             if line.startswith(f"{key}="):
-                return line.split("=", 1)[1].strip().strip("\"'")
+                return strip_matching_quotes(line.split("=", 1)[1])
     except OSError:
         pass
     return ""
@@ -154,7 +155,7 @@ def read_persisted_env_value(key: str, install_dir: str | Path) -> str:
     file_value = read_env_file_value(key, install_dir)
     if file_value or env_path.exists():
         return file_value
-    return os.environ.get(key, "").strip().strip("\"'")
+    return strip_matching_quotes(os.environ.get(key, ""))
 
 
 def read_context_length(install_dir: str | Path, default: int = 32768) -> int:

--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -19,6 +19,7 @@ import httpx
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
 
+from env_values import strip_matching_quotes
 from config import (
     DATA_DIR,
     INSTALL_DIR,
@@ -332,7 +333,7 @@ def _read_active_model() -> Optional[str]:
     try:
         for line in _ENV_PATH.read_text(encoding="utf-8").splitlines():
             if line.startswith("GGUF_FILE="):
-                return line.split("=", 1)[1].strip().strip('"').strip("'")
+                return strip_matching_quotes(line.split("=", 1)[1])
     except OSError:
         pass
     return None

--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -13,6 +13,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException
 
 from config import INSTALL_DIR
+from env_values import strip_matching_quotes
 from host_agent_client import (
     AgentHTTPError,
     AgentUnavailable,
@@ -48,7 +49,7 @@ def _read_current_version() -> str:
         try:
             for line in _read_utf8(env_file).splitlines():
                 if line.startswith("ODS_VERSION="):
-                    return line.split("=", 1)[1].strip().strip("\"'")
+                    return strip_matching_quotes(line.split("=", 1)[1])
         except OSError:
             pass
     version_file = Path(INSTALL_DIR) / ".version"
@@ -274,13 +275,7 @@ async def get_update_dry_run():
     if env_file.exists():
         for line in _read_utf8(env_file).splitlines():
             if line.startswith("ODS_VERSION="):
-                current = line.split("=", 1)[1].strip()
-                # Match _read_current_version's quote handling: a quoted
-                # ODS_VERSION would otherwise reach the semver comparison
-                # with its quotes attached, so every digit fails isdigit()
-                # and the update verdict is computed against 0.0.0.
-                if len(current) >= 2 and current[0] == current[-1] and current[0] in "\"'":
-                    current = current[1:-1]
+                current = strip_matching_quotes(line.split("=", 1)[1])
                 break
     if current == "0.0.0" and version_file.exists():
         try:

--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -13,6 +13,7 @@ from urllib.parse import urlsplit
 
 from fastapi import HTTPException
 
+from env_values import strip_matching_quotes
 from host_agent_client import AgentClientError, request_json as request_agent_json
 
 # ── Regex constants ────────────────────────────────────────────────────────────
@@ -96,13 +97,6 @@ _READ_ONLY_ENV_FIELDS = {
 # ── Env parsing ────────────────────────────────────────────────────────────────
 
 
-def _strip_env_quotes(value: str) -> str:
-    value = value.strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
-
-
 def _read_env_map_from_path(path: Path) -> tuple[dict[str, str], list[dict[str, Any]]]:
     try:
         return _parse_env_text(path.read_text(encoding="utf-8"))
@@ -129,7 +123,7 @@ def _parse_env_text(raw_text: str) -> tuple[dict[str, str], list[dict[str, Any]]
             continue
 
         key, value = match.groups()
-        values[key] = _strip_env_quotes(value)
+        values[key] = strip_matching_quotes(value)
 
     return values, issues
 

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -68,6 +68,20 @@ def test_live_env_value_preserves_explicit_empty_value(monkeypatch, tmp_path):
     assert config.read_live_env_value("LEMONADE_MODEL", "fallback") == ""
 
 
+def test_live_env_value_strips_one_pair_and_preserves_unmatched_quotes(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text(
+        "PAIRED='model-v2'\n"
+        "UNMATCHED=model-v2'\n"
+        "REPEATED=''model-v2''\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "INSTALL_DIR", str(tmp_path))
+
+    assert config.read_live_env_value("PAIRED") == "model-v2"
+    assert config.read_live_env_value("UNMATCHED") == "model-v2'"
+    assert config.read_live_env_value("REPEATED") == "'model-v2'"
+
+
 class TestReadManifestFile:
 
     def test_reads_yaml(self, tmp_path):

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -1,0 +1,26 @@
+import pytest
+
+from env_values import strip_matching_quotes
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("value", "value"),
+        ("  value  ", "value"),
+        ('"value"', "value"),
+        ("'value'", "value"),
+        ('""', ""),
+        ("''", ""),
+        ("it's", "it's"),
+        ('"value', '"value'),
+        ('value"', 'value"'),
+        ("'value", "'value"),
+        ("value'", "value'"),
+        ('"value\'', '"value\''),
+        ("''value''", "'value'"),
+        ('""value""', '"value"'),
+    ],
+)
+def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):
+    assert strip_matching_quotes(raw) == expected

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -12,6 +12,21 @@ from gpu import (
 )
 
 
+def test_gpu_assignment_env_reader_preserves_unmatched_quote(monkeypatch, tmp_path):
+    import gpu
+
+    (tmp_path / ".env").write_text(
+        "GPU_ASSIGNMENT_JSON_B64=payload'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ODS_INSTALL_DIR", str(tmp_path))
+
+    assert gpu._read_env_var_from_file_state("GPU_ASSIGNMENT_JSON_B64") == (
+        True,
+        "payload'",
+    )
+
+
 # --- get_gpu_tier (pure function, no I/O) ---
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -40,6 +40,13 @@ def test_read_installed_version_ignores_empty_env_override(tmp_path, monkeypatch
     assert _read_installed_version() == "3.1.4"
 
 
+def test_read_installed_version_preserves_unmatched_quote(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text("ODS_VERSION=3.1.4'\n", encoding="utf-8")
+    monkeypatch.setattr("main._resolve_install_root", lambda: tmp_path)
+
+    assert _read_installed_version() == "3.1.4'"
+
+
 class TestGetAllowedOrigins:
 
     def test_returns_env_origins_when_set(self, monkeypatch):

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -27,6 +27,16 @@ def _hf_sibling(filename: str, size: int, sha: str) -> dict:
     }
 
 
+def test_active_model_reader_preserves_unmatched_quote(monkeypatch, tmp_path):
+    import routers.models as models_router
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("GGUF_FILE=model-v2.gguf'\n", encoding="utf-8")
+    monkeypatch.setattr(models_router, "_ENV_PATH", env_path)
+
+    assert models_router._read_active_model() == "model-v2.gguf'"
+
+
 def test_huggingface_artifacts_group_complete_shards_and_require_integrity():
     import routers.models as models_router
 

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -13,6 +13,9 @@ from performance_oracle import (
     model_publisher,
     normalize_catalog_entry,
     rank_pre_download_models,
+    read_env_file_value,
+    read_env_value,
+    read_persisted_env_value,
 )
 
 
@@ -41,6 +44,21 @@ def _model():
         "quantization": "Q4_K_M",
         "llm_model_name": "qwen3.5-9b",
     }
+
+
+def test_performance_env_readers_share_matching_quote_contract(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text(
+        "PAIRED='catalog-v2'\n"
+        "UNMATCHED=catalog-v2'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("PAIRED", raising=False)
+    monkeypatch.setenv("PROCESS_ONLY", "'runtime-v2'")
+
+    assert read_env_file_value("PAIRED", tmp_path) == "catalog-v2"
+    assert read_env_file_value("UNMATCHED", tmp_path) == "catalog-v2'"
+    assert read_env_value("PROCESS_ONLY", tmp_path) == "runtime-v2"
+    assert read_persisted_env_value("UNMATCHED", tmp_path) == "catalog-v2'"
 
 
 def _official_model_catalog():

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -5,6 +5,23 @@ import json
 import pytest
 
 
+def test_settings_parser_strips_one_pair_and_preserves_unmatched_quotes():
+    from settings import _parse_env_text
+
+    values, issues = _parse_env_text(
+        "PAIRED='value'\n"
+        "UNMATCHED=value'\n"
+        "REPEATED=''value''\n"
+    )
+
+    assert issues == []
+    assert values == {
+        "PAIRED": "value",
+        "UNMATCHED": "value'",
+        "REPEATED": "'value'",
+    }
+
+
 @pytest.fixture()
 def settings_env_fixture(tmp_path, monkeypatch):
     install_root = tmp_path / "ods"

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -9,6 +9,15 @@ import httpx
 from host_agent_client import AgentHTTPError, AgentUnavailable
 
 
+def test_current_version_reader_preserves_unmatched_quote(monkeypatch, tmp_path):
+    import routers.updates as updates_mod
+
+    (tmp_path / ".env").write_text("ODS_VERSION=2.6.0'\n", encoding="utf-8")
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(tmp_path))
+
+    assert updates_mod._read_current_version() == "2.6.0'"
+
+
 def test_github_release_urls_use_canonical_repository():
     import routers.updates as updates_mod
 
@@ -352,6 +361,26 @@ def test_update_dry_run_parses_quoted_ods_version(test_client, tmp_path, monkeyp
 
     assert resp.status_code == 200
     assert resp.json()["current_version"] == "1.3.0"
+
+
+def test_update_dry_run_preserves_unmatched_version_quote(test_client, tmp_path, monkeypatch):
+    """Dry-run must not silently repair malformed persisted values."""
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "ods"
+    install_dir.mkdir()
+    (install_dir / ".env").write_text("ODS_VERSION=1.3.0'\n", encoding="utf-8")
+
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    with patch(
+        "routers.updates.httpx.AsyncClient.get",
+        side_effect=httpx.ConnectError("mocked network failure"),
+    ):
+        resp = test_client.get("/api/update/dry-run", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["current_version"] == "1.3.0'"
 
 
 def test_update_dry_run_version_from_version_file(test_client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

ODS had several independent Dashboard API readers using `str.strip("\"'")` for persisted `.env` values. That operation removes arbitrary quote characters from both ends, so malformed or intentional unmatched values were silently mutated.

This change defines one dependency-free quote contract and applies it consistently across settings, runtime/model metadata, GPU assignment, performance estimates, and update/version readers:

- trim surrounding whitespace
- remove exactly one complete matching outer pair (`"..."` or `'...'`)
- preserve internal, unmatched, mixed, and additional quote characters
- preserve existing missing/empty-value and source-precedence behavior

> [!NOTE]
> The issue's `it's -> it` example is not reproducible because the apostrophe is not at an edge. The underlying defect is still confirmed: for example, `value'` currently becomes `value`.

Fixes #2279

## Data flow and invariants

| Surface | Producer | Consumer | Preserved invariant |
|---|---|---|---|
| Persisted settings | installer / Settings API writes `.env` | settings parser and live config readers | One matching pair is syntax; unmatched quotes remain data |
| Model state | model activation writes `GGUF_FILE` / `LLM_MODEL` | dashboard model cards and performance oracle | Model identifiers are never silently truncated |
| GPU state | installer / reassignment writes `GPU_ASSIGNMENT_JSON_B64` | GPU topology decoder | Payload bytes remain unchanged except one valid wrapper pair |
| Version state | installer writes `ODS_VERSION` | version API and update dry-run | Normal and dry-run readers share the same quote behavior |
| Process fallback | Compose supplies environment values | performance oracle | Existing file-over-process precedence and explicit empty values remain unchanged |

## Changed surface

- Added `env_values.strip_matching_quotes()` as the single quote-boundary helper.
- Replaced destructive or duplicated parsing in all affected Dashboard API consumers.
- Added reader-level regressions for configuration, GPU, models, performance, settings, installed version, and update dry-run.

No Compose, installer, schema, frontend, network, secret, or service lifecycle contract changes are introduced.

## Validation receipt

- `python -m pytest ...test_env_values.py ...test_updates.py -q` -> **453 passed**
- `python -m py_compile` on all changed production modules -> **passed**
- `python -m ruff check ... --select E,F,W --ignore E501,E701,E731,E741,E402` -> **passed**
- `bash ods/tests/test-safe-env.sh` -> **12 passed**
- `bash ods/tests/test-macos-env-quote-strip.sh` -> **9 passed**
- `git diff --check origin/main...HEAD` -> **passed**

The Windows endpoint shell test could not be counted locally because its `/tmp/*.ps1` handoff is not executable by native Windows PowerShell from this host. This PR changes only dependency-free Python parsing and does not alter that script or the Windows installer.

## Adversarial review

The second review started from the final diff without edits and exercised empty pairs, paired single/double quotes, internal apostrophes, unmatched leading/trailing quotes, mixed delimiters, repeated pairs, and surrounding whitespace. It also reproduced the old mutation independently.

**Result:** no remaining reproducible defect was found inside this PR's scope.

## Limits

This deliberately does not turn the Dashboard API into a full dotenv/shell parser. Escape expansion, inline comments, interpolation, and multiline values retain their existing behavior.