### PR TITLE
fix(sessions): commit index before pruning files

### DIFF
--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -5,8 +5,9 @@
 #
 # Prevents context overflow crashes by automatically managing
 # session file lifecycle. When a session file exceeds the size
-# threshold, it's deleted and its reference removed from
-# sessions.json, forcing the gateway to create a fresh session.
+# threshold, its reference is atomically removed from sessions.json
+# before the file is deleted, forcing the gateway to create a fresh
+# session without leaving a dangling index entry on interruption.
 #
 # The agent doesn't notice — it just gets a clean context window.
 # ═══════════════════════════════════════════════════════════════
@@ -36,7 +37,7 @@ usage() {
     echo "  MAX_SIZE       Max session file size in bytes (default: 256000)"
     echo ""
     echo "Exit: 0 on success or when paths are missing (skipped with a log message);"
-    echo "      1 when no usable Python is found (refused before touching any session)."
+    echo "      1 when Python or sessions.json validation fails before any session mutation."
 }
 
 case "${1:-}" in
@@ -54,17 +55,66 @@ if [ ! -d "$SESSIONS_DIR" ]; then
     exit 0
 fi
 
-# ── Extract active session IDs (portable: no grep -P) ─────────
-ACTIVE_IDS_EXIT=0
-ACTIVE_IDS=$(grep -oE '"sessionId"[[:space:]]*:[[:space:]]*"[^"]+"' "$SESSIONS_JSON" 2>&1 | sed -E 's/.*"sessionId"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/') || ACTIVE_IDS_EXIT=$?
-if [[ $ACTIVE_IDS_EXIT -ne 0 ]]; then
-    ACTIVE_IDS=""
+# ── Python and index validation ────────────────────────────────
+# Resolve and validate before any cleanup mutation. Treating malformed or
+# partially-written JSON as an empty active set would otherwise delete every
+# .jsonl file as inactive.
+PYTHON_CMD="python3"
+if [[ -f "$(dirname "$0")/../lib/python-cmd.sh" ]]; then
+    . "$(dirname "$0")/../lib/python-cmd.sh"
+    PYTHON_CMD="$(ods_detect_python_cmd)" || PYTHON_CMD=""
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
 fi
+if [[ -z "$PYTHON_CMD" ]] || ! "$PYTHON_CMD" -c 'import json' >/dev/null 2>&1; then
+    echo "[$(date)] ERROR: no usable Python found; refusing to prune sessions (sessions.json updates need it)" >&2
+    exit 1
+fi
+
+ACTIVE_IDS_OUTPUT=""
+ACTIVE_IDS_EXIT=0
+ACTIVE_IDS_OUTPUT=$("$PYTHON_CMD" - "$SESSIONS_JSON" <<'PY'
+import json
+import sys
+
+sessions_file = sys.argv[1]
+try:
+    with open(sessions_file, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    print(f"invalid sessions index: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+if not isinstance(data, dict):
+    print("invalid sessions index: root must be an object", file=sys.stderr)
+    raise SystemExit(1)
+
+for value in data.values():
+    if not isinstance(value, dict):
+        continue
+    session_id = value.get("sessionId")
+    if not isinstance(session_id, str) or not session_id:
+        continue
+    if "\n" in session_id or "\r" in session_id:
+        print("invalid sessions index: sessionId contains a line break", file=sys.stderr)
+        raise SystemExit(1)
+    print(session_id)
+PY
+) || ACTIVE_IDS_EXIT=$?
+if [[ $ACTIVE_IDS_EXIT -ne 0 ]]; then
+    echo "[$(date)] ERROR: sessions.json is invalid; refusing to prune sessions" >&2
+    exit 1
+fi
+
+ACTIVE_IDS=()
+while IFS= read -r ID; do
+    [[ -n "$ID" ]] && ACTIVE_IDS+=("$ID")
+done <<< "$ACTIVE_IDS_OUTPUT"
 
 echo "[$(date)] Session cleanup starting"
 echo "[$(date)] Sessions dir: $SESSIONS_DIR"
 echo "[$(date)] Max size threshold: $MAX_SIZE bytes"
-echo "[$(date)] Active sessions found: $(echo "$ACTIVE_IDS" | wc -w)"
+echo "[$(date)] Active sessions found: ${#ACTIVE_IDS[@]}"
 
 # ── Clean up debris ────────────────────────────────────────────
 DELETED_EXIT=0
@@ -83,25 +133,9 @@ if [ "$DELETED_COUNT" -gt 0 ] || [ "$BAK_COUNT" -gt 0 ]; then
     echo "[$(date)] Cleaned up $DELETED_COUNT .deleted files, $BAK_COUNT .bak files"
 fi
 
-# ── Python (needed to update sessions.json after wipes) ───────
-# Resolved BEFORE any session file is deleted: under set -e, a failed
-# detection inside the wipe loop used to kill the script after a bloated
-# session file was already removed but before its reference was cleared
-# from sessions.json — leaving the gateway pointing at a missing file.
-PYTHON_CMD="python3"
-if [[ -f "$(dirname "$0")/../lib/python-cmd.sh" ]]; then
-    . "$(dirname "$0")/../lib/python-cmd.sh"
-    PYTHON_CMD="$(ods_detect_python_cmd)" || PYTHON_CMD=""
-elif command -v python >/dev/null 2>&1; then
-    PYTHON_CMD="python"
-fi
-if [[ -z "$PYTHON_CMD" ]] || ! "$PYTHON_CMD" -c 'import json' >/dev/null 2>&1; then
-    echo "[$(date)] ERROR: no usable Python found; refusing to prune sessions (sessions.json updates need it)" >&2
-    exit 1
-fi
-
 # ── Process session files ──────────────────────────────────────
-WIPE_IDS=""
+WIPE_IDS=()
+WIPE_FILES=()
 REMOVED_INACTIVE=0
 REMOVED_BLOATED=0
 
@@ -111,7 +145,7 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
 
     # Check if this session is active
     IS_ACTIVE=false
-    for ID in $ACTIVE_IDS; do
+    for ID in "${ACTIVE_IDS[@]}"; do
         if [ "$BASENAME" = "$ID" ]; then
             IS_ACTIVE=true
             break
@@ -137,37 +171,71 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
         if [ "$SIZE_BYTES" -gt "$MAX_SIZE" ]; then
             SIZE=$(du -h "$f" | cut -f1)
             SIZE_LABEL=$(command -v numfmt >/dev/null 2>&1 && numfmt --to=iec "$MAX_SIZE" || echo "${MAX_SIZE}B")
-            echo "[$(date)] Session $BASENAME is bloated ($SIZE > ${SIZE_LABEL}), deleting to force fresh session"
-            rm -f "$f"
-            WIPE_IDS="$WIPE_IDS $BASENAME"
-            REMOVED_BLOATED=$((REMOVED_BLOATED + 1))
+            echo "[$(date)] Session $BASENAME is bloated ($SIZE > ${SIZE_LABEL}), scheduling a fresh session"
+            WIPE_IDS+=("$BASENAME")
+            WIPE_FILES+=("$f")
         fi
     fi
 done
 
-# ── Remove wiped session references from sessions.json ─────────
-if [ -n "$WIPE_IDS" ]; then
-    echo "[$(date)] Clearing session references from sessions.json for:$WIPE_IDS"
-    cp "$SESSIONS_JSON" "$SESSIONS_JSON.bak-cleanup"
+# ── Commit index first, then delete unreferenced session files ─
+if [[ ${#WIPE_IDS[@]} -gt 0 ]]; then
+    echo "[$(date)] Clearing ${#WIPE_IDS[@]} session reference(s) from sessions.json"
+    "$PYTHON_CMD" - "$SESSIONS_JSON" "${WIPE_IDS[@]}" <<'PY'
+import json
+import os
+import stat
+import sys
+import tempfile
 
-    for ID in $WIPE_IDS; do
-        "$PYTHON_CMD" -c "
-import json, sys
-sessions_file = sys.argv[1]
-target_id = sys.argv[2]
-with open(sessions_file, 'r') as f:
-    data = json.load(f)
-to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get('sessionId') == target_id]
-for k in to_remove:
-    del data[k]
-    print(f'  Removed session key: {k}', file=sys.stderr)
-with open(sessions_file, 'w') as f:
-    json.dump(data, f, indent=2)
-" "$SESSIONS_JSON" "$ID" 2>&1
+sessions_file = os.path.abspath(sys.argv[1])
+target_ids = set(sys.argv[2:])
+parent = os.path.dirname(sessions_file)
+temp_path = None
+
+with open(sessions_file, "r", encoding="utf-8") as handle:
+    data = json.load(handle)
+if not isinstance(data, dict):
+    raise SystemExit("sessions index root must be an object")
+
+to_remove = [
+    key
+    for key, value in data.items()
+    if isinstance(value, dict) and value.get("sessionId") in target_ids
+]
+for key in to_remove:
+    del data[key]
+    print(f"  Removed session key: {key}", file=sys.stderr)
+
+original_mode = stat.S_IMODE(os.stat(sessions_file).st_mode)
+try:
+    descriptor, temp_path = tempfile.mkstemp(
+        prefix=".sessions.json.",
+        suffix=".tmp",
+        dir=parent,
+    )
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(temp_path, original_mode)
+    os.replace(temp_path, sessions_file)
+    temp_path = None
+finally:
+    if temp_path is not None:
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+PY
+
+    for f in "${WIPE_FILES[@]}"; do
+        if [[ -f "$f" ]]; then
+            rm -f "$f"
+            REMOVED_BLOATED=$((REMOVED_BLOATED + 1))
+        fi
     done
-
-    # Clean up the backup
-    rm -f "$SESSIONS_JSON.bak-cleanup"
 fi
 
 # ── Summary ────────────────────────────────────────────────────

--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -108,6 +108,7 @@ fi
 
 ACTIVE_IDS=()
 while IFS= read -r ID; do
+    ID="${ID%$'\r'}"
     [[ -n "$ID" ]] && ACTIVE_IDS+=("$ID")
 done <<< "$ACTIVE_IDS_OUTPUT"
 

--- a/ods/tests/test-session-cleanup.sh
+++ b/ods/tests/test-session-cleanup.sh
@@ -185,18 +185,102 @@ else
 fi
 
 # ============================================================================
-# Test 8c: No usable Python → refuse to delete ANYTHING (ordering guard)
+# Test 8c: Interruption cannot leave sessions.json pointing at a deleted file
+# ============================================================================
+SDIR3="$TEMP_DIR/sessions3"
+mkdir -p "$SDIR3"
+cat > "$SDIR3/sessions.json" <<'EOF'
+{"agent:main:talk": {"sessionId": "interrupt-me"}}
+EOF
+dd if=/dev/zero of="$SDIR3/interrupt-me.jsonl" bs=1024 count=2 2>/dev/null
+
+CRASH_BIN="$TEMP_DIR/crash-bin"
+mkdir -p "$CRASH_BIN"
+REAL_RM="$(command -v rm)"
+cat > "$CRASH_BIN/rm" <<EOF
+#!/bin/bash
+"$REAL_RM" "\$@"
+kill -KILL "\$PPID"
+EOF
+chmod +x "$CRASH_BIN/rm"
+
+crash_exit=0
+PATH="$CRASH_BIN:$PATH" SESSIONS_DIR="$SDIR3" MAX_SIZE=100 \
+    bash "$SESSION_CLEANUP_SCRIPT" >"$TEMP_DIR/crash.log" 2>&1 || crash_exit=$?
+if [[ $crash_exit -ne 0 ]]; then
+    pass "Injected interruption terminated cleanup"
+else
+    fail "Injected interruption did not terminate cleanup"
+fi
+
+if [[ -f "$SDIR3/interrupt-me.jsonl" ]] || ! grep -q 'interrupt-me' "$SDIR3/sessions.json"; then
+    pass "Interruption preserves the file-or-no-reference invariant"
+else
+    fail "sessions.json references a session file deleted before interruption"
+fi
+
+# ============================================================================
+# Test 8d: Malformed sessions.json fails closed before deleting files
+# ============================================================================
+SDIR4="$TEMP_DIR/sessions4"
+mkdir -p "$SDIR4"
+printf '{"agent":' > "$SDIR4/sessions.json"
+echo '{"x":1}' > "$SDIR4/preserve-me.jsonl"
+
+invalid_exit=0
+SESSIONS_DIR="$SDIR4" MAX_SIZE=1 \
+    bash "$SESSION_CLEANUP_SCRIPT" >"$TEMP_DIR/invalid.log" 2>&1 || invalid_exit=$?
+if [[ $invalid_exit -ne 0 ]] && [[ -f "$SDIR4/preserve-me.jsonl" ]]; then
+    pass "Malformed sessions.json fails closed without deleting session files"
+else
+    fail "Malformed sessions.json was treated as an empty active-session index"
+fi
+
+# ============================================================================
+# Test 8e: Index commit failure leaves the file and old reference intact
+# ============================================================================
+SDIR5="$TEMP_DIR/sessions5"
+mkdir -p "$SDIR5"
+cat > "$SDIR5/sessions.json" <<'EOF'
+{"agent:main:talk": {"sessionId": "commit-fails"}}
+EOF
+dd if=/dev/zero of="$SDIR5/commit-fails.jsonl" bs=1024 count=2 2>/dev/null
+
+REAL_PYTHON="$(command -v python3 || command -v python)"
+FAIL_PYTHON="$TEMP_DIR/fail-python"
+cat > "$FAIL_PYTHON" <<EOF
+#!/bin/bash
+if [[ "\${1:-}" == "-" && \$# -ge 3 ]]; then
+    exit 71
+fi
+exec "$REAL_PYTHON" "\$@"
+EOF
+chmod +x "$FAIL_PYTHON"
+
+commit_exit=0
+ODS_PYTHON_CMD="$FAIL_PYTHON" SESSIONS_DIR="$SDIR5" MAX_SIZE=100 \
+    bash "$SESSION_CLEANUP_SCRIPT" >"$TEMP_DIR/commit-failure.log" 2>&1 || commit_exit=$?
+if [[ $commit_exit -ne 0 ]] \
+    && [[ -f "$SDIR5/commit-fails.jsonl" ]] \
+    && grep -q 'commit-fails' "$SDIR5/sessions.json"; then
+    pass "Index commit failure leaves the session file and reference intact"
+else
+    fail "Index commit failure partially mutated the session transaction"
+fi
+
+# ============================================================================
+# Test 8f: No usable Python → refuse to delete ANYTHING (ordering guard)
 # ============================================================================
 # A mid-loop Python failure used to kill the script (set -e) after a bloated
 # session file was deleted but before sessions.json was updated, leaving the
 # gateway pointing at a missing file. The guard must fail BEFORE any rm.
-SDIR3="$TEMP_DIR/sessions3"
-mkdir -p "$SDIR3"
-cat > "$SDIR3/sessions.json" <<'EOF'
+SDIR6="$TEMP_DIR/sessions6"
+mkdir -p "$SDIR6"
+cat > "$SDIR6/sessions.json" <<'EOF'
 {"agent:main:talk": {"sessionId": "bloated-one"}}
 EOF
-dd if=/dev/zero of="$SDIR3/bloated-one.jsonl" bs=1024 count=2 2>/dev/null
-echo '{"x":1}' > "$SDIR3/inactive.jsonl"
+dd if=/dev/zero of="$SDIR6/bloated-one.jsonl" bs=1024 count=2 2>/dev/null
+echo '{"x":1}' > "$SDIR6/inactive.jsonl"
 
 NOPY_BIN="$TEMP_DIR/nopy-bin"
 mkdir -p "$NOPY_BIN"
@@ -206,11 +290,11 @@ for tool in bash sh grep sed find date basename dirname cut wc du stat rm cp mv 
 done
 
 nopy_exit=0
-PATH="$NOPY_BIN" ODS_PYTHON_CMD="" SESSIONS_DIR="$SDIR3" MAX_SIZE=100 \
+PATH="$NOPY_BIN" ODS_PYTHON_CMD="" SESSIONS_DIR="$SDIR6" MAX_SIZE=100 \
     bash "$SESSION_CLEANUP_SCRIPT" >"$TEMP_DIR/nopy.log" 2>&1 || nopy_exit=$?
 if [[ $nopy_exit -ne 0 ]]; then
     pass "Missing Python fails loudly instead of half-completing"
-    if [[ -f "$SDIR3/bloated-one.jsonl" && -f "$SDIR3/inactive.jsonl" ]] && grep -q 'bloated-one' "$SDIR3/sessions.json"; then
+    if [[ -f "$SDIR6/bloated-one.jsonl" && -f "$SDIR6/inactive.jsonl" ]] && grep -q 'bloated-one' "$SDIR6/sessions.json"; then
         pass "No files deleted and sessions.json untouched when Python is missing"
     else
         fail "Sessions were mutated despite missing Python (exit $nopy_exit)"


### PR DESCRIPTION
## Summary

Fixes #2272.

The cleanup previously deleted an oversized active `.jsonl` file before removing its entry from `sessions.json`. A signal, disk error, or process failure in that window left a dangling index entry and could break the gateway on its next session read.

This change makes the lifecycle fail closed and commits it in the safe direction:

1. Resolve Python and validate the complete JSON index before any cleanup mutation.
2. Collect oversized active sessions without deleting them.
3. Re-read the latest index, remove all selected references, write a same-directory temporary file, flush it, preserve its mode, and atomically replace `sessions.json`.
4. Delete only the files that are no longer referenced.

A failure before the atomic replace keeps both the old reference and file. A failure after the replace can only leave an unreferenced file, which is safe and is removed by the next run.

## AI Assistance

Static analysis, edge-case enumeration, and regression-test drafting were assisted. The author reviewed the implementation, selected the scope, reproduced the original failure invariant, and ran the validation listed below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Behavior And Invariants

| Requirement | Implementation | Evidence |
|---|---|---|
| Never leave a reference to a file deleted by this cleanup | Index commit precedes file removal | Signal injection kills cleanup immediately after `rm`; file-or-no-reference invariant passes |
| Do not mutate on invalid/partial JSON | Full Python parse and object-root validation happen before debris or session deletion | Malformed, zero-byte, and non-object fixtures fail closed |
| Do not partially wipe when index commit fails | Files remain queued until the atomic replace succeeds | Injected commit failure preserves both file and reference |
| Preserve unrelated/current entries | Commit re-reads the latest index and removes only matching session IDs | Concurrent-addition test preserves the new entry |
| Preserve filesystem mode | Replacement inherits the original mode | `0640` fixture remains `0640` |
| Keep repeated cleanup safe | Removed entries/files are absent and a second run succeeds | Idempotent rerun test |
| Handle multiple and non-word IDs safely | Bash arrays and argv transport replace word-splitting strings | Multiple targets and a session ID containing spaces pass |

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
bash -n ods/scripts/session-cleanup.sh
bash -n ods/tests/test-session-cleanup.sh
bash ods/tests/test-session-cleanup.sh
  19 passed, 0 failed

Independent edge matrix:
  PASS fail-closed roots
  PASS multi-target, spaced ID, mode, rerun
  PASS latest-index reread preserves concurrent addition

git diff --check
  passed
```

ShellCheck reports only the two pre-existing findings in the untouched final listing block: SC2012 and SC2034.

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

The affected operation is deterministic filesystem cleanup. Scoped fault injection exercises the relevant interruption and write-failure boundaries without requiring model or GPU hardware.

## Platform Scope

The timer installs this Bash script through the Linux OpenClaw/AMD tuning lifecycle. Windows and macOS installer, Compose, dashboard, and runtime paths are unchanged. The Python transaction uses only standard-library filesystem APIs and a same-directory replacement.

## Confirmed Bugs

- Confirmed: deletion-before-index-update interruption window from #2272.
- Confirmed during reproduction: malformed or partially written `sessions.json` was treated as an empty active set by the grep parser, allowing every `.jsonl` file to be classified as inactive.

## Risks And Limitations

- The gateway does not participate in a shared filesystem lock. This change minimizes the transaction and re-reads the latest index before replacement, but it does not introduce a cross-process locking protocol that the gateway itself does not honor.
- An interruption after index replacement may leave an orphaned `.jsonl`; this is intentionally the safe failure direction and the next cleanup removes it as inactive.
- Inactive-file pruning behavior is otherwise unchanged.

## Notes For Reviewers

PR #2277 adds atomic replacement but retains the unsafe delete-before-index order. This PR is intentionally limited to the session cleanup transaction and its focused regression coverage.
