### PR TITLE
fix(llama): respect GPU layer placement

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -225,6 +225,7 @@ SYSTEM_RAM_GB=32
 # WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda
 
 # llama-server inference tuning (advanced)
+# N_GPU_LAYERS=auto         # auto | all | non-negative layer count
 # LLAMA_BATCH_SIZE=2048      # Batch size for prompt processing (higher = faster prefill)
 # LLAMA_THREADS=4            # CPU threads for non-GPU work
 # LLAMA_PARALLEL=1           # Concurrent request slots (increase for multi-user)

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -400,9 +400,10 @@
       "default": "nvidia"
     },
     "N_GPU_LAYERS": {
-      "type": "integer",
-      "description": "Number of model layers to offload to GPU",
-      "default": 99
+      "type": "string",
+      "description": "llama.cpp GPU layer offload policy: auto, all, or a non-negative layer count. CPU and Intel/Arc overlays may set an explicit numeric value.",
+      "pattern": "^(?:auto|all|[0-9]+)$",
+      "default": "auto"
     },
     "LLAMA_BATCH_SIZE": {
       "type": "integer",

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -11770,12 +11770,13 @@ def _restart_macos_native_llama_server(
 def _launch_native_llama_server(env_path: Path, llama_bin: Path, llama_log: Path, pid_file: Path):
     """Launch the native (Metal) llama-server process and write its PID file.
 
-    Reads the current .env for GGUF_FILE, CTX_SIZE, and LLAMA_REASONING so
-    the caller only needs to ensure .env is up-to-date before calling.
+    Reads the current .env for model and llama.cpp runtime settings so the
+    caller only needs to ensure .env is up-to-date before calling.
     """
     env = load_env(env_path)
     gguf_file = env.get("GGUF_FILE", "")
     ctx_size = env.get("CTX_SIZE", "32768")
+    gpu_layers = env.get("N_GPU_LAYERS", "").strip() or "auto"
     model_path = INSTALL_DIR / "data" / "models" / gguf_file
     reasoning = env.get("LLAMA_REASONING", "off")
     reasoning_fmt = {"off": "none", "on": "deepseek"}.get(reasoning, reasoning)
@@ -11793,7 +11794,7 @@ def _launch_native_llama_server(env_path: Path, llama_bin: Path, llama_log: Path
         "--host", bind_addr, "--port", str(port),
         "--model", str(model_path),
         "--ctx-size", ctx_size,
-        "--n-gpu-layers", "999",
+        "--n-gpu-layers", gpu_layers,
         "--parallel", env.get("LLAMA_PARALLEL", "1"),
         "--reasoning-format", reasoning_fmt,
         "--metrics",

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -38,7 +38,7 @@ services:
       - --port
       - "8080"
       - --n-gpu-layers
-      - "999"
+      - "${N_GPU_LAYERS:-auto}"
       - --ctx-size
       - "${CTX_SIZE:-16384}"
       - --batch-size

--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -278,7 +278,13 @@ def _validate_env_values(
             if _normalize_bool(value) is None:
                 issues.append({"key": key, "message": "Must be true or false."})
 
-        if key == "EMBEDDING_MODEL":
+        if key == "N_GPU_LAYERS":
+            if not re.fullmatch(r"(?:auto|all|[0-9]+)", str(value).strip()):
+                issues.append({
+                    "key": key,
+                    "message": "Must be auto, all, or a non-negative whole number.",
+                })
+        elif key == "EMBEDDING_MODEL":
             if _is_unsupported_tei_model_id(value):
                 issues.append({
                     "key": key,
@@ -352,6 +358,8 @@ def _serialize_form_values(
             normalized = _normalize_bool(value)
             serialized[key] = normalized if normalized is not None else str(value).strip()
         elif field_type == "integer":
+            serialized[key] = str(value).strip()
+        elif key == "N_GPU_LAYERS":
             serialized[key] = str(value).strip()
         else:
             serialized[key] = str(value)

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -578,6 +578,33 @@ def test_api_settings_env_save_returns_llama_apply_plan(test_client, settings_en
     assert "llama-server" in payload["applyPlan"]["summary"]
 
 
+def test_api_settings_env_gpu_layer_change_recreates_llama_server(
+    test_client, settings_env_fixture,
+):
+    env_path = settings_env_fixture["env_path"]
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8") + "N_GPU_LAYERS=99\n",
+        encoding="utf-8",
+    )
+
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {
+                "N_GPU_LAYERS": "auto",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["values"]["N_GPU_LAYERS"] == "auto"
+    assert payload["applyPlan"]["status"] == "ready"
+    assert payload["applyPlan"]["services"] == ["llama-server"]
+
+
 def test_api_settings_env_save_uses_host_agent_canonical_value(
     test_client, settings_env_fixture, monkeypatch,
 ):

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1039,6 +1039,38 @@ def test_settings_validation_accepts_compose_memory_units():
         assert _validate_env_values(values, fields) == []
 
 
+@pytest.mark.parametrize("value", ["auto", "all", "0", "99", "999"])
+def test_settings_validation_accepts_gpu_layer_modes_and_counts(value):
+    from settings import _validate_env_values
+
+    assert _validate_env_values(
+        {"N_GPU_LAYERS": value},
+        {"N_GPU_LAYERS": {"type": "string"}},
+    ) == []
+
+
+def test_settings_serialization_normalizes_gpu_layer_whitespace():
+    from settings import _serialize_form_values
+
+    assert _serialize_form_values(
+        {"N_GPU_LAYERS": "  all  "},
+        {"N_GPU_LAYERS": {"type": "string"}},
+    ) == {"N_GPU_LAYERS": "all"}
+
+
+@pytest.mark.parametrize("value", ["-1", "99.5", "automatic", "AUTO", "999;exit 1"])
+def test_settings_validation_rejects_invalid_gpu_layer_values(value):
+    from settings import _validate_env_values
+
+    assert _validate_env_values(
+        {"N_GPU_LAYERS": value},
+        {"N_GPU_LAYERS": {"type": "string"}},
+    ) == [{
+        "key": "N_GPU_LAYERS",
+        "message": "Must be auto, all, or a non-negative whole number.",
+    }]
+
+
 def test_settings_validation_rejects_invalid_rag_base_url():
     from settings import _build_env_fields, _validate_env_values
 

--- a/ods/extensions/services/llama-server/README.md
+++ b/ods/extensions/services/llama-server/README.md
@@ -15,7 +15,7 @@ All other services that perform AI inference — Open WebUI, LiteLLM, Privacy Sh
 - **GPU acceleration**: CUDA (NVIDIA) and ROCm/HIP (AMD) backends
 - **Configurable context window**: Token limit tunable via `CTX_SIZE`
 - **Prometheus metrics**: `/metrics` endpoint for throughput and token stats
-- **Multi-GPU offload**: All GPU layers offloaded with `--n-gpu-layers 999`
+- **Memory-aware GPU offload**: llama.cpp selects the safe layer count by default; operators can override it with `N_GPU_LAYERS`
 - **Hardware-tier model selection**: Installer auto-selects model size based on detected VRAM
 
 ## Configuration
@@ -28,6 +28,7 @@ Environment variables (set in `.env`):
 | `CTX_SIZE` | `16384` | Context window size in tokens |
 | `OLLAMA_PORT` | `11434` | External host port (maps to internal 8080) |
 | `GPU_BACKEND` | `nvidia` | GPU backend: `nvidia` or `amd` |
+| `N_GPU_LAYERS` | `auto` | GPU offload policy: `auto`, `all`, or a non-negative layer count |
 | `LLAMA_ARG_FLASH_ATTN` | `auto` | llama.cpp Flash Attention mode: `auto`, `on`, or `off` |
 | `LLAMA_ARG_CACHE_TYPE_K` | `f16` | KV cache key precision. Use `q8_0` to reduce long-context memory pressure |
 | `LLAMA_ARG_CACHE_TYPE_V` | `f16` | KV cache value precision. Use `q8_0` to reduce long-context memory pressure |

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2182,13 +2182,15 @@ else
         _cache_type_k=$(grep '^LLAMA_ARG_CACHE_TYPE_K=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
         _cache_type_v=$(grep '^LLAMA_ARG_CACHE_TYPE_V=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
         _n_cpu_moe=$(grep '^LLAMA_ARG_N_CPU_MOE=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
+        _gpu_layers=$(grep '^N_GPU_LAYERS=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || echo "")
+        [[ -z "$_gpu_layers" ]] && _gpu_layers="auto"
         _spec_type=$(grep '^LLAMA_ARG_SPEC_TYPE=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
         _spec_draft_n_max=$(grep '^LLAMA_ARG_SPEC_DRAFT_N_MAX=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
         _llama_args=(
             --host "$_bind" --port "$_native_llama_port"
             --model "$MODEL_FULL_PATH"
             --ctx-size "$MAX_CONTEXT"
-            --n-gpu-layers 999
+            --n-gpu-layers "$_gpu_layers"
             --reasoning-format "$_reasoning_fmt"
             --metrics
         )

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -172,6 +172,13 @@ normalize_ods_model_switchboard() {
     esac
 }
 
+normalize_n_gpu_layers() {
+    local value="${1:-}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s\n' "${value:-auto}"
+}
+
 generate_ods_env() {
     local install_dir="$1"
     local tier="$2"
@@ -301,6 +308,12 @@ generate_ods_env() {
         if [[ -z "$(read_env_value "$env_path" "EMBEDDINGS_MEMORY_LIMIT")" ]]; then
             upsert_env_value "$env_path" "EMBEDDINGS_MEMORY_LIMIT" "${EMBEDDINGS_MEMORY_LIMIT:-4G}"
         fi
+        local _n_gpu_layers
+        _n_gpu_layers="$(normalize_n_gpu_layers "$(read_env_value "$env_path" "N_GPU_LAYERS")")"
+        if ! env_key_exists "$env_path" "N_GPU_LAYERS"; then
+            _n_gpu_layers="$(normalize_n_gpu_layers "${N_GPU_LAYERS:-auto}")"
+        fi
+        upsert_env_value "$env_path" "N_GPU_LAYERS" "$_n_gpu_layers"
 
         # HOST_LAN_IP backfill: the fresh-install heredoc below populates
         # HOST_LAN_IP when BIND_ADDRESS=0.0.0.0 was pre-set, so openclaw can
@@ -441,6 +454,8 @@ generate_ods_env() {
     tz=$(detect_timezone)
     local timestamp
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    local n_gpu_layers
+    n_gpu_layers="$(normalize_n_gpu_layers "${N_GPU_LAYERS:-auto}")"
     local hermes_llm_base_url="${llm_api_url}/v1"
     local hermes_llm_api_key="sk-ods-hermes-local"
     local open_webui_llm_base_url=""
@@ -522,6 +537,7 @@ MODEL_PERFORMANCE_SOURCE=benchmark_required
 MODEL_PERFORMANCE_LABEL=Benchmark after first launch
 GPU_BACKEND=apple
 HOST_RAM_GB=${SYSTEM_RAM_GB}
+N_GPU_LAYERS=${n_gpu_layers}
 $(if [[ -n "${LLAMA_SERVER_IMAGE:-}" ]]; then echo "LLAMA_SERVER_IMAGE=${LLAMA_SERVER_IMAGE}"; fi)
 #=== llama.cpp Runtime Tuning ===
 LLAMA_ARG_FLASH_ATTN=${LLAMA_ARG_FLASH_ATTN:-auto}

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -588,6 +588,9 @@ start_native_llama() {
 
     local gguf_file="${ENV_GGUF_FILE:-Qwen3.5-9B-Q4_K_M.gguf}"
     local ctx_size="${ENV_CTX_SIZE:-65536}"
+    local gpu_layers="${ENV_N_GPU_LAYERS:-auto}"
+    gpu_layers="$(printf '%s' "$gpu_layers" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    gpu_layers="${gpu_layers:-auto}"
     local native_port="${ENV_ODS_NATIVE_LLAMA_PORT:-8080}"
     local bind_address="${ENV_BIND_ADDRESS:-127.0.0.1}"
     local probe_host
@@ -615,7 +618,7 @@ start_native_llama() {
         --host "$bind_address" --port "$native_port"
         --model "$model_path"
         --ctx-size "$ctx_size"
-        --n-gpu-layers 999
+        --n-gpu-layers "$gpu_layers"
         --reasoning-format "$reasoning_fmt"
         --metrics
     )

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -703,6 +703,9 @@ raise SystemExit(1)' 2>/dev/null && return 0
     RAG_OPENAI_API_BASE_URL_VALUE=$(_env_get_preserve_empty RAG_OPENAI_API_BASE_URL "${RAG_OPENAI_API_BASE_URL:-}")
     RAG_OPENAI_API_KEY_VALUE=$(_env_get_preserve_empty RAG_OPENAI_API_KEY "${RAG_OPENAI_API_KEY:-}")
     EMBEDDINGS_MEMORY_LIMIT_VALUE=$(_env_get EMBEDDINGS_MEMORY_LIMIT "${EMBEDDINGS_MEMORY_LIMIT:-4G}")
+    N_GPU_LAYERS_VALUE=$(_env_get N_GPU_LAYERS "${N_GPU_LAYERS:-auto}")
+    N_GPU_LAYERS_VALUE="$(printf '%s' "$N_GPU_LAYERS_VALUE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    N_GPU_LAYERS_VALUE="${N_GPU_LAYERS_VALUE:-auto}"
 
     _phase06_lemonade_uses_host_9000() {
         [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]] && return 0
@@ -816,7 +819,7 @@ MODEL_PERFORMANCE_SOURCE=benchmark_required
 MODEL_PERFORMANCE_LABEL=Benchmark after first launch
 GPU_BACKEND=${GPU_BACKEND}
 SYSTEM_RAM_GB=${RAM_GB:-0}
-N_GPU_LAYERS=${N_GPU_LAYERS:-99}
+N_GPU_LAYERS=${N_GPU_LAYERS_VALUE}
 $(if [[ -n "${LLAMA_SERVER_IMAGE:-}" ]]; then echo "LLAMA_SERVER_IMAGE=${LLAMA_SERVER_IMAGE}"; fi)
 $(if [[ -n "${LLAMA_SERVER_IMAGE_FALLBACK:-}" ]]; then echo "LLAMA_SERVER_IMAGE_FALLBACK=${LLAMA_SERVER_IMAGE_FALLBACK}"; fi)
 #=== llama.cpp Runtime Tuning ===

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -710,11 +710,19 @@ if ($dryRun) {
                 # Start native llama-server
                 Write-AI "Starting native llama-server (Vulkan)..."
                 $modelFullPath = Join-Path (Join-Path $installDir "data\models") $tierConfig.GgufFile
+                $_llamaEnv = @{}
+                Get-Content -LiteralPath (Join-Path $installDir ".env") -ErrorAction SilentlyContinue | ForEach-Object {
+                    if ($_ -match '^\s*#' -or $_ -notmatch '=') { return }
+                    $parts = $_ -split '=', 2
+                    $_llamaEnv[$parts[0].Trim()] = $parts[1].Trim().Trim('"')
+                }
+                $_gpuLayers = $_llamaEnv["N_GPU_LAYERS"]
+                if (-not $_gpuLayers) { $_gpuLayers = "auto" }
                 $llamaArgs = @(
                     "--model", $modelFullPath,
                     "--host", $bindAddr,
                     "--port", [string]$script:LEMONADE_PORT,
-                    "--n-gpu-layers", "999",
+                    "--n-gpu-layers", $_gpuLayers,
                     "--ctx-size", "$($tierConfig.MaxContext)",
                     # llama.cpp keeps /metrics off unless asked. The dashboard's
                     # tokens/sec reading and the Usage page's local-runtime
@@ -722,12 +730,6 @@ if ($dryRun) {
                     # path passes this too.
                     "--metrics"
                 )
-                $_llamaEnv = @{}
-                Get-Content -LiteralPath (Join-Path $installDir ".env") -ErrorAction SilentlyContinue | ForEach-Object {
-                    if ($_ -match '^\s*#' -or $_ -notmatch '=') { return }
-                    $parts = $_ -split '=', 2
-                    $_llamaEnv[$parts[0].Trim()] = $parts[1].Trim().Trim('"')
-                }
                 # Map the .env values (off/on/auto) onto llama-server's own
                 # vocabulary, the same way scripts/bootstrap-upgrade.sh does for
                 # its Windows hot-swap. Defaulting to off keeps thinking models

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -819,6 +819,10 @@ function New-ODSEnv {
     $embeddingsMemoryLimitDefault = [Environment]::GetEnvironmentVariable("EMBEDDINGS_MEMORY_LIMIT")
     if ([string]::IsNullOrWhiteSpace($embeddingsMemoryLimitDefault)) { $embeddingsMemoryLimitDefault = "4G" }
     $embeddingsMemoryLimit = Get-EnvOrNew "EMBEDDINGS_MEMORY_LIMIT" $embeddingsMemoryLimitDefault
+    $nGpuLayersDefault = [Environment]::GetEnvironmentVariable("N_GPU_LAYERS")
+    if ([string]::IsNullOrWhiteSpace($nGpuLayersDefault)) { $nGpuLayersDefault = "auto" }
+    $nGpuLayers = (Get-EnvOrNew "N_GPU_LAYERS" $nGpuLayersDefault).Trim()
+    if ([string]::IsNullOrWhiteSpace($nGpuLayers)) { $nGpuLayers = "auto" }
 
     # Build .env content (matches Phase 06 format)
     $envContent = @"
@@ -880,6 +884,7 @@ MODEL_PERFORMANCE_SOURCE=benchmark_required
 MODEL_PERFORMANCE_LABEL=Benchmark after first launch
 GPU_BACKEND=$GpuBackend
 SYSTEM_RAM_GB=$SystemRamGB
+N_GPU_LAYERS=$nGpuLayers
 $(if ($LlamaServerImage) { "LLAMA_SERVER_IMAGE=$LlamaServerImage" } else { "#LLAMA_SERVER_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda" })
 $(if ($llamaServerImageFallback) { "LLAMA_SERVER_IMAGE_FALLBACK=$llamaServerImageFallback" } else { "#LLAMA_SERVER_IMAGE_FALLBACK=ghcr.io/ggml-org/llama.cpp:server-cuda-b9014" })
 $(if ($LemonadeServerImage) { "LEMONADE_SERVER_IMAGE=$LemonadeServerImage" } else { "#LEMONADE_SERVER_IMAGE=ghcr.io/lemonade-sdk/lemonade-server:v10.2.0" })

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1811,8 +1811,10 @@ function Start-NativeInferenceServer {
     } elseif ($backend -eq "llama-server") {
         $ggufFile = $envVars["GGUF_FILE"]
         $ctxSize  = $envVars["CTX_SIZE"]
+        $gpuLayers = $envVars["N_GPU_LAYERS"]
         if (-not $ggufFile) { $ggufFile = "Qwen3.5-9B-Q4_K_M.gguf" }
         if (-not $ctxSize)  { $ctxSize = "16384" }
+        if (-not $gpuLayers) { $gpuLayers = "auto" }
 
         $modelPath = Join-Path (Join-Path $InstallDir "data\models") $ggufFile
         if (-not (Test-Path $modelPath)) {
@@ -1836,7 +1838,7 @@ function Start-NativeInferenceServer {
             "--model", $modelPath,
             "--host", $bindAddr,
             "--port", [string]$script:LEMONADE_PORT,
-            "--n-gpu-layers", "999",
+            "--n-gpu-layers", $gpuLayers,
             "--ctx-size", $ctxSize,
             "--reasoning-format", $reasoningFmt,
             # llama.cpp keeps /metrics off unless asked. The dashboard's

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -1138,6 +1138,7 @@ restart_windows_native_llama_server_with_full_model() {
     ODS_WIN_BIND_ADDR="$bind_addr" \
     ODS_WIN_LLAMA_PORT="$llama_port" \
     ODS_WIN_CTX_SIZE="$ctx_size" \
+    ODS_WIN_GPU_LAYERS="$(read_env_value N_GPU_LAYERS)" \
     ODS_WIN_REASONING_FORMAT="$reasoning_fmt" \
     ODS_WIN_FLASH_ATTN="$(read_env_value LLAMA_ARG_FLASH_ATTN)" \
     ODS_WIN_CACHE_TYPE_K="$(read_env_value LLAMA_ARG_CACHE_TYPE_K)" \
@@ -1196,11 +1197,13 @@ restart_windows_native_llama_server_with_full_model() {
         function Start-ODSLlama {
             param([string]$ModelPath)
 
+            $gpuLayers = $env:ODS_WIN_GPU_LAYERS
+            if (-not $gpuLayers) { $gpuLayers = "auto" }
             $args = @(
                 "--model", $ModelPath,
                 "--host", $env:ODS_WIN_BIND_ADDR,
                 "--port", $env:ODS_WIN_LLAMA_PORT,
-                "--n-gpu-layers", "999",
+                "--n-gpu-layers", $gpuLayers,
                 "--ctx-size", $env:ODS_WIN_CTX_SIZE,
                 "--reasoning-format", $env:ODS_WIN_REASONING_FORMAT,
                 "--metrics"
@@ -2832,7 +2835,7 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
             #
             # Two latency hits if we skip this:
             #   1. llama-server / Lemonade loads the full model into VRAM on first
-            #      request (`--n-gpu-layers 999` is lazy). PR #1192 already warms
+            #      request. PR #1192 already warms
             #      this at install time, but that warm-up was against the
             #      bootstrap model — after the swap, the slot is cold again.
             #   2. Hermes's runtime config bakes a 14K-token system prompt
@@ -2969,13 +2972,15 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
             _cache_type_k=$(grep '^LLAMA_ARG_CACHE_TYPE_K=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
             _cache_type_v=$(grep '^LLAMA_ARG_CACHE_TYPE_V=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
             _n_cpu_moe=$(grep '^LLAMA_ARG_N_CPU_MOE=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
+            _gpu_layers=$(grep '^N_GPU_LAYERS=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || echo "")
+            [[ -z "$_gpu_layers" ]] && _gpu_layers="auto"
             _spec_type=$(grep '^LLAMA_ARG_SPEC_TYPE=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
             _spec_draft_n_max=$(grep '^LLAMA_ARG_SPEC_DRAFT_N_MAX=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
             _llama_args=(
                 --host "$_bind" --port "$_native_port"
                 --model "$_model_path"
                 --ctx-size "$_ctx_size"
-                --n-gpu-layers 999
+                --n-gpu-layers "$_gpu_layers"
                 --reasoning-format "$_reasoning_fmt"
                 --metrics
             )
@@ -3023,7 +3028,7 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
                             --host "$_bind" --port "$_native_port" \
                             --model "$_old_model_path" \
                             --ctx-size "$_ctx_size" \
-                            --n-gpu-layers 999 \
+                            --n-gpu-layers "$_gpu_layers" \
                             --reasoning-format "${_reasoning_fmt:-none}" \
                             --metrics
                     ) > "$LLAMA_SERVER_LOG" 2>&1 &

--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -418,6 +418,13 @@ if [[ -n "$remote_model" && ! "$remote_model" =~ ^[A-Za-z0-9][A-Za-z0-9._:/+-]{0
     )
 fi
 
+n_gpu_layers="${ENV_MAP[N_GPU_LAYERS]-}"
+if [[ -n "$n_gpu_layers" && ! "$n_gpu_layers" =~ ^(auto|all|[0-9]+)$ ]]; then
+    contract_errors+=(
+      "N_GPU_LAYERS: expected auto, all, or a non-negative whole number (line ${ENV_LINE[N_GPU_LAYERS]:-?})"
+    )
+fi
+
 if [[ "$remote_enabled" == "true" ]]; then
     if [[ "${ENV_MAP[ODS_MODE]-local}" != "cloud" ]]; then
         contract_errors+=(

--- a/ods/tests/contracts/test-llama-runtime-tunables.py
+++ b/ods/tests/contracts/test-llama-runtime-tunables.py
@@ -30,10 +30,21 @@ except ModuleNotFoundError as exc:
 ROOT_DIR = Path(__file__).resolve().parents[2]
 BASE_FILE = ROOT_DIR / "docker-compose.base.yml"
 SCHEMA_FILE = ROOT_DIR / ".env.schema.json"
+ENV_GENERATOR = ROOT_DIR / "installers" / "phases" / "06-directories.sh"
+MACOS_ENV_GENERATOR = ROOT_DIR / "installers" / "macos" / "lib" / "env-generator.sh"
+WINDOWS_ENV_GENERATOR = ROOT_DIR / "installers" / "windows" / "lib" / "env-generator.ps1"
+NATIVE_LAUNCHERS = (
+    ROOT_DIR / "bin" / "ods-host-agent.py",
+    ROOT_DIR / "installers" / "macos" / "install-macos.sh",
+    ROOT_DIR / "installers" / "macos" / "ods-macos.sh",
+    ROOT_DIR / "installers" / "windows" / "install-windows.ps1",
+    ROOT_DIR / "installers" / "windows" / "ods.ps1",
+    ROOT_DIR / "scripts" / "bootstrap-upgrade.sh",
+)
 
 # Flags whose value must stay operator-tunable through .env. The base file is
 # the source of truth for which variable backs each one.
-TUNABLE_FLAGS = ("--ctx-size", "--batch-size", "--threads", "--parallel")
+TUNABLE_FLAGS = ("--n-gpu-layers", "--ctx-size", "--batch-size", "--threads", "--parallel")
 VAR_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)")
 
 
@@ -82,6 +93,45 @@ def main() -> int:
             if variable not in schema_properties:
                 errors.append(f".env.schema.json: {flag} uses undocumented variable {variable}")
 
+    gpu_layer_schema = schema_properties.get("N_GPU_LAYERS") or {}
+    if gpu_layer_schema.get("default") != "auto":
+        errors.append(".env.schema.json: N_GPU_LAYERS must default to llama.cpp auto placement")
+    linux_env_generator = ENV_GENERATOR.read_text(encoding="utf-8")
+    if 'N_GPU_LAYERS_VALUE=$(_env_get N_GPU_LAYERS "${N_GPU_LAYERS:-auto}")' not in linux_env_generator:
+        errors.append("06-directories.sh: reruns do not preserve N_GPU_LAYERS")
+    if 'N_GPU_LAYERS_VALUE="${N_GPU_LAYERS_VALUE:-auto}"' not in linux_env_generator:
+        errors.append("06-directories.sh: empty N_GPU_LAYERS values do not fall back to auto")
+    if "N_GPU_LAYERS=${N_GPU_LAYERS_VALUE}" not in linux_env_generator:
+        errors.append("06-directories.sh: generated .env does not write N_GPU_LAYERS")
+
+    macos_env_generator = MACOS_ENV_GENERATOR.read_text(encoding="utf-8")
+    if "N_GPU_LAYERS=${n_gpu_layers}" not in macos_env_generator:
+        errors.append("macOS env generator: fresh installs do not write N_GPU_LAYERS")
+    if 'read_env_value "$env_path" "N_GPU_LAYERS"' not in macos_env_generator:
+        errors.append("macOS env generator: reruns do not preserve/backfill N_GPU_LAYERS")
+    if "normalize_n_gpu_layers" not in macos_env_generator:
+        errors.append("macOS env generator: N_GPU_LAYERS values are not normalized")
+
+    windows_env_generator = WINDOWS_ENV_GENERATOR.read_text(encoding="utf-8")
+    if 'N_GPU_LAYERS=$nGpuLayers' not in windows_env_generator:
+        errors.append("Windows env generator: installs/reruns do not preserve/default N_GPU_LAYERS")
+    if '$nGpuLayers = (Get-EnvOrNew "N_GPU_LAYERS" $nGpuLayersDefault).Trim()' not in windows_env_generator:
+        errors.append("Windows env generator: N_GPU_LAYERS values are not normalized")
+
+    for path in NATIVE_LAUNCHERS:
+        text = path.read_text(encoding="utf-8")
+        flag_lines = [line.strip() for line in text.splitlines() if "--n-gpu-layers" in line]
+        if not flag_lines:
+            errors.append(f"{path.relative_to(ROOT_DIR)}: native launcher no longer sets --n-gpu-layers")
+            continue
+        if "N_GPU_LAYERS" not in text:
+            errors.append(f"{path.relative_to(ROOT_DIR)}: native launcher ignores N_GPU_LAYERS")
+        for line in flag_lines:
+            if re.search(r"--n-gpu-layers[\"',\s]+[\"']?999(?:[\"'\s,]|$)", line):
+                errors.append(
+                    f"{path.relative_to(ROOT_DIR)}: native launcher still forces every GPU layer"
+                )
+
     for path in sorted(ROOT_DIR.glob("docker-compose*.yml")):
         if path == BASE_FILE:
             continue
@@ -97,6 +147,13 @@ def main() -> int:
                 )
                 continue
             if flag not in TUNABLE_FLAGS:
+                continue
+            if (
+                flag == "--n-gpu-layers"
+                and path.name == "docker-compose.cpu.yml"
+                and values[flag] == "0"
+            ):
+                # A CPU-only deployment must never inherit auto/all offload.
                 continue
             # The overlay may pick its own default, but it must stay tunable
             # through the same .env variable the base file uses.

--- a/ods/tests/test-gpu-layer-contract.py
+++ b/ods/tests/test-gpu-layer-contract.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Cross-platform persistence contract for llama.cpp GPU layer placement."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+def replace_env_value(path: Path, key: str, value: str | None) -> None:
+    lines = [
+        line
+        for line in path.read_text(encoding="utf-8-sig").splitlines()
+        if not line.startswith(f"{key}=")
+    ]
+    if value is not None:
+        lines.append(f"{key}={value}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_windows_generator(install_dir: Path, override: str | None = None) -> None:
+    env = os.environ.copy()
+    env["ODS_TEST_ROOT"] = str(ROOT)
+    env["ODS_TEST_DIR"] = str(install_dir)
+    if override is None:
+        env.pop("N_GPU_LAYERS", None)
+    else:
+        env["N_GPU_LAYERS"] = override
+    script = r'''
+$ErrorActionPreference = "Stop"
+function Write-AIWarn { param([string]$Message) }
+. (Join-Path $env:ODS_TEST_ROOT "installers/windows/lib/detection.ps1")
+. (Join-Path $env:ODS_TEST_ROOT "installers/windows/lib/env-generator.ps1")
+$tier = @{
+    TierName = "GPU layer contract"
+    LlmModel = "test-model"
+    GgufFile = "test.gguf"
+    MaxContext = 4096
+}
+New-ODSEnv -InstallDir $env:ODS_TEST_DIR -TierConfig $tier -Tier "3" -GpuBackend "nvidia" -ODSMode "local" | Out-Null
+'''
+    subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_windows_generator_gpu_layer_lifecycle() -> None:
+    with tempfile.TemporaryDirectory(prefix="ods-windows-gpu-layer-contract-") as temp:
+        root = Path(temp)
+        fresh = root / "fresh"
+        run_windows_generator(fresh)
+        assert read_env(fresh / ".env")["N_GPU_LAYERS"] == "auto"
+
+        explicit = root / "explicit"
+        run_windows_generator(explicit, "all")
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "all"
+
+        # A persisted operator value wins over a process-level override.
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", "17")
+        run_windows_generator(explicit, "all")
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "17"
+
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", "  23  ")
+        run_windows_generator(explicit)
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "23"
+
+        # Older and manually emptied environments receive the safe default.
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", None)
+        run_windows_generator(explicit)
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "auto"
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", "")
+        run_windows_generator(explicit)
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "auto"
+
+
+def run_macos_generator(install_dir: Path, force: bool, override: str | None = None) -> None:
+    install_dir.mkdir(parents=True, exist_ok=True)
+    install_arg = str(install_dir)
+    if os.name == "nt":
+        drive, tail = os.path.splitdrive(install_arg)
+        install_arg = f"/{drive[0].lower()}{tail.replace(os.sep, '/')}"
+    env = os.environ.copy()
+    if override is None:
+        env.pop("N_GPU_LAYERS", None)
+    else:
+        env["N_GPU_LAYERS"] = override
+    subprocess.run(
+        [
+            "bash",
+            "-c",
+            'if [[ "$(uname -s)" != "Darwin" ]]; then '
+            'sed() { '
+            'if [[ "${1:-}" == "-i" && "$#" -ge 2 && -z "$2" ]]; then '
+            'shift 2; command sed -i "$@"; '
+            'else command sed "$@"; fi; '
+            '}; export -f sed; fi; '
+            'source installers/macos/lib/detection.sh; '
+            'source installers/macos/lib/env-generator.sh; '
+            'generate_ods_env "$1" 3 "$2" >/dev/null',
+            "ods-gpu-layer-contract",
+            install_arg,
+            "true" if force else "false",
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_macos_generator_gpu_layer_lifecycle() -> None:
+    with tempfile.TemporaryDirectory(prefix="ods-macos-gpu-layer-contract-") as temp:
+        root = Path(temp)
+        fresh = root / "fresh"
+        run_macos_generator(fresh, force=True)
+        assert read_env(fresh / ".env")["N_GPU_LAYERS"] == "auto"
+
+        explicit = root / "explicit"
+        run_macos_generator(explicit, force=True, override="all")
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "all"
+
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", "17")
+        run_macos_generator(explicit, force=False, override="all")
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "17"
+
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", "  23  ")
+        run_macos_generator(explicit, force=False)
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "23"
+
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", None)
+        run_macos_generator(explicit, force=False)
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "auto"
+        replace_env_value(explicit / ".env", "N_GPU_LAYERS", "")
+        run_macos_generator(explicit, force=False)
+        assert read_env(explicit / ".env")["N_GPU_LAYERS"] == "auto"
+
+
+def main() -> int:
+    tests = []
+    if shutil.which("pwsh"):
+        tests.append(test_windows_generator_gpu_layer_lifecycle)
+    else:
+        print("[SKIP] Windows generator lifecycle (pwsh unavailable)")
+    if os.name != "nt" and shutil.which("bash"):
+        tests.append(test_macos_generator_gpu_layer_lifecycle)
+    else:
+        print("[SKIP] macOS generator lifecycle (POSIX bash unavailable)")
+
+    for test in tests:
+        test()
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test-gpu-layer-contract.py
+++ b/ods/tests/test-gpu-layer-contract.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from unittest import SkipTest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -67,6 +68,9 @@ New-ODSEnv -InstallDir $env:ODS_TEST_DIR -TierConfig $tier -Tier "3" -GpuBackend
 
 
 def test_windows_generator_gpu_layer_lifecycle() -> None:
+    if shutil.which("pwsh") is None:
+        raise SkipTest("PowerShell is unavailable")
+
     with tempfile.TemporaryDirectory(prefix="ods-windows-gpu-layer-contract-") as temp:
         root = Path(temp)
         fresh = root / "fresh"
@@ -133,6 +137,9 @@ def run_macos_generator(install_dir: Path, force: bool, override: str | None = N
 
 
 def test_macos_generator_gpu_layer_lifecycle() -> None:
+    if os.name == "nt" or shutil.which("bash") is None:
+        raise SkipTest("POSIX bash is unavailable")
+
     with tempfile.TemporaryDirectory(prefix="ods-macos-gpu-layer-contract-") as temp:
         root = Path(temp)
         fresh = root / "fresh"

--- a/ods/tests/test-validate-env.sh
+++ b/ods/tests/test-validate-env.sh
@@ -108,6 +108,27 @@ else
     fail "Valid .env should yield exit 0, got $r"
 fi
 
+# N_GPU_LAYERS accepts llama.cpp's symbolic policies and explicit non-negative
+# counts, but rejects malformed values before they reach any launcher.
+for gpu_layers in auto all 0 17 999; do
+    cp "$TMP_DIR/valid.env" "$TMP_DIR/gpu-layers-valid.env"
+    printf 'N_GPU_LAYERS=%s\n' "$gpu_layers" >> "$TMP_DIR/gpu-layers-valid.env"
+    "$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" \
+        "$TMP_DIR/gpu-layers-valid.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1 \
+        || fail "N_GPU_LAYERS=$gpu_layers should validate"
+done
+pass "N_GPU_LAYERS accepts auto, all, and non-negative layer counts"
+
+for gpu_layers in -1 1.5 AUTO automatic '999;exit'; do
+    cp "$TMP_DIR/valid.env" "$TMP_DIR/gpu-layers-invalid.env"
+    printf 'N_GPU_LAYERS=%s\n' "$gpu_layers" >> "$TMP_DIR/gpu-layers-invalid.env"
+    if "$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" \
+        "$TMP_DIR/gpu-layers-invalid.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1; then
+        fail "N_GPU_LAYERS=$gpu_layers should be rejected"
+    fi
+done
+pass "N_GPU_LAYERS rejects malformed and negative values"
+
 # 5. .env missing one required key → exit 2
 REAL_JQ="$(command -v jq)"
 CRLF_JQ_DIR="$TMP_DIR/crlf-jq"


### PR DESCRIPTION
## Summary

Closes #2255 and #2259.

ODS forced `--n-gpu-layers 999` in the shared Compose path and every native llama.cpp launcher. Current llama.cpp treats that as an explicit operator choice, so its memory fitter cannot reduce GPU placement when a model, context, or KV cache no longer fits. The result is a startup failure instead of the memory-aware placement that llama.cpp already provides.

This change makes `N_GPU_LAYERS=auto` the default, preserves explicit `all` or non-negative layer-count overrides, and carries the same value through clean installs, reruns, upgrades, rollback launchers, Settings, and runtime recreation.

### Behavior and invariants

| Invariant | Implementation |
|---|---|
| Default to memory-aware placement | Shared Compose and native launchers use `auto` when the key is absent or empty |
| Preserve operator intent | `all` and integer values survive installer reruns and Settings serialization |
| Keep CPU-only deployments CPU-only | The CPU overlay remains pinned to `0` |
| Preserve backend-specific Intel defaults | Intel and Arc tier selection can continue to set `99` |
| Keep every runtime path aligned | Compose, Linux host agent, Windows native, macOS native, bootstrap upgrade, and rollback consume the same key |
| Reject malformed launch arguments | Schema, Settings API, and `validate-env.sh` accept only `auto`, `all`, or a non-negative integer |
| Avoid unrelated lifecycle changes | Model identity, context, ports, health checks, and service topology are unchanged |

## AI Assistance

AI-assisted repository search, edge-case enumeration, and regression-test drafting were used. The author reviewed the implementation, selected the validation scope, reproduced the contract failure, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
python -m pytest ods/extensions/services/dashboard-api/tests/test_settings_env.py -q
88 passed

python ods/tests/test-gpu-layer-contract.py
PASS: Windows fresh/default, explicit override, rerun preservation, whitespace normalization, missing-key backfill, and empty-key backfill
SKIP: POSIX macOS lifecycle in this Windows checkout

python ods/tests/contracts/test-llama-runtime-tunables.py
PASS: every Compose overlay and native launcher preserves the runtime tunable

bash ods/tests/contracts/test-llama-reasoning-format.sh
PASS

bash ods/tests/contracts/test-llama-metrics-flag.sh
PASS

PowerShell parser: install-windows.ps1, env-generator.ps1, ods.ps1
PASS

python -m ruff check (touched Python files)
PASS

python -m py_compile (touched Python files)
PASS

git diff --check
PASS

Compose rendering verified:
- NVIDIA default -> auto
- NVIDIA explicit override -> requested count
- CPU overlay -> 0
- Intel/Arc defaults and explicit overrides remain valid
```

The macOS generator lifecycle was also exercised manually through Bash with fresh, explicit, persisted, missing, empty, and whitespace-padded values. No physical Apple Silicon or Linux GPU runtime receipt is claimed by this draft.

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Upgrade, failure, and rollback behavior

- Existing valid `N_GPU_LAYERS` values are preserved on rerun. This includes legacy `99` values because old files do not record whether `99` came from the installer or an operator; changing it silently would overwrite operator intent. Those installs can set `auto` through Settings or `.env`, and the apply plan recreates only `llama-server`.
- Older environments without the key are backfilled to `auto`.
- Empty values normalize to `auto`; malformed values fail validation before launch.
- Bootstrap and rollback launchers read the same persisted value, so a failed upgrade does not silently restore the old forced-`999` behavior.
- AMD Lemonade and cloud-provider runtime paths are not changed because they do not launch llama.cpp through this flag.

## Notes For Reviewers

This intentionally uses llama.cpp's upstream memory fitter instead of introducing a second ODS-specific VRAM calculator. The exact pinned llama.cpp builds used by ODS (`b8210`, `b8248`, and `b9014`) were checked and all accept `auto`, `all`, and explicit counts; `auto` activates their native placement fitter. The independent review attempted malformed values, whitespace, missing/empty keys, reruns, explicit overrides, CPU-only rendering, backend overlays, native launchers, and rollback paths. One serialization inconsistency was found and fixed during that review. A separate regression proves that changing `N_GPU_LAYERS` from `99` to `auto` through Settings persists the value and schedules `llama-server` recreation. No other reproducible in-scope defect remained after the final pass.

Closes #2259