### PR TITLE
fix(installer): quote NVIDIA DKMS kernel path

### DIFF
--- a/ods/installers/lib/detection.sh
+++ b/ods/installers/lib/detection.sh
@@ -723,7 +723,7 @@ fix_nvidia_secure_boot() {
 
     # Sign every nvidia DKMS module (handles .ko, .ko.zst, .ko.xz)
     local signed_count=0
-    for mod_path in /lib/modules/${kver}/updates/dkms/nvidia*.ko*; do
+    for mod_path in /lib/modules/"${kver}"/updates/dkms/nvidia*.ko*; do
         [[ -f "$mod_path" ]] || continue
         case "$mod_path" in
             *.zst)

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -666,6 +666,12 @@ PATH="$open_bin:$PATH" bash -c '
   validate_nvidia_blackwell_open_modules
 '
 
+echo "[contract] NVIDIA DKMS module discovery preserves the kernel release as one path segment"
+assert_contains "installers/lib/detection.sh" 'for mod_path in /lib/modules/"\$\{kver\}"/updates/dkms/nvidia\*\.ko\*' \
+  "NVIDIA DKMS module glob does not quote the kernel release segment"
+assert_not_contains "installers/lib/detection.sh" 'for mod_path in /lib/modules/\$\{kver\}/updates/dkms/nvidia\*\.ko\*' \
+  "NVIDIA DKMS module glob still expands an unquoted kernel release"
+
 echo "[contract] catalog selector output is parsed without eval"
 assert_contains "lib/safe-env.sh" 'load_model_selector_env_from_output' "safe env loader missing model selector allowlist"
 assert_contains "scripts/select-model.py" 'return f' "model selector no longer emits parser-friendly quoted values"


### PR DESCRIPTION
Fixes #2242

## Summary

Keep the kernel release returned by `uname -r` as one path segment while discovering NVIDIA DKMS modules for Secure Boot signing.

## Root cause

The module glob expanded `${kver}` without quoting. A release string containing whitespace or shell metacharacters could be split before pathname expansion, so the signing loop would inspect the wrong paths or silently sign no modules.

## Change

- Quote only the `/lib/modules/${kver}/updates/dkms` directory segment.
- Leave `nvidia*.ko*` unquoted so module discovery still uses pathname expansion.
- Retain the existing `[[ -f "$mod_path" ]] || continue` guard for the no-match case without changing the caller's global `nullglob` state.
- Add installer-hardening contracts that require the quoted form and reject the old unquoted form.

## Invariants

- Normal kernel releases resolve to the same DKMS module files.
- `.ko`, `.ko.zst`, and `.ko.xz` discovery remains unchanged.
- No-match behavior remains a clean zero-module iteration.
- No shell option is changed globally.
- This affects only the Linux NVIDIA Secure Boot repair path; Windows, macOS, AMD, Intel, and ordinary NVIDIA startup paths are unchanged.

## Validation

- `bash -n installers/lib/detection.sh tests/contracts/test-installer-hardening.sh`
- `bash tests/contracts/test-installer-hardening.sh` -> passed
- `git diff --check`

## Scope

This intentionally does not include the unrelated packaging and `ods-cli` trap changes from #2252. The latter does not solve a normal-return cleanup problem because an `EXIT` trap is process-scoped, not function-scoped.