### PR TITLE
fix(macos): treat absent BIND_ADDRESS as loopback on installer rerun

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -313,6 +313,9 @@ generate_ods_env() {
         # via _env_get unconditionally.
         local _existing_bind
         _existing_bind=$(read_env_value "$env_path" "BIND_ADDRESS")
+        # read_env_value returns "" for a key that predates #2237; empty is not
+        # exposure. Fall back like Linux Phase 06: .env, then env, then loopback.
+        _existing_bind="${_existing_bind:-${BIND_ADDRESS:-127.0.0.1}}"
         if [[ "$_existing_bind" == "0.0.0.0" ]] && [[ -z "$(read_env_value "$env_path" "HOST_LAN_IP")" ]]; then
             local _host_lan_ip
             _host_lan_ip=$(detect_host_lan_ip)

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -241,6 +241,42 @@ source "$ENV_GENERATOR"
 )
 pass "macOS switchboard env persists gateway consumers without hiding backend URL"
 
+# Re-running the installer over an existing .env must classify exposure from
+# BIND_ADDRESS the same way a fresh install does. BIND_ADDRESS only entered the
+# macOS .env template in #2237, so upgrades from earlier installs have no key at
+# all -- an absent value is loopback, not exposure, and must not force auth on.
+rerun_webui_auth() {
+    # $1: .env body for the pre-existing install. Echoes the resulting
+    # WEBUI_AUTH value ("" when the key was never written).
+    local env_body="$1"
+    local rerun_dir="$TMP_DIR/rerun-$2"
+    mkdir -p "$rerun_dir/config/searxng"
+    printf '%s\n' "$env_body" > "$rerun_dir/.env"
+    (
+        calculate_llama_cpu_budget() { printf '4 1 8\n'; }
+        detect_device_name() { printf 'ci-mac\n'; }
+        detect_host_lan_ip() { printf '192.168.1.50\n'; }
+        generate_ods_env "$rerun_dir" CI false >/dev/null
+    )
+    grep -E '^WEBUI_AUTH=' "$rerun_dir/.env" | tail -1 | cut -d= -f2-
+}
+
+[[ "$(rerun_webui_auth 'WEBUI_AUTH=false' pre2237)" == "false" ]] \
+    || fail "upgrade from a pre-BIND_ADDRESS install forced Open WebUI auth on"
+[[ "$(rerun_webui_auth $'BIND_ADDRESS=127.0.0.1\nWEBUI_AUTH=false' loopback)" == "false" ]] \
+    || fail "loopback rerun overwrote the operator's Open WebUI auth choice"
+[[ "$(rerun_webui_auth 'BIND_ADDRESS=127.0.0.1' loopback-nokey)" == "false" ]] \
+    || fail "loopback rerun did not default Open WebUI auth off"
+[[ "$(rerun_webui_auth $'BIND_ADDRESS=0.0.0.0\nWEBUI_AUTH=false' exposed)" == "true" ]] \
+    || fail "network-exposed rerun did not force Open WebUI auth on"
+[[ "$(rerun_webui_auth $'BIND_ADDRESS=127.0.0.1\nENABLE_ODS_PROXY=true' proxy)" == "true" ]] \
+    || fail "proxy-enabled rerun did not force Open WebUI auth on"
+# An absent key must still fail closed when the operator exports BIND_ADDRESS to
+# expose this rerun, matching Linux Phase 06's .env -> env -> loopback fallback.
+[[ "$(BIND_ADDRESS=0.0.0.0 rerun_webui_auth 'WEBUI_AUTH=false' exported)" == "true" ]] \
+    || fail "exported BIND_ADDRESS exposure did not force Open WebUI auth on"
+pass "macOS reruns classify Open WebUI auth from BIND_ADDRESS, absent or not"
+
 openclaw_dir="$TMP_DIR/openclaw-install"
 mkdir -p "$openclaw_dir/data/openclaw/home"
 printf '{"custom":{"preserve":true}}\n' > "$openclaw_dir/data/openclaw/home/openclaw.json"


### PR DESCRIPTION
## Summary

Follow-up to #2237. Treat an absent `BIND_ADDRESS` as loopback when the macOS installer re-reads an existing `.env`.

`read_env_value` returns `""` for a missing key, and `BIND_ADDRESS` was only added to the macOS `.env` template in #2237 — so every install predating it reads empty on rerun. The exposure check sees a value that isn't `127.0.0.1`/`::1`/`localhost` and forces `WEBUI_AUTH=true`, undoing the local access #2237 added and overwriting an operator's `WEBUI_AUTH=false` on every run.

The change adds one fallback, matching Linux `phases/06-directories.sh:630` and Windows `windows/lib/env-generator.ps1:497`:

```bash
_existing_bind="${_existing_bind:-${BIND_ADDRESS:-127.0.0.1}}"
```

`.env`, then env, then loopback — so an exported `BIND_ADDRESS=0.0.0.0` still forces auth on. `0.0.0.0` and proxy installs are unchanged.

Also adds a rerun case to `test-macos-installer-transitions.sh`. The existing `test-local-app-auth-defaults.sh` only greps source patterns, so it passed on the broken code too.

## AI Assistance

AI assistance was used to trace the empty-string path through `generate_ods_env`, draft the fix and test fixtures, and draft this PR description. I reviewed the final diff and ran the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A. #2237 is not in release/2.6.x.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — auth surface, but one line in one macOS-only branch. Linux, Windows and fresh macOS installs are untouched.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
git diff --check                                    Passed
bash -n installers/macos/lib/env-generator.sh       Passed
bash tests/test-macos-installer-transitions.sh      [OK] macOS installer transition contracts hold
bash tests/test-local-app-auth-defaults.sh          PASS: local app authentication defaults
```

The new case drives the real `generate_ods_env` against a temp install dir, so it fails on the bug rather than on a grep. Against `main` it reports `[FAIL] upgrade from a pre-BIND_ADDRESS install forced Open WebUI auth on`. Six fixtures: absent key, loopback with and without `WEBUI_AUTH`, `0.0.0.0`, `ENABLE_ODS_PROXY=true`, and absent key with `BIND_ADDRESS` exported.

## Operational Change Check

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [x] This is an operational change and validation is intentionally deferred for:

No macOS hardware run. The change is confined to the existing-`.env` branch of `generate_ods_env`, which the new test now drives end to end. Happy to run a hardware lane if you want one before merge.

## Notes For Reviewers

Rollback is removing the one fallback line. No `shellcheck` locally — `bash -n` is clean and CI covers it. Saw `[FAIL] Perplexica fixture did not start` once in four local runs of the transitions suite; pre-existing flake, reproduces without this change, passed the other three.

You can enable "Allow edits by maintainers." Access to secrets is not needed for this PR.
