### PR TITLE
fix: rsync data-loss, rm -rf guard, UID/GID, platform override, backup regex, preset diff, GPU fail-closed, CI permissions

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -4,6 +4,9 @@ name: AI Issue Triage
 # Advisory mode only — adds labels, doesn't close or modify issues
 # Estimated cost: ~$1.50/issue
 
+permissions:
+  contents: read
+
 on:
   issues:
     types: [opened]

--- a/.github/workflows/autonomous-code-scanner.yml
+++ b/.github/workflows/autonomous-code-scanner.yml
@@ -4,6 +4,9 @@ name: Autonomous Code Scanner
 # Creates separate draft PRs per scan category. Budget-gated at $100/run.
 # Estimated cost: $5-60 per run depending on findings.
 
+permissions:
+  contents: read
+
 on:
   # schedule:
   #   - cron: '0 2 * * *'  # 2 AM UTC daily — enable after cost validation

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,5 +1,8 @@
 name: Dashboard
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -4,6 +4,9 @@ name: Issue to PR
 # and creates draft PRs for human review.
 # Estimated cost: ~$5-15 per issue (claude-sonnet-4-6)
 
+permissions:
+  contents: read
+
 on:
   issues:
     types: [labeled]
@@ -320,6 +323,8 @@ jobs:
     name: Create Pull Request
     needs: [validate, implement, guardrails]
     if: always()
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -1,5 +1,8 @@
 name: Lint PowerShell
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/nightly-code-review.yml
+++ b/.github/workflows/nightly-code-review.yml
@@ -4,6 +4,9 @@ name: Nightly Code Review
 # improvements, then creates a draft PR requiring human approval.
 # Estimated cost: ~$3-8 per run depending on change volume.
 
+permissions:
+  contents: read
+
 on:
   # schedule:
   #   - cron: '0 3 * * *'  # 3 AM UTC daily — enable after cost validation

--- a/.github/workflows/nightly-docs-update.yml
+++ b/.github/workflows/nightly-docs-update.yml
@@ -4,6 +4,9 @@ name: Nightly Documentation Update
 # and creates draft PRs for human review.
 # Estimated cost: ~$1-3 per run (claude-sonnet-4-6)
 
+permissions:
+  contents: write
+
 on:
   # schedule:
   #   - cron: '0 4 * * *'  # 4 AM UTC daily — enable after cost validation

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,6 +4,9 @@ name: AI Release Notes
 # Analyzes commits since last release and generates structured notes
 # Estimated cost: ~$1.50/release
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,5 +1,8 @@
 name: Test Linux
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -1,5 +1,8 @@
 name: Validate .env Schema
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -22,6 +22,12 @@ WEBUI_SECRET=CHANGEME
 N8N_USER=admin@ods.local
 N8N_PASS=CHANGEME
 
+# Container user mapping for Hermes/n8n — resolved to the installing host
+# user at install time so bind-mounted data dirs are owned by the real user.
+# Override only if you need a specific uid/gid.
+# ODS_UID=1000
+# ODS_GID=1000
+
 # LiteLLM API gateway key (generate: echo "sk-ods-$(openssl rand -hex 16)")
 LITELLM_KEY=CHANGEME
 

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -616,6 +616,16 @@
       "description": "n8n external port",
       "default": 5678
     },
+    "ODS_UID": {
+      "type": "integer",
+      "description": "Host user UID used by Hermes/n8n containers so bind-mounted data is owned by the real host user",
+      "minimum": 0
+    },
+    "ODS_GID": {
+      "type": "integer",
+      "description": "Host user GID used by Hermes/n8n containers so bind-mounted data is owned by the real host user",
+      "minimum": 0
+    },
     "QDRANT_PORT": {
       "type": "integer",
       "description": "Qdrant vector DB external port",

--- a/ods/docker-compose.multigpu-nvidia.yml
+++ b/ods/docker-compose.multigpu-nvidia.yml
@@ -1,7 +1,7 @@
 services:
   llama-server:
     environment:
-      NVIDIA_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_UUIDS:-all}"
+      NVIDIA_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_UUIDS:?GPU assignment missing — set LLAMA_SERVER_GPU_UUIDS or re-run gpu-reassign}"
       LLAMA_ARG_SPLIT_MODE: "${LLAMA_ARG_SPLIT_MODE:-none}"
       LLAMA_ARG_TENSOR_SPLIT: "${LLAMA_ARG_TENSOR_SPLIT:-}"
     deploy:
@@ -9,4 +9,5 @@ services:
         reservations:
           devices:
             - driver: nvidia
+              count: all
               capabilities: [gpu]

--- a/ods/extensions/services/embeddings/compose.yaml
+++ b/ods/extensions/services/embeddings/compose.yaml
@@ -1,7 +1,7 @@
 services:
   embeddings:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1
-    platform: linux/amd64  # TEI has no arm64 image -- Rosetta 2 on Apple Silicon
+    platform: ${EMBEDDINGS_PLATFORM:-linux/amd64}  # TEI has no arm64 image -- Rosetta 2 on Apple Silicon
     container_name: ods-embeddings
     restart: unless-stopped
     security_opt:

--- a/ods/extensions/services/hermes/compose.yaml
+++ b/ods/extensions/services/hermes/compose.yaml
@@ -15,8 +15,8 @@ services:
     environment:
       # User remapping: match the host user so files written into the volume
       # are owned by the user, not container-root. Same pattern as n8n.
-      - HERMES_UID=${UID:-10000}
-      - HERMES_GID=${GID:-10000}
+      - HERMES_UID=${UID:-$(id -u)}
+      - HERMES_GID=${GID:-$(id -g)}
       # Point Hermes at the local LLM. provider=custom is the documented
       # alias for any OpenAI-compatible local server (vLLM / llama.cpp / Ollama).
       # The actual provider/model wiring lives in cli-config.yaml (mounted below).

--- a/ods/extensions/services/hermes/compose.yaml
+++ b/ods/extensions/services/hermes/compose.yaml
@@ -15,8 +15,10 @@ services:
     environment:
       # User remapping: match the host user so files written into the volume
       # are owned by the user, not container-root. Same pattern as n8n.
-      - HERMES_UID=${UID:-$(id -u)}
-      - HERMES_GID=${GID:-$(id -g)}
+      # ODS_UID/ODS_GID are resolved into .env at install time; the fallback
+      # only applies if an operator edits .env directly.
+      - HERMES_UID=${ODS_UID:-10000}
+      - HERMES_GID=${ODS_GID:-10000}
       # Point Hermes at the local LLM. provider=custom is the documented
       # alias for any OpenAI-compatible local server (vLLM / llama.cpp / Ollama).
       # The actual provider/model wiring lives in cli-config.yaml (mounted below).

--- a/ods/extensions/services/n8n/compose.yaml
+++ b/ods/extensions/services/n8n/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: n8nio/n8n:2.6.4
     container_name: ods-n8n
     restart: unless-stopped
-    user: "${UID:-1000}:${GID:-1000}"
+    user: "${UID:-$(id -u)}:${GID:-$(id -g)}"
     security_opt:
       - no-new-privileges:true
     entrypoint: ["tini", "--", "/bin/sh", "/opt/ods/n8n-entrypoint.sh"]

--- a/ods/extensions/services/n8n/compose.yaml
+++ b/ods/extensions/services/n8n/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: n8nio/n8n:2.6.4
     container_name: ods-n8n
     restart: unless-stopped
-    user: "${UID:-$(id -u)}:${GID:-$(id -g)}"
+    user: "${ODS_UID:-1000}:${ODS_GID:-1000}"
     security_opt:
       - no-new-privileges:true
     entrypoint: ["tini", "--", "/bin/sh", "/opt/ods/n8n-entrypoint.sh"]

--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -65,8 +65,24 @@ format_git_clone_error() {
 }
 
 
-remove_install_dir() {
+_is_ods_install_dir() {
     local target_dir="$1"
+    [[ -d "$target_dir" ]] && ( [[ -f "$target_dir/.env" ]] || [[ -f "$target_dir/docker-compose.base.yml" ]] || [[ -d "$target_dir/data" ]] )
+}
+
+remove_install_dir() {
+    local target_dir="${1%/}"
+
+    # Safety guard: never let rm -rf run on an unsafe path
+    if [[ -z "$target_dir" || "$target_dir" == "/" || "$target_dir" == "$HOME" ]]; then
+        echo "ERROR: refusing to remove unsafe path: $target_dir" >&2
+        return 1
+    fi
+
+    if ! _is_ods_install_dir "$target_dir"; then
+        echo "ERROR: refusing to remove $target_dir — not an ODS install directory" >&2
+        return 1
+    fi
 
     if rm -rf -- "$target_dir" 2>/dev/null; then
         return 0

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -985,6 +985,14 @@ WEBUI_AUTH=${WEBUI_AUTH}
 ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
 
+#=== Container User Mapping ===
+# Hermes and n8n containers run as this host user so bind-mounted data
+# dirs are owned by the real user, not a hardcoded fallback uid. Resolved
+# at install time because UID/GID are readonly shell vars never exported
+# into compose's interpolation environment.
+ODS_UID=$(_env_get ODS_UID "$(id -u)")
+ODS_GID=$(_env_get ODS_GID "$(id -g)")
+
 #=== n8n Settings ===
 N8N_HOST=localhost
 N8N_WEBHOOK_URL=http://localhost:5678

--- a/ods/lib/rsync.sh
+++ b/ods/lib/rsync.sh
@@ -11,6 +11,7 @@
 # Usage:
 #   . "$ODS_DIR/lib/rsync.sh"
 #   rsync_with_progress "$src" "$dest" "Optional label"
+#   rsync_with_progress "$src" "$dest" "Optional label" delete
 # ============================================================================
 
 # Rsync with progress indicator
@@ -18,10 +19,20 @@
 #   $1 - source path
 #   $2 - destination path
 #   $3 - optional label (default: "Copying")
+#   $4 - optional "delete" to enable rsync --delete (true mirror sync).
+#        Alternatively set RSYNC_DELETE=1 in the environment.
+# --delete is opt-in, never the default: backup/restore flows rely on it
+# being absent so destination data is never wiped.
 rsync_with_progress() {
     local src="$1"
     local dest="$2"
     local label="${3:-Copying}"
+    local delete="${4:-}"
+
+    local -a delete_args=()
+    if [[ "$delete" == "delete" || "${RSYNC_DELETE:-0}" == "1" ]]; then
+        delete_args+=( --delete )
+    fi
 
     # Prefer the caller's styled logger when it exists. log_info is a *function*
     # in the scripts that source this lib (ods-backup.sh, ods-restore.sh), so it
@@ -36,9 +47,9 @@ rsync_with_progress() {
     # Use --info=progress2 for compact single-line progress updates
     # Fallback to basic rsync if progress2 not supported
     if rsync --help 2>/dev/null | grep -q "info=progress2"; then
-        rsync -a --delete --info=progress2 "$src" "$dest"
+        rsync -a "${delete_args[@]}" --info=progress2 "$src" "$dest"
     else
         # Fallback: use --progress for older rsync versions
-        rsync -a --delete --progress "$src" "$dest" 2>/dev/null || rsync -a --delete "$src" "$dest"
+        rsync -a "${delete_args[@]}" --progress "$src" "$dest" 2>/dev/null || rsync -a "${delete_args[@]}" "$src" "$dest"
     fi
 }

--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -148,7 +148,7 @@ collect_backups() {
     local entry base
     while IFS= read -r -d '' entry; do
         base=$(basename "$entry")
-        [[ "$base" =~ ^([A-Za-z0-9_]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
+        [[ "$base" =~ ^[A-Za-z0-9_-]*[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
         COLLECTED_BACKUPS+=("$entry")
     done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
 }

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3370,14 +3370,22 @@ META
 
                 # Parse both env files
                 declare -A env1 env2
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+                while IFS= read -r line; do
+                    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+                    key="${line%%=*}"
+                    value="${line#*=}"
                     [[ -z "$key" ]] && continue
+                    value="${value%$'\r'}"
+                    value="${value#\"}"; value="${value%\"}"
                     env1["$key"]="$value"
                 done < "$dir1/env"
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+                while IFS= read -r line; do
+                    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+                    key="${line%%=*}"
+                    value="${line#*=}"
                     [[ -z "$key" ]] && continue
+                    value="${value%$'\r'}"
+                    value="${value#\"}"; value="${value%\"}"
                     env2["$key"]="$value"
                 done < "$dir2/env"
 


### PR DESCRIPTION
## Summary

Fixes 8 issues found in deeper codebase audit:

| # | Issue | Severity | Fix |
|---|-------|----------|-----|
| #2304 | rsync `--delete` destroys backups & live data | CRITICAL | Make `--delete` opt-in |
| #2301 | get-ods.sh `rm -rf` on unvalidated path | HIGH | Refuse unsafe/non-ODS paths |
| #2303 | Hermes/n8n UID/GID never resolve | MEDIUM | Resolve `ODS_UID`/`ODS_GID` into `.env` at install time |
| #2302 | embeddings forced linux/amd64 | MEDIUM | Configurable `EMBEDDINGS_PLATFORM` |
| #2297 | preset diff truncates at first `=` | MEDIUM | Split on first `=`, strip CR/quotes |
| #2298 | multigpu-nvidia exposes ALL GPUs | MEDIUM | Fail closed with `:?` |
| #2299 | backup regex rejects multi-segment IDs | MEDIUM | Allow `[A-Za-z0-9_-]*` prefix |
| #2300 | 10 workflows lack `permissions:` | MEDIUM | Least-privilege blocks |

## Notable
- `rsync.sh`: `--delete` now requires explicit opt-in (4th arg or `RSYNC_DELETE=1`), preventing backup/restore data loss
- `get-ods.sh`: added `_is_ods_install_dir` guard — refuses to delete `/`, `$HOME`, or non-ODS directories
- `multigpu-nvidia.yml`: `NVIDIA_VISIBLE_DEVICES` fails closed with `:?` instead of defaulting to `all`
- `#2303`: Compose interpolation does not run `$(id -u)` in defaults, so the host uid/gid is resolved into `ODS_UID`/`ODS_GID` in the generated `.env` at install time; Hermes/n8n reference those vars (schema + `.env.example` updated)