### PR TITLE
fix(gpu): keep every GPU in the hybrid llama parallelism plan

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -63,7 +63,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install manifest validator dependencies
-        run: python3 -m pip install "PyYAML>=6.0,<7.0" "jsonschema>=4.21,<5.0"
+        run: python3 -m pip install "PyYAML>=6.0,<7.0" "jsonschema>=4.21,<5.0" "pytest>=8,<9"
 
       - name: Docs Link Checks
         run: bash tests/test-doc-links.sh
@@ -195,6 +195,9 @@ jobs:
 
       - name: Perplexica Entrypoint Contract Tests
         run: python3 tests/test-perplexica-entrypoint.py
+
+      - name: Multi-GPU Assignment Planner Tests
+        run: python3 -m pytest tests/test-assign-gpus.py -q
 
       - name: CPU-Only Path Tests
         run: bash tests/test-cpu-only-path.sh

--- a/ods/scripts/assign_gpus.py
+++ b/ods/scripts/assign_gpus.py
@@ -299,7 +299,12 @@ def largest_pow2_divisor(n: int) -> int:
     Find the largest power of 2 p such that:
       - p divides n evenly
       - p <= sqrt(n)  (keeps tensor_size <= pipeline_size for balance)
-    Minimum return value is 2 (hybrid requires at least 2 tensor groups).
+
+    Returns 1 when no power of 2 divides n — every odd GPU count. Callers must
+    read 1 as "a hybrid plan cannot cover this GPU count" and fall back to
+    pipeline. Clamping the result up to 2 instead leaves GPUs out of the plan
+    entirely: hybrid derives pipeline_parallel_size as n // tensor_parallel_size,
+    so an odd n silently yields tensor * pipeline < n (5 GPUs -> 2 x 2).
     """
     p = 1
     while True:
@@ -309,7 +314,30 @@ def largest_pow2_divisor(n: int) -> int:
         if candidate > math.sqrt(n):
             break
         p = candidate
-    return max(2, p)
+    return p
+
+
+def hybrid_or_pipeline(n: int, split: Optional[list]) -> LlamaParallelism:
+    """Hybrid when a power-of-2 tensor group divides n, else pipeline.
+
+    Both modes place every GPU in the subset: hybrid as tensor x pipeline,
+    pipeline as one stage per GPU.
+    """
+    tp = largest_pow2_divisor(n)
+    if tp >= 2:
+        return LlamaParallelism(
+            mode="hybrid",
+            tensor_parallel_size=tp,
+            pipeline_parallel_size=n // tp,
+            gpu_memory_utilization=0.93,
+            tensor_split=split,
+        )
+    return LlamaParallelism(
+        mode="pipeline",
+        tensor_parallel_size=1,
+        pipeline_parallel_size=n,
+        gpu_memory_utilization=0.95,
+    )
 
 
 def is_heterogeneous(gpus: list) -> bool:
@@ -357,15 +385,7 @@ def select_parallelism(subset: Subset) -> LlamaParallelism:
                 tensor_split=split,
             )
         else:
-            tp = largest_pow2_divisor(n)
-            pp = n // tp
-            return LlamaParallelism(
-                mode="hybrid",
-                tensor_parallel_size=tp,
-                pipeline_parallel_size=pp,
-                gpu_memory_utilization=0.93,
-                tensor_split=split,
-            )
+            return hybrid_or_pipeline(n, split)
 
     # Cross-NUMA PCIe
     if rank <= 10:
@@ -386,15 +406,7 @@ def select_parallelism(subset: Subset) -> LlamaParallelism:
         )
     else:
         if rank >= 40:
-            tp = largest_pow2_divisor(n)
-            pp = n // tp
-            return LlamaParallelism(
-                mode="hybrid",
-                tensor_parallel_size=tp,
-                pipeline_parallel_size=pp,
-                gpu_memory_utilization=0.93,
-                tensor_split=split,
-            )
+            return hybrid_or_pipeline(n, split)
         else:
             return LlamaParallelism(
                 mode="pipeline",

--- a/ods/tests/test-assign-gpus.py
+++ b/ods/tests/test-assign-gpus.py
@@ -466,11 +466,13 @@ class TestEightGpuNv12FullMesh:
         assert len(set(uuids)) == 3
 
     def test_model_fits_one_gpu_extras_back_to_llama_nvlink(self):
-        # NVLink pair wins, remaining=6: 3 to services, 3 extras → llama=5 GPUs, hybrid
+        # NVLink pair wins, remaining=6: 3 to services, 3 extras → llama=5 GPUs.
+        # 5 has no power-of-2 divisor, so the plan is pipeline over all 5.
         _, out, _ = run(self.TOPO, 70000)
         p = parallelism(out)
-        assert p["mode"] == "hybrid"
-        assert p["gpu_memory_utilization"] == 0.93
+        assert p["mode"] == "pipeline"
+        assert p["pipeline_parallel_size"] == 5
+        assert p["gpu_memory_utilization"] == 0.95
 
     def test_model_fits_one_gpu_llama_5gpus(self):
         _, out, _ = run(self.TOPO, 70000)
@@ -480,13 +482,14 @@ class TestEightGpuNv12FullMesh:
         _, out, _ = run(self.TOPO, 100000)
         assert len(llama(out)["gpus"]) == 5
 
-    def test_model_needs_two_gpus_hybrid_nvlink(self):
+    def test_model_needs_two_gpus_pipeline_over_five_nvlink(self):
+        # llama ends up with 5 GPUs. A 2 x 2 hybrid would only cover 4 of them.
         _, out, _ = run(self.TOPO, 100000)
         p = parallelism(out)
-        assert p["mode"] == "hybrid"
-        assert p["tensor_parallel_size"] == 2
-        assert p["pipeline_parallel_size"] == 2
-        assert p["gpu_memory_utilization"] == 0.93
+        assert p["mode"] == "pipeline"
+        assert p["tensor_parallel_size"] == 1
+        assert p["pipeline_parallel_size"] == 5
+        assert p["gpu_memory_utilization"] == 0.95
 
     def test_model_needs_five_gpus_no_extras(self):
         # 350GB needs 5 GPUs. remaining=3 exactly → no extras → llama has 5 GPUs
@@ -494,12 +497,12 @@ class TestEightGpuNv12FullMesh:
         assert len(llama(out)["gpus"]) == 5
         assert out["strategy"] == "dedicated"
 
-    def test_model_needs_five_gpus_hybrid(self):
+    def test_model_needs_five_gpus_pipeline(self):
         _, out, _ = run(self.TOPO, 350000)
         p = parallelism(out)
-        assert p["mode"] == "hybrid"
-        assert p["tensor_parallel_size"] == 2
-        assert p["pipeline_parallel_size"] == 2
+        assert p["mode"] == "pipeline"
+        assert p["tensor_parallel_size"] == 1
+        assert p["pipeline_parallel_size"] == 5
 
     def test_model_needs_five_gpus_services_dedicated(self):
         _, out, _ = run(self.TOPO, 350000)
@@ -609,10 +612,21 @@ class TestParallelismModeSelection:
         assert p["mode"] == "pipeline"
         assert p["pipeline_parallel_size"] == 3
 
-    def test_nvlink_full_mesh_five_gpus_hybrid(self):
-        # NV12 full mesh, extras push back → 5 GPUs → hybrid
+    def test_nvlink_full_mesh_eight_gpus_hybrid(self):
+        # NV12 full mesh, model needs every GPU → 8 GPUs → hybrid 2 x 4
+        _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json"), 600000)
+        p = parallelism(out)
+        assert p["mode"] == "hybrid"
+        assert p["tensor_parallel_size"] == 2
+        assert p["pipeline_parallel_size"] == 4
+
+    def test_nvlink_full_mesh_five_gpus_pipeline(self):
+        # NV12 full mesh, extras push back → 5 GPUs. No power of 2 divides 5,
+        # so hybrid cannot cover the subset and the planner must use pipeline.
         _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json"), 100000)
-        assert parallelism(out)["mode"] == "hybrid"
+        p = parallelism(out)
+        assert p["mode"] == "pipeline"
+        assert p["pipeline_parallel_size"] == 5
 
     def test_mem_util_none_is_095(self):
         _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_1gpu_pcie.json"), 20000)
@@ -623,8 +637,42 @@ class TestParallelismModeSelection:
         assert parallelism(out)["gpu_memory_utilization"] == 0.92
 
     def test_mem_util_hybrid_is_093(self):
-        _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json"), 100000)
+        _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json"), 600000)
         assert parallelism(out)["gpu_memory_utilization"] == 0.93
+
+
+# ── Every planned GPU is covered by the parallelism plan ──────────────────────
+
+class TestParallelismCoversEveryGpu:
+    """tensor_parallel_size * pipeline_parallel_size must equal the GPU count.
+
+    llama-server derives its process layout from these two sizes. When the
+    product is smaller than the assigned subset, the remaining GPUs are
+    reserved by the assignment but never used by the model.
+    """
+
+    CASES = [
+        ("nvidia_smi_topo_matrix_2gpus_phb_coloc.json", 40000),
+        ("nvidia_smi_topo_matrix_4gpus_soc.json", 200000),
+        ("nvidia_smi_topo_matrix_4gpus_sys_separated_nv_pairs.json", 100000),
+        ("nvidia_smi_topo_matrix_5gpus_nv12_with_mlx5.json", 300000),
+        ("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json", 100000),
+        ("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json", 500000),
+        ("nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json", 600000),
+        ("nvidia_smi_topo_matrix_8gpus_nv1_nv2_partial_mesh.json", 200000),
+    ]
+
+    def test_plan_covers_every_assigned_gpu(self):
+        for name, model_size_mb in self.CASES:
+            code, out, err = run(fixture_path(name), model_size_mb)
+            assert code == 0, f"{name} @ {model_size_mb}MB: {err}"
+            p = parallelism(out)
+            covered = p["tensor_parallel_size"] * p["pipeline_parallel_size"]
+            assigned = len(llama(out)["gpus"])
+            assert covered == assigned, (
+                f"{name} @ {model_size_mb}MB: mode={p['mode']} covers {covered} "
+                f"of {assigned} assigned GPUs"
+            )
 
     def test_mem_util_pipeline_is_095(self):
         _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_4gpus_soc.json"), 100000)


### PR DESCRIPTION
## Summary

`largest_pow2_divisor()` in `scripts/assign_gpus.py` clamped its result up to 2
(`return max(2, p)`), so it could return a tensor group size that does not
divide the GPU count. `select_parallelism()` then derives
`pipeline_parallel_size = n // tensor_parallel_size`, so every odd multi-GPU
subset produced a plan that covers fewer GPUs than the assignment reserved:

| llama GPUs | emitted plan | GPUs covered |
|---|---|---|
| 5 | `hybrid` tp=2, pp=2 | 4 |
| 7 | `hybrid` tp=2, pp=3 | 6 |
| 9 | `hybrid` tp=2, pp=4 | 8 |
| 11 | `hybrid` tp=2, pp=5 | 10 |

The uncovered GPUs stay reserved for `llama_server` (so no other service can
use them) but never take a shard, and the operator sees a `dedicated` strategy
that silently wastes a device. `bin/ods-host-agent.py` consumes this plan
verbatim via `_run_gpu_planner()`, so the same gap reaches model activation.

Reproduced on a fixture already in the repo, before the change:

```text
$ python scripts/assign_gpus.py \
    --topology tests/fixtures/topology_json/nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json \
    --model-size 100000
llama gpus: 5
mode: hybrid tp: 2 pp: 2
covered: 4 of 5
```

### Fix

- `largest_pow2_divisor()` now returns `1` when no power of 2 divides `n`
  instead of clamping to 2, and documents that `1` means "hybrid cannot cover
  this GPU count".
- Both hybrid call sites go through a new `hybrid_or_pipeline()` helper, which
  falls back to pipeline parallelism (one stage per GPU) when a hybrid layout
  is not representable. Pipeline places every GPU, so no device is dropped.

Even GPU counts are unaffected — they already had a power-of-2 divisor and keep
the exact same plan (verified 2..16).

### Test changes

The existing suite had encoded the bug. `test_model_needs_five_gpus_hybrid`
asserted `tensor_parallel_size == 2` and `pipeline_parallel_size == 2` for a
**five**-GPU subset. Three such assertions are updated to the pipeline
fallback, one hybrid case is re-pointed at a genuine 8-GPU split (tp=2, pp=4),
and a new `TestParallelismCoversEveryGpu` asserts the invariant
`tensor_parallel_size * pipeline_parallel_size == len(gpus)` across the
topology fixtures.

## AI Assistance

AI assisted with reviewing the planner, drafting the regression test, and
wording this description. I read the full diff, confirmed the failing case
against the repo's own fixtures, and ran the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python -m pytest tests/test-assign-gpus.py -q
87 passed in 11.69s

# new invariant test against the unpatched planner:
$ git stash -- ods/scripts/assign_gpus.py
$ python -m pytest tests/test-assign-gpus.py::TestParallelismCoversEveryGpu -q
E  AssertionError: nvidia_smi_topo_matrix_8gpus_nv12_full_mesh.json @ 100000MB:
   mode=hybrid covers 4 of 5 assigned GPUs
1 failed, 1 passed

# every GPU count 2..16 covered after the change:
n= 4 hybrid   tp=2 pp=2 covered=4 ok
n= 5 pipeline tp=1 pp=5 covered=5 ok
n= 8 hybrid   tp=2 pp=4 covered=8 ok
n= 9 pipeline tp=1 pp=9 covered=9 ok
n=16 hybrid   tp=4 pp=4 covered=16 ok
```

## Operational Change Check

The planner is a pure function over a topology JSON file; the change only
affects which parallelism mode is emitted for GPU counts that previously
produced an under-covered plan. No installer phase, compose generation, or
host mutation is touched.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Odd-count subsets now report `pipeline` instead of `hybrid`. That is the point
of the change — a hybrid layout cannot tile an odd GPU count with a power-of-2
tensor group, and pipeline is the mode the planner already uses everywhere else
when tensor grouping does not apply.

If you would rather keep `hybrid` for counts like 9 (3 x 3), that needs
relaxing the power-of-2 constraint the function documents today. Happy to do
that instead, but it changes tensor-group semantics rather than just fixing
coverage, so I kept this diff to the coverage bug.
