### PR TITLE
fix(installer): keep the background-task registry out of shared /tmp

### DIFF
--- a/ods/installers/lib/background-tasks.sh
+++ b/ods/installers/lib/background-tasks.sh
@@ -12,8 +12,39 @@
 #   Add new background task types here.
 # ============================================================================
 
-# Registry file for background tasks
-BG_TASK_REGISTRY="${BG_TASK_REGISTRY:-/tmp/ods-bg-tasks.json}"
+# Registry file for background tasks.
+#
+# The registry must not live at a fixed path in a shared /tmp. Every local
+# user can write there, which lets an unprivileged account
+#   - pre-create the path as a symlink, so the `echo "[]" >` below truncates
+#     whatever it points at with this user's privileges; and
+#   - seed the JSON the installer later trusts — bg_task_status() and
+#     bg_task_summary() send each entry's "pid" to os.kill() and read each
+#     entry's "log_file" with Path(...).read_text(), so a planted registry
+#     turns phase 13 into an arbitrary-file-read that lands in the install log.
+#
+# Prefer the install directory's own logs/, which the installer already owns.
+# Before INSTALL_DIR exists, fall back to a per-user directory created with
+# umask 077 and verified to be owned by this user — the same ownership guard
+# installers/lib/model-lifecycle-lock.sh uses for its lock root.
+_ods_bg_default_registry() {
+    if [[ -n "${INSTALL_DIR:-}" && -d "${INSTALL_DIR}/logs" ]]; then
+        printf '%s/bg-tasks.json' "${INSTALL_DIR}/logs"
+        return 0
+    fi
+
+    local root="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/ods-bg-tasks-${UID:-$(id -u)}"
+    (umask 077 && mkdir -p "$root") || return 1
+    # Ownership is the guard that matters: an attacker who pre-created the
+    # directory keeps ownership, and tightening its mode for them would not
+    # make the contents trustworthy. Same check as ods_model_lifecycle_lock.
+    [[ -O "$root" ]] || return 1
+    printf '%s/bg-tasks.json' "$root"
+}
+
+if [[ -z "${BG_TASK_REGISTRY:-}" ]]; then
+    BG_TASK_REGISTRY="$(_ods_bg_default_registry)" || BG_TASK_REGISTRY=""
+fi
 
 # Start tracking a background task
 # Usage: bg_task_start <task_id> <pid> <description> <log_file>
@@ -22,12 +53,19 @@ bg_task_start() {
     local pid="$2"
     local description="$3"
     local log_file="$4"
-    
-    # Create registry if it doesn't exist
-    if [[ ! -f "$BG_TASK_REGISTRY" ]]; then
-        echo "[]" > "$BG_TASK_REGISTRY"
+
+    if [[ -z "${BG_TASK_REGISTRY:-}" ]]; then
+        declare -f ai_warn &>/dev/null && \
+            ai_warn "No private location for the background-task registry; not tracking $task_id"
+        return 1
     fi
-    
+
+    # Create registry if it doesn't exist. umask 077 so the file the installer
+    # later parses is not group/world writable.
+    if [[ ! -f "$BG_TASK_REGISTRY" ]]; then
+        (umask 077 && echo "[]" > "$BG_TASK_REGISTRY")
+    fi
+
     # Add task to registry
     python3 - "$BG_TASK_REGISTRY" "$task_id" "$pid" "$description" "$log_file" <<'PY'
 import json

--- a/ods/tests/bats-tests/background-tasks.bats
+++ b/ods/tests/bats-tests/background-tasks.bats
@@ -207,3 +207,52 @@ print('OK')
     assert_output --partial "task-a"
     assert_output --partial "task-b"
 }
+
+# ── default registry location ───────────────────────────────────────────────
+#
+# The installer parses this registry and feeds each entry's "pid" to os.kill()
+# and each entry's "log_file" to Path(...).read_text(). A fixed path in a
+# shared /tmp is writable by every local user, so it must never be the default.
+
+@test "default registry: is never a fixed path in shared /tmp" {
+    run bash -c '
+        unset BG_TASK_REGISTRY INSTALL_DIR
+        source "$1"
+        printf "%s" "${BG_TASK_REGISTRY:-}"
+    ' bash "$BATS_TEST_DIRNAME/../../installers/lib/background-tasks.sh"
+    assert_success
+    refute_output "/tmp/ods-bg-tasks.json"
+}
+
+@test "default registry: prefers the install directory's logs" {
+    mkdir -p "$BATS_TEST_TMPDIR/install/logs"
+    run bash -c '
+        unset BG_TASK_REGISTRY
+        INSTALL_DIR="$2"
+        source "$1"
+        printf "%s" "$BG_TASK_REGISTRY"
+    ' bash "$BATS_TEST_DIRNAME/../../installers/lib/background-tasks.sh" "$BATS_TEST_TMPDIR/install"
+    assert_success
+    assert_output "$BATS_TEST_TMPDIR/install/logs/bg-tasks.json"
+}
+
+@test "default registry: falls back to a private directory owned by this user" {
+    run bash -c '
+        unset BG_TASK_REGISTRY INSTALL_DIR XDG_RUNTIME_DIR
+        TMPDIR="$2"
+        source "$1"
+        [[ -n "$BG_TASK_REGISTRY" ]] || { echo "no registry resolved"; exit 1; }
+        dir="$(dirname "$BG_TASK_REGISTRY")"
+        [[ -d "$dir" ]] || { echo "staging dir missing"; exit 1; }
+        [[ -O "$dir" ]] || { echo "staging dir not owned by this user"; exit 1; }
+        printf "%s" "$dir"
+    ' bash "$BATS_TEST_DIRNAME/../../installers/lib/background-tasks.sh" "$BATS_TEST_TMPDIR"
+    assert_success
+    assert_output --partial "$BATS_TEST_TMPDIR/ods-bg-tasks-"
+}
+
+@test "bg_task_start: refuses to track when no private registry is available" {
+    BG_TASK_REGISTRY=""
+    run bg_task_start "orphan" "12345" "No registry" "/dev/null"
+    assert_failure
+}


### PR DESCRIPTION
## Summary

`installers/lib/background-tasks.sh` defaulted its registry to a fixed path in
shared `/tmp`:

```bash
BG_TASK_REGISTRY="${BG_TASK_REGISTRY:-/tmp/ods-bg-tasks.json}"
```

Phases 11, 12 and 13 use this registry for real work — `bg_task_start` records
the SDXL and full-model download PIDs, phase 12 gates its health wait on
`bg_task_status "full-model-download"`, and phase 13 renders `bg_task_summary`
into the install log. On a multi-user Linux host the path is writable by every
local account, which gives an unprivileged user two footholds:

1. **Symlink truncation.** Pre-create `/tmp/ods-bg-tasks.json` as a symlink.
   `bg_task_start` runs `echo "[]" > "$BG_TASK_REGISTRY"`, which follows the
   link and truncates the target with the installing user's privileges.
2. **Trusted-input injection.** Seed the file with attacker-chosen JSON. The
   installer then trusts every field:

   ```python
   pid = task["pid"]
   os.kill(pid, 0)
   ...
   log_file = task.get("log_file", "")
   if log_file and Path(log_file).exists():
       log_content = Path(log_file).read_text()
   ```

   `log_file` is an arbitrary path, so phase 13's `bg_task_summary` reads it and
   classifies the install as "failed"/"completed" based on its contents — an
   attacker-directed read of any file the installing user can open, with the
   status leaking into the install log. `pid` is likewise attacker-chosen input
   to `os.kill`.

This is the same class the project has already hardened elsewhere:
`lib/service-registry.sh` moved its cache to `mktemp` with the comment "a
predictable /tmp name would be a local code-injection vector (symlink / TOCTOU
race)", and `installers/lib/model-lifecycle-lock.sh` verifies `[[ -O ... ]]` on
its lock root.

### Fix

`_ods_bg_default_registry()` resolves the default in this order:

1. `${INSTALL_DIR}/logs/bg-tasks.json` when the install directory exists — the
   installer already owns it, and it puts the registry next to the logs it
   references.
2. Otherwise `${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/ods-bg-tasks-$UID/`, created
   with `umask 077` and rejected unless `[[ -O ... ]]` confirms this user owns
   it — mirroring `model-lifecycle-lock.sh`.
3. If neither is available, `BG_TASK_REGISTRY` stays empty and `bg_task_start`
   warns and returns non-zero instead of falling back to a shared path.

The bootstrap `echo "[]" >` now runs under `umask 077`, so the file the
installer parses is 0600 from creation rather than only after the first
`os.replace` from `mkstemp`.

An explicit `BG_TASK_REGISTRY` from the environment still wins, so the existing
BATS suite and any operator override are unchanged.

## AI Assistance

AI assisted with tracing the registry's consumers through phases 11-13,
drafting the new BATS cases, and wording this description. I read the full
diff, confirmed the phase-13 read path myself, and ran the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Happy to retarget release/2.6.x if you want the local-privilege fix on stable.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n installers/lib/background-tasks.sh
syntax OK

$ bash tests/bats/bats-core/bin/bats tests/bats-tests/background-tasks.bats
ok 13 default registry: is never a fixed path in shared /tmp
ok 14 default registry: prefers the install directory's logs
ok 15 default registry: falls back to a private directory owned by this user
ok 16 bg_task_start: refuses to track when no private registry is available

All four new cases pass. Ten of the twelve pre-existing cases fail on my
Windows/Git-Bash host because it has no `python3` (only `python`), and the
library shells out to `python3` directly:

  "Python was not found; run without arguments to install from the Microsoft
   Store..."  (exit 49)

That is not caused by this change - `git stash && bats ...` on origin/main
produces the same 10 failures. On Linux CI all 16 should run.
```

## Operational Change Check

This touches installer lifecycle code, so it is an operational change. The
behavioural surface is narrow: only where the default registry path is
resolved. Task recording, status classification, `bg_task_wait` and
`bg_task_summary` are untouched, and an explicit `BG_TASK_REGISTRY` still takes
precedence. Phases 11-13 source this file after `INSTALL_DIR` and its `logs/`
directory exist (created in phase 06), so they take branch 1.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Two related things I deliberately left out to keep this diff on the path bug:

- `bg_task_status` / `bg_task_summary` call `python3` directly rather than
  going through `lib/python-cmd.sh`. This is what makes the existing suite
  unrunnable on a host that only has `python`.
- `bg_task_wait` reads `$?` from an unguarded `bg_task_status` call, which under
  `set -e` would abort before it can observe a completed task. It has no callers
  today, which is presumably why nobody has hit it.

Happy to send either as a follow-up if you want them.
