### PR TITLE
fix(external-llm): read .env values the way safe-env.sh does

### DIFF
--- a/ods/installers/lib/external-services.sh
+++ b/ods/installers/lib/external-services.sh
@@ -166,13 +166,36 @@ PY
         "${url}/v1/chat/completions" >/dev/null
 }
 
+# Read a single KEY=VALUE out of a .env file.
+#
+# Parses the same way lib/safe-env.sh's load_env_file does, so the installer
+# reads back exactly what it wrote:
+#
+#   - strip a trailing CR. A CRLF .env (Windows editors, the Windows
+#     installer) otherwise leaves "\r" on the value, and
+#     external_llm_validate_url rejects "http://127.0.0.1:11434\r" — the
+#     installer silently drops a valid external LLM selection on re-run.
+#   - strip only a MATCHING pair of surrounding quotes. Removing each quote
+#     type independently corrupts values that legitimately start or end with
+#     the other quote, and collapses KEY="'" to an empty string. safe-env.sh
+#     carries the same warning.
+#   - match the key literally. The previous grep treated it as a regex.
 external_llm_env_value() {
-    local env_file="${1:-}" key="${2:-}" value
-    [[ -f "$env_file" ]] || return 1
-    value="$(grep -m1 "^${key}=" "$env_file" 2>/dev/null | cut -d= -f2- || true)"
-    value="${value%\"}"
-    value="${value#\"}"
-    value="${value%\'}"
-    value="${value#\'}"
+    local env_file="${1:-}" key="${2:-}" line value=""
+    [[ -f "$env_file" && -n "$key" ]] || return 1
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        [[ "$line" == "$key="* ]] || continue
+        value="${line#*=}"
+        break
+    done < "$env_file"
+    value="${value# }"
+    if [[ "$value" == '"'*'"' ]]; then
+        value="${value#\"}"
+        value="${value%\"}"
+    elif [[ "$value" == "'"*"'" ]]; then
+        value="${value#\'}"
+        value="${value%\'}"
+    fi
     printf '%s\n' "$value"
 }

--- a/ods/tests/test-external-services.sh
+++ b/ods/tests/test-external-services.sh
@@ -74,6 +74,53 @@ else
     pass "rejects unrelated model families"
 fi
 
+# ── external_llm_env_value: parses .env the way lib/safe-env.sh does ─────────
+
+_env_value_fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$_env_value_fixture_dir"' EXIT
+
+_env_lf="$_env_value_fixture_dir/lf.env"
+cat > "$_env_lf" <<'ENVEOF'
+EXTERNAL_LLM_PROVIDER=ollama
+EXTERNAL_LLM_URL=http://127.0.0.1:11434
+EXTERNAL_LLM_MODEL="qwen3.5:9b"
+QUOTED_INNER="'literal'"
+LONE_SINGLE_QUOTE="'"
+SPACED_VALUE= lmstudio
+BASE64_PADDED=YWJjZA==
+ENVEOF
+
+assert_eq "$(external_llm_env_value "$_env_lf" EXTERNAL_LLM_URL)" \
+    "http://127.0.0.1:11434" "reads an unquoted value"
+assert_eq "$(external_llm_env_value "$_env_lf" EXTERNAL_LLM_MODEL)" \
+    "qwen3.5:9b" "strips a matching double-quote pair"
+assert_eq "$(external_llm_env_value "$_env_lf" QUOTED_INNER)" \
+    "'literal'" "keeps inner single quotes inside a double-quoted value"
+assert_eq "$(external_llm_env_value "$_env_lf" LONE_SINGLE_QUOTE)" \
+    "'" "does not collapse a double-quoted lone single quote"
+assert_eq "$(external_llm_env_value "$_env_lf" SPACED_VALUE)" \
+    "lmstudio" "drops one leading space like load_env_file"
+assert_eq "$(external_llm_env_value "$_env_lf" BASE64_PADDED)" \
+    "YWJjZA==" "keeps '=' inside values"
+assert_eq "$(external_llm_env_value "$_env_lf" NOT_PRESENT)" \
+    "" "returns empty for a key the file does not define"
+
+# A CRLF .env is what the Windows installer and Windows editors produce. A
+# trailing CR makes external_llm_validate_url reject an otherwise valid URL,
+# so the installer silently forgets the external LLM selection on re-run.
+_env_crlf="$_env_value_fixture_dir/crlf.env"
+printf 'EXTERNAL_LLM_PROVIDER=ollama\r\nEXTERNAL_LLM_URL=http://127.0.0.1:11434\r\n' > "$_env_crlf"
+assert_eq "$(external_llm_env_value "$_env_crlf" EXTERNAL_LLM_URL)" \
+    "http://127.0.0.1:11434" "strips the CR from a CRLF .env"
+assert_true "a CRLF-sourced URL still passes URL validation" \
+    external_llm_validate_url "$(external_llm_env_value "$_env_crlf" EXTERNAL_LLM_URL)"
+
+# The key is matched literally, not as a regex.
+_env_regex="$_env_value_fixture_dir/regex.env"
+printf 'EXTERNAL_LLM_URL=http://127.0.0.1:11434\nEXTERNALxLLMxURL=http://evil.invalid\n' > "$_env_regex"
+assert_eq "$(external_llm_env_value "$_env_regex" EXTERNAL_LLM_URL)" \
+    "http://127.0.0.1:11434" "matches the key literally"
+
 run_phase_case() {
     set -euo pipefail
 


### PR DESCRIPTION
## Summary

`external_llm_env_value()` in `installers/lib/external-services.sh` reads
`EXTERNAL_LLM_URL`, `EXTERNAL_LLM_PROVIDER` and `EXTERNAL_LLM_MODEL` back out
of an existing `.env` so phase 02b can reuse a previous external LLM
selection. It parsed differently from the writer:

```bash
value="$(grep -m1 "^${key}=" "$env_file" 2>/dev/null | cut -d= -f2- || true)"
value="${value%\"}"
value="${value#\"}"
value="${value%\'}"
value="${value#\'}"
```

`lib/safe-env.sh` already documents why the quote handling is wrong, in a
comment added when `load_env_file` was fixed:

> Only strip when both ends carry the SAME quote character — stripping each
> quote type independently corrupts values whose content legitimately begins
> or ends with the other quote (e.g. a double-quoted `"'literal'"` would
> otherwise lose its inner single quotes, and `KEY="'"` would collapse to
> empty).

`external_llm_env_value` never got that fix, so the two readers disagree.
Three further gaps against `load_env_file`:

- **No trailing-CR strip.** A CRLF `.env` — what the Windows installer and
  Windows editors produce — leaves `\r` on the value.
  `external_llm_validate_url` then rejects `http://127.0.0.1:11434\r`, and
  phase 02b silently drops a valid external LLM selection on re-run.
  `safe-env.sh` strips the CR for exactly this reason.
- **No leading-space strip.** `KEY= value` yielded `" value"`.
- **Regex key match.** `grep -m1 "^${key}="` treats the key as a regex.

### Fix

Parse with the same line loop `load_env_file` uses: strip the trailing CR,
match the key literally, drop one leading space, and strip only a *matching*
pair of surrounding quotes.

## AI Assistance

AI assisted with spotting the divergence from `safe-env.sh`, drafting the test
cases, and wording this description. I read the full diff, ran the suite
before and after, and recorded the real output below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n installers/lib/external-services.sh && bash -n tests/test-external-services.sh
syntax OK

# new cases against the PREVIOUS implementation (lib stashed, tests kept):
[PASS] reads an unquoted value
[PASS] strips a matching double-quote pair
[FAIL] keeps inner single quotes inside a double-quoted value (expected ''literal'', got 'literal')
[FAIL] does not collapse a double-quoted lone single quote (expected ''', got '')
[FAIL] drops one leading space like load_env_file (expected 'lmstudio', got ' lmstudio')
[PASS] keeps '=' inside values
[PASS] returns empty for a key the file does not define
[PASS] matches the key literally

# same cases after the change:
[PASS] reads an unquoted value
[PASS] strips a matching double-quote pair
[PASS] keeps inner single quotes inside a double-quoted value
[PASS] does not collapse a double-quoted lone single quote
[PASS] drops one leading space like load_env_file
[PASS] keeps '=' inside values
[PASS] returns empty for a key the file does not define
[PASS] strips the CR from a CRLF .env
[PASS] matches the key literally
```

Two caveats I want to be explicit about, since my dev host is Windows/Git Bash:

1. **The CRLF case is not reproducible on my host.** Git Bash's `grep` strips
   the CR itself, so `strips the CR from a CRLF .env` passes against the *old*
   implementation here. On Linux it does not — that is the platform the
   Windows installer's `.env` gets consumed on when the same directory is used
   from WSL2, and it is why `safe-env.sh` added its own CR strip. The new
   reader strips it explicitly on every platform, so the test is
   platform-independent going forward. I'd appreciate a reviewer confirming
   that case on Linux.
2. `a CRLF-sourced URL still passes URL validation` fails locally because
   `external_llm_validate_url` shells out to `python3`, which this host does
   not have (it only has `python`). The pre-existing
   `accepts a supported external base URL` assertion fails for the same
   reason. Suite totals: origin/main 5 failures, this branch 6 — the extra one
   being that `python3`-dependent assertion.

## Operational Change Check

This touches installer code, so it is an operational change. The surface is one
pure parsing function whose only callers are the three reads in phase 02b. The
change makes it agree with `lib/safe-env.sh`, which is the parser the rest of
the installer already uses for the same file.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

If you'd rather this call `load_env_file` and read the exported variable
instead of duplicating the parse, I'm happy to rework it — I kept a local
reader because `load_env_file` exports every key in the file into the caller's
environment, which is a much wider side effect than phase 02b wants for three
lookups.
