### PR TITLE
fix(deps): scope base-compose service discovery to the services block

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -67,6 +67,9 @@ test: ## Run unit and contract tests
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
 	@echo ""
+	@echo "=== service dependency validation ==="
+	@bash tests/test-validate-dependencies.sh
+	@echo ""
 	@echo "=== QR code helper LAN detection ==="
 	@bash tests/test-qrcode-helper.sh
 	@echo ""

--- a/ods/lib/validate-dependencies.sh
+++ b/ods/lib/validate-dependencies.sh
@@ -22,13 +22,29 @@ validate_service_dependencies() {
     done
 
     # Core services defined in docker-compose.base.yml are always enabled
-    # (they have no extension manifest, so the registry does not know about them)
+    # (they have no extension manifest, so the registry does not know about it).
+    #
+    # Read only the keys under `services:`. The previous sed matched every
+    # two-space-indented key in the file, so anchors and top-level sections
+    # leaked in as "services": today that is `driver` and `options` (from
+    # `x-logging`) and `default` (from `networks`). Any name that appears in
+    # one of those blocks and also names a real extension would satisfy a
+    # depends_on entry for a service that is not actually enabled, which is
+    # the failure this function exists to catch.
     local _base_compose="${INSTALL_DIR:-$SCRIPT_DIR}/docker-compose.base.yml"
     if [[ -f "$_base_compose" ]]; then
         local _svc
         while IFS= read -r _svc; do
-            enabled_services[$_svc]=1
-        done < <(sed -n 's/^  \([a-z][a-z0-9_-]*\):.*/\1/p' "$_base_compose" 2>/dev/null)
+            [[ -n "$_svc" ]] && enabled_services[$_svc]=1
+        done < <(awk '
+            /^[^[:space:]#]/ { in_services = ($0 ~ /^services:/); next }
+            in_services && /^  [a-z][a-z0-9_-]*:/ {
+                line = $0
+                sub(/^  /, "", line)
+                sub(/:.*$/, "", line)
+                print line
+            }
+        ' "$_base_compose" 2>/dev/null)
     fi
 
     # Check each enabled service's dependencies

--- a/ods/tests/test-validate-dependencies.sh
+++ b/ods/tests/test-validate-dependencies.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# lib/validate-dependencies.sh — service dependency validation contracts.
+#
+# The core services in docker-compose.base.yml have no extension manifest, so
+# validate_service_dependencies() has to learn them by reading that file. It
+# must read only the keys under `services:` — anchors (`x-logging`), `volumes`
+# and `networks` entries are not services, and treating them as enabled makes
+# the validator accept a depends_on it should reject.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PASSED=0
+FAILED=0
+
+pass() {
+    printf '[PASS] %s\n' "$1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    printf '[FAIL] %s\n' "$1" >&2
+    FAILED=$((FAILED + 1))
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# A base compose file shaped like the real one: a YAML anchor above
+# `services:`, and a `networks:` section below it.
+cat > "$WORK_DIR/docker-compose.base.yml" <<'YAML'
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+
+services:
+  llama-server:
+    image: example/llama
+  open-webui:
+    image: example/webui
+
+networks:
+  default:
+    name: ods-net
+
+volumes:
+  qdrant-data:
+YAML
+
+# Run one validation case in a subshell so the associative arrays and the
+# sourced library never leak between cases.
+#
+# Usage: run_case <service_id> <space-separated-depends-on>
+run_case() {
+    local sid="$1" deps="$2"
+    (
+        set +e
+        # shellcheck source=/dev/null
+        source "$ROOT_DIR/lib/validate-dependencies.sh"
+
+        declare -A SERVICE_COMPOSE SERVICE_DEPENDS
+        declare -a SERVICE_IDS
+
+        SERVICE_IDS=("$sid")
+        SERVICE_COMPOSE[$sid]="$WORK_DIR/enabled-compose.yaml"
+        SERVICE_DEPENDS[$sid]="$deps"
+        : > "${SERVICE_COMPOSE[$sid]}"
+
+        INSTALL_DIR="$WORK_DIR"
+        validate_service_dependencies >/dev/null 2>&1
+        echo "$?"
+    )
+}
+
+expect_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$label"
+    else
+        fail "$label (expected rc $expected, got $actual)"
+    fi
+}
+
+expect_rc "accepts a dependency on a base-compose service" \
+    0 "$(run_case my-ext "llama-server")"
+
+expect_rc "accepts a dependency on a second base-compose service" \
+    0 "$(run_case my-ext "open-webui")"
+
+expect_rc "rejects a dependency on a service nothing provides" \
+    1 "$(run_case my-ext "nonexistent-service")"
+
+# Regression: these are YAML keys inside `x-logging`, `networks` and `volumes`,
+# not services. A validator that scans every two-space-indented key in the file
+# accepts them and lets a genuinely unmet dependency through.
+expect_rc "rejects a dependency named after a logging-anchor key" \
+    1 "$(run_case my-ext "driver")"
+
+expect_rc "rejects a dependency named after a logging-anchor option key" \
+    1 "$(run_case my-ext "options")"
+
+expect_rc "rejects a dependency named after a network" \
+    1 "$(run_case my-ext "default")"
+
+expect_rc "rejects a dependency named after a volume" \
+    1 "$(run_case my-ext "qdrant-data")"
+
+expect_rc "rejects a mixed list when one dependency is unmet" \
+    1 "$(run_case my-ext "llama-server default")"
+
+printf '\n%d passed, %d failed\n' "$PASSED" "$FAILED"
+[[ "$FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

`validate_service_dependencies()` (`lib/validate-dependencies.sh`) has to learn
the core services from `docker-compose.base.yml`, because they ship without an
extension manifest and the registry does not know about them. It did that with:

```bash
sed -n 's/^  \([a-z][a-z0-9_-]*\):.*/\1/p' "$_base_compose"
```

That matches every two-space-indented key in the file, not just the ones under
`services:`. Against the current base compose it produces:

```text
driver                          <- x-logging anchor
options                         <- x-logging anchor
llama-server
open-webui
dashboard-api
model-router
remote-provider-egress
remote-provider-ssh-tunnel
dashboard
default                         <- networks:
```

Three of those ten are not services. The error is one-directional: it only ever
marks *more* names as enabled, so the validator accepts `depends_on` entries it
should reject. A manifest declaring `depends_on: [default]` passes today, and
any name later added under `volumes:` or `networks:` that collides with a real
extension id would satisfy a dependency on that extension while the extension
is actually disabled — which is precisely the failure this function runs before
`compose up` to prevent.

### Fix

Parse the `services:` block only, with an `awk` pass that tracks which
top-level section it is inside. Output on the current base compose:

```text
llama-server
open-webui
dashboard-api
model-router
remote-provider-egress
remote-provider-ssh-tunnel
dashboard
```

### Test

New `tests/test-validate-dependencies.sh`, wired into `make test`. It builds a
base compose shaped like the real one (an `x-logging` anchor above `services:`,
`networks:` and `volumes:` below) and asserts that a real service satisfies a
dependency while an anchor key, a network name and a volume name do not.

## AI Assistance

AI assisted with spotting the over-broad `sed`, drafting the test, and wording
this description. I read the full diff, diffed the old and new extraction
against the real `docker-compose.base.yml`, and ran the suite both ways.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n lib/validate-dependencies.sh
syntax OK

$ bash tests/test-validate-dependencies.sh
[PASS] accepts a dependency on a base-compose service
[PASS] accepts a dependency on a second base-compose service
[PASS] rejects a dependency on a service nothing provides
[PASS] rejects a dependency named after a logging-anchor key
[PASS] rejects a dependency named after a logging-anchor option key
[PASS] rejects a dependency named after a network
[PASS] rejects a dependency named after a volume
[PASS] rejects a mixed list when one dependency is unmet
8 passed, 0 failed

# same tests against the previous implementation (lib stashed):
[FAIL] rejects a dependency named after a logging-anchor key (expected rc 1, got 0)
[FAIL] rejects a dependency named after a logging-anchor option key (expected rc 1, got 0)
[FAIL] rejects a dependency named after a network (expected rc 1, got 0)
[FAIL] rejects a dependency named after a volume (expected rc 1, got 0)
[FAIL] rejects a mixed list when one dependency is unmet (expected rc 1, got 0)
3 passed, 5 failed

# extraction diff against the real docker-compose.base.yml
new: llama-server open-webui dashboard-api model-router
     remote-provider-egress remote-provider-ssh-tunnel dashboard
old: driver options llama-server open-webui dashboard-api model-router
     remote-provider-egress remote-provider-ssh-tunnel dashboard default
```

No currently-shipped manifest declares `depends_on: [driver|options|default]`,
so this does not change validation for any extension in the tree today — it
closes the gap for the ones that would slip through.

## Operational Change Check

This runs in phase 11 before `compose up`, so it is an operational change. The
change is confined to which names the validator considers enabled, and it only
removes false positives — every real base-compose service is still recognised,
verified against the actual file above.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

I used `awk` rather than the PyYAML path the registry uses, to keep this
function dependency-free — it runs in phase 11 where a missing PyYAML is
already a degraded state, and reading a section header is not worth pulling in
a parser. Happy to switch if you'd rather it went through
`scripts/resolve-compose-stack.sh` or a shared helper.
