### PR TITLE
fix(healthcheck): accept bracketed IPv6 targets

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Offline Model Validation Tests
         run: python3 tests/test-offline-model-validation.py
 
+      - name: Healthcheck Target Parsing Tests
+        run: python3 tests/test-healthcheck-targets.py
+
       - name: Runtime Config Renderer Tests
         run: python3 tests/test-render-runtime-configs.py
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -89,6 +89,9 @@ test: ## Run unit and contract tests
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py
 	@echo ""
+	@echo "=== healthcheck target parsing ==="
+	@python3 tests/test-healthcheck-targets.py
+	@echo ""
 	@echo "=== Bash 3.2 guard contracts ==="
 	@bash tests/test-bash32-guards.sh
 	@echo ""

--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -98,15 +98,40 @@ def _parse_target(raw: str) -> Tuple[str, str]:
     if raw.startswith("tcp://"):
         return ("tcp", raw[len("tcp://") :])
 
-    # host:port shorthand
-    if ":" in raw and not raw.startswith("["):
+    # host:port shorthand, including the bracketed IPv6 literal [::1]:5432.
+    # Brackets are how an IPv6 address is written alongside a port, so a
+    # leading "[" is a TCP target, not an unsupported one.
+    if raw.startswith("[") or ":" in raw:
         return ("tcp", raw)
 
     raise ValueError("target must be http(s) URL, tcp://host:port, or host:port")
 
 
 def _parse_host_port(raw: str) -> Tuple[str, int]:
-    host, port_s = raw.rsplit(":", 1)
+    """Split host:port, including the bracketed IPv6 form [::1]:5432.
+
+    The brackets are address syntax, not part of the host. socket functions
+    take the bare address, so `[::1]` has to be unwrapped before connecting.
+    An unbracketed IPv6 literal cannot be split on the last colon at all —
+    `::1` would yield host `::` and port `1` — so it is rejected with a
+    message that names the supported form.
+    """
+    if raw.startswith("["):
+        end = raw.find("]")
+        if end == -1:
+            raise ValueError("unterminated IPv6 literal (missing ']')")
+        host = raw[1:end]
+        remainder = raw[end + 1 :]
+        if not remainder.startswith(":"):
+            raise ValueError("IPv6 target needs a port, e.g. [::1]:5432")
+        port_s = remainder[1:]
+    else:
+        if raw.count(":") != 1:
+            raise ValueError(
+                "target must be host:port; bracket IPv6 addresses, e.g. [::1]:5432"
+            )
+        host, port_s = raw.rsplit(":", 1)
+
     host = host.strip()
     if not host:
         raise ValueError("host is empty")

--- a/ods/tests/test-healthcheck-targets.py
+++ b/ods/tests/test-healthcheck-targets.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Target-parsing contracts for scripts/healthcheck.py.
+
+The helper documents three accepted target forms:
+
+    healthcheck.py http://localhost:8080/health
+    healthcheck.py tcp://localhost:5432
+    healthcheck.py localhost:5432
+
+An IPv6 address is written in brackets when it carries a port, so `[::1]:5432`
+and `tcp://[::1]:5432` are the IPv6 spellings of the last two. Both have to
+reach socket.create_connection() with the bare address — the brackets are
+syntax, not part of the host.
+
+Run: python3 tests/test-healthcheck-targets.py
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "healthcheck.py"
+
+_spec = importlib.util.spec_from_file_location("ods_healthcheck", SCRIPT)
+healthcheck = importlib.util.module_from_spec(_spec)
+# Register before executing: @dataclass resolves annotations through
+# sys.modules[cls.__module__], which raises if the module is not there yet.
+sys.modules["ods_healthcheck"] = healthcheck
+_spec.loader.exec_module(healthcheck)
+
+PASSED = 0
+FAILED = 0
+
+
+def check(label, actual, expected):
+    global PASSED, FAILED
+    if actual == expected:
+        print(f"[PASS] {label}")
+        PASSED += 1
+    else:
+        print(f"[FAIL] {label} (expected {expected!r}, got {actual!r})", file=sys.stderr)
+        FAILED += 1
+
+
+def check_raises(label, fn, *args):
+    global PASSED, FAILED
+    try:
+        result = fn(*args)
+    except ValueError:
+        print(f"[PASS] {label}")
+        PASSED += 1
+    else:
+        print(f"[FAIL] {label} (expected ValueError, got {result!r})", file=sys.stderr)
+        FAILED += 1
+
+
+# ── _parse_target ────────────────────────────────────────────────────────────
+
+check("http URL is an http target",
+      healthcheck._parse_target("http://localhost:8080/health"),
+      ("http", "http://localhost:8080/health"))
+
+check("https URL is an http target",
+      healthcheck._parse_target("https://localhost:8443/health"),
+      ("http", "https://localhost:8443/health"))
+
+check("tcp:// scheme is stripped",
+      healthcheck._parse_target("tcp://localhost:5432"),
+      ("tcp", "localhost:5432"))
+
+check("host:port shorthand is a tcp target",
+      healthcheck._parse_target("localhost:5432"),
+      ("tcp", "localhost:5432"))
+
+check("bracketed IPv6 shorthand is a tcp target",
+      healthcheck._parse_target("[::1]:5432"),
+      ("tcp", "[::1]:5432"))
+
+check("tcp:// with a bracketed IPv6 address keeps the brackets for the splitter",
+      healthcheck._parse_target("tcp://[fe80::1]:5432"),
+      ("tcp", "[fe80::1]:5432"))
+
+check_raises("a bare hostname with no port is rejected",
+             healthcheck._parse_target, "localhost")
+
+
+# ── _parse_host_port ─────────────────────────────────────────────────────────
+
+check("IPv4 host:port splits",
+      healthcheck._parse_host_port("127.0.0.1:5432"),
+      ("127.0.0.1", 5432))
+
+check("hostname:port splits",
+      healthcheck._parse_host_port("localhost:5432"),
+      ("localhost", 5432))
+
+check("IPv6 loopback loses its brackets",
+      healthcheck._parse_host_port("[::1]:5432"),
+      ("::1", 5432))
+
+check("full IPv6 address loses its brackets",
+      healthcheck._parse_host_port("[2001:db8::8a2e:370:7334]:8080"),
+      ("2001:db8::8a2e:370:7334", 8080))
+
+check_raises("an unterminated IPv6 literal is rejected",
+             healthcheck._parse_host_port, "[::1:5432")
+
+check_raises("a bracketed IPv6 address without a port is rejected",
+             healthcheck._parse_host_port, "[::1]")
+
+check_raises("an unbracketed IPv6 address is rejected rather than mis-split",
+             healthcheck._parse_host_port, "::1")
+
+check_raises("a non-integer port is rejected",
+             healthcheck._parse_host_port, "localhost:http")
+
+check_raises("port 0 is rejected",
+             healthcheck._parse_host_port, "localhost:0")
+
+check_raises("port 65536 is rejected",
+             healthcheck._parse_host_port, "localhost:65536")
+
+check_raises("an empty host is rejected",
+             healthcheck._parse_host_port, ":5432")
+
+
+print(f"\n{PASSED} passed, {FAILED} failed")
+sys.exit(1 if FAILED else 0)


### PR DESCRIPTION
## Summary

`scripts/healthcheck.py` documents three target forms:

```text
healthcheck.py http://localhost:8080/health
healthcheck.py tcp://localhost:5432
healthcheck.py localhost:5432
```

An IPv6 address is written in brackets when it carries a port, so `[::1]:5432`
is the IPv6 spelling of the third form. Both bracket paths were broken.

**1. The `host:port` shorthand rejected IPv6 outright.**

```python
if ":" in raw and not raw.startswith("["):
    return ("tcp", raw)
```

The `not raw.startswith("[")` guard means a bracketed address never reaches the
shorthand branch and falls through to the error:

```text
>>> _parse_target("[::1]:5432")
ValueError: target must be http(s) URL, tcp://host:port, or host:port
```

**2. The `tcp://` path kept the brackets on the host.**

```text
>>> _parse_host_port("[::1]:5432")
('[::1]', 5432)
```

`socket.create_connection(("[::1]", 5432))` then asks getaddrinfo to resolve
the literal string `[::1]`. The brackets are address syntax, not part of the
host — glibc rejects it, so `tcp://[::1]:5432` fails to resolve on Linux.
(Windows' resolver happens to tolerate it, which is why I can't demonstrate
that half on my own host; see the validation caveat below.)

**3. An unbracketed IPv6 literal was silently mangled rather than refused.**

```text
>>> _parse_target("::1")
('tcp', '::1')
>>> _parse_host_port("::1")
(':', 1)
```

`rsplit(":", 1)` on `::1` yields host `:` and port `1` — a health check that
quietly probes the wrong thing instead of telling the operator the address form
is unsupported.

### Fix

- `_parse_target()` treats a leading `[` as a TCP target.
- `_parse_host_port()` unwraps `[...]` before returning the host, and rejects
  an unbracketed IPv6 literal with a message naming the supported spelling
  (`bracket IPv6 addresses, e.g. [::1]:5432`).
- Unterminated literals (`[::1:5432`) and bracketed addresses with no port
  (`[::1]`) get their own errors instead of falling through.

IPv4, hostname, `tcp://`, and HTTP targets are unchanged.

### Test

The script had **no test coverage at all**. Adds
`tests/test-healthcheck-targets.py` (18 cases across both parsers, including
the port-range and empty-host guards that already existed) and wires it into
`make test` and the Linux CI job.

## AI Assistance

AI assisted with spotting the bracket handling, drafting the test cases, and
wording this description. I read the full diff, reproduced each old behaviour
against `origin/main`'s copy of the script, and recorded the real output below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(`scripts/healthcheck.py` is documented in `scripts/README.md` as the container
health check helper; CI wiring is also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 -m py_compile scripts/healthcheck.py
py OK

$ python3 tests/test-healthcheck-targets.py
[PASS] http URL is an http target
[PASS] https URL is an http target
[PASS] tcp:// scheme is stripped
[PASS] host:port shorthand is a tcp target
[PASS] bracketed IPv6 shorthand is a tcp target
[PASS] tcp:// with a bracketed IPv6 address keeps the brackets for the splitter
[PASS] a bare hostname with no port is rejected
[PASS] IPv4 host:port splits
[PASS] hostname:port splits
[PASS] IPv6 loopback loses its brackets
[PASS] full IPv6 address loses its brackets
[PASS] an unterminated IPv6 literal is rejected
[PASS] a bracketed IPv6 address without a port is rejected
[PASS] an unbracketed IPv6 address is rejected rather than mis-split
[PASS] a non-integer port is rejected
[PASS] port 0 is rejected
[PASS] port 65536 is rejected
[PASS] an empty host is rejected

18 passed, 0 failed

# the same suite against origin/main's healthcheck.py stops at the first
# IPv6 case:
[PASS] http URL is an http target
[PASS] https URL is an http target
[PASS] tcp:// scheme is stripped
[PASS] host:port shorthand is a tcp target
ValueError: target must be http(s) URL, tcp://host:port, or host:port

# old behaviour, reproduced directly against origin/main's script:
'[::1]:5432'      -> _parse_target RAISES target must be http(s) URL, ...
'tcp://[::1]:5432'-> _parse_target ('tcp', '[::1]:5432')
'::1'             -> _parse_target ('tcp', '::1')
old _parse_host_port("[::1]:5432") -> ('[::1]', 5432)
old _parse_host_port("::1")        -> (':', 1)
```

**Caveat:** my dev host is Windows, whose resolver accepts
`getaddrinfo("[::1]", 5432)` and returns `('::1', 5432, 0, 0)`. So I can
demonstrate points 1 and 3 locally but not the resolution failure in point 2 —
that is glibc behaviour. Points 1 and 3 are platform-independent parser bugs
and are what the new tests assert; point 2 is why unwrapping the brackets is
the right fix rather than only relaxing `_parse_target`.

## Operational Change Check

`scripts/healthcheck.py` is a standalone helper — nothing in the tree currently
invokes it (I checked: only `scripts/README.md` references it), so this cannot
change the behaviour of any running service today. It touches CI config to add
the new test step.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

While writing this I noticed the script is documented in `scripts/README.md`
as "Container health check helper" but no Dockerfile or compose `healthcheck:`
actually calls it. I left that alone — this PR just makes the helper correct
for the target forms it advertises. If it is meant to be dead code, say so and
I'll send a removal instead.
