### PR TITLE
fix(compose-images): honour ODS_PYTHON_CMD given as a command name

### DIFF
--- a/ods/installers/lib/compose-images.sh
+++ b/ods/installers/lib/compose-images.sh
@@ -9,10 +9,21 @@
 #   ods_compose_external_images <compose-cmd> [compose flags...]
 # ============================================================================
 
+# Resolve the interpreter to run the JSON filter below.
+#
+# ODS_PYTHON_CMD is a *command*, not necessarily a path: install-macos.sh's
+# _set_installer_python_cmd and scripts/pre-download.sh both export the plain
+# name "python3" as often as they export a venv path. Testing only `-x` made
+# the name form fail the check, so the interpreter the installer deliberately
+# selected was silently ignored in favour of whatever `command -v python3`
+# finds first — which lib/python-cmd.sh exists to avoid, because on Windows
+# that can be a non-functional Microsoft Store alias.
 _ods_compose_python_cmd() {
-    if [[ -n "${ODS_PYTHON_CMD:-}" && -x "${ODS_PYTHON_CMD:-}" ]]; then
-        printf '%s\n' "$ODS_PYTHON_CMD"
-        return 0
+    if [[ -n "${ODS_PYTHON_CMD:-}" ]]; then
+        if [[ -x "$ODS_PYTHON_CMD" ]] || command -v "$ODS_PYTHON_CMD" >/dev/null 2>&1; then
+            printf '%s\n' "$ODS_PYTHON_CMD"
+            return 0
+        fi
     fi
     command -v python3 2>/dev/null || command -v python 2>/dev/null || return 1
 }

--- a/ods/tests/test-compose-image-discovery.sh
+++ b/ods/tests/test-compose-image-discovery.sh
@@ -78,6 +78,44 @@ chmod +x "$TMP_DIR/docker"
 
 source "$ROOT_DIR/installers/lib/compose-images.sh"
 
+# ── ODS_PYTHON_CMD resolution ────────────────────────────────────────────────
+#
+# ODS_PYTHON_CMD is a command, not necessarily a path. install-macos.sh and
+# scripts/pre-download.sh export the plain name "python3" as readily as a venv
+# path, so both forms must resolve to the interpreter the installer chose.
+
+mkdir -p "$TMP_DIR/pybin"
+cat > "$TMP_DIR/pybin/chosen-python" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TMP_DIR/pybin/chosen-python"
+
+resolved="$(ODS_PYTHON_CMD="$TMP_DIR/pybin/chosen-python" _ods_compose_python_cmd)"
+if [[ "$resolved" == "$TMP_DIR/pybin/chosen-python" ]]; then
+    pass "honours ODS_PYTHON_CMD given as an absolute path"
+else
+    fail "honours ODS_PYTHON_CMD given as an absolute path"
+    echo "    resolved: $resolved"
+fi
+
+resolved="$(PATH="$TMP_DIR/pybin:$PATH" ODS_PYTHON_CMD="chosen-python" _ods_compose_python_cmd)"
+if [[ "$resolved" == "chosen-python" ]]; then
+    pass "honours ODS_PYTHON_CMD given as a command name on PATH"
+else
+    fail "honours ODS_PYTHON_CMD given as a command name on PATH"
+    echo "    resolved: $resolved"
+fi
+
+resolved="$(ODS_PYTHON_CMD="definitely-not-on-path-$$" _ods_compose_python_cmd || true)"
+if [[ "$resolved" != "definitely-not-on-path-$$" ]]; then
+    pass "falls back when ODS_PYTHON_CMD names nothing runnable"
+else
+    fail "falls back when ODS_PYTHON_CMD names nothing runnable"
+    echo "    resolved: $resolved"
+fi
+
+
 out="$TMP_DIR/images.out"
 ods_compose_external_images "$TMP_DIR/docker compose" -f docker-compose.base.yml > "$out"
 


### PR DESCRIPTION
## Summary

`_ods_compose_python_cmd()` in `installers/lib/compose-images.sh` accepted
`ODS_PYTHON_CMD` only when it passed `-x`, which is a test for an executable
*path*:

```bash
if [[ -n "${ODS_PYTHON_CMD:-}" && -x "${ODS_PYTHON_CMD:-}" ]]; then
    printf '%s\n' "$ODS_PYTHON_CMD"
    return 0
fi
command -v python3 2>/dev/null || command -v python 2>/dev/null || return 1
```

`ODS_PYTHON_CMD` holds a *command*, not necessarily a path. Both writers export
the plain name as readily as a path:

- `installers/macos/install-macos.sh` — `_set_installer_python_cmd "$pycmd"`,
  where `$pycmd` starts as `python3` and only becomes a venv path later;
- `scripts/pre-download.sh` — `export ODS_PYTHON_CMD="$pycmd"`.

And `lib/python-cmd.sh`, the project's own resolver, treats it as a name — it
probes with `_ods_python_runnable`, which uses `command -v`.

So the name form silently failed the `-x` check and the interpreter the
installer deliberately selected was discarded in favour of whatever
`command -v python3` finds first. On my host that fallback is precisely the
interpreter `lib/python-cmd.sh` has a dedicated guard for
(`_ods_python_is_windowsapps_alias`):

```text
ODS_PYTHON_CMD="chosen-python"    (a working interpreter, on PATH)

  before -> /c/Users/hoang/AppData/Local/Microsoft/WindowsApps/python3
  after  -> chosen-python
```

When the fallback interpreter cannot actually run,
`ods_compose_external_images` falls through to `config --images` — the path
whose own comment warns it "can include generated build tags", which is why the
local-image filter has to compensate.

### Fix

Accept either form: `-x` for a path, `command -v` for a name. Everything else
is unchanged, including the fallback order when `ODS_PYTHON_CMD` is unset or
names nothing runnable.

## AI Assistance

AI assisted with spotting the `-x`/`command -v` mismatch, drafting the
assertions, and wording this description. I read the full diff, reproduced the
old and new resolution side by side, and recorded the output below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n installers/lib/compose-images.sh tests/test-compose-image-discovery.sh
syntax OK

# resolver, side by side (a stub interpreter named chosen-python on PATH)
=== NEW ===
path form : /tmp/tmp.FnFrzmsimj/pybin/chosen-python
name form : chosen-python
bogus     : /c/Users/hoang/AppData/Local/Microsoft/WindowsApps/python3
=== OLD ===
path form : /tmp/tmp.FnFrzmsimj/pybin/chosen-python
name form : /c/Users/hoang/AppData/Local/Microsoft/WindowsApps/python3   <-- ignored
bogus     : /c/Users/hoang/AppData/Local/Microsoft/WindowsApps/python3

$ bash tests/test-compose-image-discovery.sh      # after
  PASS honours ODS_PYTHON_CMD given as an absolute path
  PASS honours ODS_PYTHON_CMD given as a command name on PATH
  PASS falls back when ODS_PYTHON_CMD names nothing runnable

$ bash tests/test-compose-image-discovery.sh      # lib stashed, before
  PASS honours ODS_PYTHON_CMD given as an absolute path
  FAIL honours ODS_PYTHON_CMD given as a command name on PATH
    resolved: /c/Users/hoang/AppData/Local/Microsoft/WindowsApps/python3
  PASS falls back when ODS_PYTHON_CMD names nothing runnable
```

**Caveat:** the rest of this suite (the docker-shim image-discovery
assertions) cannot complete on my host because it has no `python3` — only
`python` — and the same failure occurs on `origin/main`, so it is not caused by
this change. I moved the three new assertions to just after the `source`, ahead
of the docker-shim section, so they exercise the resolver on its own and run
regardless. That reordering is the only change to the existing test.

## Operational Change Check

This touches an installer library, so it is an operational change. It changes
only which interpreter is chosen to parse `docker compose config --format json`
— strictly widening the accepted forms of an explicitly-set `ODS_PYTHON_CMD`.
Behaviour when `ODS_PYTHON_CMD` is unset, or names something unrunnable, is
byte-for-byte the same.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The obvious alternative is to have this call `ods_detect_python_cmd` from
`lib/python-cmd.sh` rather than keeping its own resolver. I did not do that
because `compose-images.sh` is sourced in contexts that do not necessarily have
`lib/` on hand, and sourcing another library from here is a bigger change than
the bug warrants. Happy to do it if you'd rather converge the two.
