### PR TITLE
fix(dashboard): label the hybrid and colocated GPU assignment plans

### DIFF
--- a/ods/extensions/services/dashboard/src/components/AssignmentTable.jsx
+++ b/ods/extensions/services/dashboard/src/components/AssignmentTable.jsx
@@ -1,16 +1,27 @@
 import { memo } from 'react'
 import { Cpu } from 'lucide-react'
 
+// Strategies the backend actually emits: `single`, `colocated` and `dedicated`
+// from scripts/assign_gpus.py and installers/phases/03-features.sh, plus
+// `manual` from `ods gpu reassign --manual`. `shared` and `auto` were styled
+// here but are never produced by any writer.
 const STRATEGY_STYLE = {
   dedicated: 'bg-indigo-500/15 text-indigo-400',
-  shared:    'bg-yellow-500/15 text-yellow-400',
-  auto:      'bg-zinc-700 text-zinc-300',
+  single:    'bg-indigo-500/15 text-indigo-400',
+  colocated: 'bg-yellow-500/15 text-yellow-400',
+  manual:    'bg-sky-500/15 text-sky-400',
 }
 
+// Neutral treatment for anything a future planner adds, and for assignments
+// persisted by an older ODS.
+const STRATEGY_FALLBACK = 'bg-zinc-700 text-zinc-300'
+
+// Modes emitted by select_parallelism() in scripts/assign_gpus.py.
 const PARALLELISM_LABELS = {
+  none:     'Single Process',
   tensor:   'Tensor Parallel',
   pipeline: 'Pipeline Parallel',
-  none:     'Single Process',
+  hybrid:   'Hybrid Tensor + Pipeline',
 }
 
 export const AssignmentTable = memo(function AssignmentTable({ assignment }) {
@@ -20,7 +31,7 @@ export const AssignmentTable = memo(function AssignmentTable({ assignment }) {
   const serviceEntries = Object.entries(services)
   if (serviceEntries.length === 0) return null
 
-  const strategyStyle = STRATEGY_STYLE[strategy] || STRATEGY_STYLE.auto
+  const strategyStyle = STRATEGY_STYLE[strategy] || STRATEGY_FALLBACK
 
   return (
     <div className="p-5 bg-zinc-900/50 border border-zinc-800 rounded-xl">

--- a/ods/extensions/services/dashboard/src/components/AssignmentTable.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/AssignmentTable.test.jsx
@@ -1,0 +1,95 @@
+import { screen } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import { AssignmentTable } from './AssignmentTable' // eslint-disable-line no-unused-vars
+
+// The shapes below mirror what scripts/assign_gpus.py emits and what
+// bin/ods-host-agent.py persists. Keep them in sync with select_parallelism()
+// and the strategy values the planner and `ods gpu reassign` write.
+
+function assignment(strategy, parallelism) {
+  return {
+    version: '1.0',
+    strategy,
+    services: {
+      llama_server: {
+        gpus: ['GPU-00000000-0000-0000-0000-000000000000'],
+        gpu_indices: [0],
+        parallelism,
+      },
+    },
+  }
+}
+
+describe('AssignmentTable parallelism labels', () => {
+  it('labels a hybrid plan instead of showing the raw mode string', () => {
+    render(<AssignmentTable assignment={assignment('dedicated', {
+      mode: 'hybrid',
+      tensor_parallel_size: 2,
+      pipeline_parallel_size: 4,
+      gpu_memory_utilization: 0.93,
+    })} />)
+
+    expect(screen.getByText(/Hybrid Tensor \+ Pipeline/)).toBeInTheDocument()
+    expect(screen.getByText(/tp=2/)).toBeInTheDocument()
+    expect(screen.getByText(/pp=4/)).toBeInTheDocument()
+  })
+
+  it.each([
+    ['none', 'Single Process'],
+    ['tensor', 'Tensor Parallel'],
+    ['pipeline', 'Pipeline Parallel'],
+    ['hybrid', 'Hybrid Tensor + Pipeline'],
+  ])('labels the %s mode', (mode, label) => {
+    render(<AssignmentTable assignment={assignment('dedicated', {
+      mode,
+      tensor_parallel_size: 1,
+      pipeline_parallel_size: 1,
+      gpu_memory_utilization: 0.95,
+    })} />)
+
+    expect(screen.getByText(new RegExp(label.replace('+', '\\+')))).toBeInTheDocument()
+  })
+
+  it('falls back to the raw mode for a value the UI does not know', () => {
+    render(<AssignmentTable assignment={assignment('dedicated', {
+      mode: 'some-future-mode',
+      tensor_parallel_size: 1,
+      pipeline_parallel_size: 1,
+      gpu_memory_utilization: 0.95,
+    })} />)
+
+    expect(screen.getByText(/some-future-mode/)).toBeInTheDocument()
+  })
+})
+
+describe('AssignmentTable strategy badge', () => {
+  const NEUTRAL = 'bg-zinc-700'
+
+  it.each(['single', 'colocated', 'dedicated', 'manual'])(
+    'gives the %s strategy its own badge rather than the neutral fallback',
+    (strategy) => {
+      render(<AssignmentTable assignment={assignment(strategy, {
+        mode: 'none',
+        tensor_parallel_size: 1,
+        pipeline_parallel_size: 1,
+        gpu_memory_utilization: 0.95,
+      })} />)
+
+      const badge = screen.getByText(strategy)
+      expect(badge).toBeInTheDocument()
+      expect(badge.className).not.toContain(NEUTRAL)
+    },
+  )
+
+  it('uses the neutral badge for an unrecognised strategy', () => {
+    render(<AssignmentTable assignment={assignment('something-new', {
+      mode: 'none',
+      tensor_parallel_size: 1,
+      pipeline_parallel_size: 1,
+      gpu_memory_utilization: 0.95,
+    })} />)
+
+    const badge = screen.getByText('something-new')
+    expect(badge.className).toContain(NEUTRAL)
+  })
+})


### PR DESCRIPTION
## Summary

`AssignmentTable`'s two lookup tables had drifted from the values the backend
actually emits.

**`PARALLELISM_LABELS` is missing `hybrid`.**

```js
const PARALLELISM_LABELS = {
  tensor:   'Tensor Parallel',
  pipeline: 'Pipeline Parallel',
  none:     'Single Process',
}
```

`select_parallelism()` in `scripts/assign_gpus.py` emits four modes — `none`,
`tensor`, `pipeline` and `hybrid`. `hybrid` is what NVLink/XGMI hosts and
same-NUMA hosts with 4+ GPUs get. Those users saw the bare string `hybrid`
where every other mode renders a sentence.

**`STRATEGY_STYLE` styles values nothing emits, and misses three that are.**

```js
const STRATEGY_STYLE = {
  dedicated: '...',
  shared:    '...',   // never emitted
  auto:      '...',   // never emitted
}
```

The writers produce:

| strategy | written by |
|---|---|
| `single` | `scripts/assign_gpus.py`, `installers/phases/03-features.sh:241` |
| `colocated` | `scripts/assign_gpus.py`, `installers/phases/03-features.sh:405`, `bin/ods-host-agent.py:1011,1427` |
| `dedicated` | `scripts/assign_gpus.py`, `installers/phases/03-features.sh:404` |
| `manual` | `ods-cli:5801` (`ods gpu reassign --manual`), read back at `bin/ods-host-agent.py:1121,1274` |

So three of the four real strategies fell through to the neutral grey badge —
including `manual`, which is exactly the case an operator most wants to see
distinguished, since `ods-host-agent.py` refuses to auto-expand a manual
assignment and the badge is the only place that state is surfaced.

### Fix

- Add `hybrid` to `PARALLELISM_LABELS`.
- Style `single`, `colocated`, `dedicated` and `manual`; drop the two dead
  entries.
- Rename the fallback to `STRATEGY_FALLBACK` so it reads as a default rather
  than as a strategy literally named `auto`.

Unknown values still degrade to the neutral badge and the raw mode string, so
assignments persisted by an older ODS keep rendering.

Comments name the source of each vocabulary so the next drift is easier to
catch.

## AI Assistance

AI assisted with cross-referencing the emitted vocabulary against the
component, drafting the tests, and wording this description. I read the full
diff, traced each strategy value to its writer, and ran lint/test/build below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ npm run lint
(clean)

$ npx vitest run src/components/AssignmentTable.test.jsx
 Test Files  1 passed (1)
      Tests  11 passed (11)

# same tests against the previous component
     × labels a hybrid plan instead of showing the raw mode string
     × labels the hybrid mode
     × gives the single strategy its own badge rather than the neutral fallback
     × gives the colocated strategy its own badge rather than the neutral fallback
     × gives the manual strategy its own badge rather than the neutral fallback
      Tests  5 failed | 6 passed (11)

$ npx vitest run          # full dashboard suite
 Test Files  29 passed (29)
      Tests  269 passed (269)

$ npm run build
✓ built in 4.28s
```

## Operational Change Check

Presentation only — two lookup tables in a React component. No installer,
compose, routing, or host-mutation surface is touched, and the underlying
assignment data is unchanged.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

I picked distinct colours by meaning rather than by count: `single` shares
`dedicated`'s indigo (each service has its own GPU set), `colocated` keeps the
yellow that `shared` had (services share a GPU — worth noticing), and `manual`
gets sky so an operator-pinned assignment is visually distinct from anything
the planner chose. Happy to change any of them if the design system has a
convention I've missed.

I removed `shared` and `auto` rather than keeping them as aliases. If you'd
rather keep `shared` mapped for assignments persisted by a much older ODS, say
so and I'll add it back — the fallback already renders those readably, just in
grey.
