### PR TITLE
test(env): assert every service port knob is documented and declared

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Dependency Pin Contract Tests
         run: python3 tests/test-dependency-pins.py
 
+      - name: Service Port Env Documentation Contract
+        run: python3 tests/contracts/test-port-env-documentation.py
+
       - name: Offline Model Validation Tests
         run: python3 tests/test-offline-model-validation.py
 

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -255,6 +255,7 @@ SYSTEM_RAM_GB=32
 OLLAMA_PORT=11434          # llama-server API (external → internal 8080)
 WEBUI_PORT=3000            # Open WebUI (external → internal 8080)
 # SEARXNG_PORT=8888          # SearXNG metasearch (external → internal 8080)
+# BRAVE_SEARCH_PORT=8585     # Brave Search API proxy (external → internal 8585)
 # PERPLEXICA_PORT=3004       # Perplexica deep research (external → internal 3000)
 # WHISPER_PORT=9000          # Whisper STT (external → internal 8000)
 # TTS_PORT=8880              # Kokoro TTS (external → internal 8880)

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -101,6 +101,9 @@ test: ## Run unit and contract tests
 	@echo "=== Manifest schema source of truth ==="
 	@bash tests/test-validate-manifest-schema.sh
 	@echo ""
+	@echo "=== Service port env documentation ==="
+	@python3 tests/contracts/test-port-env-documentation.py
+	@echo ""
 	@echo "=== macOS ods config show secret-mask ==="
 	@bash tests/test-macos-config-show-secret-mask.sh
 	@echo ""

--- a/ods/tests/contracts/test-port-env-documentation.py
+++ b/ods/tests/contracts/test-port-env-documentation.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Every service port knob a manifest declares must be documented and declared.
+
+A service manifest's ``external_port_env`` is the name users set to move that
+service off its default port. Three files have to agree about it:
+
+  * ``extensions/services/<id>/manifest.yaml`` declares the name and default;
+  * ``.env.example`` documents it, so users can discover it without reading
+    manifests;
+  * ``.env.schema.json`` declares it, so ``scripts/validate-env.sh`` accepts it
+    rather than flagging it as unknown.
+
+This contract catches a new service that ships a port knob nobody can find, and
+a default that drifts between the manifest and the documented example.
+
+Run: python3 tests/contracts/test-port-env-documentation.py
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SERVICES_DIR = ROOT / "extensions" / "services"
+ENV_EXAMPLE = ROOT / ".env.example"
+ENV_SCHEMA = ROOT / ".env.schema.json"
+
+
+def manifest_port_envs():
+    """Return [(service_id, env_name, default_port)] for every declared knob."""
+    entries = []
+    for service_dir in sorted(SERVICES_DIR.iterdir()):
+        manifest = service_dir / "manifest.yaml"
+        if not manifest.is_dir() and manifest.exists():
+            loaded = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+            service = loaded.get("service") or {}
+            env_name = service.get("external_port_env")
+            if not env_name:
+                continue
+            default = service.get("external_port_default", service.get("port"))
+            entries.append((service.get("id", service_dir.name), env_name, default))
+    return entries
+
+
+def documented_value(lines, key):
+    """Return the value .env.example documents for *key*, commented or not."""
+    pattern = re.compile(r"^\s*#?\s*" + re.escape(key) + r"=([^\s#]*)")
+    for line in lines:
+        match = pattern.match(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def main():
+    entries = manifest_port_envs()
+    if not entries:
+        print("[FAIL] no service manifest declares external_port_env", file=sys.stderr)
+        return 1
+
+    env_lines = ENV_EXAMPLE.read_text(encoding="utf-8").splitlines()
+    schema_properties = set(json.loads(ENV_SCHEMA.read_text(encoding="utf-8"))["properties"])
+
+    failures = []
+    for service_id, env_name, default in entries:
+        documented = documented_value(env_lines, env_name)
+        if documented is None:
+            failures.append(
+                f"{service_id}: {env_name} is not documented in .env.example"
+            )
+        elif documented != str(default):
+            failures.append(
+                f"{service_id}: .env.example documents {env_name}={documented} "
+                f"but the manifest default is {default}"
+            )
+        if env_name not in schema_properties:
+            failures.append(
+                f"{service_id}: {env_name} is not declared in .env.schema.json"
+            )
+
+    for failure in failures:
+        print(f"[FAIL] {failure}", file=sys.stderr)
+
+    if failures:
+        print(f"\n{len(failures)} problem(s) across {len(entries)} port knobs", file=sys.stderr)
+        return 1
+
+    print(f"[PASS] {len(entries)} service port knobs are documented and declared")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

A service manifest's `external_port_env` is the name a user sets to move that
service off its default port. Three files have to agree about it:

- `extensions/services/<id>/manifest.yaml` declares the name and the default;
- `.env.example` documents it, so users can discover it without reading
  manifests;
- `.env.schema.json` declares it, so `scripts/validate-env.sh` accepts it
  instead of flagging it as unknown.

Nothing checked that they agree. Auditing all 22 declared knobs turned up one
gap:

```text
service                env                    default  in-example  in-schema
brave-search           BRAVE_SEARCH_PORT      8585     False       True
```

`BRAVE_SEARCH_PORT` is in the schema and in
`extensions/services/brave-search/manifest.yaml`, but appears nowhere in
`.env.example` — not even commented out, unlike every other optional service
port. A user who needs to move Brave Search off 8585 (it collides with nothing
in the stack today, but 8585 is a common local port) has to read the manifest
to learn the variable exists.

### Changes

1. Document `BRAVE_SEARCH_PORT` in the ports block, next to the other search
   services, in the same commented form the block uses for optional services.
2. Add `tests/contracts/test-port-env-documentation.py`, which asserts for
   every `external_port_env` in every manifest that it is:
   - documented in `.env.example` (commented or not),
   - documented with the **same default** as `external_port_default`,
   - declared in `.env.schema.json`.
3. Wire it into `make test` and the Linux CI job.

The default-drift assertion is the part with ongoing value. All 22 knobs agree
today; this keeps them agreeing when a service changes its port, which is
otherwise a silent three-way divergence.

## AI Assistance

AI assisted with auditing the manifests against the two env files, drafting the
contract test, and wording this description. I read the full diff, confirmed
the `BRAVE_SEARCH_PORT` gap by hand, and ran the test both before and after.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [x] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(One documentation line in `.env.example`, one new test, plus its `make test`
and CI wiring. No manifest or compose file is modified — the "service
manifests" box is ticked because the test reads them as its source of truth.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 tests/contracts/test-port-env-documentation.py
[PASS] 22 service port knobs are documented and declared

# same test against origin/main's .env.example
[FAIL] brave-search: BRAVE_SEARCH_PORT is not documented in .env.example
1 problem(s) across 22 port knobs

$ python3 scripts/audit-extensions.py
Summary: 27 services, 0 errors, 0 warnings, result=pass

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-linux.yml'))"
yaml OK
```

Full audit output before the fix, for reference:

```text
service                env                    default  in-example  in-schema
ape                    APE_PORT               7890     True        True
brave-search           BRAVE_SEARCH_PORT      8585     False       True
comfyui                COMFYUI_PORT           8188     True        True
dashboard              DASHBOARD_PORT         3001     True        True
dashboard-api          DASHBOARD_API_PORT     3002     True        True
embeddings             EMBEDDINGS_PORT        8090     True        True
hermes-proxy           HERMES_PROXY_PORT      9120     True        True
langfuse               LANGFUSE_PORT          3006     True        True
litellm                LITELLM_PORT           4000     True        True
llama-server           OLLAMA_PORT            11434    True        True
n8n                    N8N_PORT               5678     True        True
ods-proxy              ODS_PROXY_PORT         80       True        True
open-webui             WEBUI_PORT             3000     True        True
openclaw               OPENCLAW_PORT          7860     True        True
opencode               OPENCODE_PORT          3003     True        True
perplexica             PERPLEXICA_PORT        3004     True        True
privacy-shield         SHIELD_PORT            8085     True        True
qdrant                 QDRANT_PORT            6333     True        True
searxng                SEARXNG_PORT           8888     True        True
token-spy              TOKEN_SPY_PORT         3005     True        True
tts                    TTS_PORT               8880     True        True
whisper                WHISPER_PORT           9000     True        True
```

## Operational Change Check

The `.env.example` line is commented out, so it changes no generated
configuration — `.env.example` is documentation, and the installer renders the
real `.env` from templates. The rest is a new test plus its wiring.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The test accepts a commented line (`# FOO_PORT=1234`) as documented, matching
how the ports block already treats optional services. If you'd rather require
uncommented entries for some category, that's a one-line change to
`documented_value()`.

`QDRANT_GRPC_PORT` is documented but has no `external_port_env` pointing at it,
so it is outside this contract's scope — the test only walks knobs that
manifests actually declare.
