### PR TITLE
fix(qrcode): resolve format_duration so print_install_summary can run

### DIFF
--- a/ods/lib/qrcode.sh
+++ b/ods/lib/qrcode.sh
@@ -1,6 +1,36 @@
 #!/bin/bash
+# ============================================================================
 # ODS — ASCII QR Code Generator
-# Generates simple QR codes for terminal display without external dependencies
+# ============================================================================
+# Part of: lib/
+# Purpose: Terminal QR codes and access cards for the post-install summary.
+#
+# Expects: BOLD, NC, CYAN, GREEN colour variables (empty is fine);
+#          format_duration() from lib/progress.sh, sourced below.
+# Provides: print_dashboard_qr(), print_url_box(), print_success_card(),
+#           print_install_summary()
+#
+# Usage:
+#   . "$ODS_DIR/lib/qrcode.sh"
+# ============================================================================
+
+# print_install_summary() calls format_duration(), which is defined in
+# lib/progress.sh. Nothing sourced progress.sh alongside this file, so
+# following the usage above and calling print_install_summary died with
+# "format_duration: command not found" (exit 127) — and aborted the caller
+# outright under `set -euo pipefail`.
+if ! declare -F format_duration >/dev/null 2>&1; then
+    _ods_qrcode_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "$_ods_qrcode_lib_dir/progress.sh" ]]; then
+        # progress.sh returns non-zero on Bash 3.2 after printing its own
+        # upgrade guidance. Surface that as a warning rather than aborting a
+        # sourcing script that only wanted the QR helpers.
+        # shellcheck source=progress.sh
+        . "$_ods_qrcode_lib_dir/progress.sh" \
+            || { declare -f warn &>/dev/null && warn "lib/progress.sh unavailable; print_install_summary will not render a duration"; }
+    fi
+    unset _ods_qrcode_lib_dir
+fi
 
 # ═══════════════════════════════════════════════════════════════
 # QR CODE DISPLAY

--- a/ods/tests/test-qrcode-helper.sh
+++ b/ods/tests/test-qrcode-helper.sh
@@ -82,4 +82,26 @@ default_output=$(PATH="$tmpdir:$PATH" print_dashboard_qr)
 grep -Fq "http://10.42.0.99:3001" <<< "$default_output" \
     || fail "print_dashboard_qr did not use the discovered LAN IP by default"
 
+# ── print_install_summary resolves its own dependency ──────────────────────
+# format_duration() lives in lib/progress.sh. Sourcing lib/qrcode.sh the way
+# its header documents must be enough to render the summary — a caller under
+# `set -euo pipefail` is aborted outright by a "command not found".
+
+declare -F format_duration >/dev/null 2>&1 \
+    || fail "sourcing lib/qrcode.sh did not make format_duration available"
+
+summary=$(
+    bash -euo pipefail -c '
+        BOLD=""; NC=""; CYAN=""; GREEN=""
+        . "$1/lib/qrcode.sh"
+        print_install_summary "Pro" "qwen3-30b-a3b" 1000 1300
+    ' bash "$PROJECT_DIR"
+) || fail "print_install_summary aborted a set -euo pipefail caller"
+
+grep -Fq "Install Time:" <<< "$summary" \
+    || fail "print_install_summary did not render the install-time row"
+
+grep -Eq 'Install Time:[[:space:]]+5m' <<< "$summary" \
+    || fail "print_install_summary did not format the 300s duration as '5m': got '$summary'"
+
 echo "[PASS] qrcode helper honors explicit URLs and macOS LAN detection"


### PR DESCRIPTION
## Summary

`lib/qrcode.sh` documents its own usage at the top of the file:

```bash
. "$ODS_DIR/lib/qrcode.sh"
```

Doing exactly that and calling `print_install_summary()` fails:

```text
$ bash -c 'set -euo pipefail
           BOLD=""; NC=""; CYAN=""; GREEN=""
           . lib/qrcode.sh
           print_install_summary "Pro" "qwen3-30b-a3b" 1000 1300'
lib/qrcode.sh: line 142: format_duration: command not found
rc=127
```

`print_install_summary()` calls `format_duration()`, which is defined in
`lib/progress.sh` — a sibling file that nothing sources alongside this one.
`install-core.sh` sources `installers/lib/progress.sh`, a *different* file
with the same basename (the GUI progress protocol), which does not define it.
`format_duration` has exactly one definition in the tree, and `lib/qrcode.sh`
is one of only two callers.

Under `set -euo pipefail` — which the installer and every lifecycle script
use — a `command not found` does not degrade to a missing duration string, it
aborts the caller.

### Fix

Source `lib/progress.sh` from `lib/qrcode.sh` when `format_duration` is not
already defined, following the pattern
`installers/lib/compose-select.sh` already uses for `lib/safe-env.sh`:

```bash
[[ -f "${SCRIPT_DIR:-}/lib/safe-env.sh" ]] && . "${SCRIPT_DIR}/lib/safe-env.sh"
```

`lib/progress.sh` returns non-zero on Bash 3.2 after printing its own upgrade
guidance (it needs associative arrays for `PHASE_ESTIMATES`). That is surfaced
as a warning rather than aborting a script that only wanted the QR helpers —
the QR and access-card functions themselves are Bash 3.2-clean.

Also adds the standard module header (`Part of:` / `Expects:` / `Provides:` /
`Usage:`) that the other `lib/` and `installers/lib/` modules carry.
`lib/qrcode.sh` had none, which is how an undeclared cross-file dependency went
unnoticed.

## AI Assistance

AI assisted with tracing `format_duration` to its definition, drafting the
tests, and wording this description. I read the full diff, reproduced the
failure with the file's own documented usage, and ran the suites below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n lib/qrcode.sh tests/test-qrcode-helper.sh
syntax OK

$ bash tests/test-qrcode-helper.sh          # after
[PASS] qrcode helper honors explicit URLs and macOS LAN detection
rc=0

$ bash tests/test-qrcode-helper.sh          # lib stashed, before
[FAIL] sourcing lib/qrcode.sh did not make format_duration available
rc=1

# the reported behaviour, reproduced
$ bash -c 'set -euo pipefail; BOLD=""; NC=""; CYAN=""; GREEN=""
           . lib/qrcode.sh
           print_install_summary "Pro" "qwen3-30b-a3b" 1000 1300'
  before -> lib/qrcode.sh: line 142: format_duration: command not found  (rc=127)
  after  -> Install Time:   5m                                          (rc=0)

$ bash tests/test-bash32-guards.sh
Result: 10 passed, 0 failed
```

## Operational Change Check

This touches a lifecycle library, so I have ticked it as an operational change.
In practice the blast radius is small: no installer phase currently sources
`lib/qrcode.sh` (phase 13 uses `show_success_card` from
`installers/lib/ui.sh`), so this cannot regress a shipped install path — it
makes the module usable by the callers its own header invites.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Something I noticed while tracing this and deliberately did **not** act on:
`lib/qrcode.sh` and `lib/progress.sh` are not sourced by any installer phase,
`ods-cli`, or platform installer — only by `tests/test-qrcode-helper.sh` and
`tests/test-bash32-guards.sh`. Phase 13 renders its card via
`installers/lib/ui.sh:show_success_card()` instead.

So these two modules are, today, unreferenced production code with a test suite
in `make test` giving the appearance of coverage. That reads to me like a
feature that was built and never wired up (`print_dashboard_qr` renders a
scannable QR for the LAN dashboard URL, which `show_success_card` does not), so
deleting it is not obviously right — but neither is leaving it broken.

Two follow-ups I'm happy to send, whichever you prefer:

1. Wire `print_dashboard_qr` into phase 13 so LAN users get the QR the module
   was written for; or
2. Remove both modules and their tests as dead code.

This PR just makes the module work as documented, which is a prerequisite for
(1) and harmless if you pick (2).
