### PR TITLE
fix(auth): make magic-link revocation unambiguous

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -53,6 +53,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import threading
 import time
@@ -863,16 +864,28 @@ def revoke_magic_link(token_hash_prefix: str) -> dict:
     returns the same 404 so admins don't fingerprint state. A successful
     revocation flips revoked_at to now, leaves the audit trail intact.
     """
-    if len(token_hash_prefix) < 4 or len(token_hash_prefix) > 64:
+    if not re.fullmatch(r"[0-9a-fA-F]{8,64}", token_hash_prefix):
         raise HTTPException(status_code=400, detail="Invalid token hash prefix")
+    token_hash_prefix = token_hash_prefix.lower()
     with _STORE_LOCK:
         store = _ensure_store()
-        for record in store.get("tokens", []):
-            if record["token_hash"].startswith(token_hash_prefix) and not record.get("revoked_at"):
-                record["revoked_at"] = _now_iso()
-                _write_store(store)
-                logger.info("magic-link revoked target=%s", record["target_username"])
-                return {"revoked": True}
+        matches = [
+            record
+            for record in store.get("tokens", [])
+            if record["token_hash"].startswith(token_hash_prefix)
+            and not record.get("revoked_at")
+        ]
+        if len(matches) > 1:
+            raise HTTPException(
+                status_code=409,
+                detail="Token hash prefix is ambiguous; use more characters",
+            )
+        if matches:
+            record = matches[0]
+            record["revoked_at"] = _now_iso()
+            _write_store(store)
+            logger.info("magic-link revoked target=%s", record["target_username"])
+            return {"revoked": True}
     raise HTTPException(status_code=404, detail="No active magic link with that prefix")
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -1211,6 +1211,45 @@ def test_revoke_short_prefix_rejected(magic_link_client):
     assert resp.status_code == 400
 
 
+def test_revoke_non_hex_prefix_rejected(magic_link_client):
+    resp = magic_link_client.delete(
+        "/api/auth/magic-link/not-hex!",
+        headers=magic_link_client.auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_revoke_ambiguous_prefix_does_not_revoke_either_token(
+    magic_link_client, magic_link_module
+):
+    prefix = "deadbeef"
+    magic_link_module._write_store({
+        "tokens": [
+            {
+                "token_hash": prefix + "0" * 56,
+                "target_username": "alice",
+                "revoked_at": None,
+            },
+            {
+                "token_hash": prefix + "1" * 56,
+                "target_username": "bob",
+                "revoked_at": None,
+            },
+        ]
+    })
+
+    resp = magic_link_client.delete(
+        f"/api/auth/magic-link/{prefix}",
+        headers=magic_link_client.auth_headers,
+    )
+
+    assert resp.status_code == 409
+    assert all(
+        record["revoked_at"] is None
+        for record in magic_link_module._ensure_store()["tokens"]
+    )
+
+
 def test_revoke_unknown_prefix_returns_404(magic_link_client):
     resp = magic_link_client.delete(
         "/api/auth/magic-link/deadbeef",


### PR DESCRIPTION
## Summary
- require the 8-to-64-character hexadecimal hash prefix exposed by the admin list
- reject ambiguous active-token matches with HTTP 409 before mutating the store
- cover invalid, ambiguous, and successful revocation behavior

## Test plan
- python -m pytest tests/test_magic_link.py -q (68 passed)