### PR TITLE
fix(token-spy): harden session cleanup arguments

### DIFF
--- a/ods/extensions/services/token-spy/session-manager.sh
+++ b/ods/extensions/services/token-spy/session-manager.sh
@@ -139,17 +139,21 @@ kill_session() {
       pycmd="python"
     fi
 
-    "$pycmd" -c "
+    "$pycmd" - "$sessions_json" "$session_id" <<'PY'
 import json, sys
-with open('$sessions_json', 'r') as f:
+sessions_json, session_id = sys.argv[1:3]
+with open(sessions_json, 'r') as f:
     data = json.load(f)
-to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get('sessionId') == '$session_id']
+to_remove = [
+    k for k, v in data.items()
+    if isinstance(v, dict) and v.get('sessionId') == session_id
+]
 for k in to_remove:
     del data[k]
     print(f'  Removed session key: {k}', file=sys.stderr)
-with open('$sessions_json', 'w') as f:
+with open(sessions_json, 'w') as f:
     json.dump(data, f, indent=2)
-" 2>&1
+PY
   fi
 }
 
@@ -259,6 +263,10 @@ REMOTESCRIPT
 
   while IFS='|' read -r sid size mtime; do
     [ -z "$sid" ] && continue
+    if [[ ! "$sid" =~ ^[A-Za-z0-9._-]+$ ]] || [[ ! "$size" =~ ^[0-9]+$ ]] || [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
+      log "  [WARN] Ignoring malformed remote session metadata"
+      continue
+    fi
     session_count=$((session_count + 1))
 
     local is_active=false
@@ -286,12 +294,17 @@ REMOTESCRIPT
   log "  Sessions: $session_count total, ${#to_remove[@]} to remove"
 
   if [ "${#to_remove[@]}" -gt 0 ]; then
-    local rm_args=""
+    local rm_command="rm -f --"
+    local quoted_path
     for sid in "${to_remove[@]}"; do
-      rm_args="${rm_args} ${remote_dir}/${sid}.jsonl"
+      printf -v quoted_path '%q' "${remote_dir}/${sid}.jsonl"
+      rm_command="${rm_command} ${quoted_path}"
     done
-    ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "rm -f ${rm_args}" 2>/dev/null || true
-    log "  [DONE] Removed ${#to_remove[@]} sessions on $host"
+    if ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "$rm_command" 2>/dev/null; then
+      log "  [DONE] Removed ${#to_remove[@]} sessions on $host"
+    else
+      log "  [WARN] Failed to remove sessions on $host"
+    fi
   else
     log "  [OK] No cleanup needed"
   fi

--- a/ods/tests/test-token-spy-session-manager.sh
+++ b/ods/tests/test-token-spy-session-manager.sh
@@ -18,10 +18,10 @@ pass() { echo "  ✓ $1"; }
 fail() { echo "  ✗ $1"; exit 1; }
 
 # Source only the helpers: the script's top level defines config and then
-# main() runs under `set -euo pipefail`, so extract the two functions we drive.
+# main() runs under `set -euo pipefail`, so extract the functions we drive.
 FUNCS="$(mktemp)"
 trap 'rm -f "$FUNCS"' EXIT
-sed -n '/^extract_active_ids()/,/^}/p;/^clean_inactive()/,/^}/p' "$MANAGER" > "$FUNCS"
+sed -n '/^extract_active_ids()/,/^}/p;/^clean_inactive()/,/^}/p;/^kill_session()/,/^}/p' "$MANAGER" > "$FUNCS"
 log() { :; }   # silence the manager's logger
 # shellcheck disable=SC1090
 source "$FUNCS"
@@ -84,6 +84,24 @@ for id in aaa bbb; do
 done
 pass "no session deleted when sessions.json is a partial write"
 rm -rf "$WORK"
+
+echo "Test 6: session ids are passed to Python as data, not code"
+WORK="$(mktemp -d)/sessions"
+mkdir -p "$WORK"
+session_id="session'quoted"
+printf '{}' > "$WORK/$session_id.jsonl"
+printf '{"entry":{"sessionId":"session'\''quoted"}}\n' > "$WORK/sessions.json"
+kill_session "$WORK" "$session_id" "test"
+[ ! -f "$WORK/$session_id.jsonl" ] || fail "quoted session file was not removed"
+python3 - "$WORK/sessions.json" <<'PY' || fail "quoted session id remained in index"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    assert json.load(source) == {}
+PY
+pass "quoted values cannot alter the generated Python program"
+rm -rf "$(dirname "$WORK")"
 
 echo ""
 echo "✓ All token-spy session-manager tests passed"


### PR DESCRIPTION
## Summary
- pass session index paths and IDs to Python as argv data instead of source text
- reject malformed remote session metadata before arithmetic or deletion
- shell-quote remote paths and report SSH deletion failures

## Test plan
- bash tests/test-token-spy-session-manager.sh
- bash -n extensions/services/token-spy/session-manager.sh