### PR TITLE
fix(macos): remove seq dependency from runtime loops

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -798,7 +798,7 @@ _verify_macos_dashboard_host_agent() {
         return 1
     fi
 
-    for attempt in $(seq 1 20); do
+    for (( attempt = 1; attempt <= 20; attempt++ )); do
         if docker exec ods-dashboard-api curl -fsS --max-time 2 \
             -H "Authorization: Bearer ${api_key}" \
             "http://${host}:${port}/v1/model/status" >/dev/null 2>&1; then
@@ -887,7 +887,7 @@ _ensure_colima_private_network() {
     fi
 
     local attempt
-    for attempt in $(seq 1 60); do
+    for (( attempt = 1; attempt <= 60; attempt++ )); do
         docker info >/dev/null 2>&1 && break
         sleep 1
     done
@@ -2705,7 +2705,7 @@ for service in (data.get("services") or {}).values():
 
     if $ENABLE_HERMES; then
         _hermes_running=false
-        for _hermes_wait_i in $(seq 1 90); do
+        for (( _hermes_wait_i = 1; _hermes_wait_i <= 90; _hermes_wait_i++ )); do
             if [[ "$(docker inspect --format '{{.State.Status}}' ods-hermes 2>/dev/null || true)" == "running" ]]; then
                 _hermes_running=true
                 break
@@ -2718,7 +2718,7 @@ for service in (data.get("services") or {}).values():
         fi
 
         _hermes_live_verified=false
-        for _hermes_wait_i in $(seq 1 90); do
+        for (( _hermes_wait_i = 1; _hermes_wait_i <= 90; _hermes_wait_i++ )); do
             _hermes_patch_rc=0
             _macos_patch_hermes_persisted_config \
                 "$_hermes_model" "$_hermes_base_url" "$MAX_CONTEXT" \
@@ -2739,7 +2739,7 @@ for service in (data.get("services") or {}).values():
             exit 1
         fi
         _hermes_restarted_healthy=false
-        for _hermes_wait_i in $(seq 1 180); do
+        for (( _hermes_wait_i = 1; _hermes_wait_i <= 180; _hermes_wait_i++ )); do
             if [[ "$(docker inspect --format '{{.State.Health.Status}}' ods-hermes 2>/dev/null || true)" == "healthy" ]]; then
                 _hermes_restarted_healthy=true
                 break
@@ -3130,7 +3130,7 @@ if $CLOUD_MODE; then
     [[ "$_cloud_health_port" =~ ^[0-9]+$ ]] || _cloud_health_port="4000"
     _cloud_auth_ok=false
     if [[ -n "$_cloud_health_key" ]]; then
-        for _cloud_health_i in $(seq 1 30); do
+        for (( _cloud_health_i = 1; _cloud_health_i <= 30; _cloud_health_i++ )); do
             if curl -fsS --connect-timeout 2 --max-time 5 \
                 -H "Authorization: Bearer ${_cloud_health_key}" \
                 "http://${_cloud_health_host}:${_cloud_health_port}/v1/models" \
@@ -3213,7 +3213,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
 
     # Step 1: wait briefly for the models API to be ready (max 15s).
     _stt_api_ready=false
-    for _i in $(seq 1 15); do
+    for (( _i = 1; _i <= 15; _i++ )); do
         if curl -sf --max-time 2 "${WHISPER_URL}/v1/models" &>/dev/null; then
             _stt_api_ready=true
             break

--- a/ods/installers/macos/lib/bridge-manager.sh
+++ b/ods/installers/macos/lib/bridge-manager.sh
@@ -67,7 +67,7 @@ BRIDGE_PLIST_EOF
         return 1
     fi
     launchctl kickstart -k "gui/$(id -u)/${label}" >/dev/null 2>&1 || true
-    for _ in $(seq 1 30); do
+    for (( _ = 1; _ <= 30; _++ )); do
         if "$bridge_python" -c \
             'import socket, sys; socket.create_connection((sys.argv[1], int(sys.argv[2])), 1).close()' \
             "$listen_host" "$listen_port" >/dev/null 2>&1; then

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -418,7 +418,7 @@ restore_docker_llama_server_after_swap_failure() {
 
     [[ -n "$health_url" ]] || return 0
     log "Waiting for restored llama-server health at $health_url ..."
-    for _rollback_i in $(seq 1 60); do
+    for (( _rollback_i = 1; _rollback_i <= 60; _rollback_i++ )); do
         if curl -sf --max-time 5 "$health_url" >/dev/null 2>&1; then
             rollback_healthy=true
             break
@@ -1047,7 +1047,7 @@ restart_windows_lemonade_with_full_model() {
     # budget as the llama.cpp warm-up path; override with ODS_LEMONADE_SWAP_ATTEMPTS.
     _swap_attempts="${ODS_LEMONADE_SWAP_ATTEMPTS:-60}"
     case "$_swap_attempts" in ''|*[!0-9]*|0) _swap_attempts=60 ;; esac
-    for _i in $(seq 1 "$_swap_attempts"); do
+    for (( _i = 1; _i <= _swap_attempts; _i++ )); do
         if curl -sf --max-time 5 "http://127.0.0.1:${lemonade_port}/api/v1/models" 2>/dev/null \
             | grep -q "\"id\"[[:space:]]*:[[:space:]]*\"${model_id}\""; then
             if curl -sf --max-time 240 -X POST \
@@ -1553,7 +1553,7 @@ verify_windows_lemonade_downstream_route() {
     case "$request_timeout" in ''|*[!0-9]*|0) request_timeout=120 ;; esac
 
     log "Verifying ${route_label} through the configured downstream route: ${route_base}"
-    for _route_i in $(seq 1 "$attempts"); do
+    for (( _route_i = 1; _route_i <= attempts; _route_i++ )); do
         if [[ "$route_mode" == "container" ]]; then
             if $DOCKER_CMD exec "$route_container" curl -sf --max-time "$request_timeout" -X POST \
                 "$route_url" \
@@ -1592,7 +1592,7 @@ verify_model_completion_route() {
     case "$request_timeout" in ''|*[!0-9]*|0) request_timeout=120 ;; esac
 
     log "Verifying ${route_label} with an exact-model completion through ${route_base}..."
-    for _route_i in $(seq 1 "$attempts"); do
+    for (( _route_i = 1; _route_i <= attempts; _route_i++ )); do
         if [[ -n "$route_key" ]]; then
             response="$(curl -fsS --max-time "$request_timeout" -X POST \
                 "${route_base%/}/chat/completions" \
@@ -1853,7 +1853,7 @@ refresh_lemonade_after_bootstrap_cleanup() {
     fi
     old_model_id="extra.${BOOTSTRAP_GGUF//\"/\\\"}"
 
-    for _i in $(seq 1 60); do
+    for (( _i = 1; _i <= 60; _i++ )); do
         models_json="$(curl -sf --max-time 5 "http://127.0.0.1:${lemonade_port}/api/v1/models" 2>/dev/null || true)"
         if json_has_id "$models_json" "$model_id" && ! json_has_id "$models_json" "$old_model_id"; then
             if curl -sf --max-time 240 -X POST \
@@ -1879,7 +1879,7 @@ monitor_download() {
     local part_file="$1" total_bytes="$2"
 
     # Wait for curl to create the .part file (up to 30s)
-    for _wait in $(seq 1 30); do
+    for (( _wait = 1; _wait <= 30; _wait++ )); do
         [[ -f "$part_file" ]] && break
         sleep 1
     done
@@ -2480,7 +2480,7 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
     _healthy=false
     _warmup_sent=false
     _failed_state_attempts=0
-    for _i in $(seq 1 "$_bootstrap_health_attempts"); do
+    for (( _i = 1; _i <= _bootstrap_health_attempts; _i++ )); do
         _resp=$(curl -sf --max-time 5 "$_health_url" 2>/dev/null || echo "")
         if [[ -n "$_resp" ]]; then
             if [[ "$_gpu_backend" == "amd" ]]; then
@@ -2871,7 +2871,7 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
             # broken Hermes doesn't stall the script forever.
             log "Pre-warming Hermes system prompt (caches 14K-token prefill)..."
             _hermes_ready=false
-            for _i in $(seq 1 30); do
+            for (( _i = 1; _i <= 30; _i++ )); do
                 if $DOCKER_CMD exec ods-hermes curl -sf --max-time 3 http://127.0.0.1:9119/api/status >/dev/null 2>&1; then
                     _hermes_ready=true
                     break
@@ -2998,7 +2998,7 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
             # Wait for health
             log "Waiting for native llama-server health..."
             _healthy=false
-            for _i in $(seq 1 60); do
+            for (( _i = 1; _i <= 60; _i++ )); do
                 if curl -sf --max-time 5 "http://127.0.0.1:${_native_port}/health" &>/dev/null; then
                     _healthy=true
                     break

--- a/ods/tests/bats-tests/macos-bsd-compat.bats
+++ b/ods/tests/bats-tests/macos-bsd-compat.bats
@@ -104,3 +104,14 @@ EOF
     run grep -F "sort -V" "$REPO_ROOT/scripts/migrate-config.sh"
     assert_failure
 }
+
+@test "macOS runtime paths do not depend on the non-system seq command" {
+    local path
+    for path in \
+        "$REPO_ROOT/installers/macos/install-macos.sh" \
+        "$REPO_ROOT/installers/macos/lib/bridge-manager.sh" \
+        "$REPO_ROOT/scripts/bootstrap-upgrade.sh"; do
+        run grep -E '(^|[;&|[:space:]])seq[[:space:]]' "$path"
+        assert_failure
+    done
+}


### PR DESCRIPTION
## Summary
- replace seq command substitutions with Bash arithmetic loops
- cover the macOS installer, bridge manager, and shared bootstrap upgrade path
- add a BSD compatibility contract that prevents the dependency from returning

## Test plan
- bash -n installers/macos/install-macos.sh installers/macos/lib/bridge-manager.sh scripts/bootstrap-upgrade.sh
- verified no runtime seq invocation remains in those paths