### PR TITLE
feat(dashboard): copy text on local HTTP origins

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
+++ b/ods/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { AlertCircle, ChevronDown, ChevronUp, Terminal, Copy, Check } from 'lucide-react'
+import { copyText } from '../lib/clipboard'
 
 const commonIssues = [
   {
@@ -109,10 +110,11 @@ export function TroubleshootingAssistant({ serviceStatus }) {
   const [copied, setCopied] = useState(null)
   const [search, setSearch] = useState('')
 
-  const copyToClipboard = (text, id) => {
-    navigator.clipboard.writeText(text)
-    setCopied(id)
-    setTimeout(() => setCopied(null), 2000)
+  const copyToClipboard = async (text, id) => {
+    if (await copyText(text)) {
+      setCopied(id)
+      setTimeout(() => setCopied(null), 2000)
+    }
   }
 
   const filteredIssues = search 

--- a/ods/extensions/services/dashboard/src/lib/clipboard.js
+++ b/ods/extensions/services/dashboard/src/lib/clipboard.js
@@ -1,0 +1,34 @@
+export async function copyText(text) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch (error) {
+      console.debug('Clipboard API failed; trying the DOM fallback', error)
+    }
+  }
+
+  if (!document.body || typeof document.execCommand !== 'function') return false
+
+  const activeElement = document.activeElement
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.readOnly = true
+  textarea.setAttribute('aria-hidden', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  textarea.style.pointerEvents = 'none'
+  document.body.appendChild(textarea)
+  textarea.select()
+  textarea.setSelectionRange(0, textarea.value.length)
+
+  try {
+    return document.execCommand('copy')
+  } catch (error) {
+    console.debug('DOM clipboard fallback failed', error)
+    return false
+  } finally {
+    textarea.remove()
+    activeElement?.focus()
+  }
+}

--- a/ods/extensions/services/dashboard/src/lib/clipboard.test.js
+++ b/ods/extensions/services/dashboard/src/lib/clipboard.test.js
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copyText } from './clipboard'
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+const originalExecCommand = document.execCommand
+
+afterEach(() => {
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  } else {
+    delete navigator.clipboard
+  }
+  document.execCommand = originalExecCommand
+  vi.restoreAllMocks()
+})
+
+function setClipboard(value) {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value,
+  })
+}
+
+describe('copyText', () => {
+  it('uses the modern Clipboard API when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+
+    await expect(copyText('hello')).resolves.toBe(true)
+
+    expect(writeText).toHaveBeenCalledWith('hello')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('falls back to a temporary textarea when Clipboard API is unavailable', async () => {
+    setClipboard(undefined)
+    document.execCommand = vi.fn().mockReturnValue(true)
+
+    await expect(copyText('local ODS URL')).resolves.toBe(true)
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('uses the fallback when Clipboard API rejects the request', async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error('insecure context')) })
+    document.execCommand = vi.fn().mockReturnValue(true)
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    await expect(copyText('http://ods.local')).resolves.toBe(true)
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('reports failure when neither copy mechanism succeeds', async () => {
+    setClipboard(undefined)
+    document.execCommand = vi.fn().mockReturnValue(false)
+
+    await expect(copyText('uncopied')).resolves.toBe(false)
+  })
+
+  it('cleans up and reports failure when the fallback throws', async () => {
+    setClipboard(undefined)
+    document.execCommand = vi.fn(() => { throw new Error('copy denied') })
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    await expect(copyText('uncopied')).resolves.toBe(false)
+
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useRef } from 'react'
 import { DependencyBadges, DependencyConfirmDialog, DisableDependentWarning } from '../components/DependencyBadges'
 import { TemplatePicker } from '../components/TemplatePicker'
 import { getTemplateStatus } from '../lib/templates'
+import { copyText } from '../lib/clipboard'
 import { serviceUrl } from '../lib/serviceUrls'
 import { createRecoveryTracker } from '../utils/recoveryTracker'
 
@@ -1307,10 +1308,11 @@ function ConsoleModal({ ext, onClose }) {
 function CopyableCommand({ command }) {
   const [copied, setCopied] = useState(false)
 
-  const handleCopy = () => {
-    navigator.clipboard?.writeText(command)
-      .then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000) })
-      .catch(() => {})
+  const handleCopy = async () => {
+    if (await copyText(command)) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
   }
 
   return (

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -21,6 +21,7 @@ import {
   MessageSquare, Workflow, Boxes, Loader2, AlertCircle, Copy,
   QrCode, Share2,
 } from 'lucide-react'
+import { copyText } from '../lib/clipboard'
 
 const PROGRESS_KEY = 'ods-firstboot-progress'
 
@@ -625,12 +626,9 @@ function DoneScreen({ invite, onDone }) {
   }, [invite.url])
 
   const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(invite.url)
+    if (await copyText(invite.url)) {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Fallback: a visible input would let the user select manually.
     }
   }
 

--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -4,6 +4,7 @@ import {
   Loader2, AlertCircle, Clock, Users, KeyRound, ShieldCheck, Mic2,
   Printer, MessageSquare,
 } from 'lucide-react'
+import { copyText } from '../lib/clipboard'
 
 // Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
 // proxy_set_header for all /api/ requests (see nginx.conf). All fetches
@@ -656,12 +657,9 @@ function GeneratedTokenModal({ record, onClose }) {
   }, [record.url])
 
   const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(record.url)
+    if (await copyText(record.url)) {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Fallback: select the visible input manually.
     }
   }
 


### PR DESCRIPTION
## Summary
- add a shared copyText helper with Clipboard API and DOM fallbacks
- support ODS dashboards served from local HTTP origins where navigator.clipboard is unavailable
- use the helper across invites, first boot, extensions, and troubleshooting UI

## Test plan
- npm test (263 passed)
- npm run lint
- npm run build