### PR TITLE
fix(restore): reject invalid interactive backup selections

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -187,7 +187,12 @@ select_backup() {
     fi
 
     echo "Select a backup to restore (enter number):" >&2
+    local selection
     read -r selection
+    if [[ ! "$selection" =~ ^[1-9][0-9]*$ ]]; then
+        log_error "Invalid selection: $selection" >&2
+        return 1
+    fi
 
     local backups=()
     while IFS= read -r -d '' backup; do

--- a/ods/tests/test-restore-safety-ux.sh
+++ b/ods/tests/test-restore-safety-ux.sh
@@ -21,7 +21,8 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 FAKE_ODS="$TMP/ods"
-mkdir -p "$FAKE_ODS/.backups"
+mkdir -p "$FAKE_ODS/.backups" "$FAKE_ODS/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/"
 # minimal marker so 'is this a ODS dir' check passes
 mkdir -p "$FAKE_ODS/data"
 
@@ -41,6 +42,18 @@ cat > "$B/manifest.json" <<'JSON'
   "contents": {"user_data": true, "config": false, "cache": false}
 }
 JSON
+
+info "Interactive restore rejects non-numeric selections cleanly"
+for selection in abc 0 '1+0'; do
+    set +e
+    out=$(printf '%s\n' "$selection" | ODS_DIR="$FAKE_ODS" bash "$ODS_RESTORE" -f -d 2>&1)
+    rc=$?
+    set -e
+    [[ $rc -ne 0 ]] || fail "Expected selection '$selection' to fail"
+    echo "$out" | grep -q "Invalid selection: $selection" || fail "Selection '$selection' did not return the validation error"
+    echo "$out" | grep -qiE 'unbound variable|syntax error' && fail "Selection '$selection' reached Bash arithmetic"
+done
+pass "Invalid interactive selections never reach arithmetic evaluation"
 
 info "Restore should cancel unless backup ID is typed"
 set +e


### PR DESCRIPTION
## Summary
- require a positive decimal selection before entering Bash arithmetic evaluation
- reject expressions, zero, and non-numeric input with the normal validation error
- extend restore safety coverage for hostile and malformed selections

## Test plan
- bash tests/test-restore-safety-ux.sh
- round-trip backup test was unavailable locally because Git Bash does not provide rsync