### PR TITLE
fix(remote-provider): reject non-finite SSH timing values

### DIFF
--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import subprocess
 import threading
@@ -45,7 +46,7 @@ def _env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
     except ValueError:
         LOGGER.warning("invalid %s=%r; using default", name, raw)
         return default
-    if value < minimum:
+    if not math.isfinite(value) or value < minimum:
         LOGGER.warning("out-of-range %s=%r; using default", name, raw)
         return default
     return value

--- a/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
+++ b/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
@@ -342,6 +342,22 @@ def test_supervisor_uses_restart_cooldown_after_child_exit() -> None:
     assert_true(restarted["status"] == "starting", "restarted child should enter grace period")
 
 
+def test_timing_environment_rejects_non_finite_values() -> None:
+    ssh_app = _health_app()
+    for raw in ("nan", "NaN", "inf", "+inf", "-inf"):
+        with patched_env(ODS_TEST_SSH_TIMING=raw):
+            value = ssh_app._env_float(
+                "ODS_TEST_SSH_TIMING",
+                5.0,
+                minimum=0.1,
+            )
+        assert_true(value == 5.0, f"non-finite timing {raw!r} must use the default")
+
+    with patched_env(ODS_TEST_SSH_TIMING="0.25"):
+        value = ssh_app._env_float("ODS_TEST_SSH_TIMING", 5.0, minimum=0.1)
+    assert_true(value == 0.25, "finite timing override should be preserved")
+
+
 def test_service_source_avoids_public_secret_names() -> None:
     for path, text in _walk_service_source():
         for key in PUBLIC_SSH_SECRET_ENV:
@@ -365,6 +381,7 @@ def main() -> int:
         test_supervisor_stops_process_when_secret_custody_disappears,
         test_supervisor_restarts_process_when_route_argv_changes,
         test_supervisor_uses_restart_cooldown_after_child_exit,
+        test_timing_environment_rejects_non_finite_values,
         test_service_source_avoids_public_secret_names,
     ]
     for test in tests:


### PR DESCRIPTION
## Summary

- reject NaN and infinite SSH supervisor timing overrides
- keep the existing finite minimum/default behavior and warning path
- add regression coverage for every non-finite spelling accepted by Python float parsing

## Why

The environment parser accepted IEEE-754 non-finite values because comparisons against NaN are false and infinity satisfies the minimum. Those values can poison reconcile waits and cooldown/grace calculations.

## Testing

- `python tests/contracts/test-remote-provider-ssh-tunnel-service.py` (12 passed)