### PR TITLE
feat(lemonade): classify audio client failures

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -226,14 +226,21 @@ class LemonadeClient:
 
     async def speech(self, model: str, text: str, *, voice: str = "af_heart") -> bytes:
         client = await self._ensure_client()
-        response = await client.post(
-            self.api_url("audio/speech"),
-            json={"model": model, "input": text, "voice": voice},
-            headers=self.auth_headers(),
-            timeout=self.settings.timeout,
-        )
-        response.raise_for_status()
-        return response.content
+        try:
+            response = await client.post(
+                self.api_url("audio/speech"),
+                json={"model": model, "input": text, "voice": voice},
+                headers=self.auth_headers(),
+                timeout=self.settings.timeout,
+            )
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPStatusError as exc:
+            raise _classified_status_error(exc) from exc
+        except httpx.TimeoutException as exc:
+            raise LemonadeClientError("timeout", str(exc)) from exc
+        except httpx.RequestError as exc:
+            raise LemonadeClientError("provider_unreachable", str(exc)) from exc
 
     async def transcribe_wav(self, model: str, wav_bytes: bytes, *, filename: str = "audio.wav") -> dict[str, Any]:
         client = await self._ensure_client()
@@ -249,13 +256,23 @@ class LemonadeClient:
             payload = response.json() if response.content else {}
             return payload if isinstance(payload, dict) else {"data": payload}
         except httpx.HTTPStatusError as exc:
-            payload = _json_payload(exc.response)
-            raise LemonadeClientError(
-                classify_status(exc.response.status_code),
-                _payload_message(payload) or exc.response.text or str(exc),
-                status_code=exc.response.status_code,
-                payload=payload,
-            ) from exc
+            raise _classified_status_error(exc) from exc
+        except httpx.TimeoutException as exc:
+            raise LemonadeClientError("timeout", str(exc)) from exc
+        except httpx.RequestError as exc:
+            raise LemonadeClientError("provider_unreachable", str(exc)) from exc
+        except ValueError as exc:
+            raise LemonadeClientError("invalid_response", str(exc)) from exc
+
+
+def _classified_status_error(exc: httpx.HTTPStatusError) -> LemonadeClientError:
+    payload = _json_payload(exc.response)
+    return LemonadeClientError(
+        classify_status(exc.response.status_code),
+        _payload_message(payload) or exc.response.text or str(exc),
+        status_code=exc.response.status_code,
+        payload=payload,
+    )
 
 
 def _json_payload(response: httpx.Response) -> dict[str, Any]:

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -171,3 +171,77 @@ async def test_explicit_timeout_override_is_applied():
     await client.aclose()
 
     assert seen["timeout"].get("read") == 5.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["speech", "transcribe"])
+async def test_audio_http_errors_use_the_client_error_contract(operation):
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": {"message": "engine warming"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        if operation == "speech":
+            await adapter.speech("voice-model", "hello")
+        else:
+            await adapter.transcribe_wav("stt-model", b"RIFF")
+
+    assert exc.value.kind == "provider_error"
+    assert exc.value.status_code == 503
+    assert "engine warming" in str(exc.value)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["speech", "transcribe"])
+async def test_audio_transport_errors_use_the_client_error_contract(operation):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        if operation == "speech":
+            await adapter.speech("voice-model", "hello")
+        else:
+            await adapter.transcribe_wav("stt-model", b"RIFF")
+
+    assert exc.value.kind == "provider_unreachable"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["speech", "transcribe"])
+async def test_audio_timeouts_use_the_client_error_contract(operation):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("engine timed out", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        if operation == "speech":
+            await adapter.speech("voice-model", "hello")
+        else:
+            await adapter.transcribe_wav("stt-model", b"RIFF")
+
+    assert exc.value.kind == "timeout"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transcription_invalid_json_uses_the_client_error_contract():
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not-json")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.transcribe_wav("stt-model", b"RIFF")
+
+    assert exc.value.kind == "invalid_response"
+    await client.aclose()


### PR DESCRIPTION
## Summary

- apply LemonadeClientError classification to speech and transcription requests
- distinguish provider HTTP errors, timeouts, connection failures, and invalid transcription JSON
- share HTTP-status payload/message extraction across both audio operations
- add coverage for every audio operation and error category

## Why

The JSON client methods exposed a stable classified error contract, while speech leaked raw httpx exceptions and transcription only classified HTTP status failures. Audio callers could not handle Lemonade failures consistently.

## Testing

- `python -m pytest tests/test_lemonade_client.py -q` (16 passed)
- full Dashboard API suite: 2074 passed, 14 skipped; one unrelated Windows symlink test could not run without SeCreateSymbolicLink privilege