### PR TITLE
fix(dashboard): tolerate unavailable theme storage

### DIFF
--- a/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
@@ -12,15 +12,32 @@ const DEFAULT_THEME = 'ods'
 
 const ThemeContext = createContext(null)
 
+function readStoredTheme() {
+  try {
+    return globalThis.localStorage?.getItem(STORAGE_KEY)
+  } catch (error) {
+    if (error instanceof globalThis.DOMException) return null
+    throw error
+  }
+}
+
+function persistTheme(theme) {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, theme)
+  } catch (error) {
+    if (!(error instanceof globalThis.DOMException)) throw error
+  }
+}
+
 export function ThemeProvider({ children }) {
   const [theme, setThemeState] = useState(() => {
-    const stored = localStorage.getItem(STORAGE_KEY)
+    const stored = readStoredTheme()
     return THEMES.includes(stored) ? stored : DEFAULT_THEME
   })
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
-    localStorage.setItem(STORAGE_KEY, theme)
+    persistTheme(theme)
   }, [theme])
 
   const setTheme = useCallback((t) => {

--- a/ods/extensions/services/dashboard/src/contexts/ThemeContext.test.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/ThemeContext.test.jsx
@@ -1,0 +1,44 @@
+import { act, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { ThemeProvider, useTheme } from './ThemeContext'
+
+function ThemeProbe() {
+  const { theme, cycleTheme } = useTheme()
+  return createElement('button', { onClick: cycleTheme }, theme)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  globalThis.localStorage.clear()
+  document.documentElement.removeAttribute('data-theme')
+})
+
+describe('ThemeProvider storage resilience', () => {
+  test('uses the default theme when browser storage is unavailable', () => {
+    vi.spyOn(globalThis.Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new globalThis.DOMException('blocked', 'SecurityError')
+    })
+    vi.spyOn(globalThis.Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new globalThis.DOMException('blocked', 'SecurityError')
+    })
+
+    render(createElement(ThemeProvider, null, createElement(ThemeProbe)))
+
+    expect(screen.getByRole('button')).toHaveTextContent('ods')
+    expect(document.documentElement).toHaveAttribute('data-theme', 'ods')
+  })
+
+  test('continues changing themes when persistence is denied', () => {
+    vi.spyOn(globalThis.Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new globalThis.DOMException('quota unavailable', 'QuotaExceededError')
+    })
+
+    render(createElement(ThemeProvider, null, createElement(ThemeProbe)))
+    act(() => screen.getByRole('button').click())
+
+    expect(screen.getByRole('button')).toHaveTextContent('lemonade')
+    expect(document.documentElement).toHaveAttribute('data-theme', 'lemonade')
+  })
+})


### PR DESCRIPTION
## Summary

- keep theme initialization working when browser localStorage access is denied
- continue applying and cycling themes when persistence throws SecurityError or QuotaExceededError
- only absorb DOMException at the browser-storage boundary
- add focused provider regressions

## Why

ThemeProvider accessed localStorage during initial render and every theme change. Browsers or embedded/private contexts that deny storage could crash the entire dashboard before it rendered.

## Testing

- `npm test -- --run src/contexts/ThemeContext.test.jsx` (2 passed)
- `npm test -- --run` (260 passed)
- `npm run lint`
- `npm run build`