### PR TITLE
fix(monitoring): clear stale cluster snapshots after probe failures

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -47,6 +47,13 @@ class ClusterStatus:
         self.total_gpus = 0
         self.active_gpus = 0
 
+    def _mark_unavailable(self) -> None:
+        """Discard a previous snapshot when the current probe is unusable."""
+        self.nodes = []
+        self.total_gpus = 0
+        self.active_gpus = 0
+        self.failover_ready = False
+
     async def refresh(self):
         """Query cluster status from smart proxy"""
         logger.debug("Refreshing cluster status from proxy")
@@ -60,21 +67,40 @@ class ClusterStatus:
 
             if proc.returncode == 0:
                 data = json.loads(stdout.decode())
-                self.nodes = data.get("nodes", [])
+                if not isinstance(data, dict) or not isinstance(data.get("nodes"), list):
+                    logger.warning("Cluster proxy returned an unexpected response shape")
+                    self._mark_unavailable()
+                    return
+                nodes = data["nodes"]
+                if any(
+                    not isinstance(node, dict)
+                    or not isinstance(node.get("healthy", False), bool)
+                    for node in nodes
+                ):
+                    logger.warning("Cluster proxy returned invalid node metadata")
+                    self._mark_unavailable()
+                    return
+                self.nodes = nodes
                 self.total_gpus = len(self.nodes)
-                self.active_gpus = sum(1 for n in self.nodes if n.get("healthy", False))
+                self.active_gpus = sum(1 for n in self.nodes if n.get("healthy") is True)
                 self.failover_ready = self.active_gpus > 1
                 logger.debug("Cluster status: %d/%d GPUs active, failover_ready=%s",
                            self.active_gpus, self.total_gpus, self.failover_ready)
+            else:
+                self._mark_unavailable()
         except FileNotFoundError:
+            self._mark_unavailable()
             logger.debug("Cluster proxy not available: curl command not found")
         except asyncio.TimeoutError:
             proc.kill()
             await proc.wait()
+            self._mark_unavailable()
             logger.debug("Cluster proxy health check timed out after 5s")
         except OSError as e:
+            self._mark_unavailable()
             logger.debug("Cluster proxy connection failed: %s", e)
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            self._mark_unavailable()
             logger.warning("Cluster proxy returned invalid JSON: %s", e)
 
     def to_dict(self) -> dict:

--- a/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
@@ -283,6 +283,10 @@ class TestClusterStatusRefresh:
     async def test_refresh_invalid_json(self):
         """ClusterStatus.refresh handles invalid JSON."""
         cs = ClusterStatus()
+        cs.nodes = [{"id": "stale", "healthy": True}]
+        cs.total_gpus = 1
+        cs.active_gpus = 1
+        cs.failover_ready = True
 
         async def _fake_subprocess(*args, **kwargs):
             proc = MagicMock()
@@ -294,6 +298,47 @@ class TestClusterStatusRefresh:
             await cs.refresh()
 
         assert cs.total_gpus == 0
+        assert cs.nodes == []
+        assert cs.active_gpus == 0
+        assert cs.failover_ready is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_invalid_node_shape(self):
+        """A malformed successful response must not preserve a stale snapshot."""
+        cs = ClusterStatus()
+        cs.nodes = [{"id": "stale", "healthy": True}]
+        cs.total_gpus = 1
+        cs.active_gpus = 1
+
+        async def _fake_subprocess(*args, **kwargs):
+            proc = MagicMock()
+            proc.communicate = AsyncMock(return_value=(b'{"nodes": ["not-an-object"]}', b""))
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
+            await cs.refresh()
+
+        assert cs.nodes == []
+        assert cs.total_gpus == 0
+        assert cs.active_gpus == 0
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_non_boolean_health(self):
+        """String health values must not be counted as active GPUs."""
+        cs = ClusterStatus()
+
+        async def _fake_subprocess(*args, **kwargs):
+            proc = MagicMock()
+            proc.communicate = AsyncMock(return_value=(b'{"nodes": [{"healthy": "false"}]}', b""))
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
+            await cs.refresh()
+
+        assert cs.nodes == []
+        assert cs.active_gpus == 0
 
 
 class TestGetFullAgentMetrics:


### PR DESCRIPTION
## Summary

- clear cached cluster nodes and GPU counts when the current proxy probe fails
- reject malformed response roots, node entries, non-boolean health values, and invalid UTF-8
- use strict boolean health checks so the string false cannot count as healthy
- add regressions proving stale healthy state is not retained

## Why

ClusterStatus.refresh left its previous successful snapshot untouched on curl failures, timeouts, non-zero exits, or malformed payloads. The dashboard could therefore report disconnected GPUs as healthy indefinitely.

## Testing

- `python -m pytest tests/test_agent_monitor.py -q` (21 passed)
- full Dashboard API suite: 2069 passed, 14 skipped; one unrelated Windows symlink test could not run without SeCreateSymbolicLink privilege