### PR TITLE
fix(usage): validate Token Spy report response shape

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -403,7 +403,7 @@ async def _fetch_token_spy_report(start: str, end: str) -> dict[str, Any]:
         )
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         return _empty_report(start, end, detail=f"Token Spy unavailable: {exc}")
-    except (json.JSONDecodeError, TokenSpyProtocolError) as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError, TokenSpyProtocolError) as exc:
         return _empty_report(start, end, detail=f"Token Spy returned an invalid report: {exc}")
 
 

--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -40,6 +40,25 @@ LLAMA_CPP_PROMETHEUS_METRICS = {
 _LOCAL_RUNTIME_REQUEST_STATE: dict[str, dict[str, Any]] = {}
 
 
+class TokenSpyProtocolError(ValueError):
+    """Token Spy returned JSON that violates the usage-report contract."""
+
+
+def _validated_token_spy_report(payload: Any, start: str, end: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise TokenSpyProtocolError("response root must be an object")
+    period = payload.get("period")
+    if not isinstance(period, dict) or period.get("start") != start or period.get("end") != end:
+        raise TokenSpyProtocolError("response period does not match the request")
+    if not isinstance(payload.get("summary"), dict):
+        raise TokenSpyProtocolError("response summary must be an object")
+    for field in ("daily", "models", "services", "sources"):
+        rows = payload.get(field)
+        if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+            raise TokenSpyProtocolError(f"response {field} must be a list of objects")
+    return payload
+
+
 def _parse_date(value: str) -> date:
     return date.fromisoformat(value)
 
@@ -384,6 +403,8 @@ async def _fetch_token_spy_report(start: str, end: str) -> dict[str, Any]:
         )
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         return _empty_report(start, end, detail=f"Token Spy unavailable: {exc}")
+    except (json.JSONDecodeError, TokenSpyProtocolError) as exc:
+        return _empty_report(start, end, detail=f"Token Spy returned an invalid report: {exc}")
 
 
 def _request_token_spy_report(start: str, end: str, headers: dict[str, str]) -> dict[str, Any]:
@@ -392,6 +413,7 @@ def _request_token_spy_report(start: str, end: str, headers: dict[str, str]) -> 
     request = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(request, timeout=10) as response:
         payload = json.loads(response.read().decode("utf-8"))
+    payload = _validated_token_spy_report(payload, start, end)
     payload["source"] = {
         "name": "token-spy",
         "status": "ok",

--- a/ods/extensions/services/dashboard-api/tests/test_usage.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage.py
@@ -255,6 +255,7 @@ def test_usage_report_returns_token_spy_payload(test_client, monkeypatch):
         b"[]",
         b'"unexpected"',
         b"null",
+        b"\xff",
         b"{",
         b"{}",
         (

--- a/ods/extensions/services/dashboard-api/tests/test_usage.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
+
 
 def _usage_payload():
     return {
@@ -244,6 +246,52 @@ def test_usage_report_returns_token_spy_payload(test_client, monkeypatch):
     assert data["summary"]["spend_usd"] == 1.25
     assert data["source"]["status"] == "ok"
     fetch.assert_awaited_once_with("2026-05-01", "2026-05-31")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"[]",
+        b'"unexpected"',
+        b"null",
+        b"{",
+        b"{}",
+        (
+            b'{"period":{"start":"2026-05-01","end":"2026-05-03"},'
+            b'"summary":{},"daily":[null],"models":[],"services":[],"sources":[]}'
+        ),
+    ],
+)
+async def test_token_spy_invalid_report_degrades_to_unavailable(monkeypatch, body):
+    import routers.usage as usage_router
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return body
+
+    monkeypatch.setattr(usage_router, "TOKEN_SPY_URL", "http://token-spy:8080")
+    monkeypatch.setattr(
+        usage_router.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    report = await usage_router._fetch_token_spy_report("2026-05-01", "2026-05-03")
+
+    assert report["source"]["status"] == "unavailable"
+    assert "invalid report" in report["source"]["detail"]
+    assert [item["date"] for item in report["daily"]] == [
+        "2026-05-01",
+        "2026-05-02",
+        "2026-05-03",
+    ]
 
 
 def test_usage_report_returns_honest_empty_payload_when_token_spy_disabled(


### PR DESCRIPTION
## Summary

- validate Token Spy report roots, requested periods, summaries, and row collections
- classify malformed JSON and schema violations as an unavailable upstream report
- preserve the requested daily buckets instead of propagating a Dashboard API 500
- cover scalar, null, truncated, missing-field, and malformed-row payloads

## Why

A 200 response with valid JSON was trusted as a report object. Lists, scalars, mismatched periods, or malformed rows could escape the I/O boundary and return a broken response or raise inside the usage endpoint.

## Testing

- `python -m pytest tests/test_usage.py -q` (27 passed)
- full Dashboard API suite: 2073 passed, 14 skipped; one unrelated Windows symlink test could not run without SeCreateSymbolicLink privilege