### PR TITLE
fix(embeddings): allow platform-compatible image overrides

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -440,6 +440,10 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # Embedding model served by the bundled Hugging Face TEI runtime. Use a TEI-
 # compatible Hugging Face repository ID; GGUF/Q4 files are not supported here.
 # EMBEDDING_MODEL=BAAI/bge-base-en-v1.5
+# The bundled TEI image is amd64-only. ARM hosts must set both values to a
+# compatible image/platform pair.
+# EMBEDDINGS_IMAGE=ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1
+# EMBEDDINGS_PLATFORM=linux/amd64
 # Open WebUI uses EMBEDDING_MODEL as its first-boot default. After first boot,
 # its Admin Panel value is persistent. Set this override only when the endpoint
 # points to a different embeddings provider/model.

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -840,6 +840,17 @@
       "description": "Canonical Hugging Face model repository loaded by bundled TEI and used as the first-boot Open WebUI RAG default. Existing Open WebUI installs retain their Admin Panel value. GGUF/Q4 model files are not compatible with this runtime.",
       "default": "BAAI/bge-base-en-v1.5"
     },
+    "EMBEDDINGS_IMAGE": {
+      "type": "string",
+      "description": "Container image for the bundled embeddings service. Override together with EMBEDDINGS_PLATFORM when using an ARM-compatible image.",
+      "default": "ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1"
+    },
+    "EMBEDDINGS_PLATFORM": {
+      "type": "string",
+      "description": "Container platform for the bundled embeddings service.",
+      "default": "linux/amd64",
+      "pattern": "^linux/[A-Za-z0-9_.-]+$"
+    },
     "RAG_EMBEDDING_MODEL": {
       "type": "string",
       "description": "Optional first-boot Open WebUI embedding-model override. Leave empty to use EMBEDDING_MODEL. Existing Open WebUI installs must also update the persistent Admin Panel value. Use a different model only with a matching external RAG_OPENAI_API_BASE_URL."

--- a/ods/config/dependency-lock.json
+++ b/ods/config/dependency-lock.json
@@ -342,6 +342,12 @@
       "reason": "Hermes Agent image can be overridden for upstream registry hotfixes, but the shipped default is locked."
     },
     {
+      "path": "extensions/services/embeddings/compose.yaml",
+      "value": "${EMBEDDINGS_IMAGE:-ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1}",
+      "default": "ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1",
+      "reason": "The embeddings image can be overridden for platform compatibility while the shipped default remains locked."
+    },
+    {
       "path": "extensions/services/llama-server/Dockerfile.amd",
       "value": "rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete",
       "arg": "ROCM_VERSION",

--- a/ods/extensions/services/embeddings/compose.yaml
+++ b/ods/extensions/services/embeddings/compose.yaml
@@ -1,7 +1,9 @@
 services:
   embeddings:
-    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1
-    platform: linux/amd64  # TEI has no arm64 image -- Rosetta 2 on Apple Silicon
+    image: ${EMBEDDINGS_IMAGE:-ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1}
+    # The bundled TEI pin is amd64-only. ARM hosts can pair an arm64 platform
+    # override with an image that publishes a matching manifest.
+    platform: ${EMBEDDINGS_PLATFORM:-linux/amd64}
     container_name: ods-embeddings
     restart: unless-stopped
     security_opt:

--- a/ods/tests/test-embedding-model-contract.py
+++ b/ods/tests/test-embedding-model-contract.py
@@ -72,8 +72,21 @@ def test_bundled_rag_inherits_canonical_model() -> None:
     webui = config["services"]["open-webui"]
 
     assert embeddings["environment"]["MODEL_ID"] == "BAAI/bge-m3"
+    assert embeddings["image"] == "ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1"
+    assert embeddings["platform"] == "linux/amd64"
     assert webui["environment"]["RAG_EMBEDDING_MODEL"] == "BAAI/bge-m3"
     assert embeddings["deploy"]["resources"]["limits"]["memory"] == "6442450944"
+
+
+def test_embeddings_accept_matching_image_and_platform_overrides() -> None:
+    config = render_compose(
+        EMBEDDINGS_IMAGE="registry.example.test/tei:arm64",
+        EMBEDDINGS_PLATFORM="linux/arm64",
+    )
+    embeddings = config["services"]["embeddings"]
+
+    assert embeddings["image"] == "registry.example.test/tei:arm64"
+    assert embeddings["platform"] == "linux/arm64"
 
 
 def test_external_rag_override_does_not_change_bundled_tei() -> None:
@@ -267,6 +280,7 @@ def test_macos_env_generator_renders_embedding_contract() -> None:
 def main() -> int:
     tests = [
         test_bundled_rag_inherits_canonical_model,
+        test_embeddings_accept_matching_image_and_platform_overrides,
         test_external_rag_override_does_not_change_bundled_tei,
         test_installers_write_or_backfill_canonical_model,
     ]


### PR DESCRIPTION
## Summary
- make the embeddings container platform configurable while retaining the amd64 default
- expose a matching image override so ARM hosts are not forced to pair `linux/arm64` with the amd64-only bundled TEI pin
- declare and document both settings in the environment contract

Closes #2302

## Test plan
- [x] `bash -c 'cd ods && python3 tests/test-embedding-model-contract.py'` (5 passed; Windows-only test skipped in WSL)
- [x] `python -m json.tool ods/.env.schema.json`
- [x] `git diff --check`

Generated with Codex