### PR TITLE
fix(preset): preserve complete env values in diff

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -2219,6 +2219,28 @@ _cmd_config_is_secret() {
     return 1
 }
 
+_cmd_preset_env_entries() {
+    local env_file="$1" line key value
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        [[ "$line" == *=* ]] || continue
+        key="${line%%=*}"
+        value="${line#*=}"
+        key="${key#"${key%%[![:space:]]*}"}"
+        key="${key%"${key##*[![:space:]]}"}"
+        [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+        value="${value# }"
+        if [[ "$value" == '"'*'"' ]]; then
+            value="${value#\"}"
+            value="${value%\"}"
+        elif [[ "$value" == "'"*"'" ]]; then
+            value="${value#\'}"
+            value="${value%\'}"
+        fi
+        printf '%s\0%s\0' "$key" "$value"
+    done < "$env_file"
+}
+
 cmd_config() {
     check_install
 
@@ -3370,16 +3392,12 @@ META
 
                 # Parse both env files
                 declare -A env1 env2
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
-                    [[ -z "$key" ]] && continue
+                while IFS= read -r -d '' key && IFS= read -r -d '' value; do
                     env1["$key"]="$value"
-                done < "$dir1/env"
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
-                    [[ -z "$key" ]] && continue
+                done < <(_cmd_preset_env_entries "$dir1/env")
+                while IFS= read -r -d '' key && IFS= read -r -d '' value; do
                     env2["$key"]="$value"
-                done < "$dir2/env"
+                done < <(_cmd_preset_env_entries "$dir2/env")
 
                 # Find all unique keys
                 local all_keys=()

--- a/ods/tests/test-preset-diff.sh
+++ b/ods/tests/test-preset-diff.sh
@@ -122,6 +122,40 @@ test_diff_masks_secrets() {
     fi
 }
 
+# Test 7: Diff preserves equals signs inside values
+test_diff_preserves_equals_in_values() {
+    local presets_dir="$ODS_DIR/presets"
+    mkdir -p "$presets_dir/test-preset-i" "$presets_dir/test-preset-j"
+    echo 'PUBLIC_URL=https://example.test/callback?state=a=b' > "$presets_dir/test-preset-i/env"
+    echo 'PUBLIC_URL=https://example.test/callback?state=a=c' > "$presets_dir/test-preset-j/env"
+
+    local output
+    output=$("$ODS_CLI" preset diff test-preset-i test-preset-j 2>&1 || true)
+    if echo "$output" | grep -q 'PUBLIC_URL' \
+        && echo "$output" | grep -q 'state=a=b' \
+        && echo "$output" | grep -q 'state=a=c'; then
+        pass "Diff preserves equals signs inside values"
+    else
+        fail "Diff truncated values at an equals sign"
+    fi
+}
+
+# Test 8: CRLF and matching quotes do not create false differences
+test_diff_normalizes_env_syntax() {
+    local presets_dir="$ODS_DIR/presets"
+    mkdir -p "$presets_dir/test-preset-k" "$presets_dir/test-preset-l"
+    printf 'PUBLIC_URL="https://example.test/?state=a=b"\r\n' > "$presets_dir/test-preset-k/env"
+    printf 'PUBLIC_URL=https://example.test/?state=a=b\n' > "$presets_dir/test-preset-l/env"
+
+    local output
+    output=$("$ODS_CLI" preset diff test-preset-k test-preset-l 2>&1 || true)
+    if ! echo "$output" | grep -qE '^[[:space:]]*[~+-][[:space:]]+PUBLIC_URL'; then
+        pass "Diff normalizes CRLF and matching quotes"
+    else
+        fail "Diff reported equivalent env syntax as different"
+    fi
+}
+
 # Run tests
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Preset Diff Tests"
@@ -134,6 +168,8 @@ test_diff_identical
 test_diff_env_changes
 test_diff_service_changes
 test_diff_masks_secrets
+test_diff_preserves_equals_in_values
+test_diff_normalizes_env_syntax
 cleanup
 
 # Summary


### PR DESCRIPTION
## Summary
- split preset env entries on the first equals sign so URLs, JWTs, and base64 values stay intact
- normalize trailing CR and one matching quote pair before comparison
- share parsing between both preset files without `eval` or lossy delimiters

Closes #2297

## Test plan
- [x] `bash ods/tests/test-preset-diff.sh` (8 passed)
- [x] `bash -n ods/ods-cli ods/tests/test-preset-diff.sh`
- [x] `git diff --check`

Generated with Codex