### PR TITLE
fix(token-spy): keep tool chains intact when trimming by size

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: Token Spy Request Filter Tests
+        run: python3 tests/test-token-spy-filters.py
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -148,6 +148,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
+	@echo ""
+	@echo "=== token-spy request filters ==="
+	@python3 tests/test-token-spy-filters.py
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/ods/extensions/services/token-spy/filters.py
+++ b/ods/extensions/services/token-spy/filters.py
@@ -278,37 +278,33 @@ def _filter_history(body: dict, cfg: dict, result: FilterResult,
                         )
                         result.tool_results_truncated += 1
 
-    # Step 6: Flatten units back into message list
+    # Step 6: Apply max_total_chars by dropping whole units, oldest first.
+    #
+    # This runs on units, before the flatten. Trimming the flattened list one
+    # message at a time splits a tool chain: dropping an assistant message that
+    # carries tool_calls while keeping its `role: "tool"` reply produces a
+    # request whose tool message answers nothing, which every OpenAI-compatible
+    # server rejects with a 400. always_keep_last_n bounds how far back we go.
+    #
+    # A single unit larger than max_total is kept whole — the cap is best
+    # effort, because the alternative is emitting an invalid request.
+    # truncate_tool_results_chars is the knob for an oversized unit.
+    max_total = cfg.get("max_total_chars")
+    if max_total:
+        while len(units) > 1:
+            if _units_chars(units) <= max_total:
+                break
+            if sum(len(unit) for unit in units[1:]) < always_keep_last_n:
+                # Dropping the next unit would cut into the protected tail.
+                break
+            result.messages_removed += len(units.pop(0))
+
+    # Step 7: Flatten units back into message list
     filtered_conv = []
     for unit in units:
         filtered_conv.extend(unit)
 
-    # Step 7: Apply always_keep_last_n safety — ensure the last N raw messages
-    # from the original conversation are present (protects in-flight tool chains)
-    if always_keep_last_n and conv_msgs:
-        tail = conv_msgs[-always_keep_last_n:]
-        # Check if tail messages are already in filtered_conv
-        # by comparing the last N messages
-        tail_ids = {id(m) for m in tail}
-        existing_ids = {id(m) for m in filtered_conv[-always_keep_last_n:]} if filtered_conv else set()
-        if not tail_ids.issubset(existing_ids):
-            # Ensure tail messages are present — they may have been modified by
-            # truncation but should still be in the list since we keep recent units
-            pass  # Units-based approach already preserves recent messages
-
     result.messages_kept = len(system_msgs) + len(filtered_conv)
-
-    # Step 8: Apply max_total_chars if set
-    max_total = cfg.get("max_total_chars")
-    if max_total:
-        while len(filtered_conv) > always_keep_last_n:
-            total = sum(len(json.dumps(m, separators=(",", ":"))) for m in filtered_conv)
-            if total <= max_total:
-                break
-            # Remove the oldest non-system unit
-            filtered_conv.pop(0)
-            result.messages_removed += 1
-        result.messages_kept = len(system_msgs) + len(filtered_conv)
 
     # Reassemble: system messages first, then filtered conversation
     body["messages"] = system_msgs + filtered_conv
@@ -321,6 +317,15 @@ def _filter_history(body: dict, cfg: dict, result: FilterResult,
         )
 
     return body, result
+
+
+def _units_chars(units: list[list[dict]]) -> int:
+    """Serialized size of every message across *units*, in characters."""
+    return sum(
+        len(json.dumps(msg, separators=(",", ":")))
+        for unit in units
+        for msg in unit
+    )
 
 
 def _group_into_units(messages: list[dict]) -> list[list[dict]]:

--- a/ods/tests/test-token-spy-filters.py
+++ b/ods/tests/test-token-spy-filters.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Token Spy request-filter contracts.
+
+The history filter rewrites the `messages` array before it reaches
+llama-server. Whatever it emits must still be a valid OpenAI chat request:
+every `role: "tool"` message has to answer a `tool_calls` entry on an earlier
+assistant message, or the upstream returns 400 and the whole request is lost.
+
+Run: python3 tests/test-token-spy-filters.py
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+FILTERS_PY = ROOT / "extensions" / "services" / "token-spy" / "filters.py"
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"[PASS] {label}")
+    else:
+        FAIL += 1
+        print(f"[FAIL] {label}")
+        if detail:
+            print(f"       {detail}")
+
+
+def load_filters():
+    spec = importlib.util.spec_from_file_location("token_spy_filters", FILTERS_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def tool_chain_error(messages: list[dict]) -> str:
+    """Return why *messages* is an invalid tool chain, or "" when it is valid."""
+    announced: set[str] = set()
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            for call in msg.get("tool_calls") or []:
+                announced.add(call.get("id"))
+        elif role == "tool":
+            call_id = msg.get("tool_call_id")
+            if call_id not in announced:
+                return f"tool message {call_id!r} answers no preceding tool_calls"
+    return ""
+
+
+def turn(index: int, padding: int = 0) -> list[dict]:
+    """One user turn that goes through a tool call and back."""
+    return [
+        {"role": "user", "content": f"u{index}" + "x" * padding},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": f"call_{index}",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": f"call_{index}", "content": f"r{index}"},
+        {"role": "assistant", "content": f"a{index}"},
+    ]
+
+
+def run(filters, messages: list[dict], history_cfg: dict):
+    body = {"model": "test", "messages": copy.deepcopy(messages)}
+    settings = {"enabled": True, "history": dict({"enabled": True}, **history_cfg)}
+    return filters.apply_filters(body, settings)
+
+
+def main() -> int:
+    filters = load_filters()
+
+    # --- the regression: trimming by size used to split a unit ---------------
+    single = turn(1)
+    body, _ = run(filters, single, {"always_keep_last_n": 2, "max_total_chars": 150})
+    check(
+        "a lone oversized turn is kept whole rather than sliced",
+        body["messages"] == single,
+        f"got {body['messages']}",
+    )
+    check(
+        "a lone oversized turn stays a valid tool chain",
+        tool_chain_error(body["messages"]) == "",
+        tool_chain_error(body["messages"]),
+    )
+    check(
+        "the request never opens with an orphaned tool reply",
+        body["messages"][0].get("role") != "tool",
+        f"first message is {body['messages'][0].get('role')!r}",
+    )
+
+    # --- multi-turn: whole turns leave, partial turns never do ---------------
+    many = turn(1, padding=400) + turn(2, padding=400) + turn(3)
+    body, result = run(
+        filters, many, {"always_keep_last_n": 2, "max_total_chars": 400}
+    )
+    check(
+        "oversized history is trimmed",
+        len(body["messages"]) < len(many),
+        f"kept {len(body['messages'])} of {len(many)}",
+    )
+    check(
+        "trimmed history is still a valid tool chain",
+        tool_chain_error(body["messages"]) == "",
+        tool_chain_error(body["messages"]),
+    )
+    check(
+        "only whole turns are dropped",
+        len(body["messages"]) % 4 == 0,
+        f"kept {len(body['messages'])} messages — not a whole number of turns",
+    )
+    check(
+        "the most recent turn survives",
+        body["messages"][-1] == {"role": "assistant", "content": "a3"},
+        f"last message is {body['messages'][-1]}",
+    )
+    check(
+        "messages_removed counts every dropped message",
+        result.messages_removed == len(many) - len(body["messages"]),
+        f"reported {result.messages_removed}, actually dropped "
+        f"{len(many) - len(body['messages'])}",
+    )
+    check(
+        "messages_kept matches the emitted array",
+        result.messages_kept == len(body["messages"]),
+        f"reported {result.messages_kept}, emitted {len(body['messages'])}",
+    )
+
+    # --- always_keep_last_n still bounds how far back trimming reaches ------
+    body, _ = run(
+        filters,
+        turn(1, padding=400) + turn(2, padding=400),
+        {"always_keep_last_n": 8, "max_total_chars": 10},
+    )
+    check(
+        "always_keep_last_n stops the trim before the protected tail",
+        len(body["messages"]) == 8,
+        f"kept {len(body['messages'])}, expected 8",
+    )
+
+    # --- system messages are not part of the trimmed conversation -----------
+    with_system = [{"role": "system", "content": "you are helpful"}] + turn(
+        1, padding=400
+    ) + turn(2)
+    body, _ = run(
+        filters, with_system, {"always_keep_last_n": 2, "max_total_chars": 200}
+    )
+    check(
+        "the system prompt is preserved and stays first",
+        body["messages"][0] == {"role": "system", "content": "you are helpful"},
+        f"first message is {body['messages'][0]}",
+    )
+    check(
+        "the oldest turn is dropped, not the system prompt",
+        len(body["messages"]) == 5,
+        f"kept {len(body['messages'])}, expected system + one turn",
+    )
+
+    # --- no max_total_chars: nothing is trimmed by size ----------------------
+    untouched = turn(1, padding=4000)
+    body, result = run(filters, untouched, {"always_keep_last_n": 2})
+    check(
+        "history is untouched when max_total_chars is unset",
+        body["messages"] == untouched and result.messages_removed == 0,
+        f"removed {result.messages_removed}",
+    )
+
+    # --- filters disabled: body is returned as-is ---------------------------
+    original = turn(1)
+    body = {"model": "test", "messages": copy.deepcopy(original)}
+    body, result = filters.apply_filters(body, {"enabled": False})
+    check(
+        "a disabled filter set is a no-op",
+        body["messages"] == original and result.messages_removed == 0,
+        f"got {body['messages']}",
+    )
+
+    print()
+    print(f"Passed: {PASS}  Failed: {FAIL}")
+    if FAIL:
+        return 1
+    print("[PASS] token-spy request filter contracts")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`extensions/services/token-spy/filters.py` rewrites the `messages` array before
the request reaches llama-server. Step 2 groups messages into atomic units for
a stated reason:

```python
# An atomic unit is: [user msg, assistant reply, tool_call/tool result chain]
# We must not split these or the API contract breaks.
units = _group_into_units(conv_msgs)
```

Step 8 then split them anyway. It ran *after* the flatten and popped single
messages off the front, while its comment claimed otherwise:

```python
    # Step 8: Apply max_total_chars if set
    max_total = cfg.get("max_total_chars")
    if max_total:
        while len(filtered_conv) > always_keep_last_n:
            total = sum(len(json.dumps(m, separators=(",", ":"))) for m in filtered_conv)
            if total <= max_total:
                break
            # Remove the oldest non-system unit          <-- not what pop(0) does
            filtered_conv.pop(0)
            result.messages_removed += 1
```

`pop(0)` is message granularity, so the loop can stop halfway through a unit —
after removing the assistant message that carries `tool_calls`, but before
removing the `tool` message that answers it.

Reproduced against `origin/main`'s copy:

```python
body = {"messages": [
  {"role":"user","content":"u1"},
  {"role":"assistant","content":None,"tool_calls":[{"id":"c1","type":"function",
     "function":{"name":"f","arguments":"{}"}}]},
  {"role":"tool","tool_call_id":"c1","content":"r1"},
  {"role":"assistant","content":"a1"},
]}
cfg = {"enabled":True,"history":{"enabled":True,"always_keep_last_n":2,
                                 "max_total_chars":150}}
filters.apply_filters(body, cfg)
```

```text
[
 {"role": "tool", "tool_call_id": "c1", "content": "r1"},
 {"role": "assistant", "content": "a1"}
]
```

The request now opens with a `role: "tool"` message answering `c1`, and nothing
in the array ever announced `c1`. Every OpenAI-compatible server rejects that
with a 400, so the user loses the whole turn — and it only happens once the
conversation is long enough to trip the size cap, which is exactly the
situation the filter exists to handle.

### Fix

- Move the size trim onto `units`, ahead of the flatten, and drop whole units
  oldest-first.
- `always_keep_last_n` bounds how far back the trim reaches (same intent as the
  old `while len(filtered_conv) > always_keep_last_n` guard, now counted across
  units).
- A single unit larger than the cap is kept whole. `max_total_chars` becomes
  best effort rather than absolute, which is the right trade: the alternative
  is an invalid request. `truncate_tool_results_chars` (Step 5) remains the
  knob for an oversized unit, and it runs first.

Also removes the old Step 7. It built two `id()` sets, compared them, and then
executed `pass` — the `always_keep_last_n` safety it described was never
implemented. The guard in the new trim loop is where that intent now lives.

Behaviour with `max_total_chars` unset is unchanged.

### Test

`filters.py` had **no test coverage at all** — nothing under
`extensions/services/token-spy/tests/` referenced it, and the Linux CI job runs
only `test_recent_events_cursor_postgres.py`.

Adds `tests/test-token-spy-filters.py` (14 assertions), including a
`tool_chain_error()` validator that walks the emitted array and reports any
`tool` message whose `tool_call_id` was never announced. Wired into `make test`
and the Linux CI job.

## AI Assistance

AI assisted with spotting the flatten/trim ordering, drafting the test cases,
and wording this description. I read the full diff, reproduced the old
behaviour against `origin/main`'s copy of the module, and confirmed the new
suite fails on the unpatched file before it passes on the patched one.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(`token-spy` is a bundled extension service that sits on the request path to
llama-server. CI config and the Makefile test target are also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 -m py_compile extensions/services/token-spy/filters.py
py OK

$ python3 tests/test-token-spy-filters.py
[PASS] a lone oversized turn is kept whole rather than sliced
[PASS] a lone oversized turn stays a valid tool chain
[PASS] the request never opens with an orphaned tool reply
[PASS] oversized history is trimmed
[PASS] trimmed history is still a valid tool chain
[PASS] only whole turns are dropped
[PASS] the most recent turn survives
[PASS] messages_removed counts every dropped message
[PASS] messages_kept matches the emitted array
[PASS] always_keep_last_n stops the trim before the protected tail
[PASS] the system prompt is preserved and stays first
[PASS] the oldest turn is dropped, not the system prompt
[PASS] history is untouched when max_total_chars is unset
[PASS] a disabled filter set is a no-op

Passed: 14  Failed: 0
[PASS] token-spy request filter contracts

# the same suite against origin/main's filters.py:
[FAIL] a lone oversized turn is kept whole rather than sliced
       got [{'role': 'tool', 'tool_call_id': 'call_1', 'content': 'r1'},
            {'role': 'assistant', 'content': 'a1'}]
[FAIL] a lone oversized turn stays a valid tool chain
       tool message 'call_1' answers no preceding tool_calls
[FAIL] the request never opens with an orphaned tool reply
       first message is 'tool'
[FAIL] trimmed history is still a valid tool chain
       tool message 'call_2' answers no preceding tool_calls
[FAIL] only whole turns are dropped
       kept 6 messages — not a whole number of turns
[FAIL] the oldest turn is dropped, not the system prompt
       kept 3, expected system + one turn

Passed: 8  Failed: 6
```

## Operational Change Check

`filters.py` runs inside the `token-spy` container on the request path. This
changes which messages a size-capped request keeps: strictly *more* messages
than before in the split-unit case, never fewer, and always a valid array.
Requests that do not set `history.max_total_chars` take an identical path to
today. No compose, port, image, or settings-schema change.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The behavioural question worth your call: with the fix, `max_total_chars` can
be exceeded when a single turn is larger than the cap. I chose that over
splitting the turn, because an over-budget request still gets an answer and a
split one gets a 400. If you would rather the filter hard-fail or fall back to
truncating the oversized turn's tool results more aggressively, say so and I
will send that as a follow-up.
