### PR TITLE
fix(cold-storage): make the archive path actually archive

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: LLM Cold Storage Tests
+        run: bash tests/test-llm-cold-storage.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -148,6 +148,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
+	@echo ""
+	@echo "=== LLM cold storage archive path ==="
+	@bash tests/test-llm-cold-storage.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -71,15 +71,18 @@ get_last_access_days() {
         # GNU: stat -c %X (atime as epoch seconds)
         newest_atime="$(find "$dir" -type f -exec stat -c %X {} + 2>/dev/null | sort -rn | sed -n '1p')"
     fi
-    if [[ -z "$newest_atime" ]]; then
+    newest_atime="${newest_atime%.*}"
+    if [[ ! "$newest_atime" =~ ^[0-9]+$ ]]; then
         echo "9999"
         return
     fi
     local now
     now="$(date +%s)"
-    local age_secs
-    age_secs="$(echo "$now - ${newest_atime%.*}" | bc)"
-    echo "$(( age_secs / 86400 ))"
+    # Shell arithmetic, not bc: bc is not installed by default on Debian,
+    # Ubuntu Server, Fedora or Arch. When it was missing the substitution
+    # produced an empty string, which bash evaluates as 0 — every model looked
+    # idle for 0 days and nothing was ever archived.
+    echo "$(( (now - newest_atime) / 86400 ))"
 }
 
 do_archive() {
@@ -88,6 +91,15 @@ do_archive() {
     local skipped=0
 
     log "========== LLM cold storage scan started (dry_run=$dry_run) =========="
+
+    # The archive destination has to exist before the first mv. Without this,
+    # every `mv` failed with "No such file or directory" while the log still
+    # reported "ARCHIVED" and the summary still counted the model.
+    if [[ "$dry_run" != "true" ]] && ! mkdir -p "$COLD_DIR"; then
+        log "ERROR: cannot create cold storage directory: $COLD_DIR"
+        log "Set COLD_DIR to a writable path (is the backup drive mounted?)"
+        return 1
+    fi
 
     for model_dir in "$HF_CACHE"/models--*/; do
         [[ -d "$model_dir" ]] || continue
@@ -121,10 +133,26 @@ do_archive() {
                 log "WOULD ARCHIVE: $name ($size, idle ${idle_days}d)"
             else
                 log "ARCHIVING: $name ($size, idle ${idle_days}d)"
+                if [[ -e "$COLD_DIR/$name" ]]; then
+                    # mv would nest it as $COLD_DIR/$name/$name and the symlink
+                    # would then point one level above the real model.
+                    log "ERROR: cold storage already holds $name — leaving it hot"
+                    ((skipped++))
+                    continue
+                fi
                 # Move to cold storage
-                mv "$model_dir" "$COLD_DIR/$name"
+                if ! mv "${model_dir%/}" "$COLD_DIR/$name"; then
+                    log "ERROR: could not move $name to $COLD_DIR — leaving it hot"
+                    ((skipped++))
+                    continue
+                fi
                 # Create symlink so HF cache still resolves
-                ln -s "$COLD_DIR/$name" "${model_dir%/}"
+                if ! ln -s "$COLD_DIR/$name" "${model_dir%/}"; then
+                    log "ERROR: could not link $name back into the cache — restoring"
+                    mv "$COLD_DIR/$name" "${model_dir%/}"
+                    ((skipped++))
+                    continue
+                fi
                 log "ARCHIVED: $name -> $COLD_DIR/$name"
             fi
             ((archived++))

--- a/ods/tests/test-llm-cold-storage.sh
+++ b/ods/tests/test-llm-cold-storage.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Contracts for scripts/llm-cold-storage.sh
+#
+# The archive path moves multi-GB model directories off the primary disk and
+# leaves a symlink behind. If it reports success without moving anything, the
+# operator believes they reclaimed space they did not reclaim.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COLD_STORAGE_SCRIPT="$SCRIPT_DIR/scripts/llm-cold-storage.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS=$((PASS + 1)); }
+skip() { echo -e "${YELLOW}[SKIP]${NC} $1"; }
+fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    [[ -n "${2:-}" ]] && echo "       $2"
+    FAIL=$((FAIL + 1))
+}
+
+# Git Bash / MSYS turns `ln -s` on a directory into a junction, so `-L` is
+# false there even though the path resolves. The archive path only ships on
+# Linux and macOS; assert the link type where the script actually runs.
+REAL_SYMLINKS=true
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) REAL_SYMLINKS=false ;;
+esac
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# A stub `bc` that always fails, shadowing any real one. The script must not
+# need it: bc is absent from a default Debian, Ubuntu Server, Fedora or Arch
+# install, and the idle-day maths has to work without it.
+STUB_BIN="$TMP_ROOT/stubbin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/bc" <<'STUB'
+#!/bin/sh
+echo "bc: stubbed out for this test" >&2
+exit 127
+STUB
+chmod +x "$STUB_BIN/bc"
+
+# Build a throwaway HF cache. $2 is the atime to stamp on the model file.
+make_cache() {
+    local root="$1" name="$2" atime="$3"
+    mkdir -p "$root/hf/$name"
+    echo "weights for $name" > "$root/hf/$name/model.bin"
+    touch -a -d "$atime" "$root/hf/$name/model.bin"
+}
+
+run_cold_storage() {
+    local root="$1"
+    shift
+    PATH="$STUB_BIN:$PATH" \
+    HF_CACHE="$root/hf" \
+    COLD_DIR="$root/cold" \
+    LOG_FILE="$root/log/cold-storage.log" \
+        bash "$COLD_STORAGE_SCRIPT" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# The script no longer shells out to bc
+# ---------------------------------------------------------------------------
+if grep -qE '\|[[:space:]]*bc([[:space:]]|$)' "$COLD_STORAGE_SCRIPT"; then
+    fail "llm-cold-storage.sh still pipes into bc" \
+         "$(grep -nE '\|[[:space:]]*bc([[:space:]]|$)' "$COLD_STORAGE_SCRIPT")"
+else
+    pass "idle-day maths does not depend on bc"
+fi
+
+# ---------------------------------------------------------------------------
+# --execute archives an idle model even when the cold dir does not exist yet
+# ---------------------------------------------------------------------------
+CASE="$TMP_ROOT/archive"
+make_cache "$CASE" "models--Idle--Model" "2020-01-01"
+[[ ! -d "$CASE/cold" ]] || fail "fixture error: cold dir should not pre-exist"
+
+OUT="$(run_cold_storage "$CASE" --execute 2>&1)" || true
+
+if [[ -d "$CASE/cold/models--Idle--Model" ]]; then
+    pass "--execute creates the cold storage directory and moves the model"
+else
+    fail "--execute did not move the model into cold storage" "$OUT"
+fi
+
+if ! $REAL_SYMLINKS; then
+    skip "symlink type check (MSYS has no real symlinks)"
+elif [[ -L "$CASE/hf/models--Idle--Model" ]]; then
+    pass "a symlink is left behind in the HF cache"
+else
+    fail "no symlink left behind in the HF cache" "$(ls -l "$CASE/hf")"
+fi
+
+if [[ "$(cat "$CASE/hf/models--Idle--Model/model.bin" 2>/dev/null || true)" \
+      == "weights for models--Idle--Model" ]]; then
+    pass "the symlink still resolves to the model weights"
+else
+    fail "the symlink does not resolve to the model weights"
+fi
+
+if grep -q "ARCHIVED: models--Idle--Model" <<<"$OUT" \
+   && grep -q "1 archived" <<<"$OUT"; then
+    pass "the summary reports the archive that actually happened"
+else
+    fail "the summary did not report the archive" "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# A recently used model is left alone
+# ---------------------------------------------------------------------------
+CASE="$TMP_ROOT/recent"
+make_cache "$CASE" "models--Hot--Model" "$(date '+%Y-%m-%d')"
+OUT="$(run_cold_storage "$CASE" --execute 2>&1)" || true
+
+if [[ -f "$CASE/hf/models--Hot--Model/model.bin" && ! -e "$CASE/cold/models--Hot--Model" ]]; then
+    pass "a recently used model stays hot"
+else
+    fail "a recently used model was archived" "$OUT"
+fi
+
+if grep -q "0 archived" <<<"$OUT"; then
+    pass "the summary reports nothing archived when nothing moved"
+else
+    fail "the summary miscounts an untouched scan" "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Dry run (the default) never touches the cache
+# ---------------------------------------------------------------------------
+CASE="$TMP_ROOT/dryrun"
+make_cache "$CASE" "models--Idle--Model" "2020-01-01"
+OUT="$(run_cold_storage "$CASE" 2>&1)" || true
+
+if [[ -f "$CASE/hf/models--Idle--Model/model.bin" && ! -d "$CASE/cold" ]]; then
+    pass "the default dry run moves nothing and creates no cold directory"
+else
+    fail "the default dry run touched the filesystem" "$OUT"
+fi
+
+if grep -q "WOULD ARCHIVE: models--Idle--Model" <<<"$OUT"; then
+    pass "the dry run names what it would archive"
+else
+    fail "the dry run did not name the candidate" "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# A name already present in cold storage is refused, not nested
+# ---------------------------------------------------------------------------
+CASE="$TMP_ROOT/collision"
+make_cache "$CASE" "models--Idle--Model" "2020-01-01"
+mkdir -p "$CASE/cold/models--Idle--Model"
+echo "older copy" > "$CASE/cold/models--Idle--Model/model.bin"
+OUT="$(run_cold_storage "$CASE" --execute 2>&1)" || true
+
+if [[ ! -e "$CASE/cold/models--Idle--Model/models--Idle--Model" ]]; then
+    pass "an existing cold copy is not nested inside itself"
+else
+    fail "the model was nested under the existing cold copy" "$OUT"
+fi
+
+if [[ -f "$CASE/hf/models--Idle--Model/model.bin" ]] && grep -q "leaving it hot" <<<"$OUT"; then
+    pass "a collision leaves the model hot and says so"
+else
+    fail "a collision was not reported" "$OUT"
+fi
+
+if grep -q "0 archived" <<<"$OUT"; then
+    pass "a refused archive is not counted as archived"
+else
+    fail "a refused archive was counted as archived" "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Protected models are never archived
+# ---------------------------------------------------------------------------
+CASE="$TMP_ROOT/protected"
+make_cache "$CASE" "models--BAAI--bge-base-en-v1.5" "2020-01-01"
+OUT="$(run_cold_storage "$CASE" --execute 2>&1)" || true
+
+if [[ -f "$CASE/hf/models--BAAI--bge-base-en-v1.5/model.bin" ]] \
+   && grep -q "SKIP (protected)" <<<"$OUT"; then
+    pass "a protected model is skipped even when idle"
+else
+    fail "a protected model was archived" "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# --restore puts an archived model back
+# ---------------------------------------------------------------------------
+CASE="$TMP_ROOT/restore"
+make_cache "$CASE" "models--Idle--Model" "2020-01-01"
+run_cold_storage "$CASE" --execute >/dev/null 2>&1 || true
+OUT="$(run_cold_storage "$CASE" --restore "Idle/Model" 2>&1)" || true
+
+if [[ -f "$CASE/hf/models--Idle--Model/model.bin" && ! -L "$CASE/hf/models--Idle--Model" ]] \
+   && [[ ! -e "$CASE/cold/models--Idle--Model" ]]; then
+    pass "--restore moves the model back into the HF cache"
+else
+    fail "--restore did not move the model back" "$OUT"
+fi
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]
+echo "[PASS] llm-cold-storage contracts"


### PR DESCRIPTION
## Summary

`scripts/llm-cold-storage.sh --execute` prints an archive summary while moving
nothing. Two independent faults sit on the same code path, and either one alone
is enough to make the feature a no-op.

**1. `$COLD_DIR` is never created.**

Only the log directory gets a `mkdir`:

```bash
LOG_FILE="${LOG_FILE:-$HOME/.local/log/llm-cold-storage.log}"
mkdir -p "$(dirname "$LOG_FILE")"
```

so the first move into a not-yet-existing archive directory fails. The script
runs under `set -uo pipefail` — no `-e` — so nothing notices:

```bash
mv "$model_dir" "$COLD_DIR/$name"
ln -s "$COLD_DIR/$name" "${model_dir%/}"
log "ARCHIVED: $name -> $COLD_DIR/$name"
```

Reproduced on a scratch cache (a working `bc` shim on PATH so fault 2 does not
mask this one):

```text
$ HF_CACHE=/tmp/cs/hf COLD_DIR=/tmp/cs/cold bash scripts/llm-cold-storage.sh --execute
[...] ========== LLM cold storage scan started (dry_run=false) ==========
[...] ARCHIVING: models--Foo--Bar (1.0K, idle 581d)
mv: cannot move '/tmp/cs/hf/models--Foo--Bar/' to '/tmp/cs/cold/models--Foo--Bar': No such file or directory
ln: failed to create symbolic link '/tmp/cs/hf/models--Foo--Bar/models--Foo--Bar': No such file or directory
[...] ARCHIVED: models--Foo--Bar -> /tmp/cs/cold/models--Foo--Bar
[...] ========== Scan complete: 1 archived, 0 skipped ==========
$ echo $?
0
```

"1 archived", exit 0, and the model never moved. Note the `ln` line too: because
the model directory is still there, the symlink is aimed *inside* it. Had the
destination existed but the `mv` failed for some other reason, that would leave
a dangling link inside a live model directory.

**2. The idle-day calculation shells out to `bc`.**

```bash
age_secs="$(echo "$now - ${newest_atime%.*}" | bc)"
echo "$(( age_secs / 86400 ))"
```

`bc` is not installed by default on Debian, Ubuntu Server, Fedora or Arch. When
it is missing the substitution yields an empty string, bash evaluates that as
`0` in `$(( ))`, and every model reports "idle 0d":

```text
$ HF_CACHE=/tmp/cs/hf COLD_DIR=/tmp/cs/cold bash scripts/llm-cold-storage.sh --execute
scripts/llm-cold-storage.sh: line 81: bc: command not found
[...] SKIP (recent, 0d): models--Foo--Bar (1.0K)
[...] ========== Scan complete: 0 archived, 1 skipped ==========
```

The file's atime was 2025-01-01. Nothing is ever a candidate, so on those
distros the feature has never done anything at all.

### Fix

- `mkdir -p "$COLD_DIR"` before the loop on the `--execute` path, and **fail
  loudly** when it cannot be created. A missing archive directory usually means
  the backup drive is not mounted; silently relocating multi-GB models onto the
  root filesystem instead is worse than stopping. Dry runs still create nothing.
- Shell arithmetic instead of `bc`, with a numeric guard so a non-numeric atime
  falls back to the existing `9999` sentinel rather than producing garbage.
- Check `mv` and `ln`. If the link cannot be created, move the model back before
  giving up. Only log `ARCHIVED` and bump the counter when both succeeded, so
  the summary line is true.
- Refuse a name that already exists in cold storage. `mv src dst` where `dst` is
  an existing directory nests it as `$COLD_DIR/$name/$name`, and the symlink
  would then point one level above the real model — a silently broken cache
  entry.

`--restore`, `--restore-all`, `--status`, the protected list and the dry-run
default are unchanged.

### Test

The script had **no test coverage**. Adds `tests/test-llm-cold-storage.sh` —
13 assertions over archive, dry run, collision, protected models, restore, and
summary-counter accuracy, each against a throwaway HF cache with an explicitly
stamped atime. A stub `bc` that exits 127 sits first on `PATH` for every case,
so the suite would catch a reintroduced `bc` dependency. Wired into `make test`
and the Linux CI job.

## AI Assistance

AI assisted with spotting the missing `mkdir`, drafting the test fixtures, and
wording this description. I read the full diff, reproduced both faults against
`origin/main`'s copy of the script (output above is real), and confirmed the new
suite fails on the unpatched script before it passes on the patched one.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Standalone operator tooling under `scripts/`. Nothing in the installer,
compose stack, `ods-cli`, or any service invokes it — I checked. CI config and
the Makefile test target are also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n scripts/llm-cold-storage.sh
syntax OK

$ bash tests/test-llm-cold-storage.sh
[PASS] idle-day maths does not depend on bc
[PASS] --execute creates the cold storage directory and moves the model
[SKIP] symlink type check (MSYS has no real symlinks)
[PASS] the symlink still resolves to the model weights
[PASS] the summary reports the archive that actually happened
[PASS] a recently used model stays hot
[PASS] the summary reports nothing archived when nothing moved
[PASS] the default dry run moves nothing and creates no cold directory
[PASS] the dry run names what it would archive
[PASS] an existing cold copy is not nested inside itself
[PASS] a collision leaves the model hot and says so
[PASS] a refused archive is not counted as archived
[PASS] a protected model is skipped even when idle
[PASS] --restore moves the model back into the HF cache

Passed: 13  Failed: 0
[PASS] llm-cold-storage contracts

# the same suite against origin/main's script:
[FAIL] --execute did not move the model into cold storage
[FAIL] the summary did not report the archive
[FAIL] the dry run did not name the candidate
[FAIL] a collision was not reported

Passed: 9  Failed: 4

# end-to-end after the fix (one idle model, one fresh):
[...] ARCHIVING: models--Foo--Bar (1.0K, idle 581d)
[...] ARCHIVED: models--Foo--Bar -> /tmp/cs2/cold/models--Foo--Bar
[...] SKIP (recent, 0d): models--Fresh--Model (1.0K)
[...] ========== Scan complete: 1 archived, 1 skipped ==========
$ cat /tmp/cs2/hf/models--Foo--Bar/model.bin   # through the symlink
hello
```

**Caveat:** my dev host is Windows. Git Bash/MSYS turns `ln -s` on a directory
into a junction, so `[[ -L ]]` is false there even though the path resolves —
the suite reports that one assertion as `[SKIP]` on MSYS and asserts it
normally on Linux and macOS, where this script actually runs. Everything else
in the suite is platform-independent and runs everywhere.

## Operational Change Check

`llm-cold-storage.sh` is a standalone operator script. It is not sourced or
invoked by the installer, `ods-cli`, any compose service, or any systemd unit
in this repo — the only references are its own file and now its test. It does
not read or write `.env`, touch Docker, or change any service's runtime.

The one behaviour change a user could notice: `--execute` can now exit 1 when
`$COLD_DIR` cannot be created, where before it exited 0 having done nothing.
That is the point of the change.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Two things I left alone, deliberately:

1. `is_model_in_use()` matches with `pgrep -f "$model_id"`, where `model_id` is
   derived from a directory name and is used as a pattern, not a literal. A
   model whose name contains regex metacharacters could match the wrong
   process — or nothing. It is a separate concern and the fix is a `-F`-style
   rewrite, so I did not fold it in.
2. `$COLD_DIR` defaults to `$HOME/llm-cold-storage`, which the header describes
   as "a backup drive". If you would rather the script refuse to run when
   `$COLD_DIR` is on the same filesystem as `$HF_CACHE` — archiving to the same
   disk reclaims nothing — say so and I will send that separately.
