### PR TITLE
fix(memory-shepherd): stop a blocked run from clearing the held lock

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: Memory Shepherd Lock Tests
+        run: bash tests/test-memory-shepherd-lock.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -148,6 +148,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
+	@echo ""
+	@echo "=== memory-shepherd run lock ==="
+	@bash tests/test-memory-shepherd-lock.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/ods/memory-shepherd/memory-shepherd.sh
+++ b/ods/memory-shepherd/memory-shepherd.sh
@@ -21,7 +21,7 @@ _stat_size() {
 }
 
 TIMESTAMP=$(date '+%Y-%m-%d_%H%M')
-LOCKFILE=/tmp/memory-shepherd.lock
+LOCKFILE="${MEMORY_SHEPHERD_LOCKFILE:-/tmp/memory-shepherd.lock}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ── Logging ────────────────────────────────────────────────────────────
@@ -31,19 +31,40 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [memory-shepherd] $1"; }
 # ── Lock Management ────────────────────────────────────────────────────
 
 cleanup_lock() { rm -f "$LOCKFILE"; }
-trap cleanup_lock EXIT
 
-if [ -f "$LOCKFILE" ]; then
-    lock_age=$(( $(date +%s) - $(_stat_mtime "$LOCKFILE") ))
+# Create-or-fail in one step. `[ -f ]` followed by a separate write is not a
+# lock: two runs starting together both see no lock file and both proceed.
+acquire_lock() {
+    ( set -o noclobber; echo $$ > "$LOCKFILE" ) 2>/dev/null
+}
+
+lock_age_seconds() {
+    local mtime
+    mtime="$(_stat_mtime "$LOCKFILE" 2>/dev/null)" || mtime=""
+    [[ "$mtime" =~ ^[0-9]+$ ]] || { echo 999999; return 0; }
+    echo $(( $(date +%s) - mtime ))
+}
+
+if ! acquire_lock; then
+    lock_age="$(lock_age_seconds)"
     if [ "$lock_age" -gt 120 ]; then
         log "WARN: Stale lock (age: ${lock_age}s) — removing"
         rm -f "$LOCKFILE"
+        if ! acquire_lock; then
+            log "Another reset claimed the lock — exiting"
+            exit 0
+        fi
     else
         log "Another reset running (lock age: ${lock_age}s) — exiting"
         exit 0
     fi
 fi
-echo $$ > "$LOCKFILE"
+
+# Arm the cleanup only now that this process owns the lock. Arming it before
+# the check meant the "another reset running" exit above deleted the *other*
+# run's lock on its way out, so the next invocation started concurrently with
+# a reset that was still rewriting MEMORY.md files.
+trap cleanup_lock EXIT
 
 # ── Config Parser ──────────────────────────────────────────────────────
 

--- a/ods/tests/test-memory-shepherd-lock.sh
+++ b/ods/tests/test-memory-shepherd-lock.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Contracts for the memory-shepherd run lock.
+#
+# memory-shepherd rewrites agent MEMORY.md files in place. Two runs overlapping
+# can archive and reset the same file at the same time, so the lock is the only
+# thing standing between a scheduled reset and lost scratch notes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SHEPHERD="$SCRIPT_DIR/memory-shepherd/memory-shepherd.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS=$((PASS + 1)); }
+fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    [[ -n "${2:-}" ]] && echo "       $2"
+    FAIL=$((FAIL + 1))
+}
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+LOCKFILE="$TMP_ROOT/shepherd.lock"
+CONF="$TMP_ROOT/memory-shepherd.conf"
+BASELINE_DIR="$TMP_ROOT/baselines"
+mkdir -p "$BASELINE_DIR" "$TMP_ROOT/archives"
+
+# One agent with a real baseline and memory file, so a run that gets past the
+# lock does observable work.
+head -c 2000 /dev/urandom | base64 > "$BASELINE_DIR/agent.md"
+cp "$BASELINE_DIR/agent.md" "$TMP_ROOT/MEMORY.md"
+cat > "$CONF" <<EOF
+[general]
+baseline_dir=$BASELINE_DIR
+archive_dir=$TMP_ROOT/archives
+
+[agent]
+memory_file=$TMP_ROOT/MEMORY.md
+baseline=agent.md
+EOF
+
+run_shepherd() {
+    MEMORY_SHEPHERD_LOCKFILE="$LOCKFILE" \
+    MEMORY_SHEPHERD_CONF="$CONF" \
+        bash "$SHEPHERD" all 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
+# A blocked run must not delete the lock it was blocked by
+# ---------------------------------------------------------------------------
+echo "12345" > "$LOCKFILE"
+BEFORE="$(cat "$LOCKFILE")"
+
+OUT="$(run_shepherd)"
+
+if grep -q "Another reset running" <<<"$OUT"; then
+    pass "a held lock blocks a second run"
+else
+    fail "a held lock did not block a second run" "$OUT"
+fi
+
+if [[ -f "$LOCKFILE" ]]; then
+    pass "the blocked run leaves the held lock in place"
+else
+    fail "the blocked run deleted the lock belonging to the running reset" "$OUT"
+fi
+
+if [[ -f "$LOCKFILE" && "$(cat "$LOCKFILE")" == "$BEFORE" ]]; then
+    pass "the blocked run does not rewrite the held lock"
+else
+    fail "the blocked run rewrote the held lock" \
+         "expected '$BEFORE', got '$(cat "$LOCKFILE" 2>/dev/null || echo '<missing>')'"
+fi
+
+# The lock has to survive being hit repeatedly, not just once.
+run_shepherd >/dev/null
+run_shepherd >/dev/null
+if [[ -f "$LOCKFILE" ]]; then
+    pass "the lock survives repeated blocked invocations"
+else
+    fail "the lock was cleared by a later blocked invocation"
+fi
+
+if [[ "$(cat "$TMP_ROOT/MEMORY.md")" == "$(cat "$BASELINE_DIR/agent.md")" ]]; then
+    pass "a blocked run performs no agent work"
+else
+    fail "a blocked run touched the agent memory file"
+fi
+
+# ---------------------------------------------------------------------------
+# A stale lock is reclaimed, and the run cleans up after itself
+# ---------------------------------------------------------------------------
+echo "12345" > "$LOCKFILE"
+touch -d "-10 minutes" "$LOCKFILE"
+
+OUT="$(run_shepherd)"
+
+if grep -q "Stale lock" <<<"$OUT"; then
+    pass "a lock older than the timeout is reported stale"
+else
+    fail "a stale lock was not reclaimed" "$OUT"
+fi
+
+if grep -q "Loaded config" <<<"$OUT"; then
+    pass "the run proceeds after reclaiming a stale lock"
+else
+    fail "the run did not proceed after reclaiming a stale lock" "$OUT"
+fi
+
+if [[ ! -e "$LOCKFILE" ]]; then
+    pass "a run that owns the lock removes it on exit"
+else
+    fail "the lock was left behind after a completed run"
+fi
+
+# ---------------------------------------------------------------------------
+# A clean start acquires and releases
+# ---------------------------------------------------------------------------
+rm -f "$LOCKFILE"
+OUT="$(run_shepherd)"
+
+if grep -q "Loaded config" <<<"$OUT" && [[ ! -e "$LOCKFILE" ]]; then
+    pass "a clean run acquires the lock and releases it"
+else
+    fail "a clean run did not acquire/release cleanly" "$OUT"
+fi
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]
+echo "[PASS] memory-shepherd lock contracts"


### PR DESCRIPTION
## Summary

`memory-shepherd.sh` arms its cleanup trap before it takes the lock:

```bash
cleanup_lock() { rm -f "$LOCKFILE"; }
trap cleanup_lock EXIT                       # armed here

if [ -f "$LOCKFILE" ]; then
    lock_age=$(( $(date +%s) - $(_stat_mtime "$LOCKFILE") ))
    if [ "$lock_age" -gt 120 ]; then
        log "WARN: Stale lock (age: ${lock_age}s) — removing"
        rm -f "$LOCKFILE"
    else
        log "Another reset running (lock age: ${lock_age}s) — exiting"
        exit 0                               # trap fires -> rm -f "$LOCKFILE"
    fi
fi
echo $$ > "$LOCKFILE"                        # ...acquired only here
```

The run that correctly detects a reset in progress deletes *that reset's* lock
on its way out.

Reproduced against `origin/main`'s logic (only the hardcoded lock path made
overridable, so the run could be pointed at a scratch file — no other change):

```text
$ echo "12345" > /tmp/w/lock          # stand in for a reset already running
$ MEMORY_SHEPHERD_LOCKFILE=/tmp/w/lock bash memory-shepherd.sh all
[...] [memory-shepherd] Another reset running (lock age: 0s) — exiting
$ ls -l /tmp/w/lock
ls: cannot access '/tmp/w/lock': No such file or directory
```

The blocked run reported the collision correctly and then cleared the lock, so
mutual exclusion survives exactly one collision. The next invocation — the next
cron tick, or a manual `memory-shepherd.sh all` — finds no lock and starts
concurrently with the first run, which is still walking agents, archiving
scratch notes, and replacing MEMORY.md files. `reset_agent()` reads the memory
file, writes an archive, then overwrites the memory file from the baseline;
two of those interleaving on the same agent is how scratch notes go missing.

There is a second, quieter problem in the same block. `[ -f "$LOCKFILE" ]`
followed by a separate `echo $$ > "$LOCKFILE"` is check-then-act: two runs
starting at the same moment both see no lock and both proceed. The window is
small but this script is normally driven by a timer, which is exactly the
setup that produces simultaneous starts.

### Fix

- Arm `trap cleanup_lock EXIT` only after this process owns the lock. A blocked
  run now exits without touching anything.
- Acquire with a `noclobber` redirect, which creates-or-fails in one step:

  ```bash
  acquire_lock() { ( set -o noclobber; echo $$ > "$LOCKFILE" ) 2>/dev/null; }
  ```

- Keep the 120s stale reclaim, but re-acquire after clearing a stale lock
  rather than assuming the clear won the race to replace it. A non-numeric or
  vanished mtime now reads as "very old" instead of feeding garbage into the
  arithmetic.
- `LOCKFILE` honours `MEMORY_SHEPHERD_LOCKFILE`. This is the test seam — the
  path was hardcoded, so the lock lifecycle could not be exercised without
  writing to the real `/tmp/memory-shepherd.lock` on the developer's machine.
  The default is unchanged.

### Test

The script had no test coverage. Adds `tests/test-memory-shepherd-lock.sh`
(9 assertions): a held lock blocks and survives (including repeated blocked
invocations, and byte-identical content so a rewrite is caught too), a blocked
run does no agent work, a stale lock is reclaimed and the run proceeds, and a
run that owns the lock releases it on exit. Wired into `make test` and the
Linux CI job.

## AI Assistance

AI assisted with spotting the trap/acquire ordering, drafting the test cases,
and wording this description. I read the full diff, built the seam-only copy of
`origin/main`'s script to isolate the lock bug from the testability change, and
captured the output above from that run.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Standalone agent-maintenance tooling under `memory-shepherd/`. Nothing in the
installer, `ods-cli`, or the compose stack invokes it. CI config and the
Makefile test target are also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n memory-shepherd/memory-shepherd.sh
syntax OK

$ bash tests/test-memory-shepherd-lock.sh
[PASS] a held lock blocks a second run
[PASS] the blocked run leaves the held lock in place
[PASS] the blocked run does not rewrite the held lock
[PASS] the lock survives repeated blocked invocations
[PASS] a blocked run performs no agent work
[PASS] a lock older than the timeout is reported stale
[PASS] the run proceeds after reclaiming a stale lock
[PASS] a run that owns the lock removes it on exit
[PASS] a clean run acquires the lock and releases it

Passed: 9  Failed: 0
[PASS] memory-shepherd lock contracts

# the same suite against origin/main's logic (lock path seam applied, nothing
# else changed) — the three lock-lifecycle assertions are the delta:
[PASS] a held lock blocks a second run
[FAIL] the blocked run deleted the lock belonging to the running reset
[FAIL] the blocked run rewrote the held lock
       expected '12345', got '<missing>'
[FAIL] the lock was cleared by a later blocked invocation
[PASS] a blocked run performs no agent work
[PASS] a lock older than the timeout is reported stale
[PASS] the run proceeds after reclaiming a stale lock
[PASS] a run that owns the lock removes it on exit
[PASS] a clean run acquires the lock and releases it

Passed: 6  Failed: 3

# stale-lock path after the fix:
$ touch -d "-10 minutes" $LOCKFILE && bash memory-shepherd.sh all
[...] WARN: Stale lock (age: 600s) — removing
[...] Loaded config from ... (1 agents)
[...] Done
$ ls $LOCKFILE
ls: cannot access ...: No such file or directory     # released on exit
```

**Note on the "before" run:** `origin/main` hardcodes `LOCKFILE=/tmp/memory-shepherd.lock`,
so the suite cannot target it as shipped. I applied only the one-line path seam
to a copy of `origin/main`'s script and ran the unmodified suite against that,
which isolates the lock-lifecycle failures from the testability change.

## Operational Change Check

`memory-shepherd.sh` is standalone tooling under `memory-shepherd/`. It is not
sourced or invoked by the installer, `ods-cli`, any compose service, or any
phase in this repo. It does not read `.env`, touch Docker, or affect any
running service.

The only user-visible change: a run that is blocked now leaves the lock alone,
which is the intent of the lock. No change to what a successful run does to
baselines, archives, or MEMORY.md files.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Deliberately left for a separate PR so this one stays on the lock-correctness
concern:

1. The default lock path is `/tmp/memory-shepherd.lock` — a fixed name in a
   world-writable directory, with no owner check. On a shared host another
   local user can pre-create it (blocking every run) or point it at a symlink
   the `echo $$ >` would then truncate. `reset_remote_agent()` has the same
   shape with `/tmp/memory-shepherd-${agent}-current.md`. That is the pattern
   already addressed elsewhere in the tree for the background-task registry and
   the AMD GTT staging file, and I am happy to send the equivalent change here.
2. The lock stores the writing PID but nothing ever reads it. A liveness check
   (`kill -0`) would beat the 120s timeout for detecting a crashed run, but
   that is new behaviour rather than a fix.
