### PR TITLE
fix(readiness): stop filing healthy containers under "needs attention"

### DIFF
--- a/ods/installers/lib/readiness-summary.sh
+++ b/ods/installers/lib/readiness-summary.sh
@@ -74,7 +74,14 @@ ods_readiness_summary() {
         if _ods_readiness_is_ready_code "$http_code"; then
             state="ready"
             detail="HTTP $http_code"
-        elif [[ "$container_state" == "running" || "$container_state" == "starting" || "$container_state" == "host" ]]; then
+        # `healthy` comes from .State.Health.Status and only exists for a
+        # container that declares a healthcheck and is passing it. It replaces
+        # the `running` string for those containers, so leaving it out of this
+        # list filed the best-behaved services under "needs attention" while an
+        # identical container with no healthcheck was reported as "starting".
+        # `unhealthy` deliberately stays in the else branch.
+        elif [[ "$container_state" == "running" || "$container_state" == "healthy" \
+             || "$container_state" == "starting" || "$container_state" == "host" ]]; then
             state="starting"
             detail="HTTP $http_code"
         elif [[ "$container_state" == "missing" || "$container_state" == "docker-unavailable" ]]; then

--- a/ods/installers/windows/lib/readiness-summary.ps1
+++ b/ods/installers/windows/lib/readiness-summary.ps1
@@ -74,7 +74,11 @@ function Write-ODSInstallReadinessSummary {
         else {
             $state = "starting"
             $detail = "HTTP $($http.Code)"
-            if ($containerState -and $containerState -notin @("running", "starting", "host")) {
+            # "healthy" comes from .State.Health.Status and replaces "running"
+            # for any container that declares a healthcheck, so omitting it
+            # filed passing containers under "needs attention". "unhealthy"
+            # deliberately stays out of this list.
+            if ($containerState -and $containerState -notin @("running", "healthy", "starting", "host")) {
                 $state = "needs attention"
                 $detail = "container $containerState, HTTP $($http.Code)"
             }

--- a/ods/tests/test-install-readiness-summary.sh
+++ b/ods/tests/test-install-readiness-summary.sh
@@ -54,6 +54,8 @@ case "$url" in
   *3001*) printf "200" ;;
   *3000*) printf "000"; exit 7 ;;
   *6333*) printf "000"; exit 7 ;;
+  *5678*) printf "000"; exit 7 ;;
+  *8188*) printf "000"; exit 7 ;;
   *) printf "404" ;;
 esac
 EOF
@@ -66,6 +68,10 @@ if [[ "$1" == "inspect" ]]; then
   case "$container" in
     ods-dashboard) echo "healthy"; exit 0 ;;
     ods-webui) echo "running"; exit 0 ;;
+    # Passing its own healthcheck, but not reachable from the host yet.
+    ods-n8n) echo "healthy"; exit 0 ;;
+    # Failing its own healthcheck — this one really does need attention.
+    ods-comfyui) echo "unhealthy"; exit 0 ;;
     ods-qdrant) exit 1 ;;
     *) echo "missing"; exit 1 ;;
   esac
@@ -94,6 +100,8 @@ OUTPUT="$TMP_DIR/readiness.txt"
     printf 'Dashboard|http://127.0.0.1:3001|ods-dashboard|http://localhost:3001\n'
     printf 'Chat UI (Open WebUI)|http://127.0.0.1:3000|ods-webui|http://localhost:3000\n'
     printf 'Qdrant|http://127.0.0.1:6333|ods-qdrant|http://localhost:6333\n'
+    printf 'n8n|http://127.0.0.1:5678|ods-n8n|http://localhost:5678\n'
+    printf 'ComfyUI|http://127.0.0.1:8188|ods-comfyui|http://localhost:8188\n'
 } | ods_readiness_summary "ods status" "/tmp/ods-install.log" "http://localhost:3001" > "$OUTPUT"
 
 echo ""
@@ -101,7 +109,7 @@ echo "=== Install readiness summary tests ==="
 echo ""
 
 assert_contains "$OUTPUT" "INSTALL READINESS" "summary has heading"
-assert_contains "$OUTPUT" "Ready now: 1/3" "summary counts ready services"
+assert_contains "$OUTPUT" "Ready now: 1/5" "summary counts ready services"
 assert_contains "$OUTPUT" "[OK] Dashboard" "summary lists ready service"
 [[ -s "$SUDO_MARKER" ]] && pass "summary honors DOCKER_CMD wrapper for docker inspect" || fail "summary ignored DOCKER_CMD wrapper"
 assert_contains "$OUTPUT" "[!!] Chat UI (Open WebUI)" "summary lists starting service"
@@ -109,6 +117,13 @@ assert_contains "$OUTPUT" "starting - HTTP 000" "summary explains starting servi
 assert_not_contains "$OUTPUT" "000000" "failed curl probe is normalized to a single 000 code"
 assert_contains "$OUTPUT" "[!!] Qdrant" "summary lists missing service"
 assert_contains "$OUTPUT" "not detected - missing" "summary explains missing container"
+# A container passing its own healthcheck is at least as started as one with no
+# healthcheck at all — it must not be filed under "needs attention".
+assert_contains "$OUTPUT" "n8n                          starting" "healthy container reports as starting, not needs attention"
+assert_not_contains "$OUTPUT" "container healthy" "healthy container is never described as needing attention"
+# A container failing its own healthcheck genuinely does need attention.
+assert_contains "$OUTPUT" "ComfyUI                      needs attention" "unhealthy container still needs attention"
+assert_contains "$OUTPUT" "container unhealthy" "unhealthy container reports its docker state"
 assert_contains "$OUTPUT" "HTTP 000" "summary includes failed HTTP code"
 assert_contains "$OUTPUT" "Open dashboard: http://localhost:3001" "summary shows dashboard next step"
 assert_contains "$OUTPUT" "Check status: ods status" "summary shows status command"

--- a/ods/tests/test-windows-readiness-summary.sh
+++ b/ods/tests/test-windows-readiness-summary.sh
@@ -60,21 +60,35 @@ if command -v pwsh >/dev/null 2>&1; then
             param([string]$Container)
             if ($Container -eq "ods-webui") { return "running" }
             if ($Container -eq "ods-qdrant") { return "missing" }
+            if ($Container -eq "ods-comfyui") { return "unhealthy" }
             return "healthy"
         }
         $checks = @(
             @{ Name = "Dashboard"; Url = "http://localhost:3001"; Container = "ods-dashboard"; OpenUrl = "http://localhost:3001" },
             @{ Name = "Chat UI"; Url = "http://localhost:3000"; Container = "ods-webui"; OpenUrl = "http://localhost:3000" },
-            @{ Name = "Qdrant"; Url = "http://localhost:6333"; Container = "ods-qdrant"; OpenUrl = "http://localhost:6333" }
+            @{ Name = "Qdrant"; Url = "http://localhost:6333"; Container = "ods-qdrant"; OpenUrl = "http://localhost:6333" },
+            @{ Name = "n8n"; Url = "http://localhost:5678"; Container = "ods-n8n"; OpenUrl = "http://localhost:5678" },
+            @{ Name = "ComfyUI"; Url = "http://localhost:8188"; Container = "ods-comfyui"; OpenUrl = "http://localhost:8188" }
         )
         Write-ODSInstallReadinessSummary -Checks $checks -StatusCommand ".\ods.ps1 status" -LogPath "C:\ods\logs\install.log" -DashboardUrl "http://localhost:3001"
     ')"
 
     [[ "$OUTPUT" == *"INSTALL READINESS"* ]] && pass "runtime summary has heading" || fail "runtime summary missing heading"
-    [[ "$OUTPUT" == *"Ready now: 1/3"* ]] && pass "runtime summary counts ready services" || fail "runtime summary count mismatch"
+    [[ "$OUTPUT" == *"Ready now: 1/5"* ]] && pass "runtime summary counts ready services" || fail "runtime summary count mismatch"
     [[ "$OUTPUT" == *"[OK] Dashboard"* ]] && pass "runtime summary lists ready service" || fail "runtime summary missing ready service"
     [[ "$OUTPUT" == *"[!!] Chat UI"* ]] && pass "runtime summary lists starting service" || fail "runtime summary missing starting service"
     [[ "$OUTPUT" == *"[!!] Qdrant"* ]] && pass "runtime summary lists missing service" || fail "runtime summary missing missing service"
+    # A container passing its own healthcheck is at least as started as one
+    # with no healthcheck; only a failing healthcheck is "needs attention".
+    [[ "$OUTPUT" == *"n8n                          starting"* ]] \
+        && pass "runtime summary reports a healthy container as starting" \
+        || fail "runtime summary flags a healthy container as needing attention"
+    [[ "$OUTPUT" != *"container healthy"* ]] \
+        && pass "runtime summary never describes a healthy container as a problem" \
+        || fail "runtime summary describes a healthy container as a problem"
+    [[ "$OUTPUT" == *"container unhealthy"* ]] \
+        && pass "runtime summary still flags an unhealthy container" \
+        || fail "runtime summary lost the unhealthy container case"
 else
     pass "PowerShell runtime behavior skipped (pwsh unavailable)"
 fi


### PR DESCRIPTION
## Summary

Both install readiness summaries read container state the same way:

```bash
# installers/lib/readiness-summary.sh
_ods_readiness_docker inspect \
  --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container"
```

When a container declares a `healthcheck:`, that expression returns
`.State.Health.Status` — `starting`, `healthy` or `unhealthy` — *instead of*
`.State.Status`. A passing container reports `healthy`, never `running`.

Neither implementation listed `healthy` among the states that count as started:

```bash
# installers/lib/readiness-summary.sh
elif [[ "$container_state" == "running" || "$container_state" == "starting" || "$container_state" == "host" ]]; then
    state="starting"
...
else
    state="needs attention"
```

```powershell
# installers/windows/lib/readiness-summary.ps1
if ($containerState -and $containerState -notin @("running", "starting", "host")) {
    $state = "needs attention"
```

So it lands in the catch-all. Reproduced with a stub `docker` that reports
`healthy` and a health URL that does not answer:

```text
$ printf 'Open WebUI|http://127.0.0.1:65533/health|ods-open-webui|http://127.0.0.1:3000\n' \
    | ods_readiness_summary
INSTALL READINESS
Ready now: 0/1
Needs attention:
  [!!] Open WebUI                   needs attention - container healthy, HTTP 000
```

Same on Windows, verified against the PowerShell library directly:

```text
INSTALL READINESS
Ready now: 0/1
Needs attention:
  [!!] n8n                          needs attention - container healthy, HTTP 0
```

The signal is inverted. An identical container that declares *no* healthcheck
reports `running` and is labelled "starting" — the calm wording. The container
that declares one and is passing it gets "needs attention". This shows on the
post-install summary, in the window right after `docker compose up` where a
host-side probe not having landed yet is completely normal, so the services
doing the most to prove they are up are exactly the ones the installer tells
the user to go investigate.

### Fix

Add `healthy` to the started set in both implementations. `unhealthy` stays out
of it — a container failing its own healthcheck genuinely does need attention,
and that branch is now pinned by a test so it cannot be lost.

One line each. No change to the ready/HTTP classification, the "not detected"
branch, the counts, or the output format.

### Test

Both suites already existed but only covered `healthy` on a service whose HTTP
probe *succeeded*, so the ready branch short-circuited before the container
state was ever consulted — the bug was invisible to them.

Each suite gains two fixtures: a `healthy` container whose probe fails (must
read "starting"), and an `unhealthy` one (must still read "needs attention",
with its docker state named in the detail).

## AI Assistance

AI assisted with tracing the `.State.Health.Status` substitution, drafting the
fixtures, and wording this description. I read the full diff, reproduced the old
labelling on both the bash and PowerShell implementations, and confirmed the
extended suites fail on the unpatched libraries.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Post-install reporting only — both readiness summary libraries and their
tests.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash tests/test-install-readiness-summary.sh
=== Install readiness summary tests ===
  PASS summary has heading
  PASS summary counts ready services
  PASS summary lists ready service
  PASS summary honors DOCKER_CMD wrapper for docker inspect
  PASS summary lists starting service
  PASS summary explains starting service
  PASS failed curl probe is normalized to a single 000 code
  PASS summary lists missing service
  PASS summary explains missing container
  PASS healthy container reports as starting, not needs attention
  PASS healthy container is never described as needing attention
  PASS unhealthy container still needs attention
  PASS unhealthy container reports its docker state
  PASS summary includes failed HTTP code
  PASS summary shows dashboard next step
  PASS summary shows status command
  PASS summary shows log path
  PASS summary shows compose launch record
  PASS summary shows compose logs command

Result: 19 passed, 0 failed

# the same suite against origin/main's readiness-summary.sh:
  FAIL healthy container reports as starting, not needs attention
  FAIL healthy container is never described as needing attention
Result: 17 passed, 2 failed

$ bash tests/test-windows-readiness-summary.sh
Result: 15 passed, 0 failed

# PowerShell library exercised directly with stubbed probes, after the fix:
INSTALL READINESS
Ready now: 1/5
Ready:
  [OK] Dashboard                    http://localhost:3001 (HTTP 200)
Needs attention:
  [!!] Chat UI                      starting - HTTP 0
  [!!] Qdrant                       needs attention - container missing, HTTP 0
  [!!] n8n                          starting - HTTP 0
  [!!] ComfyUI                      needs attention - container unhealthy, HTTP 0
```

**Caveat:** `pwsh` is not installed on my dev host, so
`tests/test-windows-readiness-summary.sh` takes its `pwsh unavailable` skip
branch locally and the 15 passes above are the static checks only. I exercised
`Write-ODSInstallReadinessSummary` directly under Windows PowerShell 5.1 to get
the runtime output above, and captured the pre-fix output the same way. CI has
`pwsh` and will run the runtime assertions.

## Operational Change Check

This touches installer phase output. It changes only how an already-collected
state string is labelled in the printed summary — no probing, ordering,
gating, or exit-code behaviour changes, and `AllReady` on the Windows side is
computed from the HTTP result, which is untouched. A service that was reported
"needs attention" purely because it was `healthy` now reports "starting"; every
other state keeps its current label.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Two adjacent things I noticed and left alone:

1. The bash summary has a "not detected" branch for `missing` /
   `docker-unavailable`; the PowerShell one does not, so a missing container on
   Windows reads "needs attention - container missing". That is a wording
   parity gap rather than a wrong classification, so I did not fold it in.
2. `_ods_readiness_is_ready_code()` counts 401/403 as ready — an
   auth-protected endpoint answering at all proves the service is up.
   `scripts/extension-runtime-check.sh` uses plain `curl -sf` for the same
   question, which treats 401/403 as a failure. Worth aligning, separately.
