### PR TITLE
fix(python): route two entry points through the shared resolver

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Offline Model Validation Tests
         run: python3 tests/test-offline-model-validation.py
 
+      - name: Python Resolver Entry Point Tests
+        run: bash tests/test-python-resolver-entrypoints.sh
+
       - name: Runtime Config Renderer Tests
         run: python3 tests/test-render-runtime-configs.py
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -89,6 +89,9 @@ test: ## Run unit and contract tests
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py
 	@echo ""
+	@echo "=== python resolver entry points ==="
+	@bash tests/test-python-resolver-entrypoints.sh
+	@echo ""
 	@echo "=== Bash 3.2 guard contracts ==="
 	@bash tests/test-bash32-guards.sh
 	@echo ""

--- a/ods/scripts/check-offline-models.sh
+++ b/ods/scripts/check-offline-models.sh
@@ -10,12 +10,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-if command -v python3 >/dev/null 2>&1; then
+# Resolve Python through the shared resolver. `command -v python3` alone is not
+# enough on Windows: the Microsoft Store app-execution alias is on PATH by
+# default, so `command -v` succeeds and the interpreter then refuses to run and
+# prints a Store advert instead. lib/python-cmd.sh probes that the candidate
+# actually executes, skips the alias, and honours ODS_PYTHON_CMD.
+PYTHON_CMD=""
+if [[ -f "$ODS_DIR/lib/python-cmd.sh" ]]; then
+    # shellcheck source=../lib/python-cmd.sh
+    . "$ODS_DIR/lib/python-cmd.sh"
+    PYTHON_CMD="$(ods_detect_python_cmd 2>/dev/null)" || PYTHON_CMD=""
+elif command -v python3 >/dev/null 2>&1; then
     PYTHON_CMD=python3
 elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD=python
-else
+fi
+
+if [[ -z "$PYTHON_CMD" ]]; then
     echo "ERROR: Python is required to validate offline model artifacts." >&2
+    echo "       Install Python 3, or set ODS_PYTHON_CMD to a working interpreter." >&2
     exit 2
 fi
 

--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -58,14 +58,26 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Mirrors detect_bash below: a candidate only counts once it has been proven to
+# run. `command -v python3` on its own accepts the Windows Microsoft Store
+# app-execution alias, which is on PATH by default and prints a Store advert
+# instead of executing. lib/python-cmd.sh does that probe, skips the alias, and
+# honours ODS_PYTHON_CMD.
 detect_python() {
-    if command -v python3 >/dev/null 2>&1; then
-        command -v python3
-    elif command -v python >/dev/null 2>&1; then
-        command -v python
-    else
-        return 1
+    if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then
+        # shellcheck source=../lib/python-cmd.sh
+        . "$ROOT_DIR/lib/python-cmd.sh"
+        ods_detect_python_cmd 2>/dev/null && return 0
     fi
+    local candidate
+    for candidate in python3 python; do
+        if command -v "$candidate" >/dev/null 2>&1 \
+           && "$candidate" -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
+            command -v "$candidate"
+            return 0
+        fi
+    done
+    return 1
 }
 
 detect_bash() {

--- a/ods/tests/test-python-resolver-entrypoints.sh
+++ b/ods/tests/test-python-resolver-entrypoints.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Contracts for scripts that pick a Python interpreter for themselves.
+#
+# `command -v python3` succeeding is not proof of a usable interpreter. On
+# Windows the Microsoft Store app-execution alias ships on PATH by default: it
+# resolves like a real binary, then refuses to run and prints an advert. Any
+# script that selects an interpreter must probe that it executes — that is what
+# lib/python-cmd.sh is for.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SH="$ROOT_DIR/scripts/check-offline-models.sh"
+BUNDLE_SH="$ROOT_DIR/scripts/ods-support-bundle.sh"
+PYTHON_CMD_LIB="$ROOT_DIR/lib/python-cmd.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS=$((PASS + 1)); }
+skip() { echo -e "${YELLOW}[SKIP]${NC} $1"; }
+fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    [[ -n "${2:-}" ]] && echo "       $2"
+    FAIL=$((FAIL + 1))
+}
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# A `python3` shaped like the Store alias: found by `command -v`, refuses to run.
+STUB_BIN="$TMP_ROOT/stubbin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/python3" <<'STUB'
+#!/bin/sh
+echo "Python was not found; run without arguments to install from the Microsoft Store," >&2
+echo "or disable this shortcut from Settings > Apps > App execution aliases." >&2
+exit 49
+STUB
+chmod +x "$STUB_BIN/python3"
+
+# The fallback the resolver is expected to reach instead.
+REAL_PYTHON=""
+for _candidate in python3 python; do
+    if command -v "$_candidate" >/dev/null 2>&1 \
+       && "$_candidate" -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
+        REAL_PYTHON="$(command -v "$_candidate")"
+        break
+    fi
+done
+
+if [[ -z "$REAL_PYTHON" ]]; then
+    skip "no working Python on this host — resolver contracts need one"
+    echo ""
+    echo "Passed: $PASS  Failed: $FAIL"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Both entry points route through the shared resolver
+# ---------------------------------------------------------------------------
+for script in "$CHECK_SH" "$BUNDLE_SH"; do
+    name="$(basename "$script")"
+    if grep -q 'lib/python-cmd.sh' "$script"; then
+        pass "$name sources the shared Python resolver"
+    else
+        fail "$name hand-rolls Python detection instead of sourcing lib/python-cmd.sh"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# check-offline-models.sh: end to end with the alias shadowing python3
+# ---------------------------------------------------------------------------
+FIXTURE="$TMP_ROOT/install"
+mkdir -p "$FIXTURE/scripts" "$FIXTURE/lib" "$FIXTURE/data/models"
+cp "$CHECK_SH" "$ROOT_DIR/scripts/validate-models.py" "$FIXTURE/scripts/"
+cp "$PYTHON_CMD_LIB" "$FIXTURE/lib/"
+
+run_checker() {
+    local extra_path="$1"
+    shift
+    ( cd "$FIXTURE/scripts" \
+      && PATH="$extra_path:$PATH" env "$@" bash check-offline-models.sh ) \
+        >"$TMP_ROOT/checker.out" 2>&1
+}
+
+set +e
+run_checker "$STUB_BIN"
+CHECKER_RC=$?
+set -e
+CHECKER_OUT="$(cat "$TMP_ROOT/checker.out")"
+
+if [[ "$CHECKER_RC" -ne 49 ]]; then
+    pass "check-offline-models.sh does not exec the unusable python3"
+else
+    fail "check-offline-models.sh exec'd the unusable python3" "rc=$CHECKER_RC"
+fi
+
+if ! grep -q "Microsoft Store" <<<"$CHECKER_OUT"; then
+    pass "check-offline-models.sh does not surface the Store advert"
+else
+    fail "check-offline-models.sh surfaced the Store advert instead of a report" \
+         "$CHECKER_OUT"
+fi
+
+if grep -q "ODS Offline Mode" <<<"$CHECKER_OUT"; then
+    pass "check-offline-models.sh still produces a readiness report"
+else
+    fail "check-offline-models.sh produced no readiness report" "$CHECKER_OUT"
+fi
+
+# ODS_PYTHON_CMD is the documented override and must win over PATH order.
+set +e
+run_checker "$STUB_BIN" "ODS_PYTHON_CMD=$REAL_PYTHON"
+OVERRIDE_RC=$?
+set -e
+if [[ "$OVERRIDE_RC" -ne 49 ]] && grep -q "ODS Offline Mode" "$TMP_ROOT/checker.out"; then
+    pass "check-offline-models.sh honours ODS_PYTHON_CMD"
+else
+    fail "check-offline-models.sh ignored ODS_PYTHON_CMD" \
+         "rc=$OVERRIDE_RC$(printf '\n')$(cat "$TMP_ROOT/checker.out")"
+fi
+
+# ---------------------------------------------------------------------------
+# ods-support-bundle.sh: detect_python in isolation
+# ---------------------------------------------------------------------------
+FN_FILE="$TMP_ROOT/detect_python.sh"
+awk '/^detect_python\(\) \{/,/^\}/' "$BUNDLE_SH" > "$FN_FILE"
+
+if [[ -s "$FN_FILE" ]] && grep -q '^}' "$FN_FILE"; then
+    pass "detect_python() extracted from ods-support-bundle.sh"
+else
+    fail "could not extract detect_python() from ods-support-bundle.sh"
+fi
+
+RESOLVED="$(
+    PATH="$STUB_BIN:$PATH" ROOT_DIR="$ROOT_DIR" bash -c '
+        . "$0"
+        detect_python
+    ' "$FN_FILE" 2>/dev/null || true
+)"
+
+if [[ -n "$RESOLVED" ]] && "$RESOLVED" -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
+    pass "ods-support-bundle.sh detect_python returns a runnable interpreter"
+else
+    fail "ods-support-bundle.sh detect_python returned an unusable interpreter" \
+         "got: ${RESOLVED:-<empty>}"
+fi
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]
+echo "[PASS] python resolver entry-point contracts"


### PR DESCRIPTION
## Summary

Two scripts pick their own interpreter with a chain that treats "on PATH" as
"usable":

```bash
# scripts/check-offline-models.sh
if command -v python3 >/dev/null 2>&1; then
    PYTHON_CMD=python3
elif command -v python >/dev/null 2>&1; then
    PYTHON_CMD=python
```

```bash
# scripts/ods-support-bundle.sh
detect_python() {
    if command -v python3 >/dev/null 2>&1; then
        command -v python3
    elif command -v python >/dev/null 2>&1; then
        command -v python
    ...
```

On Windows that assumption is wrong. The Microsoft Store app-execution alias
for `python3` is enabled by default, sits in `%LOCALAPPDATA%\Microsoft\WindowsApps`
on PATH, resolves like a real binary, and then refuses to run.

Reproduced on my own host, no fixtures involved:

```text
$ bash scripts/check-offline-models.sh
Python was not found; run without arguments to install from the Microsoft Store,
or disable this shortcut from Settings > Apps > Advanced app settings > App
execution aliases.
$ echo $?
49
```

That is the entire output. The script is documented as the host-side model
readiness check and normally prints a per-artifact report and exits 0 or 1;
here it exits 49 with a Store advert. A perfectly good `python` was one branch
further down the chain, and the script never reached it because `python3`
"existed".

This is not a hypothetical. `lib/python-cmd.sh` was written for it and says so:

```
# On Windows Git Bash, python3 can resolve to a Microsoft Store/App Installer
# Python without PyYAML while python has the module, so "runnable" is not enough.
```

It carries `_ods_python_is_windowsapps_alias()` to recognise the alias by path,
`_ods_python_runnable()` to prove the candidate executes, and `ODS_PYTHON_CMD`
support. These two scripts were the ones still bypassing it.

There is an in-file precedent for the right shape too — `ods-support-bundle.sh`'s
own `detect_bash()`, immediately below `detect_python()`, only accepts a
candidate after running it:

```bash
if "$candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
```

### Fix

Both scripts source `lib/python-cmd.sh` and resolve through
`ods_detect_python_cmd`, keeping their previous chain — plus a runnability
probe — as the fallback for a tree without the lib. `check-offline-models.sh`'s
error message now also names `ODS_PYTHON_CMD` as the escape hatch.

After the fix, on the same host:

```text
$ bash scripts/check-offline-models.sh
========================================================================
ODS Offline Mode - Model Validation
========================================================================
[MISSING] Primary LLM (GGUF model)       Not found: data/models/*.gguf
...
$ echo $?
1
```

### Test

Adds `tests/test-python-resolver-entrypoints.sh` (8 assertions). It puts an
alias-shaped `python3` first on PATH — found by `command -v`, exits 49 with the
Store text — and asserts that `check-offline-models.sh` still produces a
readiness report, never surfaces the advert, and honours `ODS_PYTHON_CMD`; and
that `ods-support-bundle.sh`'s `detect_python` returns an interpreter that
actually runs. The suite skips itself when the host has no working Python at
all. Wired into `make test` and the Linux CI job.

## AI Assistance

AI assisted with locating the other hand-rolled detection sites, drafting the
stub harness, and wording this description. I read the full diff, hit the
failure on my own machine first (that is what led me here), and confirmed the
new suite fails 7 of 8 against `origin/main`'s copies of both scripts.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

(Interpreter selection for two `scripts/` entry points. CI config and the
Makefile test target are also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n scripts/check-offline-models.sh && bash -n scripts/ods-support-bundle.sh
syntax OK

$ bash tests/test-python-resolver-entrypoints.sh
[PASS] check-offline-models.sh sources the shared Python resolver
[PASS] ods-support-bundle.sh sources the shared Python resolver
[PASS] check-offline-models.sh does not exec the unusable python3
[PASS] check-offline-models.sh does not surface the Store advert
[PASS] check-offline-models.sh still produces a readiness report
[PASS] check-offline-models.sh honours ODS_PYTHON_CMD
[PASS] detect_python() extracted from ods-support-bundle.sh
[PASS] ods-support-bundle.sh detect_python returns a runnable interpreter

Passed: 8  Failed: 0
[PASS] python resolver entry-point contracts

# the same suite against origin/main's copies of both scripts:
[FAIL] check-offline-models.sh hand-rolls Python detection instead of sourcing lib/python-cmd.sh
[FAIL] ods-support-bundle.sh hand-rolls Python detection instead of sourcing lib/python-cmd.sh
[FAIL] check-offline-models.sh surfaced the Store advert instead of a report
[FAIL] check-offline-models.sh produced no readiness report
[FAIL] check-offline-models.sh ignored ODS_PYTHON_CMD
[FAIL] ods-support-bundle.sh detect_python returned an unusable interpreter
       got: /tmp/tmp.rOIH2ZHYfO/stubbin/python3

Passed: 1  Failed: 7

# the existing offline-model suite is unaffected:
$ python3 tests/test-offline-model-validation.py
Passed: 43  Failed: 0
[PASS] offline model validation contracts
```

## Operational Change Check

Neither script is part of installer phase execution, compose generation, or any
service runtime. `check-offline-models.sh` is a host-side readiness check;
`ods-support-bundle.sh` builds a redacted diagnostic archive. Both are invoked
by an operator. The change affects only which interpreter they select, and the
selection is strictly more permissive: any host where the old chain worked
resolves to the same interpreter, because `ods_detect_python_cmd` tries
`python3` then `python` in the same order and only rejects candidates that fail
to execute.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

I scoped this to the two sites with **no** runnability probe at all. Several
others already gate on `python3 -c 'import sys; sys.exit(0)'`
(`scripts/pre-download.sh`, `extensions/services/token-spy/start.sh`,
`extensions/services/comfyui/startup.sh`, `extensions/services/whisper/docker-entrypoint.sh`),
so they survive the alias even though they do not use the shared resolver.
Converting those too would be a wider sweep for consistency rather than a bug
fix — happy to send it separately if you want the whole tree on one resolver.

`installers/phases/07-devtools.sh` uses a bare `AGENT_PYTHON="$(command -v python3)"`,
but that path is Linux-only where the alias does not exist, so I left it alone.
