### PR TITLE
docs(privacy-shield): describe the patterns that actually ship

### DIFF
--- a/ods/extensions/services/privacy-shield/PII_COVERAGE.md
+++ b/ods/extensions/services/privacy-shield/PII_COVERAGE.md
@@ -4,31 +4,54 @@
 
 Privacy Shield provides PII (Personally Identifiable Information) detection and redaction for voice agent conversations.
 
+Detected values are replaced with a stable `<PII_<type>_<hash>>` token before the
+request leaves the host, and restored from the response on the way back. This
+page describes what the shipped patterns actually match. The source of truth is
+`PIIDetector.PATTERNS` in [`pii_scrubber.py`](pii_scrubber.py); the cases below
+are covered by [`tests/test_pii_scrubber.py`](tests/test_pii_scrubber.py).
+
 ## Current Implementation: Regex-Only Detection
 
 **Status:** The current implementation uses regex-based pattern matching for PII detection.
 
 ### Detected PII Types
 
-| Type | Pattern | Example |
-|------|---------|---------|
-| Email addresses | `\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b` | user@example.com |
-| Phone numbers (US) | `\b\d{3}[-.]?\d{3}[-.]?\d{4}\b` | 555-123-4567 |
-| Social Security Numbers | `\b\d{3}-\d{2}-\d{4}\b` | 123-45-6789 |
-| Credit card numbers | `\b(?:\d[ -]*?){13,16}\b` | 4111 1111 1111 1111 |
-| IP addresses | `\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b` | 192.168.1.1 |
+| Type | Matches | Does not match |
+|------|---------|----------------|
+| Email addresses | `user@example.com`, `user+tag@example.com`, `john.doe.jr@sub.example.co.uk` | — |
+| Phone numbers (US) | `555-123-4567`, `555.123.4567`, `555 123 4567`, `(555) 123-4567`, `+1 555 123 4567` | International formats other than a leading `+1` |
+| Social Security Numbers | `123-45-6789`, `123.45.6789`, `123 45 6789` | A leading `19xx`/`20xx` group, so `2019-05-1234` is treated as a date range, not an SSN |
+| Credit card numbers | 16-digit numbers that pass a Luhn check: `4111 1111 1111 1111`, `4111-1111-1111-1111`, `4111111111111111` | Any other length — 15-digit Amex, 14-digit Diners, 13-digit Visa. 16-digit numbers that fail Luhn are left alone on purpose |
+| IP addresses | IPv4 `192.168.1.100`; IPv6 full, leading `::`, trailing `::` and middle `::` forms | — |
+| API keys and tokens | A `api_key` / `api-key` / `apikey` / `token` label, then `=` or `:`, then 16+ characters of `[A-Za-z0-9_-]` — e.g. `api_key=sk-abc123xyz789abcdef`, `X-Api-Key: sk-abc123xyz789abcdef` | Values shorter than 16 characters. `Authorization: Bearer <token>` — the label is `Bearer`, not `token` |
+
+The whole match is replaced, label included, so `api_key=sk-...` becomes a single
+`<PII_api_key_...>` token rather than `api_key=<PII_api_key_...>`.
 
 ### Limitations
 
-The following PII types are **NOT currently detected**:
+The following PII types are **not** currently detected:
 
-- Person names (e.g., "John Smith")
+- Person names (e.g. "John Smith")
 - Physical addresses
 - Dates of birth
 - Passport numbers
 - Driver's license numbers
 - Bank account numbers
 - Medical record numbers
+- `Authorization: Bearer <token>` headers
+- Payment cards that are not exactly 16 digits
+
+Two behaviours worth knowing about:
+
+- **Patterns are applied in order and can overlap.** `email`, `phone`, `ssn`,
+  `ip_address`, `api_key`, `credit_card` — in that order. A 14-digit card such as
+  `3056 930902 5904` has its trailing ten digits consumed by the phone pattern
+  first, so it is redacted as a phone number and the leading `3056` is left in
+  the text. Treat non-16-digit cards as unprotected.
+- **Detection is per-conversation, not per-line.** The token for a given value is
+  stable within a `PIIDetector` instance, so the same email in a later turn gets
+  the same token and restores correctly.
 
 ## Future Enhancement: Presidio Integration
 


### PR DESCRIPTION
## Summary

`extensions/services/privacy-shield/PII_COVERAGE.md` documents a set of regexes
that are not the ones in the code, and every difference points the same way —
the doc claims more coverage than exists.

| Documented | Actually shipped |
|---|---|
| Credit cards: `\b(?:\d[ -]*?){13,16}\b` | `\b(?:\d{4}[-\s]?){3}\d{4}\b` plus `_luhn_check`, which returns `False` for anything that is not exactly 16 digits |
| Phone: `\b\d{3}[-.]?\d{3}[-.]?\d{4}\b` | also accepts a leading `+1`, parentheses, and spaces |
| SSN: `\b\d{3}-\d{2}-\d{4}\b` | also accepts `.` and space separators, and carries a `(?!(?:19\|20)\d{2}...)` lookahead |
| IP: IPv4 only | IPv4 plus four IPv6 forms |
| *(no row)* | `api_key` — an `api_key`/`api-key`/`apikey`/`token` label followed by a 16+ character value |
| Email: `[A-Z\|a-z]{2,}` | `[A-Za-z]{2,}` (the documented class has a stray `\|` in it) |

The credit-card row is the one that matters. A reader is told 13-to-16 digits
are covered. Checked against the shipped module:

```text
  PASSED THROUGH  Amex 15-digit            Card: 3782 822463 10005
  PASSED THROUGH  Visa 13-digit            Card: 4222222222222
        REDACTED  Visa 16-digit            Card: <PII_credit_card_05dd1b91f0a8>
```

Worse, a 14-digit Diners number is not simply missed — the phone pattern runs
first and eats its tail:

```text
        REDACTED  Diners 14-digit          Card: 3056 <PII_phone_c37e5611a0f5>
```

so four digits stay in the clear and the value is mislabelled as a phone number
in the stats. For a page whose only job is telling an operator what does and
does not leave the host, over-claiming is the worst failure mode it has.

### Change

Rewrites the table around what each pattern matches **and does not match**,
with concrete examples on both sides. Adds the missing `api_key` row. Documents
two behaviours that are not obvious from the pattern list:

- Patterns are applied in order and can overlap, with the Diners case as the
  worked example.
- `Authorization: Bearer <token>` is not covered — the label is `Bearer`, not
  `token`.

Also points at `pii_scrubber.py` and `tests/test_pii_scrubber.py` as the source
of truth, so the next drift is easier to catch.

No code change. The "Limitations", Presidio, Configuration and Error Handling
sections keep their existing content, extended with the gaps found above.

## AI Assistance

AI assisted with diffing the documented regexes against the shipped ones and
drafting the table. Every row in the new table is a claim I ran against the
module rather than read off the source — see the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [x] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash tests/test-doc-links.sh
[PASS] No broken local links found in repo README, ods root docs, and ods/docs

# every match / non-match claim in the new table, run against the shipped
# PIIDetector — 28 inputs, expected outcome asserted per input:
28/28 documented claims verified against the code

# the two relative links the page adds:
$ ls extensions/services/privacy-shield/pii_scrubber.py \
     extensions/services/privacy-shield/tests/test_pii_scrubber.py
extensions/services/privacy-shield/pii_scrubber.py
extensions/services/privacy-shield/tests/test_pii_scrubber.py
```

**Note:** `tests/test-doc-links.sh` only walks the repo README, `ods/` root docs
and `ods/docs/`. `PII_COVERAGE.md` lives under `extensions/services/`, so it is
outside that sweep — I checked its two relative links by hand, above.

## Operational Change Check

Markdown only. No code, config, compose, manifest, or CI change; nothing reads
this file at runtime.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The `api_key` row describes `main` as it stands today, which is why it lists
`api_key` / `api-key` / `apikey` / `token` and not the spaced `API Key:` form —
that spelling is not matched on `main`. I have a separate PR open
(#2363) that adds the space to the pattern. Whichever of the two lands second,
I will rebase it so the doc and the regex agree; ping me and I will push the
one-word update rather than have you hold either PR for the other.

If you would rather this page not enumerate the exact gaps (a coverage doc is
also a map of what gets through), say so and I will cut it back to types and
formats without the negative examples. My read is that an operator deciding
whether to route a conversation through the shield needs the negative cases
more than an attacker does, since the module is open source either way.
