### PR TITLE
fix(auth): reuse generated dashboard API keys

### DIFF
--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import secrets
+import tempfile
 from pathlib import Path
 
 from fastapi import HTTPException, Security
@@ -10,17 +11,48 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 logger = logging.getLogger(__name__)
 
-DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY")
-if not DASHBOARD_API_KEY:
-    DASHBOARD_API_KEY = secrets.token_urlsafe(32)
-    key_file = Path("/data/dashboard-api-key.txt")
+
+def _load_or_create_api_key(configured_key: str | None, key_file: Path) -> str:
+    """Return the configured key or a stable generated key from disk."""
+    if configured_key:
+        return configured_key
+
+    try:
+        persisted = key_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        persisted = ""
+    if persisted:
+        logger.info("Loaded generated DASHBOARD_API_KEY from %s", key_file)
+        return persisted
+
+    generated = secrets.token_urlsafe(32)
     key_file.parent.mkdir(parents=True, exist_ok=True)
-    key_file.write_text(DASHBOARD_API_KEY)
-    key_file.chmod(0o600)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{key_file.name}.",
+        suffix=".tmp",
+        dir=key_file.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            os.fchmod(handle.fileno(), 0o600)
+            handle.write(generated)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, key_file)
+    finally:
+        temporary.unlink(missing_ok=True)
     logger.warning(
-        "DASHBOARD_API_KEY not set. Generated temporary key and wrote to %s (mode 0600). "
+        "DASHBOARD_API_KEY not set. Generated a persistent key at %s (mode 0600). "
         "Set DASHBOARD_API_KEY in your .env file for production.", key_file
     )
+    return generated
+
+
+DASHBOARD_API_KEY = _load_or_create_api_key(
+    os.environ.get("DASHBOARD_API_KEY"),
+    Path(os.environ.get("DASHBOARD_API_KEY_FILE", "/data/dashboard-api-key.txt")),
+)
 
 security_scheme = HTTPBearer(auto_error=False)
 

--- a/ods/extensions/services/dashboard-api/tests/test_security.py
+++ b/ods/extensions/services/dashboard-api/tests/test_security.py
@@ -1,11 +1,43 @@
 """Tests for security.py — API key authentication."""
 
+import os
+import stat
+
 import pytest
 
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 
 import security
+
+
+def test_generated_key_is_reused_after_restart(tmp_path, monkeypatch):
+    key_file = tmp_path / "dashboard-api-key.txt"
+    generated = security._load_or_create_api_key(None, key_file)
+
+    monkeypatch.setattr(
+        security.secrets,
+        "token_urlsafe",
+        lambda _size: pytest.fail("persisted key should be reused"),
+    )
+
+    assert security._load_or_create_api_key(None, key_file) == generated
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are not enforced on Windows")
+def test_generated_key_file_is_private(tmp_path):
+    key_file = tmp_path / "dashboard-api-key.txt"
+
+    security._load_or_create_api_key(None, key_file)
+
+    assert stat.S_IMODE(key_file.stat().st_mode) == 0o600
+
+
+def test_explicit_key_does_not_touch_persisted_file(tmp_path):
+    key_file = tmp_path / "dashboard-api-key.txt"
+
+    assert security._load_or_create_api_key("configured", key_file) == "configured"
+    assert not key_file.exists()
 
 
 class TestVerifyApiKey:


### PR DESCRIPTION
## Summary
- reuse the generated dashboard API key from the shared data file after API-only restarts
- write newly generated keys atomically with private permissions while preserving explicit environment configuration
- cover restart persistence, file permissions, and configured-key precedence

## Test plan
- `pytest tests/test_security.py -q`
- `python -m compileall -q security.py`
- `git diff --check`