### PR TITLE
fix(hermes): escape generated YAML scalars

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -24,6 +24,7 @@ test: ## Run unit and contract tests
 	@echo "=== Tier map tests ==="
 	@bash tests/test-tier-map.sh
 	@bash tests/test-installer-context-parity.sh
+	@python3 tests/test-hermes-config-scalar-escaping.py
 	@bash tests/test-hermes-context-floor.sh
 	@echo ""
 	@echo "=== Hermes slash worker prune ==="

--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -10,6 +10,7 @@ the rest of the user's config.
 from __future__ import annotations
 
 import argparse
+import json
 import re
 from pathlib import Path
 
@@ -75,6 +76,11 @@ def _key_value(lines: list[str], block: tuple[int, int], key: str, indent: int) 
     return None
 
 
+def _yaml_scalar(value: str) -> str:
+    """Encode a string as a YAML-safe double-quoted scalar."""
+    return json.dumps(value, ensure_ascii=False)
+
+
 def _ensure_model(
     lines: list[str],
     model: str | None,
@@ -87,12 +93,12 @@ def _ensure_model(
     if block is None:
         insert = ["model:"]
         if model:
-            insert.append(f'  default: "{model}"')
+            insert.append(f"  default: {_yaml_scalar(model)}")
         if base_url:
             insert.append('  provider: "custom"')
-            insert.append(f'  base_url: "{base_url}"')
+            insert.append(f"  base_url: {_yaml_scalar(base_url)}")
         if api_key:
-            insert.append(f'  api_key: "{api_key}"')
+            insert.append(f"  api_key: {_yaml_scalar(api_key)}")
         if context_length:
             insert.append(f"  context_length: {context_length}")
         if max_tokens:
@@ -101,11 +107,11 @@ def _ensure_model(
         return
 
     if model:
-        block = _set_key(lines, block, "default", f'"{model}"', 2)
+        block = _set_key(lines, block, "default", _yaml_scalar(model), 2)
     if base_url:
-        block = _set_key(lines, block, "base_url", f'"{base_url}"', 2)
+        block = _set_key(lines, block, "base_url", _yaml_scalar(base_url), 2)
     if api_key:
-        block = _set_key(lines, block, "api_key", f'"{api_key}"', 2)
+        block = _set_key(lines, block, "api_key", _yaml_scalar(api_key), 2)
     if context_length:
         block = _set_key(lines, block, "context_length", str(context_length), 2)
     # Existing operator values win, but migrate configs that predate ODS's

--- a/ods/tests/test-hermes-config-scalar-escaping.py
+++ b/ods/tests/test-hermes-config-scalar-escaping.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Regression tests for YAML scalar handling in the Hermes config patcher."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "patch-hermes-config.py"
+SPEC = importlib.util.spec_from_file_location("patch_hermes_config", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+PATCHER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PATCHER)
+
+
+class TestHermesConfigScalarEscaping(unittest.TestCase):
+    MODEL = 'model"\\name\ninjected_model: true'
+    BASE_URL = 'http://local.example/"\\v1\ninjected_url: true'
+    API_KEY = 'secret"\\value\ninjected_key: true'
+
+    def _patch_and_load(self, initial: str) -> dict:
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = Path(directory) / "config.yaml"
+            config_path.write_text(initial, encoding="utf-8")
+
+            PATCHER.patch_config(
+                config_path,
+                self.MODEL,
+                self.BASE_URL,
+                65536,
+                self.API_KEY,
+            )
+
+            return yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    def _assert_values_are_data(self, config: dict) -> None:
+        self.assertEqual(config["model"]["default"], self.MODEL)
+        self.assertEqual(config["model"]["base_url"], self.BASE_URL)
+        self.assertEqual(config["model"]["api_key"], self.API_KEY)
+        self.assertNotIn("injected_model", config)
+        self.assertNotIn("injected_url", config)
+        self.assertNotIn("injected_key", config)
+
+    def test_escapes_values_in_existing_model_block(self):
+        config = self._patch_and_load(
+            'model:\n  default: "old-model"\n  base_url: "http://old/v1"\n'
+        )
+
+        self._assert_values_are_data(config)
+
+    def test_escapes_values_when_creating_model_block(self):
+        config = self._patch_and_load('terminal:\n  backend: "local"\n')
+
+        self._assert_values_are_data(config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- serialize Hermes model, base URL, and API key values as YAML-safe quoted scalars
- protect both newly created and existing model blocks from quotes, backslashes, and newline injection
- add the regression suite to `make test`

## Test plan
- `python tests/test-hermes-config-scalar-escaping.py` (2 passed)
- `python -m compileall -q scripts/patch-hermes-config.py tests/test-hermes-config-scalar-escaping.py`
- `git diff --check`