### PR TITLE
fix(validation): use last duplicate env value

### DIFF
--- a/ods/scripts/validate-models.py
+++ b/ods/scripts/validate-models.py
@@ -39,12 +39,13 @@ def ods_root() -> Path:
 
 
 def env_value(root: Path, key: str, default: str = "") -> str:
-    """Read one KEY=value from the install's .env, or return ``default``."""
+    """Read the last KEY=value from .env, matching Docker Compose precedence."""
     env_path = root / ".env"
     if not env_path.is_file():
         return default
 
     prefix = f"{key}="
+    result = default
     for raw in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
         line = raw.strip()
         if not line.startswith(prefix):
@@ -52,8 +53,8 @@ def env_value(root: Path, key: str, default: str = "") -> str:
         value = line[len(prefix):].strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]
-        return value or default
-    return default
+        result = value or default
+    return result
 
 
 def model_candidates(cache_root: Path, repo_id: str) -> list[Path]:

--- a/ods/tests/test-offline-model-validation.py
+++ b/ods/tests/test-offline-model-validation.py
@@ -173,17 +173,33 @@ def main() -> int:
 
     with temp_root() as root:
         (root / ".env").write_text(
-            'AUDIO_STT_MODEL="org/quoted-model"\r\nEMPTY=\r\n',
+            'AUDIO_STT_MODEL=org/old-model\r\n'
+            'AUDIO_STT_MODEL="org/quoted-model"\r\n'
+            'EMPTY=old-value\r\nEMPTY=\r\n',
             encoding="utf-8",
         )
         check(
-            "matched quotes and CRLF are normalized",
+            "last duplicate value wins with normalized quotes and CRLF",
             validator.env_value(root, "AUDIO_STT_MODEL", "fallback")
             == "org/quoted-model",
         )
         check(
-            "empty values use the caller default",
+            "last empty duplicate uses the caller default",
             validator.env_value(root, "EMPTY", "fallback") == "fallback",
+        )
+
+    with temp_root() as root:
+        (root / ".env").write_text(
+            "ENABLE_VOICE=true\nENABLE_VOICE=false\n",
+            encoding="utf-8",
+        )
+        check(
+            "last duplicate feature flag controls service activation",
+            not validator.service_enabled(
+                root,
+                validator.WHISPER_COMPOSE,
+                ("ENABLE_VOICE",),
+            ),
         )
 
     for layout, stt, label in (


### PR DESCRIPTION
## Summary
- read the last duplicate `.env` assignment to match Docker Compose precedence
- preserve quote, CRLF, empty-value, and caller-default behavior
- verify duplicate feature flags control offline service activation correctly

## Test plan
- `python tests/test-offline-model-validation.py` (44 passed)
- `python -m compileall -q scripts/validate-models.py tests/test-offline-model-validation.py`
- `git diff --check`