### PR TITLE
fix(ape): classify an edit as a write, not a read

### DIFF
--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -627,19 +627,45 @@ def in_warmup(now: float) -> bool:
 
 _EXEC_VERBS = {"exec", "run", "execute", "shell", "bash", "sh", "cmd"}
 _READ_VERBS  = {"read", "cat", "head", "tail", "get_file", "read_file", "view"}
-_WRITE_VERBS = {"write", "create", "append", "write_file", "save", "put"}
+# Editing a file is writing to it. Agent frameworks name these tools `edit`,
+# `apply_patch`, `str_replace_editor`, `update` and so on — none of which
+# contain "write", so they used to miss WriteFile and its path guard.
+_WRITE_VERBS = {"write", "create", "append", "write_file", "save", "put",
+                "edit", "patch", "apply", "replace", "insert", "modify",
+                "update", "mkdir", "touch", "tee", "upload"}
 _NET_VERBS   = {"fetch", "curl", "wget", "web_fetch", "http_get", "request"}
 _SPAWN_VERBS = {"spawn", "agent", "sub_agent", "subagent", "delegate"}
+
+# Arg keys that name the file a tool is acting on. `evaluate()`'s path_guard
+# reads the same list, so a tool whose path lands here is also guarded there.
+PATH_ARG_KEYS = ("path", "file", "filename", "file_path", "filepath",
+                 "target_path", "dest", "destination")
+
+# Arg keys that carry bytes to be written. Their presence makes a call a write
+# regardless of whether the caller volunteered a `mode`; real file-edit tool
+# schemas send `content` / `new_str` / `text`, not `mode`.
+_WRITE_PAYLOAD_KEYS = ("content", "contents", "text", "data", "body",
+                       "new_str", "new_string", "new_text", "patch", "diff")
+
+_READ_MODES = {"r", "rb", "rt", "read"}
+
+
+def _path_arg(args: dict) -> Optional[str]:
+    """Return the first path-shaped argument value, or None."""
+    for key in PATH_ARG_KEYS:
+        if key in args:
+            return args[key]
+    return None
 
 
 def classify_intent(tool_name: str, args: dict) -> str:
     tokens = set(re.split(r"[^a-z0-9]", tool_name.lower()))
     if tokens & _EXEC_VERBS:
         return "ExecuteCommand"
-    if tokens & _READ_VERBS:
-        return "ReadFile"
     if tokens & _WRITE_VERBS:
         return "WriteFile"
+    if tokens & _READ_VERBS:
+        return "ReadFile"
     if tokens & _NET_VERBS:
         return "NetworkFetch"
     if tokens & _SPAWN_VERBS:
@@ -647,8 +673,17 @@ def classify_intent(tool_name: str, args: dict) -> str:
     # Infer from args
     if "command" in args or "cmd" in args:
         return "ExecuteCommand"
-    if "path" in args or "file" in args:
-        return "ReadFile" if args.get("mode", "r") == "r" else "WriteFile"
+    if _path_arg(args) is not None:
+        # An explicit mode wins. Otherwise a write payload decides it: only a
+        # call with neither is treated as a read. Defaulting a payload-carrying
+        # call to "r" sent every edit tool down the ReadFile branch, which is
+        # `mode: allow`, so the WriteFile path guard never ran.
+        mode = args.get("mode")
+        if mode is not None:
+            return "ReadFile" if str(mode).lower() in _READ_MODES else "WriteFile"
+        if any(key in args for key in _WRITE_PAYLOAD_KEYS):
+            return "WriteFile"
+        return "ReadFile"
     if "url" in args:
         return "NetworkFetch"
     return "Other"
@@ -683,7 +718,10 @@ def evaluate(intent: str, tool_name: str, args: dict, policy: dict) -> tuple[boo
         return True, f"command '{base}' is in allowlist"
 
     if mode == "path_guard":
-        path = str(args.get("path", args.get("file", args.get("filename", ""))))
+        # Same key list classify_intent uses, so a call routed here by its
+        # path argument is guarded on that same argument.
+        raw_path = _path_arg(args)
+        path = "" if raw_path is None else str(raw_path)
         if not path:
             return True, "no path specified"
         real = os.path.realpath(path)

--- a/ods/extensions/services/ape/tests/test_write_intent.py
+++ b/ods/extensions/services/ape/tests/test_write_intent.py
@@ -1,0 +1,157 @@
+"""WriteFile classification contracts.
+
+`WriteFile` is the only intent whose default policy is `path_guard`. Every
+other file intent is `mode: allow`. So a write that is classified as anything
+else is a write that nothing checks — the path guard never runs on it.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def ape(ape_env):
+    """The imported APE module with an isolated environment."""
+    import importlib
+
+    import main as ape_main
+
+    return importlib.reload(ape_main)
+
+
+# ── Edit-shaped tools are writes ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "tool_name,args",
+    [
+        # The name says write, in one spelling or another.
+        ("write_file", {"path": "/etc/cron.d/x", "content": "x"}),
+        ("edit_file", {"path": "/etc/cron.d/x", "content": "x"}),
+        ("apply_patch", {"path": "/etc/cron.d/x", "content": "x"}),
+        ("str_replace_editor", {"path": "/root/.ssh/authorized_keys",
+                                "new_str": "ssh-rsa AAAA"}),
+        ("update_config", {"file": "/home/other/.bashrc", "content": "x"}),
+        ("Edit", {"file_path": "/etc/passwd", "new_string": "x"}),
+        # The name says nothing, but the payload does.
+        ("do_thing", {"path": "/etc/cron.d/x", "content": "x"}),
+        ("do_thing", {"path": "/etc/cron.d/x", "text": "x"}),
+        ("do_thing", {"path": "/etc/cron.d/x", "new_str": "x"}),
+        # An explicit non-read mode is a write whatever the payload looks like.
+        ("open", {"path": "/etc/hosts", "mode": "w"}),
+        ("open", {"path": "/etc/hosts", "mode": "a"}),
+        ("open", {"path": "/etc/hosts", "mode": "wb"}),
+    ],
+)
+def test_writes_are_classified_as_writefile(ape, tool_name, args):
+    assert ape.classify_intent(tool_name, args) == "WriteFile"
+
+
+@pytest.mark.parametrize(
+    "tool_name,args",
+    [
+        ("write_file", {"path": "/etc/cron.d/x", "content": "x"}),
+        ("edit_file", {"path": "/etc/cron.d/x", "content": "x"}),
+        ("str_replace_editor", {"path": "/root/.ssh/authorized_keys",
+                                "new_str": "ssh-rsa AAAA"}),
+        ("Edit", {"file_path": "/etc/passwd", "new_string": "x"}),
+    ],
+)
+def test_writes_outside_the_workspace_are_denied(ape, tool_name, args):
+    """End to end: classification plus the guard it exists to reach."""
+    intent = ape.classify_intent(tool_name, args)
+    allowed, reason = ape.evaluate(intent, tool_name, args, ape.DEFAULT_POLICY)
+    assert not allowed, f"{tool_name} {args} was allowed: {reason}"
+    assert "outside allowed paths" in reason
+
+
+# ── Reads stay reads ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "tool_name,args",
+    [
+        ("read_file", {"path": "/etc/hostname"}),
+        ("cat", {"path": "/etc/hostname"}),
+        ("view", {"path": "/etc/hostname"}),
+        ("head", {"file": "/etc/hostname"}),
+        # No verb match and no write payload: still a read.
+        ("some_tool", {"path": "/etc/hostname"}),
+        ("open", {"path": "/etc/hostname", "mode": "r"}),
+        ("open", {"path": "/etc/hostname", "mode": "rb"}),
+    ],
+)
+def test_reads_are_classified_as_readfile(ape, tool_name, args):
+    assert ape.classify_intent(tool_name, args) == "ReadFile"
+
+
+def test_reads_are_not_blocked_by_the_write_guard(ape):
+    """A read outside the workspace is still allowed — this is not a lockdown."""
+    args = {"path": "/etc/hostname"}
+    intent = ape.classify_intent("read_file", args)
+    allowed, _ = ape.evaluate(intent, "read_file", args, ape.DEFAULT_POLICY)
+    assert allowed
+
+
+# ── Writes inside the workspace still pass ───────────────────────────────────
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="path_guard joins allowed_paths with a literal '/', so the prefix "
+           "match cannot succeed against a Windows realpath. APE ships in a "
+           "Linux container; assert the allow side where it runs.",
+)
+def test_write_inside_an_allowed_path_is_permitted(ape, tmp_path):
+    """Built from realpath so the assertion holds on any platform."""
+    allowed_root = os.path.realpath(str(tmp_path))
+    target = os.path.join(allowed_root, "notes.txt")
+    policy = {
+        "intents": {
+            "WriteFile": {"mode": "path_guard", "allowed_paths": [allowed_root]}
+        }
+    }
+    args = {"path": target, "content": "ok"}
+    intent = ape.classify_intent("edit_file", args)
+    assert intent == "WriteFile"
+    allowed, reason = ape.evaluate(intent, "edit_file", args, policy)
+    assert allowed, reason
+
+
+# ── Other intents are untouched ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "tool_name,args,expected",
+    [
+        ("exec", {"command": "ls"}, "ExecuteCommand"),
+        ("run_shell", {"command": "ls"}, "ExecuteCommand"),
+        ("anything", {"command": "ls"}, "ExecuteCommand"),
+        ("web_fetch", {"url": "https://example.com"}, "NetworkFetch"),
+        ("anything", {"url": "https://example.com"}, "NetworkFetch"),
+        ("spawn_agent", {}, "SpawnAgent"),
+        ("mystery", {}, "Other"),
+    ],
+)
+def test_other_intents_unchanged(ape, tool_name, args, expected):
+    assert ape.classify_intent(tool_name, args) == expected
+
+
+def test_exec_wins_over_a_write_shaped_name(ape):
+    """`run` is an exec verb; the exec check must stay first."""
+    assert ape.classify_intent("run_update", {"command": "ls"}) == "ExecuteCommand"
+
+
+# ── The path-argument helper is shared with path_guard ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "key", ["path", "file", "filename", "file_path", "filepath",
+            "target_path", "dest", "destination"],
+)
+def test_path_guard_reads_every_documented_path_key(ape, key):
+    args = {key: "/etc/cron.d/backdoor", "content": "x"}
+    assert ape.classify_intent("edit", args) == "WriteFile"
+    allowed, reason = ape.evaluate("WriteFile", "edit", args, ape.DEFAULT_POLICY)
+    assert not allowed, f"{key} was not guarded: {reason}"


### PR DESCRIPTION
## Summary

In `DEFAULT_POLICY`, `WriteFile` is the only file intent with a guard:

```python
"WriteFile": {
    "mode": "path_guard",
    "allowed_paths": ["/home/node/.openclaw/workspace", "/tmp"],
},
"ReadFile":     {"mode": "allow"},
"NetworkFetch": {"mode": "allow"},
"SpawnAgent":   {"mode": "allow"},
"Other":        {"mode": "allow"},
```

So anything misclassified away from `WriteFile` is a write that nothing checks.
`classify_intent` decides between the two like this:

```python
if "path" in args or "file" in args:
    return "ReadFile" if args.get("mode", "r") == "r" else "WriteFile"
```

The default is `"r"`. A tool that does not volunteer a `mode` is treated as a
read — and real file-edit tool schemas do not send `mode`; they send `content`,
`new_str`, `text`. Combined with `_WRITE_VERBS` knowing only
`write/create/append/write_file/save/put`, the guard is bypassed by any editing
tool that is not literally named "write":

```text
write_file             {'path': '/etc/cron.d/backdoor', 'content': 'x'}   -> WriteFile  DENY
edit_file              {'path': '/etc/cron.d/backdoor', 'content': 'x'}   -> ReadFile   ALLOW
apply_patch            {'path': '/etc/cron.d/backdoor', 'content': 'x'}   -> ReadFile   ALLOW
str_replace_editor     {'path': '/root/.ssh/authorized_keys', 'new_str':…} -> ReadFile   ALLOW
update                 {'file': '/home/other/.bashrc', 'content': 'x'}    -> ReadFile   ALLOW
Edit                   {'file_path': '/etc/passwd', 'new_string': 'x'}    -> Other      ALLOW
```

One spelling is guarded. The rest write anywhere on the host, and the audit log
records them as reads.

The last row is a second, smaller crack: `classify_intent` looks only at `path`
and `file`, so a tool sending `file_path` falls through to `Other` (allow). Even
if it had reached the guard, `path_guard` reads
`args.get("path", args.get("file", args.get("filename", "")))` — a different,
also-incomplete list — and would have found no path, hitting its
`return True, "no path specified"` branch.

### Fix

Three changes, all in service of "a write must be classified as a write":

- **Mode handling.** An explicit `mode` still decides, and now recognises
  `r`/`rb`/`rt` as reads and anything else as a write. With no `mode`, a write
  payload (`content`, `contents`, `text`, `data`, `body`, `new_str`,
  `new_string`, `new_text`, `patch`, `diff`) makes it a write. Only a call with
  neither is a read — same as today for genuine reads.
- **Verbs.** `_WRITE_VERBS` learns the names agent frameworks actually use:
  `edit`, `patch`, `apply`, `replace`, `insert`, `modify`, `update`, `mkdir`,
  `touch`, `tee`, `upload`. The write check moves ahead of the read check so a
  tool like `read_and_edit` is not claimed by `read`.
- **One path-key list.** `classify_intent` and `path_guard` now share
  `PATH_ARG_KEYS` (`path`, `file`, `filename`, `file_path`, `filepath`,
  `target_path`, `dest`, `destination`), so a call routed here by its path
  argument is guarded on that same argument.

Reads are deliberately unaffected — a read outside the workspace is still
allowed. This is not a lockdown, it is routing writes to the guard that already
exists.

### Test

Adds `tests/test_write_intent.py` — 41 assertions covering edit-shaped tools,
payload-only inference, explicit modes both ways, reads staying reads, a write
inside an allowed path still passing, every path key reaching the guard, and
the other intents being untouched (including `run_update`, where the exec check
must still win over the new `update` write verb).

## AI Assistance

AI assisted with enumerating the tool-name spellings, drafting the parametrised
cases, and wording this description. I read the full diff, produced the intent
table above by running `classify_intent` + `evaluate` on both the old and new
code, and confirmed the new suite fails 20 of 41 against `origin/main`.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Same note as #2450: this is a bypass of a shipped security control, so you
may want it on the stable lane. Targeting main because I cannot validate
release/2.6.x myself.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(`ape` is a bundled extension service acting as an authorization gate.
Classification and policy evaluation only — no compose, port, manifest, or
API-schema change.)

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 -m py_compile extensions/services/ape/main.py
py OK

$ python3 -m pytest tests/ -q          # in extensions/services/ape
84 passed, 1 skipped, 1 warning in 3.71s
  (43 pre-existing + 41 new; no pre-existing test changed)

# the new suite against origin/main's main.py:
20 failed, 20 passed, 1 skipped

# behaviour after the fix:
edit_file          {'path': '/etc/cron.d/backdoor', 'content': 'x'}  -> WriteFile DENY
apply_patch        {'path': '/etc/cron.d/backdoor', 'content': 'x'}  -> WriteFile DENY
str_replace_editor {'path': '/root/.ssh/authorized_keys', ...}       -> WriteFile DENY
Edit               {'file_path': '/etc/passwd', 'new_string': 'x'}   -> WriteFile DENY
read_file          {'path': '/etc/hostname'}                         -> ReadFile  ALLOW
open               {'path': '/etc/hostname', 'mode': 'r'}            -> ReadFile  ALLOW
```

Medium rather than Low: this moves real traffic from an unguarded intent to a
guarded one. A deployment whose agents edit files outside
`/home/node/.openclaw/workspace` and `/tmp` will start seeing denials. That is
the intended behaviour, but it is a live-path change and deserves a look.

**Caveat:** one assertion — a write *inside* an allowed path being permitted —
is skipped on my host. `path_guard` builds its prefix with a literal `/`
(`p.rstrip("/") + "/"`), which cannot match a Windows `realpath` such as
`C:\...\notes.txt`. APE ships in a Linux container, so this is a dev-host
artifact, not a deployment bug, and I did not "fix" it — the test carries a
`skipif(os.name == "nt")` with that reason so the assertion runs in CI where
APE actually runs. Every other assertion is platform-independent.

## Operational Change Check

`classify_intent` and `evaluate` run inside the `ape` container on every
`/verify` call. Decisions move in one direction: calls that carry a file path
plus a write payload now route to `WriteFile` and its path guard instead of the
`allow` branches. No call that was denied becomes allowed. Reads, exec,
network, and spawn classification are unchanged, and there is no change to the
`/verify` schema, STRICT_MODE, rate limiting, windowed governance, the circuit
breaker, or the audit format — though audit entries for edit tools will now
record `WriteFile` where they previously recorded `ReadFile`, which is the
correction.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The verb list is a heuristic and will always be incomplete.** Widening it
helps, but the payload-key inference is what actually closes the hole for
unknown tool names. If you would rather invert the default entirely — treat any
call carrying a path as a write unless it proves it is a read — say so; that is
a one-line change from here, and strictly safer, at the cost of routing some
genuine reads through the path guard (which would then deny reads outside the
workspace, a visible behaviour change I did not want to make unilaterally).

Related, and deliberately not in this PR: `path_guard`'s prefix match uses a
literal `/` separator and `os.path.realpath` resolves symlinks on the *host*
running APE, not inside the sandbox it is protecting. Neither is wrong on the
Linux container APE ships in, so I left both alone.

This sits alongside #2450 (allowlist chaining) — same service, independent
defects, no overlapping lines. Either can merge first.
