### PR TITLE
fix(models): pin the tier-0 and Windows coder-next GGUF checksums

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Tier Map Unit Tests
         run: bash tests/test-tier-map.sh
 
+      - name: GGUF Checksum Parity Tests
+        run: python3 tests/test-gguf-checksum-parity.py
+
       - name: Service Registry Tests
         run: bash tests/test-service-registry.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -23,6 +23,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Tier map tests ==="
 	@bash tests/test-tier-map.sh
+	@python3 tests/test-gguf-checksum-parity.py
 	@bash tests/test-installer-context-parity.sh
 	@bash tests/test-hermes-context-floor.sh
 	@echo ""

--- a/ods/installers/lib/tier-map.sh
+++ b/ods/installers/lib/tier-map.sh
@@ -150,7 +150,7 @@ set_qwen_tier_config() {
             LLM_MODEL="qwen3.5-2b"
             GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
-            GGUF_SHA256=""
+            GGUF_SHA256="aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
             MAX_CONTEXT=8192
             LLM_MODEL_SIZE_MB=1221    # Qwen3.5-2B-Q4_K_M (1,280,835,840 bytes)
             ;;
@@ -263,7 +263,7 @@ set_gemma4_tier_config() {
             LLM_MODEL="qwen3.5-2b"
             GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
-            GGUF_SHA256=""
+            GGUF_SHA256="aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
             MAX_CONTEXT=8192
             LLM_MODEL_SIZE_MB=1221
             ;;

--- a/ods/installers/macos/lib/tier-map.sh
+++ b/ods/installers/macos/lib/tier-map.sh
@@ -89,7 +89,7 @@ set_qwen_tier_config() {
             LLM_MODEL="qwen3.5-2b"
             GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
-            GGUF_SHA256=""
+            GGUF_SHA256="aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
             MAX_CONTEXT=8192
             ;;
         1)
@@ -148,7 +148,7 @@ set_gemma4_tier_config() {
             LLM_MODEL="qwen3.5-2b"
             GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
-            GGUF_SHA256=""
+            GGUF_SHA256="aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
             MAX_CONTEXT=8192
             ;;
         1)

--- a/ods/installers/windows/lib/tier-map.ps1
+++ b/ods/installers/windows/lib/tier-map.ps1
@@ -117,7 +117,7 @@ function Resolve-QwenTierConfig {
                 LlmModel   = "qwen3-coder-next"
                 GgufFile   = "qwen3-coder-next-Q4_K_M.gguf"
                 GgufUrl    = "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
-                GgufSha256 = ""
+                GgufSha256 = "9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090"
                 MaxContext = 131072
                 ModelProfileRequested = "qwen"
                 ModelProfileEffective = "qwen"
@@ -163,7 +163,7 @@ function Resolve-QwenTierConfig {
                 LlmModel   = "qwen3.5-2b"
                 GgufFile   = "Qwen3.5-2B-Q4_K_M.gguf"
                 GgufUrl    = "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
-                GgufSha256 = ""
+                GgufSha256 = "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
                 MaxContext = 8192
                 ModelProfileRequested = "qwen"
                 ModelProfileEffective = "qwen"
@@ -307,7 +307,7 @@ function Resolve-GemmaTierConfig {
                 LlmModel   = "qwen3.5-2b"
                 GgufFile   = "Qwen3.5-2B-Q4_K_M.gguf"
                 GgufUrl    = "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
-                GgufSha256 = ""
+                GgufSha256 = "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
                 MaxContext = 8192
                 ModelProfileRequested = $RequestedProfile
                 ModelProfileEffective = "qwen"

--- a/ods/tests/test-gguf-checksum-parity.py
+++ b/ods/tests/test-gguf-checksum-parity.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""GGUF artifact checksum parity across platforms and model profiles.
+
+The same model artifact is declared in several places: the Linux, macOS and
+Windows tier maps, and the bootstrap fast-start constants. An artifact that is
+pinned in one of them and left empty in another downloads unverified on
+whichever path reads the empty one — verify_sha256() logs "No SHA256 hash
+provided, skipping verification" and returns success.
+
+This asserts that every declaration of one artifact URL agrees on its checksum.
+
+Run: python3 tests/test-gguf-checksum-parity.py
+"""
+
+from __future__ import annotations
+
+import collections
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Each entry: (path, regex with named groups `url` and `sha`).
+# Bash tier maps and bootstrap constants both use KEY="value" lines; the
+# PowerShell tier map uses `Key = "value"`.
+SOURCES = [
+    (ROOT / "installers" / "lib" / "tier-map.sh",
+     r'GGUF_URL="(?P<url>[^"]+)"(?P<gap>.{0,400}?)GGUF_SHA256="(?P<sha>[^"]*)"'),
+    (ROOT / "installers" / "lib" / "bootstrap-model.sh",
+     r'BOOTSTRAP_GGUF_URL="(?P<url>[^"]+)"(?P<gap>.{0,400}?)BOOTSTRAP_GGUF_SHA256="(?P<sha>[^"]*)"'),
+    (ROOT / "installers" / "macos" / "lib" / "tier-map.sh",
+     r'GGUF_URL="(?P<url>[^"]+)"(?P<gap>.{0,400}?)GGUF_SHA256="(?P<sha>[^"]*)"'),
+    (ROOT / "installers" / "macos" / "lib" / "tier-map.sh",
+     r'BOOTSTRAP_GGUF_URL="(?P<url>[^"]+)"(?P<gap>.{0,400}?)BOOTSTRAP_GGUF_SHA256="(?P<sha>[^"]*)"'),
+    (ROOT / "installers" / "windows" / "lib" / "tier-map.ps1",
+     r'GgufUrl\s*=\s*"(?P<url>[^"]+)"(?P<gap>.{0,400}?)GgufSha256\s*=\s*"(?P<sha>[^"]*)"'),
+    (ROOT / "installers" / "windows" / "lib" / "tier-map.ps1",
+     r'BOOTSTRAP_GGUF_URL\s*=\s*"(?P<url>[^"]+)"(?P<gap>.{0,400}?)BOOTSTRAP_GGUF_SHA256\s*=\s*"(?P<sha>[^"]*)"'),
+]
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"[PASS] {label}")
+    else:
+        FAIL += 1
+        print(f"[FAIL] {label}")
+        if detail:
+            for line in detail.splitlines():
+                print(f"       {line}")
+
+
+def collect() -> dict[str, list[tuple[str, str]]]:
+    """Map artifact URL -> [(sha, where), ...] across every declaration."""
+    found: dict[str, list[tuple[str, str]]] = collections.defaultdict(list)
+    for path, pattern in SOURCES:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        rel = path.relative_to(ROOT).as_posix()
+        for match in re.finditer(pattern, text, re.S):
+            # A "gap" containing another URL means the two halves belong to
+            # different tier blocks; skip rather than pair them up wrongly.
+            if "GGUF_URL" in match.group("gap") or "GgufUrl" in match.group("gap"):
+                continue
+            found[match.group("url")].append((match.group("sha"), rel))
+    return found
+
+
+def main() -> int:
+    declarations = collect()
+
+    check(
+        "GGUF declarations were found to compare",
+        len(declarations) > 0,
+        "the extraction patterns matched nothing — has a tier map moved?",
+    )
+
+    for url in sorted(declarations):
+        artifact = url.rsplit("/", 1)[-1]
+        entries = declarations[url]
+        shas = {sha for sha, _ in entries}
+
+        check(
+            f"{artifact}: every declaration agrees on a checksum",
+            len(shas) == 1,
+            "\n".join(f"sha={sha or '<EMPTY>'}  {where}" for sha, where in sorted(entries)),
+        )
+
+        for sha, where in sorted(entries):
+            if not sha:
+                continue
+            check(
+                f"{artifact}: {where} declares a well-formed SHA256",
+                bool(SHA256_RE.match(sha)),
+                f"got {sha!r}",
+            )
+
+    # The bootstrap artifact is downloaded on every fast-start install; it must
+    # never be the unpinned one.
+    bootstrap = [
+        (url, entries)
+        for url, entries in declarations.items()
+        if url.endswith("Qwen3.5-2B-Q4_K_M.gguf")
+    ]
+    check(
+        "the bootstrap artifact is declared somewhere",
+        len(bootstrap) == 1,
+        repr([u for u, _ in bootstrap]),
+    )
+    for _url, entries in bootstrap:
+        check(
+            "the bootstrap artifact is pinned everywhere it is declared",
+            all(sha for sha, _ in entries),
+            "\n".join(f"sha={sha or '<EMPTY>'}  {where}" for sha, where in sorted(entries)),
+        )
+
+    print()
+    print(f"Passed: {PASS}  Failed: {FAIL}")
+    if FAIL:
+        return 1
+    print("[PASS] GGUF checksum parity")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`verify_sha256()` treats an empty expected hash as "nothing to check":

```bash
if [[ -z "$expected_hash" ]]; then
    ai_warn "No SHA256 hash provided for ${label}, skipping verification"
    return 0
fi
```

Two artifacts are pinned in one declaration and left empty in another, so the
**same file from the same URL** is verified on one install path and not on
another.

**1. The bootstrap model, `Qwen3.5-2B-Q4_K_M.gguf`.**

Pinned on all three platforms as the fast-start constant:

```text
installers/lib/bootstrap-model.sh:23      BOOTSTRAP_GGUF_SHA256="aaf42c8b…99223"
installers/macos/lib/tier-map.sh:224      BOOTSTRAP_GGUF_SHA256="aaf42c8b…99223"
installers/windows/lib/tier-map.ps1:824   $script:BOOTSTRAP_GGUF_SHA256 = "aaf42c8b…99223"
```

Empty in every tier-0 entry — same URL, same filename, same declared size:

```text
installers/lib/tier-map.sh:153            GGUF_SHA256=""       # qwen profile
installers/lib/tier-map.sh:266            GGUF_SHA256=""       # gemma4 profile
installers/macos/lib/tier-map.sh:92,151   GGUF_SHA256=""
installers/windows/lib/tier-map.ps1:166,310  GgufSha256 = ""
```

A fast-start install verifies this file. A plain tier-0 install downloads the
identical artifact unverified. Tier 0 is the documented "$200 laptop, no GPU"
path — the audience least equipped to notice a corrupted or substituted
download.

**2. `Qwen3-Coder-Next-Q4_K_M.gguf` (48.5 GB, NV_ULTRA).**

```text
installers/lib/tier-map.sh                sha=9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090
installers/windows/lib/tier-map.ps1       sha=<EMPTY>
```

Linux verifies it, Windows does not.

### Fix

Copy the already-vetted hashes to the declarations that lack them. **No new
hash is invented here** — every value already exists in this tree for the same
URL, put there by the model-vetting process. This only stops the same artifact
being described two different ways.

### Test

Adds `tests/test-gguf-checksum-parity.py`. It extracts every `(url, sha256)`
pair from the Linux, macOS and Windows tier maps plus the bootstrap constants,
groups them by artifact URL, and asserts that all declarations of one artifact
agree — plus that any non-empty value is a well-formed 64-hex SHA256, and that
the bootstrap artifact is pinned wherever it appears.

I wrote it for the tier-0 case. It then found the coder-next/Windows case,
which I had not spotted by reading.

## AI Assistance

AI assisted with the extraction patterns and wording this description. I read
the full diff, confirmed each copied hash against the existing declaration of
the same URL, and ran the new suite both ways.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Tier-map data on all three platforms. CI config and the Makefile test target
are also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n installers/lib/tier-map.sh && bash -n installers/macos/lib/tier-map.sh
bash syntax OK

$ python3 tests/test-gguf-checksum-parity.py
...
[PASS] Qwen3.5-2B-Q4_K_M.gguf: every declaration agrees on a checksum
[PASS] Qwen3-Coder-Next-Q4_K_M.gguf: every declaration agrees on a checksum
[PASS] the bootstrap artifact is pinned everywhere it is declared

Passed: 44  Failed: 0
[PASS] GGUF checksum parity

# the same suite against origin/main's tier maps:
[FAIL] Qwen3-Coder-Next-Q4_K_M.gguf: every declaration agrees on a checksum
       sha=<EMPTY>  installers/windows/lib/tier-map.ps1
       sha=9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090  installers/lib/tier-map.sh
[FAIL] Qwen3.5-2B-Q4_K_M.gguf: every declaration agrees on a checksum
       sha=<EMPTY>  installers/lib/tier-map.sh          (x2)
       sha=<EMPTY>  installers/macos/lib/tier-map.sh    (x2)
       sha=<EMPTY>  installers/windows/lib/tier-map.ps1 (x2)
       sha=aaf42c8b…99223  installers/lib/bootstrap-model.sh
       sha=aaf42c8b…99223  installers/macos/lib/tier-map.sh
       sha=aaf42c8b…99223  installers/windows/lib/tier-map.ps1
[FAIL] the bootstrap artifact is pinned everywhere it is declared

Passed: 34  Failed: 3
```

**Caveat:** `tests/test-tier-map.sh` reports `95 passed, 33 failed` on my host —
identical numbers on unmodified `origin/main`, which I checked before and after.
The failures are all `SELECTOR_*` assertions that shell out to `python3`, which
on my Windows dev box resolves to the Microsoft Store alias. Environmental, not
a regression from this change. CI has a real `python3`.

## Operational Change Check

This is tier-map data. The only behaviour change is that
`verify_sha256`/`Test-ODSFileHash` now has a value to compare on the tier-0 and
Windows NV_ULTRA download paths, where it previously logged "No SHA256 hash
provided … skipping verification" and returned success. No model, URL, context
size, or tier assignment changes.

The failure mode this introduces is a *correct* one: a tier-0 download that
does not match the pinned hash will now be rejected instead of silently
accepted. If upstream ever republishes that artifact under the same URL with
different bytes, tier-0 installs will start failing — which is the point, and
which the fast-start path already had.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The test asserts parity, not presence.** Artifacts that are unpinned
*everywhere* pass it — that is every `gemma-4-*` GGUF, plus `Qwen3.5-4B` on the
platforms that do not declare it. Those have no vetted value anywhere in the
tree, so I could not fill them in without downloading and hashing 20-100 GB of
weights, which is your model-vetting process's job rather than something I
should guess at. If you want the test tightened to "every artifact must be
pinned", say the word and I will flip the assertion — it will fail loudly until
those hashes land, which may be exactly what you want as a release gate.

Two things I checked so you do not have to:

- The gemma4 tier-0 block deliberately reuses the qwen bootstrap artifact
  (there is a comment saying so), so it takes the same hash. Both are updated.
- The extraction pairs a URL with the *next* checksum assignment and skips the
  match if another URL appears in between, so two adjacent tier blocks are
  never paired up wrongly.
