### PR TITLE
fix(backup): pre-secure backup archive permissions before compression in ods-backup.sh

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -461,11 +461,11 @@ compress_backup() {
     local parent_dir
     parent_dir=$(dirname "$backup_dir")
 
-    tar czf "$parent_dir/$backup_name.tar.gz" -C "$parent_dir" "$backup_name"
-    # The archive bundles the raw .env (DASHBOARD_API_KEY, session secret, service
-    # passwords). Restrict it to the owner rather than leaving it world-readable
-    # at the umask default, matching the 0600 the .env itself carries.
+    # Pre-create the archive file and apply restricted permissions before tar
+    # populates it, avoiding window of umask permissive mode.
+    touch "$parent_dir/$backup_name.tar.gz"
     chmod 600 "$parent_dir/$backup_name.tar.gz"
+    tar czf "$parent_dir/$backup_name.tar.gz" -C "$parent_dir" "$backup_name"
     local compressed_size
     compressed_size=$(du -sh "$parent_dir/$backup_name.tar.gz" | cut -f1)
 


### PR DESCRIPTION
## Summary

When `ods-backup.sh` compresses a backup directory using `tar czf`, the archive file was previously created first with default process umask permissions before `chmod 600` was invoked on the resulting `.tar.gz` file. Because system backups bundle sensitive configuration files like `.env` (which store tokens, API keys, and database credentials), this ordering left a brief window during compression where the archive file could be read by other users on multi-user systems.

## Solution

Pre-touch the destination `.tar.gz` archive path and apply `chmod 600` prior to running `tar czf`. This ensures the file is created with restricted permissions from the outset.

## Testing

- Tested shell script syntax via `bash -n ods/ods-backup.sh`.
- Verified clean git diff with `git diff --check`.