### PR TITLE
fix(restore): exit subshell with error code on checksum mismatch in ods-restore.sh

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -294,7 +294,7 @@ validate_backup() {
                         log_error "Backup integrity check FAILED - checksums do not match"
                         log_error "This backup may be corrupted or tampered with"
                         log_error "Use --skip-verify to restore anyway (NOT RECOMMENDED)"
-                        return 1
+                        exit 1
                     fi
                 )
                 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
## Summary

In `ods-restore.sh`, the checksum integrity check runs inside a subshell `(` ... `)`. On verification failure, the script previously invoked `return 1`. While `return` exits functions, inside a standalone subshell block it exits the subshell scope but is less explicit than `exit 1`.

## Solution

Replace `return 1` with `exit 1` inside the checksum verification subshell block in `validate_backup()`, making subshell failure propagation clean and explicit.

## Testing

- Tested shell script syntax via `bash -n ods/ods-restore.sh`.
- Verified clean git diff with `git diff --check`.