### PR TITLE
fix(update): preserve docker-compose override stack resolution in ods-update.sh

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -132,6 +132,9 @@ resolve_compose_flags() {
                 fi
                 ;;
         esac
+        if [[ -f "${INSTALL_DIR}/docker-compose.override.yml" ]]; then
+            fallback="$fallback -f docker-compose.override.yml"
+        fi
         echo "$fallback"
         return 0
     fi


### PR DESCRIPTION
## Summary

When `ods-update.sh` resolves fallback docker compose stack flags, it scans for `docker-compose.base.yml` and backend-specific compose files like `docker-compose.nvidia.yml`. However, if an operator has created custom local overrides in `docker-compose.override.yml`, the fallback flag resolver previously omitted it from the compose file chain.

## Solution

Update the fallback compose resolver in `ods-update.sh` to check for `docker-compose.override.yml` in `INSTALL_DIR` and append `-f docker-compose.override.yml` to the flag list when present.

## Testing

- Tested shell script syntax via `bash -n ods/ods-update.sh`.
- Verified clean git diff with `git diff --check`.