### PR TITLE
fix(uninstall): add path safety validation for INSTALL_DIR in ods-uninstall.sh

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -95,6 +95,11 @@ if [[ -d "$SCRIPT_DIR" && -f "$SCRIPT_DIR/ods-cli" ]]; then
     INSTALL_DIR="$SCRIPT_DIR"
 fi
 
+if [[ -z "$INSTALL_DIR" || "$INSTALL_DIR" == "/" || "$INSTALL_DIR" == "$HOME" ]]; then
+    log_error "Refusing to uninstall from unsafe install directory path: '$INSTALL_DIR'"
+    exit 1
+fi
+
 if [[ ! -d "$INSTALL_DIR" ]]; then
     log_error "Install directory not found: $INSTALL_DIR"
     exit 1


### PR DESCRIPTION
## Summary

When `ods-uninstall.sh` executes, it checks whether `INSTALL_DIR` exists before purging containers and files. However, if `INSTALL_DIR` is mistakenly set to empty, system root (`/`), or user home (`$HOME`), the uninstaller could attempt destructive file removal on critical system directories.

## Solution

Add an explicit validation check in `ods-uninstall.sh` that aborts uninstallation immediately with an error if `INSTALL_DIR` evaluates to empty, `/`, or `$HOME`.

## Testing

- Tested shell script syntax via `bash -n ods/ods-uninstall.sh`.
- Verified clean git diff with `git diff --check`.