### PR TITLE
fix(preflight): ensure bash 3.2 compatibility in is_external_lemonade helper in ods-preflight.sh

### DIFF
--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -73,10 +73,13 @@ detect_backend() {
 BACKEND=$(detect_backend)
 
 is_external_lemonade() {
-    local external="${LEMONADE_EXTERNAL:-false}"
-    local managed="${AMD_INFERENCE_MANAGED:-}"
-    local mode="${ODS_MODE:-local}"
-    [[ "${external,,}" == "true" ]] || [[ "${mode,,}" == "lemonade" && "${managed,,}" == "false" ]]
+    local external
+    external="$(echo "${LEMONADE_EXTERNAL:-false}" | tr '[:upper:]' '[:lower:]')"
+    local managed
+    managed="$(echo "${AMD_INFERENCE_MANAGED:-}" | tr '[:upper:]' '[:lower:]')"
+    local mode
+    mode="$(echo "${ODS_MODE:-local}" | tr '[:upper:]' '[:lower:]')"
+    [[ "$external" == "true" ]] || [[ "$mode" == "lemonade" && "$managed" == "false" ]]
 }
 
 # Colors


### PR DESCRIPTION
## Summary

In `ods-preflight.sh`, the `is_external_lemonade()` helper function converted variable values to lowercase using Bash 4.0+ parameter expansion (`${external,,}`). On systems running macOS default `/bin/bash` (Bash 3.2), this syntax throws a bad substitution error, failing the preflight check.

## Solution

Replace `${var,,}` parameter expansion in `is_external_lemonade()` with POSIX-compatible `tr '[:upper:]' '[:lower:]'`, ensuring compatibility with both default macOS Bash 3.2 and Linux Bash 4+.

## Testing

- Tested shell script syntax via `bash -n ods/ods-preflight.sh`.
- Verified clean git diff with `git diff --check`.