### PR TITLE
fix(gpus): validate positive model size in assign_gpus.py

### DIFF
--- a/ods/scripts/assign_gpus.py
+++ b/ods/scripts/assign_gpus.py
@@ -463,6 +463,10 @@ def main():
     model_size_mb    = args.model_size
     gpu_count        = topology.get("gpu_count", 0)
 
+    if model_size_mb <= 0:
+        print("ERROR: --model-size must be a positive number", file=sys.stderr)
+        sys.exit(1)
+
     if gpu_count == 0:
         print("ERROR: no GPUs found in topology", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

In `ods/scripts/assign_gpus.py`, the `--model-size` argument is parsed as a float. However, if a non-positive value (e.g. 0 or negative numbers) was passed, the script previously proceeded into GPU assignment and subset enumeration, leading to unexpected zero-VRAM memory calculations.

## Solution

Add an explicit check after parsing CLI arguments in `assign_gpus.py` to verify `model_size_mb > 0`, exiting with error message and exit code 1 if invalid.

## Testing

- Verified syntax via `python3 -m py_compile ods/scripts/assign_gpus.py`.
- Verified clean git diff with `git diff --check`.