### PR TITLE
fix(remote-provider): log invalid SSH plan reason

### DIFF
--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
@@ -301,7 +301,8 @@ class SshProcessSupervisor:
             self._notice_exited_locked(now)
             try:
                 argv = _combined_ssh_argv(plan)
-            except ValueError:
+            except ValueError as exc:
+                LOGGER.warning("SSH plan argv invalid: %s", exc)
                 self._stop_process_locked()
                 self._last_payload = _health_from_plan(
                     _error_plan("ssh_plan_unavailable", secret_dir=self.secret_dir),

--- a/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
+++ b/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
@@ -8,8 +8,10 @@ import json
 import os
 import sys
 import tempfile
+import unittest
 from pathlib import Path
 from typing import Iterator
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -342,6 +344,41 @@ def test_supervisor_uses_restart_cooldown_after_child_exit() -> None:
     assert_true(restarted["status"] == "starting", "restarted child should enter grace period")
 
 
+def test_supervisor_logs_invalid_combined_argv_reason() -> None:
+    ssh_app = _health_app()
+    invalid_plan = {
+        "schema": SSH_SUPERVISOR_PLAN_SCHEMA,
+        "status": "planned",
+        "ready": False,
+        "readyToStart": True,
+        "reason": "tunnel_process_not_started",
+        "tunnelBaseUrl": "http://remote-provider-ssh-tunnel:18091/v1",
+        "tunnels": [{"argv": ["ssh", "gpu.example.test"]}],
+        "secrets": {},
+        "missingSecrets": [],
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        supervisor, factory, _clock = _new_fake_supervisor(
+            root / "routing-state.json",
+            root / "secrets",
+        )
+        with (
+            patch.object(ssh_app, "_supervisor_plan_for_paths", return_value=invalid_plan),
+            unittest.TestCase().assertLogs("remote-provider-ssh-tunnel", level="WARNING") as logs,
+        ):
+            payload = supervisor.reconcile()
+    assert_true(not factory.calls, "invalid SSH argv must not start a child")
+    assert_true(payload["reason"] == "ssh_plan_unavailable", "invalid SSH argv reason drifted")
+    expected_warning = (
+        "SSH plan argv invalid: SSH tunnel argv is missing a local forward"
+    )
+    assert_true(
+        any(expected_warning in line for line in logs.output),
+        "invalid SSH argv warning must include the validation reason",
+    )
+
+
 def test_service_source_avoids_public_secret_names() -> None:
     for path, text in _walk_service_source():
         for key in PUBLIC_SSH_SECRET_ENV:
@@ -365,6 +402,7 @@ def main() -> int:
         test_supervisor_stops_process_when_secret_custody_disappears,
         test_supervisor_restarts_process_when_route_argv_changes,
         test_supervisor_uses_restart_cooldown_after_child_exit,
+        test_supervisor_logs_invalid_combined_argv_reason,
         test_service_source_avoids_public_secret_names,
     ]
     for test in tests:


### PR DESCRIPTION
## Summary

- log the validation reason when an otherwise startable SSH supervisor plan contains invalid process arguments
- preserve the existing fail-closed stopped health state and avoid logging the full SSH command
- add a regression contract proving no child starts and the actionable warning is emitted

Closes #2338

## AI Assistance

Codex helped triage the issue, implement the focused fix and regression test, and run validation. The human author remains responsible for the final diff and review responses.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — isolated behavior change in the internal SSH tunnel supervisor service
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because: no install, compose, auth, or routing-policy behavior changed

Commands/results:

```text
python ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
12 tests passed

python -m py_compile ods/extensions/services/remote-provider-ssh-tunnel/app/main.py ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
passed

git diff --check
passed
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The warning contains only the bounded validation message raised by `_combined_ssh_argv`; it does not serialize the plan or SSH argv, so destinations and key paths are not added to logs. Rollback is a one-commit revert.