### PR TITLE
fix(dashboard-api): terminate cluster status subprocess on timeout in agent_monitor.py

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -56,7 +56,16 @@ class ClusterStatus:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            except asyncio.TimeoutError:
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except OSError:
+                    pass
+                logger.debug("Cluster proxy status probe timed out")
+                return
 
             if proc.returncode == 0:
                 data = json.loads(stdout.decode())


### PR DESCRIPTION
## Context

Inside `ClusterStatus.refresh()`, the cluster status module queries the smart proxy by running a background `curl` process wrapped in `asyncio.wait_for(proc.communicate(), timeout=5)`. If the proxy connection hangs or stalls, `asyncio.TimeoutError` was previously caught at the outer block without explicitly terminating the child process handle.

## Solution

Wrap `proc.communicate()` in an inner `try...except asyncio.TimeoutError` block that explicitly calls `proc.kill()` and awaits process completion before returning early.

## Validation

- Ran `pytest ods/extensions/services/dashboard-api/tests/test_agent_monitor.py` (19/19 passed).
- Verified clean git diff with `git diff --check`.