### PR TITLE
fix(env): skip all readonly Bash variables

### DIFF
--- a/ods/lib/safe-env.sh
+++ b/ods/lib/safe-env.sh
@@ -9,6 +9,17 @@
 # - load_env_from_output  — parse KEY="value" lines from stdin (for script output)
 # ============================================================================
 
+_safe_env_shell_var_is_readonly() {
+    local _safe_env_candidate="$1"
+    local _safe_env_declaration _safe_env_attributes
+    if ! _safe_env_declaration="$(declare -p "$_safe_env_candidate" 2>&1)"; then
+        return 1
+    fi
+    _safe_env_attributes="${_safe_env_declaration#declare -}"
+    _safe_env_attributes="${_safe_env_attributes%% *}"
+    [[ "$_safe_env_attributes" == *r* ]]
+}
+
 # Load a .env file safely: comments and empty lines skipped; key names must be
 # valid identifiers; values may be unquoted or quoted; no eval or word-splitting.
 load_env_file() {
@@ -34,10 +45,11 @@ load_env_file() {
         key="${key%"${key##*[![:space:]]}"}"
         [[ -z "$key" ]] && continue
         [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        # Bash exposes UID as a readonly shell variable. A .env line such as
-        # UID=1000 is valid for Docker Compose, but exporting it here aborts
-        # lifecycle commands under set -e before they can reach compose.
-        [[ "$key" == "UID" ]] && continue
+        # UID/GID overrides and other keys may be valid Docker Compose input,
+        # but Bash exposes several names (UID, EUID, BASHOPTS, SHELLOPTS, ...)
+        # as readonly variables. Exporting any of them aborts lifecycle
+        # commands under set -e before they can reach compose.
+        _safe_env_shell_var_is_readonly "$key" && continue
         # Strip one leading space, then a single matching pair of surrounding
         # quotes. Only strip when both ends carry the SAME quote character —
         # stripping each quote type independently corrupts values whose content

--- a/ods/tests/test-safe-env.sh
+++ b/ods/tests/test-safe-env.sh
@@ -101,15 +101,21 @@ load_model_selector_env_from_output < <(printf '%s\n' 'LLM_MODEL="qwen-test"' 'E
 [[ -z "${EVIL_SELECTOR_KEY:-}" ]] || fail "EVIL_SELECTOR_KEY should not be loaded"
 pass "model selector loader is allowlisted"
 
-echo "Test 10: load_env_file skips Bash readonly UID"
+echo "Test 10: load_env_file skips Bash readonly variables"
 cat > "$tmpdir/.env-readonly" << 'EOF'
 UID=12345
-AFTER_READONLY_UID=still_loads
+EUID=12345
+BASHOPTS=malicious-options
+SHELLOPTS=malicious-options
+AFTER_READONLY=still_loads
 EOF
 load_env_file "$tmpdir/.env-readonly"
 [[ "${UID}" != "12345" ]] || fail "UID should not be overwritten"
-[[ "${AFTER_READONLY_UID:-}" == "still_loads" ]] || fail "load_env_file stopped after readonly UID"
-pass "load_env_file tolerates UID from .env"
+[[ "${EUID}" != "12345" ]] || fail "EUID should not be overwritten"
+[[ "${BASHOPTS}" != "malicious-options" ]] || fail "BASHOPTS should not be overwritten"
+[[ "${SHELLOPTS}" != "malicious-options" ]] || fail "SHELLOPTS should not be overwritten"
+[[ "${AFTER_READONLY:-}" == "still_loads" ]] || fail "load_env_file stopped after a readonly variable"
+pass "load_env_file tolerates Bash readonly variables from .env"
 
 echo "Test 11: load_env_file tolerates CRLF .env files (Windows/WSL2)"
 unset CRLF_PORT CRLF_PATH CRLF_QUOTED 2>/dev/null || true


### PR DESCRIPTION
## Summary

- detect Bash readonly variables from their declaration attributes instead of special-casing only `UID`
- skip readonly `.env` keys before export so lifecycle commands continue loading later settings under `set -e`
- cover `UID`, `EUID`, `BASHOPTS`, and `SHELLOPTS` plus a value after them in the regression test

## AI Assistance

Codex found and reproduced the generalized readonly-variable failure, implemented the attribute-based guard, expanded regression coverage, and ran related environment/lifecycle tests. The human author remains responsible for the final diff and review responses.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — shared `.env` loading changes only the handling of variables Bash already forbids assigning
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because: writable variables retain the existing parser/export path

Commands/results:

```text
bash tests/test-safe-env.sh
12 scenarios passed

bash tests/test-validate-env.sh
43 passed, 0 failed

bash tests/test-mode-switch-status.sh
20 passed, 0 failed

bash -n lib/safe-env.sh tests/test-safe-env.sh
passed

git diff --check
passed
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Before the fix, a valid-looking `.env` line such as `EUID=12345` aborts the loader immediately and prevents every later setting from loading. Docker Compose may still consume such keys directly from `.env`; skipping only the Bash export preserves that behavior, matching the existing `UID` intent. Rollback is a one-commit revert.