### PR TITLE
fix(dashboard-api): catch socket timeout in AMD health probe in gpu.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/gpu.py
+++ b/ods/extensions/services/dashboard-api/routers/gpu.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import socket
 import time
 import urllib.error
 import urllib.request
@@ -264,7 +265,7 @@ def _probe_amd_health(health_url: str) -> tuple[str, str, Optional[str]]:
             body = response.read(4096).decode("utf-8", errors="replace")
     except urllib.error.HTTPError as exc:
         return "unhealthy", "unknown", f"health_http_{exc.code}"
-    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+    except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
         logger.debug("AMD runtime health probe failed for %s: %s", health_url, exc)
         return "unreachable", "unknown", "health_unreachable"
 


### PR DESCRIPTION
## Context

In `ods/extensions/services/dashboard-api/routers/gpu.py`, `_probe_amd_health()` probes the AMD runtime health endpoint using `urllib.request.urlopen()`. When socket timeouts occur, Python can raise `socket.timeout` directly or wrapped inside `urllib.error.URLError`.

## Solution

Import `socket` module and include `socket.timeout` explicitly in the exception tuple caught by `_probe_amd_health()`.

## Validation

- Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed).
- Verified clean git diff with `git diff --check`.