### PR TITLE
fix(mode): honor last duplicate env value

### DIFF
--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -25,8 +25,21 @@ success() { echo -e "${GREEN}✓${NC} $1"; }
 warn() { echo -e "${YELLOW}⚠${NC} $1"; }
 error() { echo -e "${RED}✗${NC} $1" >&2; exit 1; }
 
-# Update or add a key=value in .env
-# Uses awk index() instead of sed to avoid delimiter collisions
+# Match Docker Compose's last-value precedence for duplicate .env keys.
+env_get_last() {
+    local key="$1"
+    [[ -f "$ENV_FILE" ]] || return 0
+    awk -v key="$key" '
+        index($0, key "=") == 1 {
+            value = substr($0, length(key) + 2)
+            found = 1
+        }
+        END { if (found) print value }
+    ' "$ENV_FILE" | tr -d '"\047\r'
+}
+
+# Update or add a key=value in .env.
+# Uses awk index() instead of sed to avoid delimiter collisions.
 env_set() {
     local key="$1" val="$2"
     if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
@@ -41,10 +54,7 @@ env_set() {
 show_status() {
     local current=""
     if [[ -f "$ENV_FILE" ]]; then
-        # `grep` exits 1 when the key is absent and the script runs under
-        # `set -euo pipefail`, so a bare pipeline here aborted the whole script
-        # before the default below could apply — status printed nothing at all.
-        current=$(grep -m1 "^ODS_MODE=" "$ENV_FILE" | cut -d= -f2- | tr -d '"\047\r' || true)
+        current="$(env_get_last ODS_MODE)"
     else
         warn ".env not found at $ENV_FILE — showing defaults"
     fi
@@ -68,7 +78,7 @@ switch_mode() {
     [[ -f "$ENV_FILE" ]] || error ".env not found at $ENV_FILE"
 
     local configured_backend
-    configured_backend=$(grep -m1 "^LLM_BACKEND=" "$ENV_FILE" 2>/dev/null | cut -d= -f2- | tr -d '"\047\r' || true)
+    configured_backend="$(env_get_last LLM_BACKEND)"
     if [[ "${configured_backend,,}" == "external" ]]; then
         error "External LLM routing is installer-managed. Run './install.sh --no-external-llm' first, then retry the mode switch."
     fi

--- a/ods/tests/test-mode-switch-status.sh
+++ b/ods/tests/test-mode-switch-status.sh
@@ -100,6 +100,10 @@ ROOT="$(new_root)"
 printf 'ODS_MODE=cloud\r\n' > "$ROOT/.env"
 check_eq "CRLF .env does not leak a carriage return" "Current mode: cloud" "$(current_mode_line "$(run_mode "$ROOT" --status)")"
 
+ROOT="$(new_root)"
+printf 'ODS_MODE=local\nODS_MODE=cloud\n' > "$ROOT/.env"
+check_eq "duplicate mode uses Compose-compatible last value" "Current mode: cloud" "$(current_mode_line "$(run_mode "$ROOT" --status)")"
+
 # ── 4. Bare invocation defaults to status ─────────────────────────────────
 
 ROOT="$(new_root)"
@@ -134,6 +138,22 @@ OUT="$(run_mode "$ROOT" cloud)"
 check_eq "external backend rejects direct mode switch" "1" "$(run_rc "$ROOT" cloud)"
 check_contains "external backend points to the transactional reset" "--no-external-llm" "$OUT"
 check_eq "rejected external mode switch leaves .env unchanged" "$BEFORE" "$(cat "$ROOT/.env")"
+
+ROOT="$(new_root)"
+cat > "$ROOT/.env" <<'EOF'
+LLM_BACKEND=llama-server
+LLM_BACKEND=external
+ODS_MODE=local
+EOF
+check_eq "last duplicate external backend blocks switching" "1" "$(run_rc "$ROOT" cloud)"
+
+ROOT="$(new_root)"
+cat > "$ROOT/.env" <<'EOF'
+LLM_BACKEND=external
+LLM_BACKEND=llama-server
+ODS_MODE=local
+EOF
+check_eq "last duplicate local backend permits switching" "0" "$(run_rc "$ROOT" cloud)"
 
 # ── 7. Bad input is rejected ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- read the last exact `ODS_MODE` and `LLM_BACKEND` assignment from `.env`, matching Docker Compose precedence
- report the effective mode when upgrades or reruns leave duplicate keys
- enforce external-backend switching guards from the effective value instead of a stale earlier line
- add regression coverage for both duplicate-value orderings

## AI Assistance

Codex identified the precedence mismatch, built red regression cases for status and backend safety decisions, implemented the focused parser, and ran validation. The human author remains responsible for the final diff and review responses.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — isolated mode status/switch decisions now match the runtime `.env` consumer
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because: compose files and service startup behavior are unchanged

Commands/results:

```text
bash tests/test-mode-switch-status.sh
23 passed, 0 failed

bash -n scripts/mode-switch.sh tests/test-mode-switch-status.sh
passed

git diff --check
passed
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The external-backend guard is safety-sensitive in both directions: `local` then `external` must block a partial mode switch, while `external` then `llama-server` must not remain falsely blocked by stale history. The test covers both orderings. Rollback is a one-commit revert.