### PR TITLE
fix(workflows): validate n8n list responses

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -58,7 +58,16 @@ async def get_n8n_workflows() -> list[dict]:
             async with session.get(f"{N8N_URL}/api/v1/workflows", headers=headers) as resp:
                 if resp.status == 200:
                     data = await resp.json()
-                    return data.get("data", [])
+                    if not isinstance(data, dict):
+                        logger.warning("n8n workflows response must be a JSON object")
+                        return []
+                    workflows = data.get("data", [])
+                    if not isinstance(workflows, list) or not all(
+                        isinstance(workflow, dict) for workflow in workflows
+                    ):
+                        logger.warning("n8n workflows response contains invalid workflow data")
+                        return []
+                    return workflows
     except (aiohttp.ClientError, OSError, json.JSONDecodeError) as e:
         logger.warning(f"Failed to fetch workflows from n8n: {e}")
     return []

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -191,6 +191,38 @@ def test_get_n8n_workflows_failure(test_client, monkeypatch):
     assert result == []
 
 
+@pytest.mark.parametrize(
+    "n8n_data",
+    [
+        [],
+        {"data": "not-a-list"},
+        {"data": [None]},
+    ],
+)
+def test_get_n8n_workflows_rejects_malformed_payload(test_client, n8n_data):
+    """Malformed successful responses must not crash workflow endpoints."""
+    import asyncio
+    import routers.workflows as wf_mod
+
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(return_value=n8n_data)
+
+    response_context = AsyncMock()
+    response_context.__aenter__ = AsyncMock(return_value=resp_mock)
+    response_context.__aexit__ = AsyncMock(return_value=False)
+
+    session_mock = AsyncMock()
+    session_mock.get = MagicMock(return_value=response_context)
+    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+    session_mock.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+        result = asyncio.run(wf_mod.get_n8n_workflows())
+
+    assert result == []
+
+
 # ---------------------------------------------------------------------------
 # check_workflow_dependencies() unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate successful n8n workflow-list responses before consuming them
- treat non-object payloads, non-list `data`, and malformed workflow entries as unavailable data
- add regression coverage for each malformed response shape

## Tests
- `pytest tests/test_workflows.py -q` (48 passed)
- `python -m py_compile routers/workflows.py tests/test_workflows.py`
- `git diff --check`