### PR TITLE
fix(bootstrap): read effective env values

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -119,6 +119,9 @@ test: ## Run unit and contract tests
 	@echo "=== bootstrap-upgrade compose-flags recovery ==="
 	@bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
 	@echo ""
+	@echo "=== bootstrap-upgrade env parsing ==="
+	@bash tests/test-bootstrap-upgrade-env-values.sh
+	@echo ""
 	@echo "=== macOS ods-host-agent bootstrap verification ==="
 	@bash tests/test-macos-host-agent-verification.sh
 	@echo ""

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -526,10 +526,29 @@ sync_windows_opencode_config() {
         >/dev/null 2>&1 || log "WARNING: OpenCode config refresh failed (non-fatal)"
 }
 
+read_env_file_value() {
+    local env_path="$1" key="$2" value
+    [[ -f "$env_path" ]] || return 0
+    value="$(awk -v key="$key" '
+        index($0, key "=") == 1 {
+            value = substr($0, length(key) + 2)
+            found = 1
+        }
+        END { if (found) print value }
+    ' "$env_path")"
+    value="${value%$'\r'}"
+    if [[ "$value" == '"'*'"' ]]; then
+        value="${value#\"}"
+        value="${value%\"}"
+    elif [[ "$value" == "'"*"'" ]]; then
+        value="${value#\'}"
+        value="${value%\'}"
+    fi
+    printf '%s\n' "$value"
+}
+
 read_env_value() {
-    local key="$1"
-    [[ -f "$ENV_FILE" ]] || return 0
-    grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"\047\r'
+    read_env_file_value "$ENV_FILE" "$1"
 }
 
 write_env_value() {
@@ -1664,8 +1683,7 @@ restart_windows_lemonade_dependents_after_rollback() {
 
 snapshot_env_value() {
     local key="$1" snapshot_env="${ACTIVE_CONFIG_SNAPSHOT_DIR:-}/env"
-    [[ -f "$snapshot_env" ]] || return 0
-    grep -E "^${key}=" "$snapshot_env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"\047\r'
+    read_env_file_value "$snapshot_env" "$key"
 }
 
 rollback_windows_lemonade_swap() {

--- a/ods/tests/test-bootstrap-upgrade-env-values.sh
+++ b/ods/tests/test-bootstrap-upgrade-env-values.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression coverage for bootstrap-upgrade .env reads used by model promotion
+# and Windows Lemonade rollback.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-bootstrap-env.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+extract_function() {
+    local name="$1"
+    awk -v signature="$name() {" '
+        $0 == signature { capture = 1 }
+        capture { print }
+        capture && $0 == "}" { exit }
+    ' "$TARGET"
+}
+
+eval "$(extract_function read_env_file_value)"
+eval "$(extract_function read_env_value)"
+eval "$(extract_function snapshot_env_value)"
+
+ENV_FILE="$FIXTURE/.env"
+cat > "$ENV_FILE" <<'EOF'
+LLM_MODEL=stale-model
+TOKEN=left=middle=right
+QUOTED="outer=value"
+INNER_QUOTE=abc"def
+LLM_MODEL=active-model
+EOF
+
+[[ "$(read_env_value LLM_MODEL)" == "active-model" ]] \
+    || { echo "FAIL: active env did not use the last duplicate value" >&2; exit 1; }
+[[ "$(read_env_value TOKEN)" == "left=middle=right" ]] \
+    || { echo "FAIL: active env truncated equals signs" >&2; exit 1; }
+[[ "$(read_env_value QUOTED)" == "outer=value" ]] \
+    || { echo "FAIL: active env did not strip matching outer quotes" >&2; exit 1; }
+[[ "$(read_env_value INNER_QUOTE)" == 'abc"def' ]] \
+    || { echo "FAIL: active env removed an interior quote" >&2; exit 1; }
+
+ACTIVE_CONFIG_SNAPSHOT_DIR="$FIXTURE/snapshot"
+mkdir -p "$ACTIVE_CONFIG_SNAPSHOT_DIR"
+printf 'GGUF_FILE=old.gguf\r\nGGUF_FILE="restored.gguf"\r\n' \
+    > "$ACTIVE_CONFIG_SNAPSHOT_DIR/env"
+
+[[ "$(snapshot_env_value GGUF_FILE)" == "restored.gguf" ]] \
+    || { echo "FAIL: snapshot env did not use and normalize the last value" >&2; exit 1; }
+
+echo "PASS: bootstrap upgrade reads active and snapshot env values safely"


### PR DESCRIPTION
## Summary
- make bootstrap-upgrade env reads follow the effective last duplicate value used by Compose
- preserve embedded quotes and equals signs while stripping only matching outer quotes and CRLF endings
- share the parser between active configuration and rollback snapshots
- add the regression suite to the main test gate

## Tests
- `bash tests/test-bootstrap-upgrade-env-values.sh`
- `bash tests/test-bootstrap-upgrade-hotswap-contract.sh`
- `bash -n scripts/bootstrap-upgrade.sh tests/test-bootstrap-upgrade-env-values.sh`
- `git diff --check`