### PR TITLE
fix(models): validate benchmark introspection payloads

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -1762,26 +1762,41 @@ async def _fetch_llama_loaded_model(host: str, port: int, api_prefix: str) -> st
                 resp = await client.get(f"{base_url}{api_prefix}/health")
                 resp.raise_for_status()
                 health = resp.json()
-                loaded = health.get("model_loaded")
-                if loaded:
-                    return loaded
-                if "model_loaded" in health:
-                    return None
+                if isinstance(health, dict):
+                    loaded = health.get("model_loaded")
+                    if isinstance(loaded, str) and loaded:
+                        return loaded
+                    if "model_loaded" in health and loaded is None:
+                        return None
             except (httpx.HTTPError, ValueError):
                 pass
 
         try:
             resp = await client.get(f"{base_url}{api_prefix}/models")
             resp.raise_for_status()
-            data = resp.json().get("data") or []
+            payload = resp.json()
+            if not isinstance(payload, dict):
+                raise ValueError("model list response must be an object")
+            data = payload.get("data") or []
+            if not isinstance(data, list):
+                raise ValueError("model list data must be a list")
             for model in data:
+                if not isinstance(model, dict):
+                    continue
                 status = model.get("status", {})
-                if isinstance(status, dict) and status.get("value") == "loaded":
-                    return model.get("id")
+                model_id = model.get("id")
+                if (
+                    isinstance(status, dict)
+                    and status.get("value") == "loaded"
+                    and isinstance(model_id, str)
+                    and model_id
+                ):
+                    return model_id
             if lemonade_api:
                 return None
-            if data and data[0].get("id"):
-                return data[0]["id"]
+            for model in data:
+                if isinstance(model, dict) and isinstance(model.get("id"), str):
+                    return model["id"]
         except (httpx.HTTPError, ValueError):
             pass
 
@@ -1789,10 +1804,14 @@ async def _fetch_llama_loaded_model(host: str, port: int, api_prefix: str) -> st
             resp = await client.get(f"{base_url}/props")
             resp.raise_for_status()
             props = resp.json()
-            if props.get("model_alias"):
-                return props["model_alias"]
-            if props.get("model_path"):
-                return Path(props["model_path"]).name
+            if not isinstance(props, dict):
+                raise ValueError("model props response must be an object")
+            model_alias = props.get("model_alias")
+            if isinstance(model_alias, str) and model_alias:
+                return model_alias
+            model_path = props.get("model_path")
+            if isinstance(model_path, str) and model_path:
+                return Path(model_path).name
         except (httpx.HTTPError, ValueError):
             return None
     return None

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -1214,6 +1214,95 @@ def test_fetch_loaded_model_does_not_prefer_configured_lemonade_gguf_when_health
     ]
 
 
+def test_fetch_loaded_model_skips_malformed_model_entries(monkeypatch):
+    """Malformed model rows fall through to the props endpoint."""
+    import routers.models as models_router
+
+    seen_urls: list[str] = []
+
+    class _Response:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class _Client:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            seen_urls.append(url)
+            if url.endswith("/health"):
+                return _Response([])
+            if url.endswith("/models"):
+                return _Response({"data": [None, {"id": 42}]})
+            return _Response({"model_path": "/models/fallback.gguf"})
+
+    monkeypatch.setenv("LLM_URL", "http://host.docker.internal:8080")
+    monkeypatch.setattr(models_router.httpx, "AsyncClient", _Client)
+
+    result = asyncio.run(
+        models_router._fetch_llama_loaded_model("llama-server", 8080, "/v1")
+    )
+
+    assert result == "fallback.gguf"
+    assert seen_urls == [
+        "http://host.docker.internal:8080/v1/models",
+        "http://host.docker.internal:8080/props",
+    ]
+
+
+def test_fetch_loaded_model_falls_back_after_malformed_lemonade_health(monkeypatch):
+    """A non-object health payload must not block the model-list fallback."""
+    import routers.models as models_router
+
+    class _Response:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class _Client:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            if url.endswith("/health"):
+                return _Response([])
+            return _Response({
+                "data": [{"id": "loaded.gguf", "status": {"value": "loaded"}}]
+            })
+
+    monkeypatch.setenv("LLM_URL", "http://host.docker.internal:8080")
+    monkeypatch.setattr(models_router.httpx, "AsyncClient", _Client)
+
+    result = asyncio.run(
+        models_router._fetch_llama_loaded_model("llama-server", 8080, "/api/v1")
+    )
+
+    assert result == "loaded.gguf"
+
+
 def test_already_active_model_uses_env_file_before_stale_process_env(
     monkeypatch,
     tmp_path,


### PR DESCRIPTION
## Summary
- validate benchmark model introspection payloads before nested access
- accept only non-empty string model identifiers and paths
- skip malformed model-list entries and fall through to the next authoritative endpoint
- preserve Lemonade's explicit `model_loaded: null` contract

## Tests
- `pytest tests/test_models.py -q` (104 passed)
- `python -m py_compile routers/models.py tests/test_models.py`
- `git diff --check`