### PR TITLE
fix(privacy): validate shield statistics

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/privacy.py
+++ b/ods/extensions/services/dashboard-api/routers/privacy.py
@@ -1,6 +1,7 @@
 """Privacy Shield management endpoints."""
 
 import asyncio
+import json
 import logging
 import os
 
@@ -21,6 +22,22 @@ from security import verify_api_key
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["privacy"])
+
+_PRIVACY_STATS_TYPES = {
+    "cache_enabled": bool,
+    "cache_size": int,
+    "active_sessions": int,
+    "total_pii_scrubbed": int,
+}
+
+
+def _validated_privacy_stats(value: object) -> dict | None:
+    """Validate the response contract exposed by privacy-shield /stats."""
+    if not isinstance(value, dict):
+        return None
+    if any(type(value.get(key)) is not expected for key, expected in _PRIVACY_STATS_TYPES.items()):
+        return None
+    return value
 
 
 @router.get("/api/privacy-shield/status", response_model=PrivacyShieldStatus)
@@ -105,9 +122,16 @@ async def get_privacy_shield_stats(api_key: str = Depends(verify_api_key)):
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5)) as session:
             async with session.get(f"{shield_url}/stats", headers=headers) as resp:
                 if resp.status == 200:
-                    return await resp.json()
+                    stats = _validated_privacy_stats(await resp.json())
+                    if stats is not None:
+                        return stats
+                    logger.warning("Privacy Shield returned malformed statistics")
+                    return {
+                        "error": "Privacy Shield returned invalid statistics",
+                        "enabled": False,
+                    }
                 else:
                     return {"error": "Privacy Shield not responding", "status": resp.status}
-    except (asyncio.TimeoutError, aiohttp.ClientError, OSError):
+    except (asyncio.TimeoutError, aiohttp.ClientError, json.JSONDecodeError, OSError):
         logger.exception("Cannot reach Privacy Shield")
         return {"error": "Cannot reach Privacy Shield", "enabled": False}

--- a/ods/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/ods/extensions/services/dashboard-api/tests/test_privacy.py
@@ -1,5 +1,7 @@
 """Tests for privacy router endpoints."""
 
+import json
+
 import aiohttp
 from unittest.mock import patch, AsyncMock, MagicMock
 
@@ -193,7 +195,13 @@ def test_privacy_shield_stats_success(test_client):
     """
     resp_mock = AsyncMock()
     resp_mock.status = 200
-    resp_mock.json = AsyncMock(return_value={"requests": 42, "pii_detected": 3})
+    stats = {
+        "cache_enabled": True,
+        "cache_size": 1000,
+        "active_sessions": 2,
+        "total_pii_scrubbed": 42,
+    }
+    resp_mock.json = AsyncMock(return_value=stats)
 
     ctx = AsyncMock()
     ctx.__aenter__ = AsyncMock(return_value=resp_mock)
@@ -210,12 +218,61 @@ def test_privacy_shield_stats_success(test_client):
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["requests"] == 42
+    assert data == stats
 
     # The upstream call must forward a Bearer token built from SHIELD_API_KEY.
     session_mock.get.assert_called_once()
     forwarded_headers = session_mock.get.call_args.kwargs.get("headers", {})
     assert forwarded_headers.get("Authorization") == "Bearer test-shield-key-fixture"
+
+
+def test_privacy_shield_stats_rejects_malformed_payload(test_client):
+    """A successful response with the wrong schema is reported without a 500."""
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(return_value={"active_sessions": "two"})
+
+    response_context = AsyncMock()
+    response_context.__aenter__ = AsyncMock(return_value=resp_mock)
+    response_context.__aexit__ = AsyncMock(return_value=False)
+    session_mock = MagicMock()
+    session_mock.get = MagicMock(return_value=response_context)
+    session_context = AsyncMock()
+    session_context.__aenter__ = AsyncMock(return_value=session_mock)
+    session_context.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.privacy.aiohttp.ClientSession", return_value=session_context):
+        resp = test_client.get("/api/privacy-shield/stats", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "error": "Privacy Shield returned invalid statistics",
+        "enabled": False,
+    }
+
+
+def test_privacy_shield_stats_handles_invalid_json(test_client):
+    """Invalid JSON from the service follows the existing unavailable contract."""
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(
+        side_effect=json.JSONDecodeError("invalid stats", "not-json", 0)
+    )
+
+    response_context = AsyncMock()
+    response_context.__aenter__ = AsyncMock(return_value=resp_mock)
+    response_context.__aexit__ = AsyncMock(return_value=False)
+    session_mock = MagicMock()
+    session_mock.get = MagicMock(return_value=response_context)
+    session_context = AsyncMock()
+    session_context.__aenter__ = AsyncMock(return_value=session_mock)
+    session_context.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.privacy.aiohttp.ClientSession", return_value=session_context):
+        resp = test_client.get("/api/privacy-shield/stats", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"error": "Cannot reach Privacy Shield", "enabled": False}
 
 
 def test_privacy_shield_stats_missing_shield_key(test_client, monkeypatch):


### PR DESCRIPTION
## Summary
- validate Privacy Shield `/stats` responses against the service's documented schema
- reject malformed successful payloads without leaking them into the dashboard API contract
- map invalid JSON to the existing service-unavailable response
- update the success fixture to mirror the real Privacy Shield payload

## Tests
- `pytest tests/test_privacy.py -q` (19 passed)
- `python -m py_compile routers/privacy.py tests/test_privacy.py`
- `git diff --check`