### PR TITLE
fix(dashboard-api): handle encoding and permission errors in load_workflow_catalog in workflows.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -31,7 +31,7 @@ def load_workflow_catalog() -> dict:
     if not WORKFLOW_CATALOG_FILE.exists():
         return DEFAULT_WORKFLOW_CATALOG
     try:
-        with open(WORKFLOW_CATALOG_FILE) as f:
+        with open(WORKFLOW_CATALOG_FILE, encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
             logger.warning("Workflow catalog must be a JSON object: %s", WORKFLOW_CATALOG_FILE)
@@ -43,7 +43,7 @@ def load_workflow_catalog() -> dict:
         if not isinstance(categories, dict):
             categories = {}
         return {"workflows": workflows, "categories": categories}
-    except (json.JSONDecodeError, OSError, KeyError) as e:
+    except (json.JSONDecodeError, OSError, ValueError, KeyError) as e:
         logger.warning("Failed to load workflow catalog from %s: %s", WORKFLOW_CATALOG_FILE, e)
         return DEFAULT_WORKFLOW_CATALOG
 


### PR DESCRIPTION
## Context

In `ods/extensions/services/dashboard-api/routers/workflows.py`, `load_workflow_catalog()` opens `WORKFLOW_CATALOG_FILE` to read catalog definitions. The file was previously opened without an explicit encoding parameter, and the exception handling block omitted `ValueError` when decoding raw content.

## Solution

1. Specify `encoding="utf-8"` in `open(WORKFLOW_CATALOG_FILE)`.
2. Add `ValueError` to the exception tuple caught during catalog file loading, ensuring clean fallback to `DEFAULT_WORKFLOW_CATALOG`.

## Validation

- Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed).
- Verified clean git diff with `git diff --check`.