### PR TITLE
fix(dashboard-api): use explicit UTF-8 decoding when reading version file in node.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/node.py
+++ b/ods/extensions/services/dashboard-api/routers/node.py
@@ -49,7 +49,7 @@ def _read_ods_version(fallback: str) -> str:
 
     version_file = root / ".version"
     try:
-        raw = version_file.read_text().strip()
+        raw = version_file.read_text(encoding="utf-8", errors="replace").strip()
         if raw:
             if raw.startswith("{"):
                 data = json.loads(raw)


### PR DESCRIPTION
## Context

In `ods/extensions/services/dashboard-api/routers/node.py`, `_read_ods_version()` reads system version data from the `.version` file at the install root. The file was previously read with system default encoding (`version_file.read_text()`), which can cause decoding errors on systems running non-UTF-8 default locales.

## Solution

Update `_read_ods_version()` in `node.py` to read the version file with explicit `encoding="utf-8"` and `errors="replace"`.

## Validation

- Ran `pytest ods/extensions/services/dashboard-api/tests/test_node.py` (11/11 passed).
- Verified clean git diff with `git diff --check`.