### PR TITLE
fix(cold-storage): remove bc age dependency

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -119,6 +119,9 @@ test: ## Run unit and contract tests
 	@echo "=== bootstrap-upgrade compose-flags recovery ==="
 	@bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
 	@echo ""
+	@echo "=== LLM cold-storage access age ==="
+	@bash tests/test-llm-cold-storage-age.sh
+	@echo ""
 	@echo "=== macOS ods-host-agent bootstrap verification ==="
 	@bash tests/test-macos-host-agent-verification.sh
 	@echo ""

--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -77,8 +77,13 @@ get_last_access_days() {
     fi
     local now
     now="$(date +%s)"
-    local age_secs
-    age_secs="$(echo "$now - ${newest_atime%.*}" | bc)"
+    newest_atime="${newest_atime%.*}"
+    if [[ ! "$now" =~ ^[0-9]+$ || ! "$newest_atime" =~ ^[0-9]+$ ]]; then
+        echo "0"
+        return
+    fi
+    local age_secs=$(( now - newest_atime ))
+    (( age_secs < 0 )) && age_secs=0
     echo "$(( age_secs / 86400 ))"
 }
 

--- a/ods/tests/test-llm-cold-storage-age.sh
+++ b/ods/tests/test-llm-cold-storage-age.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/llm-cold-storage.sh"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-cold-age.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+awk '
+    /^get_last_access_days\(\) \{/ { capture = 1 }
+    capture { print }
+    capture && /^}/ { exit }
+' "$TARGET" > "$FIXTURE/function.sh"
+# shellcheck source=/dev/null
+. "$FIXTURE/function.sh"
+
+mkdir -p "$FIXTURE/bin"
+cat > "$FIXTURE/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+echo Linux
+EOF
+cat > "$FIXTURE/bin/find" <<'EOF'
+#!/usr/bin/env bash
+echo 100000
+EOF
+cat > "$FIXTURE/bin/date" <<'EOF'
+#!/usr/bin/env bash
+echo 272800
+EOF
+cat > "$FIXTURE/bin/bc" <<'EOF'
+#!/usr/bin/env bash
+echo "bc must not be called" >&2
+exit 99
+EOF
+chmod +x "$FIXTURE/bin/"*
+
+age="$(PATH="$FIXTURE/bin:$PATH" get_last_access_days "$FIXTURE")"
+[[ "$age" == "2" ]] || { echo "FAIL: expected 2 days, got '$age'" >&2; exit 1; }
+
+cat > "$FIXTURE/bin/find" <<'EOF'
+#!/usr/bin/env bash
+echo 300000
+EOF
+future_age="$(PATH="$FIXTURE/bin:$PATH" get_last_access_days "$FIXTURE")"
+[[ "$future_age" == "0" ]] \
+    || { echo "FAIL: future timestamps must clamp to 0 days, got '$future_age'" >&2; exit 1; }
+
+echo "PASS: cold-storage age calculation is dependency-free and bounded"


### PR DESCRIPTION
## Summary
- replace the `bc` subprocess with Bash integer arithmetic for model access ages
- fail safe on malformed timestamps and clamp future access times to zero days
- add a regression test that disables `bc` and covers normal and future timestamps
- run the new test from the main test gate

## Tests
- `bash tests/test-llm-cold-storage-age.sh`
- `bash -n scripts/llm-cold-storage.sh tests/test-llm-cold-storage-age.sh`
- `git diff --check`