### PR TITLE
refactor(doctor): use shared env loader

### DIFF
--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -37,27 +37,12 @@ if [[ -f "$ROOT_DIR/lib/service-registry.sh" ]]; then
     . "$ROOT_DIR/lib/service-registry.sh"
     sr_load
 fi
-if [[ -f "$ROOT_DIR/lib/safe-env.sh" ]]; then
-    . "$ROOT_DIR/lib/safe-env.sh"
+if [[ ! -f "$ROOT_DIR/lib/safe-env.sh" ]]; then
+    echo "lib/safe-env.sh not found" >&2
+    exit 1
 fi
-
-# Safe .env loading (no direct source to avoid injection)
-load_env_safe() {
-    local env_file="${1:-$ROOT_DIR/.env}"
-    [[ -f "$env_file" ]] || return 0
-    while IFS='=' read -r key value; do
-        value="${value%$'\r'}"
-        [[ "$key" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "$key" ]] && continue
-        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        value="${value%\"}"
-        value="${value#\"}"
-        value="${value%\'}"
-        value="${value#\'}"
-        export "$key=$value"
-    done < "$env_file"
-}
-load_env_safe "$ROOT_DIR/.env"
+. "$ROOT_DIR/lib/safe-env.sh"
+load_env_file "$ROOT_DIR/.env"
 sr_resolve_ports
 _DASHBOARD_PORT="${SERVICE_PORTS[dashboard]:-3001}"
 _WEBUI_PORT="${SERVICE_PORTS[open-webui]:-3000}"

--- a/ods/tests/test-ods-doctor.sh
+++ b/ods/tests/test-ods-doctor.sh
@@ -297,7 +297,7 @@ EOF
     cat << 'EOF' > "$REAL_ENV"
 EXTERNAL_LLM_URL="https://mock-llm.example.com"
 EXTERNAL_LLM_PROVIDER="ollama"
-EXTERNAL_LLM_MODEL="llama3-test"
+EXTERNAL_LLM_MODEL=llama3-test"
 EOF
 
     rm -f /tmp/curl_calls.log
@@ -338,8 +338,8 @@ EOF
     if [[ "$status" == "ok" ]] && \
        [[ "$provider" == "ollama" ]] && \
        [[ "$url" == "https://mock-llm.example.com" ]] && \
-       [[ "$model" == "llama3-test" ]]; then
-        pass "External LLM report JSON contains correct unquoted fields"
+       [[ "$model" == 'llama3-test"' ]]; then
+        pass "External LLM report preserves mismatched quotes via the shared env loader"
     else
         fail "External LLM report JSON fields are incorrect. got: status=$status, provider=$provider, url=$url, model=$model"
     fi


### PR DESCRIPTION
## Summary
- remove the doctor-specific `.env` parser
- load persisted settings through the same injection-safe parser used by ODS lifecycle commands
- fail clearly if the shared parser is missing
- add behavioral coverage proving mismatched quotes are preserved instead of silently stripped

## Tests
- `bash tests/test-ods-doctor.sh` (24 passed)
- `bash -n scripts/ods-doctor.sh tests/test-ods-doctor.sh`
- `git diff --check`