### PR TITLE
fix(migrate): compare prerelease versions safely

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -84,7 +84,15 @@ compare_versions() {
     for i in {0..2}; do
         local p1="${V1_PARTS[$i]:-0}"
         local p2="${V2_PARTS[$i]:-0}"
-        
+
+        # Migration filenames target major.minor.patch. Compare that numeric
+        # core even when a release version carries a prerelease/build suffix,
+        # and force base 10 so zero-padded components such as 08 stay valid.
+        p1="${p1%%[!0-9]*}"
+        p2="${p2%%[!0-9]*}"
+        p1=$((10#${p1:-0}))
+        p2=$((10#${p2:-0}))
+
         if [[ "$p1" -gt "$p2" ]]; then
             return 1
         elif [[ "$p1" -lt "$p2" ]]; then

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -237,6 +237,29 @@ else
     fail "Behavioral test: check misreported up-to-date state (exit $check_exit): $check_output"
 fi
 
+# Test 13: prerelease suffixes and zero-padded components compare by their
+# numeric semantic-version core instead of causing a Bash integer error.
+echo "v2.08.0-rc.1" > "$INSTALL_DIR/.version"
+echo "2.7.9" > "$DATA_DIR/.migration-state"
+check_exit=0
+check_output=$(bash "$MIGRATE_CONFIG_SCRIPT" check 2>&1) || check_exit=$?
+if [[ $check_exit -eq 2 ]] && echo "$check_output" | grep -q "Migration needed"; then
+    pass "Behavioral test: prerelease and zero-padded versions compare safely"
+else
+    fail "Behavioral test: prerelease comparison failed (exit $check_exit): $check_output"
+fi
+
+# A prerelease and its final release share the same migration core, so no
+# migration should be replayed solely because the suffix differs.
+echo "2.8.0" > "$DATA_DIR/.migration-state"
+check_exit=0
+check_output=$(bash "$MIGRATE_CONFIG_SCRIPT" check 2>&1) || check_exit=$?
+if [[ $check_exit -eq 0 ]] && echo "$check_output" | grep -q "No migration needed"; then
+    pass "Behavioral test: prerelease suffix does not replay core migration"
+else
+    fail "Behavioral test: prerelease suffix replayed migration (exit $check_exit): $check_output"
+fi
+
 # ============================================================================
 # Summary
 # ============================================================================


### PR DESCRIPTION
## Summary
- compare the numeric semantic-version core used by migration filenames
- tolerate prerelease/build suffixes without Bash integer errors
- force base-10 comparison for zero-padded version components
- avoid replaying a core migration solely because a prerelease suffix differs

## Tests
- `bash tests/test-migrate-config.sh` (16 passed)
- `bash -n scripts/migrate-config.sh tests/test-migrate-config.sh`
- `git diff --check`