### PR TITLE
fix(download): reject decoded artifact traversal

### DIFF
--- a/ods/scripts/download-hf-artifact.py
+++ b/ods/scripts/download-hf-artifact.py
@@ -15,6 +15,13 @@ from pathlib import Path
 from urllib.parse import unquote, urlparse
 
 
+def _validate_path_parts(parts: list[str], label: str) -> None:
+    """Reject decoded path components that could escape their namespace."""
+    for part in parts:
+        if not part or part in {".", ".."} or "\\" in part or "\x00" in part:
+            raise ValueError(f"Hugging Face {label} contains an unsafe path component")
+
+
 def parse_huggingface_resolve_url(url: str) -> tuple[str, str, str]:
     parsed = urlparse(url)
     host = parsed.netloc.lower()
@@ -25,11 +32,15 @@ def parse_huggingface_resolve_url(url: str) -> tuple[str, str, str]:
     if len(parts) < 5 or parts[2] != "resolve":
         raise ValueError("URL is not a Hugging Face /resolve/ artifact URL")
 
+    _validate_path_parts(parts[:2], "repository")
+    if any("/" in part for part in parts[:2]):
+        raise ValueError("Hugging Face repository contains an unsafe path component")
+
     repo_id = f"{parts[0]}/{parts[1]}"
     revision = parts[3]
     filename = "/".join(parts[4:])
-    if not filename:
-        raise ValueError("Hugging Face artifact filename is empty")
+    _validate_path_parts(revision.split("/"), "revision")
+    _validate_path_parts(filename.split("/"), "artifact filename")
     return repo_id, revision, filename
 
 

--- a/ods/tests/test_hf_download_helper.py
+++ b/ods/tests/test_hf_download_helper.py
@@ -54,6 +54,22 @@ def test_parse_huggingface_resolve_url_rejects_non_hf_url():
         helper.parse_huggingface_resolve_url("https://example.com/model.gguf")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://huggingface.co/org/repo/resolve/main/%2e%2e/secret.gguf",
+        "https://huggingface.co/org/repo/resolve/main/dir%5csecret.gguf",
+        "https://huggingface.co/org%2frepo/name/resolve/main/model.gguf",
+        "https://huggingface.co/org/repo/resolve/%2e%2e/model.gguf",
+    ],
+)
+def test_parse_huggingface_resolve_url_rejects_decoded_traversal(url):
+    helper = _load_helper()
+
+    with pytest.raises(ValueError, match="unsafe path component"):
+        helper.parse_huggingface_resolve_url(url)
+
+
 def test_download_snapshot_passes_cache_revision_and_patterns(monkeypatch, tmp_path):
     helper = _load_snapshot_helper()
     calls = []


### PR DESCRIPTION
## Summary
- validate Hugging Face repository, revision, and artifact path components after URL decoding
- reject dot traversal, backslash separators, NULs, and encoded repository separators
- preserve valid nested artifact filenames
- add focused traversal regression coverage

## Tests
- `pytest tests/test_hf_download_helper.py -q` (7 passed)
- `python -m py_compile scripts/download-hf-artifact.py tests/test_hf_download_helper.py`
- `git diff --check`