### PR TITLE
fix(healthcheck): reject non-finite timeouts

### DIFF
--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import socket
 import sys
@@ -308,12 +309,17 @@ def main(argv: Sequence[str]) -> int:
             print(f"[FAIL] {res.detail}")
         return 2
 
-    if args.timeout <= 0:
-        res = Result(ok=False, target=args.target, kind=kind, detail="--timeout must be > 0")
+    if not math.isfinite(args.timeout) or args.timeout <= 0:
+        res = Result(
+            ok=False,
+            target=args.target,
+            kind=kind,
+            detail="--timeout must be a finite number > 0",
+        )
         if args.json:
             print(res.to_json())
         else:
-            print("[FAIL] --timeout must be > 0")
+            print(f"[FAIL] {res.detail}")
         return 2
 
     if args.retries < 0 or args.retries > 50:

--- a/ods/tests/test_healthcheck_cli.py
+++ b/ods/tests/test_healthcheck_cli.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "healthcheck.py"
+
+
+def _load_healthcheck():
+    spec = importlib.util.spec_from_file_location("ods_healthcheck", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("timeout", ["nan", "inf", "-inf", "0", "-1"])
+def test_main_rejects_non_finite_and_non_positive_timeouts(timeout, capsys):
+    healthcheck = _load_healthcheck()
+
+    exit_code = healthcheck.main(
+        ["tcp://127.0.0.1:1", f"--timeout={timeout}", "--json"]
+    )
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["detail"] == "--timeout must be a finite number > 0"


### PR DESCRIPTION
## Summary

- reject NaN, infinite, and non-positive healthcheck timeouts before network I/O
- return the same machine-readable usage error in JSON mode
- cover all invalid floating-point forms with parameterized CLI tests

## Validation

- `pytest tests/test_healthcheck_cli.py -q`
- `python -m py_compile scripts/healthcheck.py tests/test_healthcheck_cli.py`
- `git diff --check`