### PR TITLE
feat(maintenance): add JSON stale-branch reports

### DIFF
--- a/ods/docs/BRANCH_HYGIENE.md
+++ b/ods/docs/BRANCH_HYGIENE.md
@@ -50,6 +50,13 @@ anything:
 python ods/scripts/maintainers/list-stale-branches.py --days 45
 ```
 
+For automation, request a single JSON document instead of the human-readable
+report:
+
+```bash
+python ods/scripts/maintainers/list-stale-branches.py --days 45 --format json
+```
+
 By default the helper excludes `main`, `master`, `develop`, `release/*`,
 `support/*`, and branches backing open PRs when the GitHub CLI is available.
 

--- a/ods/scripts/maintainers/list-stale-branches.py
+++ b/ods/scripts/maintainers/list-stale-branches.py
@@ -79,31 +79,14 @@ def remote_branches() -> list[tuple[datetime, str, str]]:
     return branches
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--days", type=int, default=45, help="stale age threshold")
-    parser.add_argument(
-        "--include-open-prs",
-        action="store_true",
-        help="do not exclude branches that back open PRs",
-    )
-    args = parser.parse_args()
-
-    root = repo_root()
-    heads = set() if args.include_open_prs else open_pr_heads()
-    now = datetime.now(timezone.utc)
-    cutoff_days = args.days
-
-    print(f"Repository: {root}")
-    print(f"Stale threshold: {cutoff_days} days")
-    if heads:
-        print(f"Excluding {len(heads)} open PR branch(es)")
-    elif not args.include_open_prs:
-        print("Open PR branch exclusion unavailable or empty")
-    print()
-
+def find_candidates(
+    branches: list[tuple[datetime, str, str]],
+    heads: set[str],
+    cutoff_days: int,
+    now: datetime,
+) -> list[tuple[int, str, str, str]]:
     candidates: list[tuple[int, str, str, str]] = []
-    for date, ref, sha in remote_branches():
+    for date, ref, sha in branches:
         if ref in DEFAULT_EXCLUDE_EXACT or ref.startswith(DEFAULT_EXCLUDE_PREFIXES):
             continue
         short = ref.removeprefix("origin/")
@@ -113,13 +96,60 @@ def main() -> int:
         if age_days < cutoff_days:
             continue
         candidates.append((age_days, ref, sha, date.date().isoformat()))
+    return sorted(candidates, reverse=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=45, help="stale age threshold")
+    parser.add_argument(
+        "--include-open-prs",
+        action="store_true",
+        help="do not exclude branches that back open PRs",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="output format (default: text)",
+    )
+    args = parser.parse_args(argv)
+    if args.days < 1:
+        parser.error("--days must be at least 1")
+
+    root = repo_root()
+    heads = set() if args.include_open_prs else open_pr_heads()
+    now = datetime.now(timezone.utc)
+    cutoff_days = args.days
+    candidates = find_candidates(remote_branches(), heads, cutoff_days, now)
+
+    if args.format == "json":
+        payload = {
+            "repository": str(root),
+            "stale_threshold_days": cutoff_days,
+            "excluded_open_pr_branches": len(heads),
+            "candidates": [
+                {"age_days": age, "date": date, "sha": sha, "ref": ref}
+                for age, ref, sha, date in candidates
+            ],
+        }
+        print(json.dumps(payload, sort_keys=True))
+        return 0
+
+    print(f"Repository: {root}")
+    print(f"Stale threshold: {cutoff_days} days")
+    if heads:
+        print(f"Excluding {len(heads)} open PR branch(es)")
+    elif not args.include_open_prs:
+        print("Open PR branch exclusion unavailable or empty")
+    print()
 
     if not candidates:
         print("No stale branch candidates found.")
         return 0
 
     print("Dry-run candidates. Review before deleting anything:")
-    for age_days, ref, sha, date_s in sorted(candidates, reverse=True):
+    for age_days, ref, sha, date_s in candidates:
         print(f"{age_days:4d}d  {date_s}  {sha}  {ref}")
     return 0
 

--- a/ods/tests/test_list_stale_branches.py
+++ b/ods/tests/test_list_stale_branches.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "maintainers"
+    / "list-stale-branches.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("ods_list_stale_branches", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_find_candidates_excludes_protected_and_open_branches():
+    module = load_module()
+    now = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    old = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    recent = datetime(2026, 8, 1, tzinfo=timezone.utc)
+
+    candidates = module.find_candidates(
+        [
+            (old, "origin/main", "aaaaaaa"),
+            (old, "origin/release/1.0", "bbbbbbb"),
+            (old, "origin/open-change", "ccccccc"),
+            (recent, "origin/recent-change", "ddddddd"),
+            (old, "origin/stale-change", "eeeeeee"),
+        ],
+        {"open-change"},
+        45,
+        now,
+    )
+
+    assert candidates == [(217, "origin/stale-change", "eeeeeee", "2026-01-01")]
+
+
+def test_json_output_is_machine_readable(monkeypatch, capsys, tmp_path):
+    module = load_module()
+    old = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(module, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(module, "open_pr_heads", lambda: {"open-change"})
+    monkeypatch.setattr(
+        module,
+        "remote_branches",
+        lambda: [(old, "origin/stale-change", "abcdef0")],
+    )
+
+    assert module.main(["--days", "45", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["repository"] == str(tmp_path)
+    assert payload["stale_threshold_days"] == 45
+    assert payload["excluded_open_pr_branches"] == 1
+    assert payload["candidates"][0]["ref"] == "origin/stale-change"
+
+
+def test_days_must_be_positive():
+    module = load_module()
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main(["--days", "0"])
+
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

- add a stable `--format json` mode to the stale-branch dry-run helper
- separate candidate selection into a testable pure function
- reject nonsensical non-positive age thresholds
- document the automation-friendly output and cover filtering/output behavior

## Validation

- `pytest tests/test_list_stale_branches.py -q`
- `python -m py_compile scripts/maintainers/list-stale-branches.py tests/test_list_stale_branches.py`
- `git diff --check`