### PR TITLE
fix(hermes): reject non-positive runtime limits

### DIFF
--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -294,15 +294,22 @@ def patch_config(
     return True
 
 
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Patch ODS Hermes config defaults.")
     parser.add_argument("path", type=Path)
     parser.add_argument("--model")
     parser.add_argument("--base-url")
     parser.add_argument("--api-key", help="Bearer token Hermes uses to call the LLM (needed when routing through litellm)")
-    parser.add_argument("--context-length", type=int)
-    parser.add_argument("--request-timeout-seconds", type=int, default=180)
-    parser.add_argument("--max-tokens", type=int, default=1024)
+    parser.add_argument("--context-length", type=positive_int)
+    parser.add_argument("--request-timeout-seconds", type=positive_int, default=180)
+    parser.add_argument("--max-tokens", type=positive_int, default=1024)
     args = parser.parse_args()
 
     if not args.path.exists():

--- a/ods/tests/test_patch_hermes_config_cli.py
+++ b/ods/tests/test_patch_hermes_config_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "patch-hermes-config.py"
+
+
+@pytest.mark.parametrize(
+    "option,value",
+    [
+        ("--context-length", "0"),
+        ("--context-length", "-1"),
+        ("--request-timeout-seconds", "0"),
+        ("--max-tokens", "-8"),
+    ],
+)
+def test_cli_rejects_non_positive_runtime_limits(tmp_path, option, value):
+    config = tmp_path / "config.yaml"
+    config.write_text("model:\n  default: test\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(config), option, value],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert f"argument {option}: must be a positive integer" in result.stderr
+    assert config.read_text(encoding="utf-8") == "model:\n  default: test\n"
+
+
+def test_cli_accepts_positive_runtime_limits(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("model:\n  default: test\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(config),
+            "--context-length",
+            "4096",
+            "--request-timeout-seconds",
+            "300",
+            "--max-tokens",
+            "512",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    rendered = config.read_text(encoding="utf-8")
+    assert "context_length: 4096" in rendered
+    assert "request_timeout_seconds: 300" in rendered
+    assert "max_tokens: 512" in rendered


### PR DESCRIPTION
## Summary

- reject zero and negative Hermes context, timeout, and output-token limits at the CLI boundary
- keep invalid invocations from mutating the target configuration
- cover each limit plus a valid end-to-end render

## Validation

- `pytest tests/test_patch_hermes_config_cli.py -q`
- `python -m py_compile scripts/patch-hermes-config.py tests/test_patch_hermes_config_cli.py`
- `git diff --check`