### PR TITLE
fix(runtime): validate rendered numeric settings

### DIFF
--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -633,6 +633,20 @@ def parse_remote_enabled(value: str) -> bool:
     return value.strip().lower() == "true"
 
 
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def tcp_port(value: str) -> int:
+    parsed = int(value)
+    if not 1 <= parsed <= 65535:
+        raise argparse.ArgumentTypeError("must be between 1 and 65535")
+    return parsed
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--surface", choices=["all", *sorted(RENDERERS)], default="all")
@@ -649,8 +663,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--ods-mode", choices=["local", "cloud", "hybrid", "lemonade"], default="local")
     parser.add_argument("--llm-base-url", default="http://llama-server:8080/v1")
     parser.add_argument("--litellm-key", default=DEFAULT_LITELLM_KEY)
-    parser.add_argument("--opencode-port", type=int, default=3003)
-    parser.add_argument("--context-length", type=int, default=DEFAULT_CONTEXT)
+    parser.add_argument("--opencode-port", type=tcp_port, default=3003)
+    parser.add_argument("--context-length", type=positive_int, default=DEFAULT_CONTEXT)
     parser.add_argument(
         "--remote-llm-enabled",
         choices=["", "true", "false"],

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -63,6 +63,27 @@ def test_all_surfaces_render() -> None:
     assert payload["mode"] == "dry-run"
 
 
+def test_numeric_runtime_inputs_are_bounded() -> None:
+    invalid = [
+        ("--opencode-port", "0", "must be between 1 and 65535"),
+        ("--opencode-port", "65536", "must be between 1 and 65535"),
+        ("--context-length", "0", "must be a positive integer"),
+        ("--context-length", "-1", "must be a positive integer"),
+    ]
+    for option, value, expected_error in invalid:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), option, value],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert proc.returncode == 2
+        assert f"argument {option}: {expected_error}" in proc.stderr
+        assert proc.stdout == ""
+
+
 def test_switchboard_surface_gated_on_enabled_mode() -> None:
     observed = run_renderer("--surface", "all", "--switchboard-mode", "observe")
     assert "litellm-switchboard" not in {i["surface"] for i in observed["files"]}
@@ -550,6 +571,7 @@ def test_atomic_write_failure_preserves_known_good_config() -> None:
 def main() -> int:
     tests = [
         test_all_surfaces_render,
+        test_numeric_runtime_inputs_are_bounded,
         test_switchboard_surface_gated_on_enabled_mode,
         test_all_selects_one_mode_config,
         test_cloud_enabled_never_renders_local_switchboard,


### PR DESCRIPTION
## Summary

- enforce the valid TCP port range for generated OpenCode configuration
- require a positive context length before rendering any runtime surface
- cover lower and upper boundary failures without producing partial output

## Validation

- `pytest tests/test-render-runtime-configs.py -q` (25 passed)
- `python -m py_compile scripts/render-runtime-configs.py tests/test-render-runtime-configs.py`
- `git diff --check`