### PR TITLE
fix(simulation): validate timestamp calendar dates

### DIFF
--- a/ods/scripts/validate-sim-summary.py
+++ b/ods/scripts/validate-sim-summary.py
@@ -31,6 +31,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
@@ -143,12 +144,19 @@ def _require_path_like(v: Validator, value: Any, path: str) -> None:
 
 
 def _require_iso8601ish(v: Validator, value: Any, path: str) -> None:
-    # We intentionally avoid strict RFC3339 parsing to keep dependencies at 0.
     _require_type(v, value, path, "string")
     if isinstance(value, str):
-        # Very lightweight check: 2026-03-15T12:34:56+00:00 / Z / with fractional seconds.
-        if not re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$", value):
+        timestamp_pattern = (
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+            r"(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+        )
+        if not re.fullmatch(timestamp_pattern, value):
             v.add(path, "expected ISO8601 timestamp (UTC or offset)")
+            return
+        try:
+            datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            v.add(path, "expected a valid ISO8601 calendar timestamp")
 
 
 # -----------------------------

--- a/ods/tests/test-validate-sim-summary.sh
+++ b/ods/tests/test-validate-sim-summary.sh
@@ -210,6 +210,32 @@ else
     fail "strict mode missing generated_at should exit 2, got $r"
 fi
 
+python3 - <<'PY' "$TMP_DIR/valid.json" "$TMP_DIR/invalid-calendar-date.json"
+import json
+import sys
+src, dest = sys.argv[1], sys.argv[2]
+with open(src, encoding="utf-8") as f:
+    data = json.load(f)
+data["generated_at"] = "2026-02-30T12:34:56Z"
+with open(dest, "w", encoding="utf-8") as f:
+    json.dump(data, f)
+PY
+
+set +e
+out=$(python3 "$ROOT_DIR/scripts/validate-sim-summary.py" "$TMP_DIR/invalid-calendar-date.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]]; then
+    pass "invalid calendar timestamp exits 2"
+else
+    fail "invalid calendar timestamp should exit 2, got $r"
+fi
+if echo "$out" | grep -q "valid ISO8601 calendar timestamp"; then
+    pass "invalid calendar timestamp has an actionable error"
+else
+    fail "invalid calendar timestamp should have an actionable error"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

- parse simulation timestamps after the RFC3339-shaped format check
- reject impossible calendar dates such as February 30 instead of accepting them by regex alone
- preserve dependency-free validation and add an actionable regression assertion

## Validation

- `bash tests/test-validate-sim-summary.sh` (14 passed)
- `python -m py_compile scripts/validate-sim-summary.py`
- `bash -n tests/test-validate-sim-summary.sh`
- `git diff --check`