### PR TITLE
fix(workflows): resolve the kokoro dependency to the tts service

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -124,6 +124,9 @@ jobs:
       - name: n8n Cookie Policy Tests
         run: bash tests/test-n8n-cookie-policy.sh
 
+      - name: n8n Catalog Contract Tests
+        run: python3 tests/test-n8n-catalog-contract.py
+
       - name: brave-search searxng Compat Tests
         run: bash tests/test-brave-search-searxng-compat.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -76,6 +76,7 @@ test: ## Run unit and contract tests
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh
+	@python3 tests/test-n8n-catalog-contract.py
 	@echo ""
 	@echo "=== config migration (version check under set -e) ==="
 	@bash tests/test-migrate-config.sh

--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -68,7 +68,10 @@ async def check_workflow_dependencies(deps: list[str], health_cache: dict[str, b
     """Check if required services are running. Uses health_cache to avoid duplicate checks."""
     from helpers import check_service_health
 
-    _DEP_ALIASES = {"ollama": "llama-server"}
+    # Catalog dependency names that are not service ids. An unresolved name
+    # falls through to the `else` below and is reported satisfied without any
+    # health check, so every alias the catalog uses has to be listed here.
+    _DEP_ALIASES = {"ollama": "llama-server", "kokoro": "tts"}
     if health_cache is None:
         health_cache = {}
     results = {}

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -938,3 +938,30 @@ def test_workflow_enable_rejects_path_traversal_in_catalog_file(test_client, mon
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Invalid workflow file path"
+
+
+@pytest.mark.asyncio
+async def test_dependency_aliases_resolve_to_real_services():
+    """An unresolved dependency name is reported satisfied without a probe.
+
+    check_workflow_dependencies() falls through to `results[dep] = True` for a
+    name it does not recognise, so a catalog entry naming a service by a
+    non-id label advertises itself as ready with that service down. `kokoro`
+    is the tts service; `ollama` is llama-server.
+    """
+    from routers.workflows import check_workflow_dependencies
+
+    probed = {"llama-server": True, "tts": False}
+    result = await check_workflow_dependencies(
+        ["ollama", "kokoro"], health_cache=dict(probed)
+    )
+    assert result == {"ollama": True, "kokoro": False}
+
+
+@pytest.mark.asyncio
+async def test_unknown_dependency_still_falls_through_as_satisfied():
+    """Documents the existing fail-open behaviour this alias works around."""
+    from routers.workflows import check_workflow_dependencies
+
+    result = await check_workflow_dependencies(["not-a-service"], health_cache={})
+    assert result == {"not-a-service": True}

--- a/ods/tests/test-n8n-catalog-contract.py
+++ b/ods/tests/test-n8n-catalog-contract.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""n8n workflow catalog contracts.
+
+The dashboard Workflows page is driven entirely by config/n8n/catalog.json.
+Each entry names a file to import, a category to group under, and the services
+it needs. A name that does not resolve is not an error anyone sees:
+check_workflow_dependencies() reports an unknown dependency as *satisfied*
+without probing anything, so the card says "ready" and the import fails later
+at the node that needed the missing service.
+
+Run: python3 tests/test-n8n-catalog-contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "config" / "n8n" / "catalog.json"
+WORKFLOW_DIR = CATALOG.parent
+SERVICES_DIR = ROOT / "extensions" / "services"
+WORKFLOWS_ROUTER = (
+    ROOT / "extensions" / "services" / "dashboard-api" / "routers" / "workflows.py"
+)
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+PASS = 0
+FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"[PASS] {label}")
+    else:
+        FAIL += 1
+        print(f"[FAIL] {label}")
+        for line in str(detail).splitlines():
+            if line:
+                print(f"       {line}")
+
+
+def service_ids() -> set[str]:
+    return {p.name for p in SERVICES_DIR.iterdir() if p.is_dir()}
+
+
+def dependency_aliases() -> dict[str, str]:
+    """Read _DEP_ALIASES out of the router without importing FastAPI."""
+    text = WORKFLOWS_ROUTER.read_text(encoding="utf-8")
+    match = re.search(r"_DEP_ALIASES\s*=\s*\{([^}]*)\}", text, re.S)
+    if not match:
+        return {}
+    return dict(re.findall(r'"([^"]+)"\s*:\s*"([^"]+)"', match.group(1)))
+
+
+def main() -> int:
+    check("catalog.json exists", CATALOG.exists(), str(CATALOG))
+    if not CATALOG.exists():
+        print(f"\nPassed: {PASS}  Failed: {FAIL}")
+        return 1
+
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    workflows = catalog.get("workflows", [])
+    categories = catalog.get("categories", {})
+    services = service_ids()
+    aliases = dependency_aliases()
+
+    check("catalog declares workflows", bool(workflows), repr(catalog.keys()))
+    check("catalog declares categories", bool(categories), repr(catalog.keys()))
+
+    ids = [w.get("id") for w in workflows]
+    duplicates = sorted({i for i in ids if ids.count(i) > 1})
+    check("workflow ids are unique", not duplicates, f"duplicated: {duplicates}")
+
+    for wf in workflows:
+        wid = wf.get("id", "<no id>")
+
+        for field in ("id", "file", "name", "description", "category"):
+            check(
+                f"{wid}: declares {field}",
+                bool(wf.get(field)),
+                f"entry: {json.dumps(wf)}",
+            )
+
+        path = WORKFLOW_DIR / wf.get("file", "")
+        check(f"{wid}: its file exists", path.is_file(), str(path))
+
+        check(
+            f"{wid}: category '{wf.get('category')}' is declared",
+            wf.get("category") in categories,
+            f"declared categories: {sorted(categories)}",
+        )
+
+        for dep in wf.get("dependencies", []):
+            resolved = aliases.get(dep, dep)
+            check(
+                f"{wid}: dependency '{dep}' resolves to a service",
+                resolved in services,
+                f"'{dep}' resolves to '{resolved}', which is not a directory under "
+                f"extensions/services/. check_workflow_dependencies() reports an "
+                f"unresolved dependency as satisfied without probing it, so this "
+                f"workflow would advertise itself as ready with the service down. "
+                f"Add an alias to _DEP_ALIASES in routers/workflows.py, or use the "
+                f"service id in the catalog.",
+            )
+
+    listed = {w.get("file") for w in workflows}
+    on_disk = {p.name for p in WORKFLOW_DIR.glob("*.json")} - {CATALOG.name}
+    check(
+        "every workflow file on disk is in the catalog",
+        not (on_disk - listed),
+        f"unlisted: {sorted(on_disk - listed)}",
+    )
+
+    # Every workflow file must at least parse and carry the n8n export shape.
+    for path in sorted(WORKFLOW_DIR.glob("*.json")):
+        if path.name == CATALOG.name:
+            continue
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            check(f"{path.name}: parses as JSON", False, str(exc))
+            continue
+        check(f"{path.name}: parses as JSON", True)
+        check(
+            f"{path.name}: has an n8n nodes array",
+            isinstance(doc.get("nodes"), list),
+            f"nodes is {type(doc.get('nodes')).__name__}",
+        )
+        check(
+            f"{path.name}: has a connections object",
+            isinstance(doc.get("connections"), dict),
+            f"connections is {type(doc.get('connections')).__name__}",
+        )
+
+        node_names = {n.get("name") for n in doc.get("nodes", []) if isinstance(n, dict)}
+        dangling = []
+        for source, outputs in (doc.get("connections") or {}).items():
+            if source not in node_names:
+                dangling.append(f"source {source!r}")
+            for output in (outputs or {}).get("main", []) or []:
+                for link in output or []:
+                    target = (link or {}).get("node")
+                    if target not in node_names:
+                        dangling.append(f"target {target!r} (from {source!r})")
+        check(
+            f"{path.name}: every connection references a node that exists",
+            not dangling,
+            "\n".join(dangling),
+        )
+
+    print()
+    print(f"Passed: {PASS}  Failed: {FAIL}")
+    if FAIL:
+        return 1
+    print("[PASS] n8n catalog contracts")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`check_workflow_dependencies()` reports a dependency it cannot resolve as
**satisfied**, without probing anything:

```python
_DEP_ALIASES = {"ollama": "llama-server"}
...
for dep in deps:
    resolved = _DEP_ALIASES.get(dep, dep)
    if resolved in health_cache:
        results[dep] = health_cache[resolved]
    elif resolved in SERVICES:
        status = await check_service_health(resolved, SERVICES[resolved])
        ...
    else:
        results[dep] = True          # unknown name -> "ready"
```

`config/n8n/catalog.json` gives `voice-to-voice` the dependencies
`["whisper", "llama-server", "kokoro"]`. There is no `kokoro` service —
Kokoro is the *model* the `tts` service serves (`ghcr.io/remsky/kokoro-fastapi-cpu`),
and the service id is `tts`:

```text
$ ls extensions/services/ | grep -c '^kokoro$'
0
$ python3 -c "import yaml;print(yaml.safe_load(open('extensions/services/tts/manifest.yaml'))['service']['id'])"
tts
```

So `kokoro` misses both the alias map and `SERVICES`, falls through the `else`,
and the Workflows page shows `voice-to-voice` with its dependencies met whether
or not TTS is installed or running. `all_deps_met` is computed from exactly
these values:

```python
dep_status = await check_workflow_dependencies(wf.get("dependencies", []), health_cache)
all_deps_met = all(dep_status.values())
```

The user sees a ready card, imports the workflow, and it fails at the speech
node. Of the three declared dependencies, whisper and llama-server are checked
honestly; the one that is silently assumed is the one most likely to be absent,
since `tts` is an optional extension.

### Fix

`_DEP_ALIASES` exists for precisely this case — `"ollama"` is already mapped to
`"llama-server"`. Add `"kokoro"` → `"tts"` so the tts health probe actually
runs.

I chose the alias over renaming the dependency in the catalog because `kokoro`
is the name a user recognises from the workflow's description, and the alias
map is where the codebase already handles this mismatch.

I deliberately did **not** change the fail-open `else` branch to fail closed.
It is load-bearing for dependencies that are not ODS services at all, and
flipping it is a behaviour change on the dashboard that deserves its own
discussion. The contract test below makes the typo case impossible instead.

### Test

Two additions to `tests/test_workflows.py`: one asserting `kokoro` and `ollama`
both resolve to a probed service, one pinning the fail-open behaviour for a
genuinely unknown name so a future change to it is deliberate.

Plus `tests/test-n8n-catalog-contract.py`, which reads `_DEP_ALIASES` back out
of the router source (no FastAPI import needed) and asserts, for the whole
catalog:

- every dependency resolves to a directory under `extensions/services/`;
- every entry names a file that exists, in a declared category, with required
  fields and unique ids;
- no workflow file on disk is missing from the catalog;
- every workflow's `connections` reference nodes that exist.

229 assertions today. Wired into `make test` and the Linux CI job.

## AI Assistance

AI assisted with tracing the fail-open branch, drafting the contract test, and
wording this description. I read the full diff, confirmed there is no `kokoro`
service directory and that `tts` is the id, and ran both suites against
`origin/main` and the patch.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(One entry in a lookup table in `routers/workflows.py`, plus tests. CI config
and the Makefile test target are also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 -m pytest tests/test_workflows.py -q     # in dashboard-api
47 passed, 20 warnings in 12.50s
  (45 pre-existing + 2 new; no pre-existing test changed)

# the new dependency test against origin/main's router:
FAILED tests/test_workflows.py::test_dependency_aliases_resolve_to_real_services
1 failed

$ python3 tests/test-n8n-catalog-contract.py
...
Passed: 229  Failed: 0
[PASS] n8n catalog contracts

# the same contract test against origin/main's router:
[FAIL] voice-to-voice: dependency 'kokoro' resolves to a service
       'kokoro' resolves to 'kokoro', which is not a directory under
       extensions/services/. check_workflow_dependencies() reports an
       unresolved dependency as satisfied without probing it, so this
       workflow would advertise itself as ready with the service down.
Passed: 228  Failed: 1
```

## Operational Change Check

`check_workflow_dependencies()` runs on the dashboard-api `/api/workflows`
read path. The change makes one more dependency name route to a real health
probe. The only behaviour change: `voice-to-voice` now shows its TTS
dependency as unmet when the tts service is down or not installed, instead of
always showing it met. No write path, no schema change, no other workflow
affected.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The bigger thing I found while writing the contract test, and am not fixing
here:** all 18 workflows in `config/n8n/` are placeholders. Every one is a
`manualTrigger` plus a `stickyNote` reading *"This is a template workflow…
Customize the nodes below to match your setup"*, with `"connections": {}` —
nothing is wired to anything:

```text
id                           nodes conns  node types
m4-deterministic-voice           2     0  manualTrigger,stickyNote
document-qa                      2     0  manualTrigger,stickyNote
voice-transcription              2     0  manualTrigger,stickyNote
...  (18 of 18)
```

Meanwhile the catalog advertises them with real descriptions and
`"setupTime": "2 minutes"`. `tests/integration-test.sh` passes them because it
only checks that the JSON parses and has a `nodes` key.

That is a content gap rather than a defect in this code path, and filling it is
`ods/CONTRIBUTING.md`'s "Workflow templates — pre-built n8n workflows that
solve actual problems people have". I am working through implementing them as
separate PRs, starting with the llama-server-only ones. The connection-graph
assertions in this contract test are there to catch a half-wired workflow when
those land.

Tell me if you would rather the catalog mark unimplemented entries explicitly
(e.g. a `"status": "template"` field the dashboard can badge) — that is a
smaller change than implementing all 18 and would stop the page over-promising
in the meantime.
