### PR TITLE
feat(workflows): make the chat and code-assistant templates real

### DIFF
--- a/ods/config/n8n/01-chat-endpoint.json
+++ b/ods/config/n8n/01-chat-endpoint.json
@@ -2,27 +2,223 @@
   "name": "Chat API Endpoint",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## Chat API Endpoint\n\nTurns your local llama-server into a small REST API.\n\n**Call it:**\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-chat \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"message\": \"Explain RAG in one sentence.\"}'\n```\n\n**Optional body fields:** `system`, `temperature`, `max_tokens`.\n\nThe HTTP node talks to `llama-server:8080` over the `ods-network` Docker\nnetwork, so nothing is exposed beyond the box.",
+        "height": 420,
+        "width": 460
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [
+        -40,
+        40
+      ]
     },
     {
       "parameters": {
-        "content": "## Chat API Endpoint\n\nThis is a template workflow for REST API chat completions.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "httpMethod": "POST",
+        "path": "ods-chat",
+        "responseMode": "responseNode",
+        "options": {}
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "webhook-chat",
+      "name": "Chat Request",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        460,
+        300
+      ],
+      "webhookId": "8f2b1c30-6a1e-4a1e-9c0e-7c1f0a2b3c40"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1",
+              "name": "message",
+              "value": "={{ $json.body.message || $json.body.prompt || '' }}",
+              "type": "string"
+            },
+            {
+              "id": "a2",
+              "name": "system",
+              "value": "={{ $json.body.system || 'You are a concise, helpful assistant running fully offline on the user\\'s own hardware.' }}",
+              "type": "string"
+            },
+            {
+              "id": "a3",
+              "name": "temperature",
+              "value": "={{ $json.body.temperature ?? 0.7 }}",
+              "type": "number"
+            },
+            {
+              "id": "a4",
+              "name": "max_tokens",
+              "value": "={{ $json.body.max_tokens ?? 512 }}",
+              "type": "number"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-inputs",
+      "name": "Read Request",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        680,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1",
+              "leftValue": "={{ $json.message }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-has-message",
+      "name": "Message Present?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        900,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://llama-server:8080/v1/chat/completions",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'local-model', messages: [ { role: 'system', content: $json.system }, { role: 'user', content: $json.message } ], temperature: $json.temperature, max_tokens: $json.max_tokens, stream: false }) }}",
+        "options": {
+          "timeout": 120000,
+          "response": {
+            "response": {
+              "neverError": false
+            }
+          }
+        }
+      },
+      "id": "http-llama",
+      "name": "llama-server Chat",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ reply: $json.choices[0].message.content, model: $json.model, usage: $json.usage }) }}",
+        "options": {}
+      },
+      "id": "respond-ok",
+      "name": "Return Reply",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1380,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: \"Body must include a non-empty 'message' (or 'prompt') field.\" }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-bad-request",
+      "name": "Return 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1140,
+        420
+      ]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Chat Request": {
+      "main": [
+        [
+          {
+            "node": "Read Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Request": {
+      "main": [
+        [
+          {
+            "node": "Message Present?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Message Present?": {
+      "main": [
+        [
+          {
+            "node": "llama-server Chat",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Return 400",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "llama-server Chat": {
+      "main": [
+        [
+          {
+            "node": "Return Reply",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },

--- a/ods/config/n8n/07-code-assistant.json
+++ b/ods/config/n8n/07-code-assistant.json
@@ -2,27 +2,222 @@
   "name": "Code Assistant",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## Code Assistant\n\nA coding-focused endpoint on top of your local llama-server: send code plus\na task, get an answer back. Temperature is pinned low (0.2) because code\nquestions want determinism, not variety.\n\n**Call it:**\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-code \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n        \"task\": \"explain what this does and name one bug\",\n        \"language\": \"python\",\n        \"code\": \"def f(x):\\n    return [i for i in range(x) if x % i == 0]\"\n      }'\n```\n\n**Body fields:** `task` (required), `code` (required), `language` (optional).\n\nNothing leaves the machine \u2014 the HTTP node reaches `llama-server:8080`\nover the internal `ods-network`.",
+        "height": 460,
+        "width": 480
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [
+        -60,
+        40
+      ]
     },
     {
       "parameters": {
-        "content": "## Code Assistant\n\nThis is a template workflow for AI-powered coding help via API.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "httpMethod": "POST",
+        "path": "ods-code",
+        "responseMode": "responseNode",
+        "options": {}
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "webhook-code",
+      "name": "Code Request",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        460,
+        300
+      ],
+      "webhookId": "1d4e9a72-5b83-4f26-9a11-2e6c8d0f4b71"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1",
+              "name": "task",
+              "value": "={{ $json.body.task || '' }}",
+              "type": "string"
+            },
+            {
+              "id": "a2",
+              "name": "code",
+              "value": "={{ $json.body.code || '' }}",
+              "type": "string"
+            },
+            {
+              "id": "a3",
+              "name": "language",
+              "value": "={{ $json.body.language || 'text' }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-inputs",
+      "name": "Read Request",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        680,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1",
+              "leftValue": "={{ $json.task }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "c2",
+              "leftValue": "={{ $json.code }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Task And Code Present?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        900,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://llama-server:8080/v1/chat/completions",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'local-model', messages: [ { role: 'system', content: 'You are a precise code assistant. Answer the task about the supplied code. Be specific, cite line content when you refer to it, and say plainly when you are unsure. Do not invent APIs.' }, { role: 'user', content: 'Task: ' + $json.task + '\\n\\nLanguage: ' + $json.language + '\\n\\nCode:\\n```' + $json.language + '\\n' + $json.code + '\\n```' } ], temperature: 0.2, max_tokens: 1024, stream: false }) }}",
+        "options": {
+          "timeout": 180000
+        }
+      },
+      "id": "http-llama",
+      "name": "llama-server Review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1160,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ answer: $json.choices[0].message.content, model: $json.model, usage: $json.usage }) }}",
+        "options": {}
+      },
+      "id": "respond-ok",
+      "name": "Return Answer",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1400,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: \"Body must include non-empty 'task' and 'code' fields.\" }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-bad-request",
+      "name": "Return 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1160,
+        440
+      ]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Code Request": {
+      "main": [
+        [
+          {
+            "node": "Read Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Request": {
+      "main": [
+        [
+          {
+            "node": "Task And Code Present?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Task And Code Present?": {
+      "main": [
+        [
+          {
+            "node": "llama-server Review",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Return 400",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "llama-server Review": {
+      "main": [
+        [
+          {
+            "node": "Return Answer",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },


### PR DESCRIPTION
## Summary

`ods/CONTRIBUTING.md` asks for *"Workflow templates — pre-built n8n workflows
that solve actual problems people have."* The two llama-server-only entries in
the catalog were not that. Both were:

```json
{
  "nodes": [
    { "type": "n8n-nodes-base.manualTrigger", "parameters": {} },
    { "type": "n8n-nodes-base.stickyNote",
      "parameters": { "content": "## Chat API Endpoint\n\nThis is a template workflow for REST API chat completions.\n\nCustomize the nodes below to match your setup." } }
  ],
  "connections": {}
}
```

An empty canvas and a note telling you to build it yourself — while the
dashboard advertises *"Chat API Endpoint — REST API for chat completions"* with
`"setupTime": "1 minute"`.

(For what it is worth, all 18 catalog entries are currently in this state. I am
starting with the two that need only `llama-server`, so the dependency surface
is as small as possible.)

### What they do now

**`chat-endpoint`** — turns llama-server into a small REST API.

```
Webhook POST /webhook/ods-chat
  -> Read Request      (message | prompt, optional system/temperature/max_tokens)
  -> Message Present?  (IF)
       true  -> llama-server /v1/chat/completions -> Return Reply  (200 JSON)
       false -> Return 400
```

```bash
curl -X POST http://localhost:5678/webhook/ods-chat \
  -H 'Content-Type: application/json' \
  -d '{"message": "Explain RAG in one sentence."}'
```

**`code-assistant`** — same shape, tuned for code.

```
Webhook POST /webhook/ods-code
  -> Read Request           (task, code, optional language)
  -> Task And Code Present? (IF)
       true  -> llama-server with a code-review system prompt, temperature 0.2
             -> Return Answer (200 JSON)
       false -> Return 400
```

Design points worth reviewing:

- Both call **`http://llama-server:8080`** — the manifest's in-network `port`,
  not the published `external_port_default` (11434). n8n is on `ods-network`
  with everything else, so the request never leaves the Docker network. Same
  reasoning as the rest of the stack talking service-to-service.
- Temperature is pinned at 0.2 for `code-assistant` and defaults to 0.7 for
  chat, overridable per request.
- A missing/empty body field returns a 400 with a message naming the field,
  rather than letting the HTTP node fail with a provider error the caller
  cannot interpret.
- The sticky note in each is now a working `curl` example instead of a
  placeholder.

## AI Assistance

AI assisted with drafting the node graphs, the system prompts, and this
description. I chose the endpoints and ports against the service manifests,
built the validation harness described below, and fixed the one real defect it
found before pushing.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Two JSON files under `config/n8n/`. These are import payloads for n8n; no ODS
code reads them at runtime. The catalog entries, categories, dependencies, ids
and filenames are unchanged.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Both files validated against the exact node package ODS ships.
# compose.yaml pins n8nio/n8n:2.6.4; `npm view n8n@2.6.4 dependencies.n8n-nodes-base`
# -> 2.6.2, so that is the version I checked against.

$ node verify.js 01-chat-endpoint.json 07-code-assistant.json
n8n-nodes-base version: 2.6.2
node types loaded: 417
  checked 01-chat-endpoint.json: 7 nodes
  checked 07-code-assistant.json: 7 nodes

ALL WORKFLOWS VALID

# The harness loads every node class out of n8n-nodes-base and asserts, per node:
#   - the `type` string resolves to a real node
#   - `typeVersion` is one the node declares
#   - every parameter key set is a property the node actually declares
#   - node names are unique
#   - every connection source and target names a node in the file
#
# It caught a genuine mistake before I pushed: I had put `responseCode` at the
# top level of respondToWebhook, where it belongs under `options`:
#
#   FAIL 01-chat-endpoint.json: n8n-nodes-base.respondToWebhook has no parameter 'responseCode'
#   FAIL 07-code-assistant.json: n8n-nodes-base.respondToWebhook has no parameter 'responseCode'
#
# Also clean against the current 2.15.1 for forward compatibility.

$ python3 -c "import json; [json.load(open(f)) for f in (...)]"
01-chat-endpoint.json  nodes=7 connections=4
07-code-assistant.json nodes=7 connections=4
```

**Caveat, and the one thing I could not do:** Docker is not running on my dev
host, so I could not stand up n8n + llama-server and fire a real request end to
end. Everything above is static validation against the real node definitions —
it proves the files import and that no node has an invented parameter or
version, but it does not prove the llama-server response shape flows through
the expression in `Return Reply` at runtime. That expression reads
`$json.choices[0].message.content`, which is the standard OpenAI-compatible
chat response llama.cpp's server returns, and is the same path
`scripts/ods-test-functional.sh` asserts on. If you would like a live run
before merging, say so and I will get one on a machine with Docker.

## Operational Change Check

These files are import payloads for n8n. Nothing in the installer, compose
stack, `ods-cli`, or dashboard-api executes them — dashboard-api only reads
`catalog.json` for the Workflows page listing, and the file itself is sent to
n8n's import API when the user clicks install. No existing install is affected
until a user chooses to import.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**On the model id.** Both workflows send `"model": "local-model"`. llama.cpp's
server ignores the field and serves whatever model it was started with, so any
string works — but if you would rather these read the configured `LLM_MODEL`,
n8n would need it in its environment (`compose.yaml` does not pass it today).
Say the word and I will send that as a separate change rather than smuggling an
env addition into a workflow PR.

**On webhook paths.** I used `ods-chat` and `ods-code`. They are unregistered
until a user activates the workflow, and I checked no other catalog workflow
claims them. If you have a naming convention for ODS-shipped webhooks, tell me
and I will rename.

**Should the remaining 16 follow?** I would like to keep going — the voice ones
(whisper, tts) and the RAG ones (qdrant, embeddings) are the obvious next
batch. Tell me if you would rather they land as one large PR than as a series,
or if the whole idea needs an issue first.

Related: #2495 adds a catalog contract test whose connection-graph assertions
cover files like these. Independent change, no overlapping lines.
