### PR TITLE
feat(workflows): make the voice-to-voice template real

### DIFF
--- a/ods/config/n8n/05-voice-to-voice.json
+++ b/ods/config/n8n/05-voice-to-voice.json
@@ -2,32 +2,166 @@
   "name": "Voice to Voice",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## Voice to Voice\n\nSpeak, get spoken audio back — the whole loop on your own hardware.\n\n```\naudio in -> whisper (transcribe) -> llama-server (answer) -> tts (speak) -> audio out\n```\n\n**Call it:**\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-voice \\n  -F 'file=@question.wav' --output answer.mp3\n```\n\nOptional form fields: `voice` (default `af_heart`), `system` (system\nprompt), `stt_model`.\n\nEvery hop stays on the internal `ods-network`: whisper:8000,\nllama-server:8080, tts:8880. No audio and no transcript leaves the box.\n\n**Requires** whisper, llama-server and tts to be enabled.",
+        "height": 520,
+        "width": 500
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [-80, 40]
     },
     {
       "parameters": {
-        "content": "## Voice to Voice\n\nThis is a template workflow for speaking and getting AI response as audio.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "httpMethod": "POST",
+        "path": "ods-voice",
+        "responseMode": "responseNode",
+        "options": {}
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "webhook-voice",
+      "name": "Voice Upload",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 320],
+      "webhookId": "6b2c9e47-1a58-4d3f-8e06-4c9b7a1d5f62"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1",
+              "leftValue": "={{ $binary?.file?.fileName || $binary?.file?.mimeType }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-has-audio",
+      "name": "Audio Attached?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [660, 320]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://whisper:8000/v1/audio/transcriptions",
+        "sendBody": true,
+        "contentType": "multipart-form-data",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "parameterType": "formBinaryData",
+              "name": "file",
+              "inputDataFieldName": "file"
+            },
+            {
+              "name": "model",
+              "value": "={{ $json.body?.stt_model || 'Systran/faster-whisper-base' }}"
+            }
+          ]
+        },
+        "options": { "timeout": 300000 }
+      },
+      "id": "http-whisper",
+      "name": "Whisper Transcribe",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 220]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://llama-server:8080/v1/chat/completions",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'local-model', messages: [ { role: 'system', content: ($('Voice Upload').item.json.body?.system) || 'You are a voice assistant. Answer in two or three short spoken sentences. No markdown, no lists, no code blocks — the reply will be read aloud.' }, { role: 'user', content: $json.text } ], temperature: 0.6, max_tokens: 400, stream: false }) }}",
+        "options": { "timeout": 180000 }
+      },
+      "id": "http-llama",
+      "name": "llama-server Answer",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 220]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://tts:8880/v1/audio/speech",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'kokoro', input: $json.choices[0].message.content, voice: ($('Voice Upload').item.json.body?.voice) || 'af_heart' }) }}",
+        "options": {
+          "timeout": 180000,
+          "response": {
+            "response": {
+              "responseFormat": "file",
+              "outputPropertyName": "speech"
+            }
+          }
+        }
+      },
+      "id": "http-tts",
+      "name": "Kokoro Speak",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 220]
+    },
+    {
+      "parameters": {
+        "respondWith": "binary",
+        "responseDataSource": "set",
+        "inputFieldName": "speech",
+        "options": {}
+      },
+      "id": "respond-audio",
+      "name": "Return Audio",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1620, 220]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: \"Send an audio file as multipart form data, e.g. curl -F 'file=@question.wav'.\" }) }}",
+        "options": { "responseCode": 400 }
+      },
+      "id": "respond-bad-request",
+      "name": "Return 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
     }
   ],
-  "connections": {},
-  "settings": {
-    "executionOrder": "v1"
+  "connections": {
+    "Voice Upload": { "main": [[{ "node": "Audio Attached?", "type": "main", "index": 0 }]] },
+    "Audio Attached?": {
+      "main": [
+        [{ "node": "Whisper Transcribe", "type": "main", "index": 0 }],
+        [{ "node": "Return 400", "type": "main", "index": 0 }]
+      ]
+    },
+    "Whisper Transcribe": { "main": [[{ "node": "llama-server Answer", "type": "main", "index": 0 }]] },
+    "llama-server Answer": { "main": [[{ "node": "Kokoro Speak", "type": "main", "index": 0 }]] },
+    "Kokoro Speak": { "main": [[{ "node": "Return Audio", "type": "main", "index": 0 }]] }
   },
-  "meta": {
-    "templateId": "voice-to-voice"
-  },
+  "settings": { "executionOrder": "v1" },
+  "meta": { "templateId": "voice-to-voice" },
   "tags": []
 }


### PR DESCRIPTION
## Summary

`config/n8n/05-voice-to-voice.json` was a placeholder — `manualTrigger` +
sticky note + `"connections": {}` — behind a catalog card advertising *"Speak,
get AI response as audio"*, `"featured": true`, `"setupTime": "2 minutes"`.

It is now the full loop, on your own hardware:

```
Webhook POST /webhook/ods-voice  (multipart audio)
  -> Audio Attached? (IF)
       false -> Return 400
       true  -> whisper:8000      /v1/audio/transcriptions
             -> llama-server:8080 /v1/chat/completions
             -> tts:8880          /v1/audio/speech   (responseFormat: file)
             -> Return Audio      (binary)
```

```bash
curl -X POST http://localhost:5678/webhook/ods-voice \
  -F 'file=@question.wav' --output answer.mp3
```

Optional form fields: `voice` (default `af_heart`, matching the tts README),
`system` (override the assistant prompt), `stt_model`.

Every hop uses the manifest's in-network `port`, not the published one, so
neither the audio nor the transcript ever leaves `ods-network`.

### Three details this needed to actually work

- **The TTS response is binary.** The node sets
  `options.response.response.responseFormat = "file"` with
  `outputPropertyName: "speech"`, and the responder uses
  `respondWith: "binary"` / `responseDataSource: "set"` /
  `inputFieldName: "speech"`. Without the file format n8n would try to parse
  the MP3 as JSON and fail at the last step.
- **The system prompt is written for speech, not screen** — two or three short
  sentences, no markdown, no lists, no code blocks, because the reply is read
  aloud. A default chat prompt produces bullet points that Kokoro then reads
  out as literal asterisks.
- **The upload is referenced as `file`, not `data`.** n8n's `handleFormData()`
  names a webhook binary property after the form field key, and setting
  `options.binaryPropertyName` appends a counter (`data0`) rather than
  renaming it — see #2498 for the code path.

## AI Assistance

AI assisted with drafting the node graph, the spoken-output prompt, and this
description. I verified all three endpoints and ports against their service
manifests, and confirmed the binary-response parameter shapes against the node
definitions rather than from memory.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(One JSON file under `config/n8n/`. An import payload for n8n; no ODS code
executes it. The catalog entry is unchanged.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Validated against the exact node package ODS ships. compose.yaml pins
# n8nio/n8n:2.6.4; `npm view n8n@2.6.4 dependencies.n8n-nodes-base` -> 2.6.2.

$ node verify.js 05-voice-to-voice.json
n8n-nodes-base version: 2.6.2
node types loaded: 417
  checked 05-voice-to-voice.json: 8 nodes

ALL WORKFLOWS VALID

# Binary-path parameter shapes checked against the node definitions:
#   httpRequest options.response.response values
#     -> fullResponse, neverError, responseFormat[autodetect|file|json|text],
#        outputPropertyName
#   respondToWebhook respondWith options
#     -> allIncomingItems, binary, firstIncomingItem, json, jwt, noData,
#        redirect, text
#   respondToWebhook responseDataSource -> automatically | set
#   respondToWebhook inputFieldName     -> string
#
# Endpoints checked against extensions/services/*/manifest.yaml:
#   whisper      port 8000  (published 9000)
#   llama-server port 8080  (published 11434)
#   tts          port 8880
```

**Caveat, and it is a bigger one for this workflow than the others:** Docker is
not running on my dev host, so I could not run the three-hop chain end to end.
Static validation proves the file imports and that every node parameter and
version is real; it does not prove the data actually threads through three
services. This is the longest chain of the set, so it is the one I would most
want a live run on. Say the word and I will get one on a machine with Docker
before you merge.

## Operational Change Check

An import payload for n8n. Nothing in the installer, compose stack, `ods-cli`,
or dashboard-api executes it. No existing install changes until a user imports
it.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**This is the workflow whose catalog dependencies were wrong.** It declares
`["whisper", "llama-server", "kokoro"]`, and `kokoro` matches no service, so
`check_workflow_dependencies()` silently reports it satisfied — the card says
"ready" even with TTS stopped. #2495 fixes that with a `kokoro` -> `tts` alias.
Worth landing that one first, or this workflow will look installable on a box
with no TTS and fail at the last hop.

**Voice list.** `af_heart` is the tts README's example voice. If ODS pins a
different default anywhere I did not find it, point me at it.

Part of the series making the 18 stub templates real: #2496 (chat,
code-assistant), #2497 (summarizer), #2498 (transcription). Independent files,
no overlapping lines.
