### PR TITLE
feat(workflows): make the deterministic intent router real

### DIFF
--- a/ods/config/n8n/08-m4-deterministic-voice.json
+++ b/ods/config/n8n/08-m4-deterministic-voice.json
@@ -2,27 +2,279 @@
   "name": "M4 Deterministic Voice",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## M4 Deterministic Voice\n\nIntent classification with **deterministic** routing: the model only ever\npicks a label from a fixed list, and a Switch node — not the model —\ndecides what happens next.\n\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-intent \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"utterance\": \"turn the kitchen lights off\"}'\n```\n\n**Intents:** `smart_home`, `timer`, `question`, `unknown`\n\nWhy this shape: the classifier runs at `temperature: 0` and is told to\nreply with one word. Its answer is then normalised and matched against\nthe allowed set, so a hallucinated or chatty label lands in `unknown`\ninstead of routing somewhere unintended.",
+        "height": 520,
+        "width": 500
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [-80, 20]
     },
     {
       "parameters": {
-        "content": "## M4 Deterministic Voice\n\nThis is a template workflow for intent classification with deterministic routing.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
+        "httpMethod": "POST",
+        "path": "ods-intent",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-intent",
+      "name": "Utterance In",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 320],
+      "webhookId": "9c1f3a68-4b72-4e05-a3d9-5f2b8e7c1a04"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1",
+              "name": "utterance",
+              "value": "={{ ($json.body.utterance || $json.body.text || '').slice(0, 2000) }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-utterance",
+      "name": "Read Utterance",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [660, 320]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1",
+              "leftValue": "={{ $json.utterance }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-has-utterance",
+      "name": "Utterance Present?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 320]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://llama-server:8080/v1/chat/completions",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'local-model', messages: [ { role: 'system', content: 'Classify the user utterance into exactly one label: smart_home, timer, question, unknown. Reply with the label only - one word, lowercase, nothing else. If it fits none of them, reply unknown.' }, { role: 'user', content: $json.utterance } ], temperature: 0, max_tokens: 8, stream: false }) }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "http-classify",
+      "name": "Classify Intent",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 220]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "n1",
+              "name": "intent",
+              "value": "={{ ['smart_home','timer','question'].includes(($json.choices[0].message.content || '').toLowerCase().replace(/[^a-z_]/g, '')) ? ($json.choices[0].message.content || '').toLowerCase().replace(/[^a-z_]/g, '') : 'unknown' }}",
+              "type": "string"
+            },
+            {
+              "id": "n2",
+              "name": "raw_label",
+              "value": "={{ ($json.choices[0].message.content || '').trim() }}",
+              "type": "string"
+            },
+            {
+              "id": "n3",
+              "name": "utterance",
+              "value": "={{ $('Read Utterance').item.json.utterance }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-normalise",
+      "name": "Constrain To Allowed Set",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1360, 220]
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "loose",
+                  "version": 2
+                },
+                "conditions": [
+                  {
+                    "id": "s1",
+                    "leftValue": "={{ $json.intent }}",
+                    "rightValue": "smart_home",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "smart_home"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "loose",
+                  "version": 2
+                },
+                "conditions": [
+                  {
+                    "id": "s2",
+                    "leftValue": "={{ $json.intent }}",
+                    "rightValue": "timer",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "timer"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "loose",
+                  "version": 2
+                },
+                "conditions": [
+                  {
+                    "id": "s3",
+                    "leftValue": "={{ $json.intent }}",
+                    "rightValue": "question",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "question"
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "extra",
+          "renameFallbackOutput": "unknown"
+        }
+      },
+      "id": "switch-intent",
+      "name": "Route By Intent",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [1600, 220]
+    },
+    {
+      "parameters": {
+        "content": "### Wire your actions here\n\nEach Switch output is a branch you own:\n\n- **smart_home** — call your hub's API\n- **timer** — create a schedule or reminder\n- **question** — hand off to `ods-chat` (Chat API Endpoint template)\n- **unknown** — ask the user to rephrase\n\nAll four converge on the responder for now, so the workflow is runnable\nexactly as shipped and you can see the classification before you build\non it.",
+        "height": 320,
         "width": 400
       },
-      "id": "note",
-      "name": "Setup Instructions",
+      "id": "note-branches",
+      "name": "Wire your actions here",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [440, 140]
+      "position": [1580, 460]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ intent: $json.intent, raw_label: $json.raw_label, utterance: $json.utterance }) }}",
+        "options": {}
+      },
+      "id": "respond-ok",
+      "name": "Return Intent",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1920, 220]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: \"Body must include a non-empty 'utterance' (or 'text') field.\" }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-bad-request",
+      "name": "Return 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 460]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Utterance In": {
+      "main": [[{ "node": "Read Utterance", "type": "main", "index": 0 }]]
+    },
+    "Read Utterance": {
+      "main": [[{ "node": "Utterance Present?", "type": "main", "index": 0 }]]
+    },
+    "Utterance Present?": {
+      "main": [
+        [{ "node": "Classify Intent", "type": "main", "index": 0 }],
+        [{ "node": "Return 400", "type": "main", "index": 0 }]
+      ]
+    },
+    "Classify Intent": {
+      "main": [[{ "node": "Constrain To Allowed Set", "type": "main", "index": 0 }]]
+    },
+    "Constrain To Allowed Set": {
+      "main": [[{ "node": "Route By Intent", "type": "main", "index": 0 }]]
+    },
+    "Route By Intent": {
+      "main": [
+        [{ "node": "Return Intent", "type": "main", "index": 0 }],
+        [{ "node": "Return Intent", "type": "main", "index": 0 }],
+        [{ "node": "Return Intent", "type": "main", "index": 0 }],
+        [{ "node": "Return Intent", "type": "main", "index": 0 }]
+      ]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },


### PR DESCRIPTION
## Summary

`config/n8n/08-m4-deterministic-voice.json` was a placeholder — `manualTrigger`
+ sticky note + `"connections": {}` — behind a **featured** catalog card
advertising *"Intent classification with deterministic routing"*.

```
Webhook POST /webhook/ods-intent  {utterance}
  -> Utterance Present? (IF)      false -> Return 400
  -> Classify Intent              llama-server, temperature 0, max_tokens 8
  -> Constrain To Allowed Set     normalise + whitelist
  -> Route By Intent (Switch)     smart_home | timer | question | unknown
  -> Return Intent
```

```bash
curl -X POST http://localhost:5678/webhook/ods-intent \
  -H 'Content-Type: application/json' \
  -d '{"utterance": "turn the kitchen lights off"}'
```

### The "deterministic" part is built in, not prompted for

The card promises deterministic routing, so the workflow enforces it rather
than trusting the model to behave:

- The classifier runs at **`temperature: 0`** with **`max_tokens: 8`** and is
  told to answer with a single lowercase word.
- Its reply is then lowercased, stripped to `[a-z_]`, and **matched against the
  allowed set**. A sentence, a made-up label, a chatty preamble, or an empty
  completion all normalise to `unknown`.
- A **Switch node — not the model — selects the branch**, with a named
  fallback output for `unknown`.

That ordering matters: a hallucinated label cannot route a smart-home command
into a branch that actuates something. It lands in the branch that exists for
"I could not classify this". The raw label is returned alongside the
constrained one, so you can see when the model went off-script.

All four Switch outputs converge on the responder, so the workflow runs
correctly as shipped and you can watch classifications before wiring real
actions to the branches. A sticky note on the Switch says what each branch is
for.

## AI Assistance

AI assisted with drafting the node graph, the classifier prompt, and this
description. I confirmed the Switch node's rule/fallback parameter shape
against the node definition (`rules.values` → `conditions`, `renameOutput`,
`outputKey`; `options` → `fallbackOutput`, `renameFallbackOutput`) rather than
from memory, and validated the file before pushing.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(One JSON file under `config/n8n/`. An import payload for n8n; no ODS code
executes it. The catalog entry is unchanged.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Validated against the exact node package ODS ships (n8n 2.6.4 -> 2.6.2).

$ node verify.js 08-m4-deterministic-voice.json
n8n-nodes-base version: 2.6.2
node types loaded: 417
  checked 08-m4-deterministic-voice.json: 10 nodes

ALL WORKFLOWS VALID

# Switch parameter shape confirmed against the node definition:
#   switch versions: 1, 2, 3, 3.1, 3.2, 3.3, 3.4
#   props:   mode, numberOutputs, output, rules, looseTypeValidation, options
#   options: fallbackOutput, ignoreCase, looseTypeValidation,
#            renameFallbackOutput, allMatchingOutputs
#   rules.values: conditions, renameOutput, outputKey
```

**Caveat:** Docker is not running on my dev host, so I could not run a real
utterance through llama-server and watch the Switch fire. The validation is
static against the real node definitions. The normalisation and whitelist are
plain JS in a Set node, so their behaviour does not depend on the model — the
part I cannot demonstrate is the model's own label quality, which is exactly
what the whitelist exists to contain. Happy to get a live run before merge.

## Operational Change Check

An import payload for n8n. Nothing in the installer, compose stack, `ods-cli`,
or dashboard-api executes it. No existing install changes until a user imports
it.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The intent set is a placeholder I had to choose.** `smart_home`, `timer`,
`question`, `unknown` are a reasonable voice-assistant starting set and match
what the card implies, but "M4" suggests this template came from a specific
milestone with its own intent taxonomy. If there is a canonical ODS intent list
I did not find, tell me and I will swap it — the shape of the workflow does not
change, only the strings in the prompt, the whitelist, and the Switch rules.

**Branches deliberately converge.** I could have left three outputs
disconnected to make "fill this in" obvious, but a workflow that half-runs on
import is worse than one that runs and returns its classification. The sticky
note carries the intent.

Part of the series making the 18 stub templates real: #2496, #2497, #2498,
#2499, #2500. Independent files, no overlapping lines.
