### PR TITLE
feat(workflows): make the voice memo template real

### DIFF
--- a/ods/config/n8n/voice-memo.json
+++ b/ods/config/n8n/voice-memo.json
@@ -2,27 +2,203 @@
   "name": "Voice Memo",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## Voice Memo\n\nTalk into your phone, get a dated text file on the box. Transcription\nruns on your own Whisper — no cloud round trip.\n\n**Call it:**\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-memo \\\n  -F 'file=@memo.m4a'\n```\n\n**Where memos land:** `/home/node/.n8n/voice-memos/` inside the n8n\ncontainer, which is the `./data/n8n` bind mount — so on the host they\nappear under `data/n8n/voice-memos/`. They survive container restarts and\nare picked up by `ods backup`.\n\nFilenames are `YYYY-MM-DD-HHmmss.txt` in the container's timezone\n(`GENERIC_TIMEZONE`, set from `TIMEZONE` in `.env`).\n\nThe response includes both the transcript and the path written, so a\nphone shortcut can show the text immediately.",
+        "height": 580,
+        "width": 520
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [-100, 20]
     },
     {
       "parameters": {
-        "content": "## Voice Memo\n\nThis is a template workflow for recording and transcribing voice memos.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "httpMethod": "POST",
+        "path": "ods-memo",
+        "responseMode": "responseNode",
+        "options": {}
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "webhook-memo",
+      "name": "Memo Upload",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 320],
+      "webhookId": "5a8e0d34-7c96-4b18-83f5-2b6d9a4e1c07"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1",
+              "leftValue": "={{ $binary?.file?.fileName || $binary?.file?.mimeType }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-has-audio",
+      "name": "Memo Attached?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [660, 320]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://whisper:8000/v1/audio/transcriptions",
+        "sendBody": true,
+        "contentType": "multipart-form-data",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "parameterType": "formBinaryData",
+              "name": "file",
+              "inputDataFieldName": "file"
+            },
+            {
+              "name": "model",
+              "value": "={{ $json.body?.stt_model || 'Systran/faster-whisper-base' }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "http-whisper",
+      "name": "Whisper Transcribe",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 220]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "m1",
+              "name": "transcript",
+              "value": "={{ $json.text || '' }}",
+              "type": "string"
+            },
+            {
+              "id": "m2",
+              "name": "recorded_at",
+              "value": "={{ $now.toISO() }}",
+              "type": "string"
+            },
+            {
+              "id": "m3",
+              "name": "path",
+              "value": "={{ '/home/node/.n8n/voice-memos/' + $now.toFormat('yyyy-LL-dd-HHmmss') + '.txt' }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-memo",
+      "name": "Name The Memo",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1140, 220]
+    },
+    {
+      "parameters": {
+        "operation": "toText",
+        "sourceProperty": "transcript",
+        "binaryPropertyName": "memo",
+        "options": {
+          "fileName": "={{ $json.path.split('/').pop() }}"
+        }
+      },
+      "id": "convert-text",
+      "name": "Transcript To File",
+      "type": "n8n-nodes-base.convertToFile",
+      "typeVersion": 1.1,
+      "position": [1380, 220]
+    },
+    {
+      "parameters": {
+        "operation": "write",
+        "fileName": "={{ $('Name The Memo').item.json.path }}",
+        "dataPropertyName": "memo",
+        "options": {
+          "append": false
+        }
+      },
+      "id": "write-file",
+      "name": "Save Memo",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [1620, 220]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ transcript: $('Name The Memo').item.json.transcript, saved_to: $('Name The Memo').item.json.path, recorded_at: $('Name The Memo').item.json.recorded_at }) }}",
+        "options": {}
+      },
+      "id": "respond-ok",
+      "name": "Return Memo",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1860, 220]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: \"Send an audio memo as multipart form data, e.g. curl -F 'file=@memo.m4a'.\" }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-bad-request",
+      "name": "Return 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Memo Upload": {
+      "main": [[{ "node": "Memo Attached?", "type": "main", "index": 0 }]]
+    },
+    "Memo Attached?": {
+      "main": [
+        [{ "node": "Whisper Transcribe", "type": "main", "index": 0 }],
+        [{ "node": "Return 400", "type": "main", "index": 0 }]
+      ]
+    },
+    "Whisper Transcribe": {
+      "main": [[{ "node": "Name The Memo", "type": "main", "index": 0 }]]
+    },
+    "Name The Memo": {
+      "main": [[{ "node": "Transcript To File", "type": "main", "index": 0 }]]
+    },
+    "Transcript To File": {
+      "main": [[{ "node": "Save Memo", "type": "main", "index": 0 }]]
+    },
+    "Save Memo": {
+      "main": [[{ "node": "Return Memo", "type": "main", "index": 0 }]]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },


### PR DESCRIPTION
## Summary

`config/n8n/voice-memo.json` was a placeholder — `manualTrigger` + sticky note
+ `"connections": {}` — behind a catalog card advertising *"Record voice memos,
get text back"*.

```
Webhook POST /webhook/ods-memo  (multipart audio)
  -> Memo Attached? (IF)     false -> Return 400
  -> whisper:8000 /v1/audio/transcriptions
  -> Name The Memo           (timestamped path)
  -> Transcript To File      (convertToFile: toText)
  -> Save Memo               (readWriteFile: write)
  -> Return Memo             (transcript + path)
```

```bash
curl -X POST http://localhost:5678/webhook/ods-memo -F 'file=@memo.m4a'
```

### Where the memos actually go, and why there

`/home/node/.n8n/voice-memos/` inside the container. That is the `./data/n8n`
bind mount:

```yaml
volumes:
  - ./data/n8n:/home/node/.n8n:z
```

so on the host they appear under `data/n8n/voice-memos/`. Three reasons for
that path over anything else:

- it is the only writable, persistent mount n8n has;
- it survives container restarts and image upgrades;
- `data/n8n` is a path `ods-backup.sh` already covers, so memos are not a new
  category of unbacked-up user data.

Filenames are `YYYY-MM-DD-HHmmss.txt` in the container timezone — `compose.yaml`
sets `GENERIC_TIMEZONE` from `TIMEZONE` in `.env` — so they sort
chronologically without needing an index.

The response returns the transcript **as well as** the path, so a phone
shortcut can display the text immediately instead of round-tripping to read the
file back.

## AI Assistance

AI assisted with drafting the node graph and this description. I verified the
Whisper endpoint against its manifest, confirmed the writable mount and the
`convertToFile` / `readWriteFile` operation names against the node definitions
and `compose.yaml`, and validated the file before pushing.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(One JSON file under `config/n8n/`. An import payload for n8n; no ODS code
executes it. The catalog entry is unchanged.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Validated against the exact node package ODS ships (n8n 2.6.4 -> 2.6.2).

$ node verify.js voice-memo.json
n8n-nodes-base version: 2.6.2
node types loaded: 417
  checked voice-memo.json: 9 nodes

ALL WORKFLOWS VALID

# File-node operations confirmed against the node definitions:
#   readWriteFile v[1, 1.1]  operations: read | write
#     props: operation, fileSelector, options, fileName, dataPropertyName
#   convertToFile v[1, 1.1]  operations: csv | html | iCal | toJson | ods |
#                                        rtf | toText | xls | xlsx | toBinary

# Writable mount confirmed in extensions/services/n8n/compose.yaml:
24:      - ./data/n8n:/home/node/.n8n:z
```

**Caveat:** Docker is not running on my dev host, so I could not post a real
memo and confirm the file lands on disk. Static validation proves the file
imports and every parameter, version and operation name is real; the mount path
comes from `compose.yaml`. What I have not proven at runtime is that
`readWriteFile` creates the `voice-memos/` directory if it does not exist — see
the note below. Happy to get a live run before merge.

## Operational Change Check

An import payload for n8n. Nothing in the installer, compose stack, `ods-cli`,
or dashboard-api executes it. Once a user imports and runs it, it writes files
under the n8n data volume — new files in an existing backed-up location, no
change to any existing file.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The one thing I could not verify statically.** n8n's `readWriteFile` write
operation may or may not create a missing parent directory. If it does not, the
first run fails until the user creates `data/n8n/voice-memos/`. Two ways to make
that robust and I would rather you pick:

1. Add an `Execute Command` node to `mkdir -p` first — reliable, but it puts a
   shell node in a template, which I would rather not do unasked.
2. Write memos flat into `/home/node/.n8n/` with a `voice-memo-` filename
   prefix — no directory needed, slightly messier on disk.

I went with the subdirectory because it keeps the data volume tidy, and flagged
it here rather than guessing. Tell me which you prefer and I will follow up.

**Retention.** Nothing prunes old memos. If you want that, it belongs in
`scripts/` next to `session-cleanup.sh` rather than inside a workflow.

Part of the series making the 18 stub templates real: #2496, #2497, #2498,
#2499, #2500, #2501, #2502.
