### PR TITLE
feat(workflows): make the scheduled web search template real

### DIFF
--- a/ods/config/n8n/catalog.json
+++ b/ods/config/n8n/catalog.json
@@ -335,6 +335,7 @@
       "icon": "Globe",
       "category": "automation",
       "dependencies": [
+        "searxng",
         "llama-server"
       ],
       "setupTime": "5 minutes",

--- a/ods/config/n8n/scheduled-web-search.json
+++ b/ods/config/n8n/scheduled-web-search.json
@@ -2,27 +2,191 @@
   "name": "Scheduled Web Search",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## Scheduled Web Search\n\nEvery morning at 07:00, run a saved query through your own SearXNG\ninstance and have the local model brief you on what came back.\n\n```\ncron 07:00 -> searxng (JSON) -> llama-server (brief) -> data/n8n/search-briefs/\n```\n\n**Set your query** in the *Search Terms* node — it ships with\n`local AI self-hosting` as a placeholder.\n\n**Change the schedule** on the trigger; it is a plain daily rule at hour\n7, minute 0, in the container timezone (`GENERIC_TIMEZONE`, from\n`TIMEZONE` in `.env`).\n\nSearXNG aggregates the engines listed in `config/searxng/settings.yml`\nand returns JSON because that format is enabled there. No search API key\nand no tracking — the query leaves your box only as an ordinary search,\nand the briefing is written locally.\n\n**Requires** searxng and llama-server.",
+        "height": 620,
+        "width": 540
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [-120, 20]
     },
     {
       "parameters": {
-        "content": "## Scheduled Web Search\n\nThis is a template workflow for running search queries on a cron schedule, summarizing top results with the LLM, and posting a digest.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "rule": {
+          "interval": [
+            {
+              "field": "days",
+              "triggerAtHour": 7,
+              "triggerAtMinute": 0
+            }
+          ]
+        }
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "schedule",
+      "name": "Every Morning",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "q1",
+              "name": "query",
+              "value": "local AI self-hosting",
+              "type": "string"
+            },
+            {
+              "id": "q2",
+              "name": "max_results",
+              "value": 8,
+              "type": "number"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-query",
+      "name": "Search Terms",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "http://searxng:8080/search",
+        "sendQuery": true,
+        "specifyQuery": "keypair",
+        "queryParameters": {
+          "parameters": [
+            { "name": "q", "value": "={{ $json.query }}" },
+            { "name": "format", "value": "json" },
+            { "name": "safesearch", "value": "0" }
+          ]
+        },
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "http-searxng",
+      "name": "SearXNG Search",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [920, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// SearXNG returns { query, results: [{ url, title, content, engine }], ... }.\n// Keep the top N, drop anything without a URL, and trim snippets so a\n// long result set cannot overrun the model's context window.\nconst payload = $input.first().json;\nconst wanted = $('Search Terms').first().json.max_results || 8;\nconst results = Array.isArray(payload.results) ? payload.results : [];\n\nconst top = results\n  .filter((r) => r && r.url)\n  .slice(0, wanted)\n  .map((r, i) => ({\n    rank: i + 1,\n    title: (r.title || '').trim(),\n    url: r.url,\n    snippet: (r.content || '').trim().slice(0, 400),\n    engine: r.engine || '',\n  }));\n\nreturn [{\n  json: {\n    query: $('Search Terms').first().json.query,\n    result_count: top.length,\n    results: top,\n    digest_input: top\n      .map((r) => `[${r.rank}] ${r.title}\\n${r.url}\\n${r.snippet}`)\n      .join('\\n\\n'),\n  },\n}];"
+      },
+      "id": "code-shape",
+      "name": "Top Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://llama-server:8080/v1/chat/completions",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'local-model', messages: [ { role: 'system', content: 'You write short morning briefings from search results. Summarise only what the snippets say. Cite sources by their [n] number. If the results do not actually address the query, say so plainly instead of padding.' }, { role: 'user', content: 'Query: ' + $json.query + '\\n\\nResults:\\n' + $json.digest_input } ], temperature: 0.3, max_tokens: 900, stream: false }) }}",
+        "options": {
+          "timeout": 180000
+        }
+      },
+      "id": "http-llama",
+      "name": "Write Briefing",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1400, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "b1",
+              "name": "brief",
+              "value": "={{ '# ' + $('Top Results').item.json.query + '\\n\\n_' + $now.toISO() + ' — ' + $('Top Results').item.json.result_count + ' results_\\n\\n' + $json.choices[0].message.content + '\\n\\n## Sources\\n' + $('Top Results').item.json.results.map(r => '[' + r.rank + '] ' + r.title + ' — ' + r.url).join('\\n') + '\\n' }}",
+              "type": "string"
+            },
+            {
+              "id": "b2",
+              "name": "path",
+              "value": "={{ '/home/node/.n8n/search-briefs/' + $now.toFormat('yyyy-LL-dd') + '.md' }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-brief",
+      "name": "Compose Brief",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1640, 300]
+    },
+    {
+      "parameters": {
+        "operation": "toText",
+        "sourceProperty": "brief",
+        "binaryPropertyName": "brief",
+        "options": {
+          "fileName": "={{ $json.path.split('/').pop() }}"
+        }
+      },
+      "id": "convert-text",
+      "name": "Brief To File",
+      "type": "n8n-nodes-base.convertToFile",
+      "typeVersion": 1.1,
+      "position": [1880, 300]
+    },
+    {
+      "parameters": {
+        "operation": "write",
+        "fileName": "={{ $('Compose Brief').item.json.path }}",
+        "dataPropertyName": "brief",
+        "options": {
+          "append": false
+        }
+      },
+      "id": "write-file",
+      "name": "Save Brief",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [2120, 300]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Every Morning": {
+      "main": [[{ "node": "Search Terms", "type": "main", "index": 0 }]]
+    },
+    "Search Terms": {
+      "main": [[{ "node": "SearXNG Search", "type": "main", "index": 0 }]]
+    },
+    "SearXNG Search": {
+      "main": [[{ "node": "Top Results", "type": "main", "index": 0 }]]
+    },
+    "Top Results": {
+      "main": [[{ "node": "Write Briefing", "type": "main", "index": 0 }]]
+    },
+    "Write Briefing": {
+      "main": [[{ "node": "Compose Brief", "type": "main", "index": 0 }]]
+    },
+    "Compose Brief": {
+      "main": [[{ "node": "Brief To File", "type": "main", "index": 0 }]]
+    },
+    "Brief To File": {
+      "main": [[{ "node": "Save Brief", "type": "main", "index": 0 }]]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },


### PR DESCRIPTION
## Summary

`config/n8n/scheduled-web-search.json` was a placeholder — `manualTrigger` +
sticky note + `"connections": {}` — behind a catalog card advertising *"Search
the web on a schedule and summarize"*.

```
Schedule (daily 07:00)
  -> Search Terms      (your saved query)
  -> searxng:8080  /search?format=json
  -> Top Results (Code)  shape + clamp
  -> llama-server:8080 /v1/chat/completions
  -> Compose Brief -> Save Brief  (data/n8n/search-briefs/YYYY-MM-DD.md)
```

SearXNG returns JSON because `config/searxng/settings.yml` enables it, and its
limiter is off:

```yaml
server:
  limiter: false
search:
  formats:
    - html
    - json
```

So no API key, no per-request auth, no tracking account. The query leaves the
box only as an ordinary search, and the briefing is written locally.

### Choices worth reviewing

- **A Code node shapes the results before the model sees them:** drop entries
  with no URL, keep the top N (default 8), clamp each snippet to 400
  characters. Without that, a broad query returning 60 results overruns the
  context window and the whole scheduled run produces nothing.
- **The prompt is told to admit a miss.** *"If the results do not actually
  address the query, say so plainly instead of padding."* A scheduled job that
  confidently summarises irrelevant results is worse than one that says the
  search was bad.
- **The brief is Markdown with a Sources section** listing every URL used and
  its `[n]`, so the summary can be audited against what was actually returned.
- Written to `data/n8n/search-briefs/` — the same persistent, backed-up mount
  as #2503, dated one file per day.

### It also fixes the catalog entry

`scheduled-web-search` declared `["llama-server"]` only. The workflow cannot
run without SearXNG, and an **undeclared** dependency is not probed at all —
`check_workflow_dependencies()` only checks what the entry lists — so the card
showed "ready" on a box with no searxng installed. Now
`["searxng", "llama-server"]`.

(Same family as #2495, which fixes a dependency that is declared but names no
service. This one is the other half: a dependency that is not declared at all.)

## AI Assistance

AI assisted with drafting the node graph, the briefing prompt, and this
description. I confirmed SearXNG's JSON format and limiter settings in
`config/searxng/settings.yml`, the schedule-trigger rule shape against the node
definition, and validated the file before pushing.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(The workflow JSON, plus one `dependencies` array in `config/n8n/catalog.json`
which the dashboard Workflows page reads.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Validated against the exact node package ODS ships (n8n 2.6.4 -> 2.6.2).

$ node verify.js scheduled-web-search.json
n8n-nodes-base version: 2.6.2
node types loaded: 417
  checked scheduled-web-search.json: 9 nodes

ALL WORKFLOWS VALID

$ node -e "new Function(<the Code node body>)"
Code node body parses as JS

# scheduleTrigger rule shape confirmed against the node definition:
#   scheduleTrigger v[1, 1.1, 1.2, 1.3]
#   rule.interval values: field, secondsInterval, minutesInterval,
#     hoursInterval, daysInterval, weeksInterval, monthsInterval,
#     triggerAtDayOfMonth, triggerAtDay, triggerAtHour, triggerAtMinute,
#     expression

$ python3 -c "<read catalog>"
catalog deps before: ['llama-server']
catalog deps after:  ['searxng', 'llama-server']
```

**Caveat:** Docker is not running on my dev host, so I could not run a real
search through SearXNG and watch a brief land on disk. The JSON format and
limiter settings come from `config/searxng/settings.yml` in this repo, and the
result field names (`results[].url/title/content/engine`) are SearXNG's
documented JSON shape — but I have not seen a live response from this pinned
image (`searxng/searxng:2026.3.8-a563127a2`). That is the assumption I would
most want checked. Happy to get a live run before merge.

## Operational Change Check

The workflow JSON is an import payload — nothing in ODS executes it. The
catalog change affects one read path: the dashboard Workflows page will now
probe searxng's health for this entry, where it previously did not check it at
all. That moves the card from always-"ready" to accurate. No write path, no
schema change.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The catalog fix is bundled deliberately.** Normally I would split it, but
shipping a workflow that needs SearXNG while leaving the entry claiming it does
not seemed worse than the scope creep. Say the word and I will pull it into its
own PR.

**Directory creation** is the same open question as #2503: I have not confirmed
`readWriteFile` creates a missing `search-briefs/` parent. Whatever you decide
there, I will apply the same answer here.

**Default query** is `local AI self-hosting` as an obvious placeholder in a
named *Search Terms* node, rather than something the user might not notice was
a default.

Part of the series making the 18 stub templates real: #2496, #2497, #2498,
#2499, #2500, #2501, #2502, #2503.
