### PR TITLE
feat(workflows): make the RAG ingest template real

### DIFF
--- a/ods/config/n8n/catalog.json
+++ b/ods/config/n8n/catalog.json
@@ -177,12 +177,12 @@
       "id": "rag-pipeline-trigger",
       "file": "rag-pipeline-trigger.json",
       "name": "RAG Pipeline Trigger",
-      "description": "Ingest documents from a watched folder into Qdrant, then answer questions over the indexed corpus.",
+      "description": "Chunk, embed and index a document into Qdrant for retrieval",
       "icon": "Database",
       "category": "development",
       "dependencies": [
-        "llama-server",
-        "qdrant"
+        "qdrant",
+        "embeddings"
       ],
       "setupTime": "3 minutes",
       "featured": true,

--- a/ods/config/n8n/rag-pipeline-trigger.json
+++ b/ods/config/n8n/rag-pipeline-trigger.json
@@ -2,27 +2,191 @@
   "name": "RAG Pipeline Trigger",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## RAG Pipeline Trigger\n\nThe **ingest** half of RAG: push a document in, get it chunked, embedded\nand stored in Qdrant. Ask questions over it with the *Document Q&A*\ntemplate, which reads the same collection.\n\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-rag-ingest \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"source\": \"handbook.md\", \"text\": \"<document text>\"}'\n```\n\n**Body:** `text` (required), `source` (optional label), `collection`\n(optional, default `ods_docs`).\n\n**Chunking:** ~1200 characters with a 150-character overlap, split on\nparagraph boundaries where possible so a sentence is rarely cut in half.\n\n**Embeddings:** `embeddings:80/v1/embeddings`, the bundled TEI serving\n`BAAI/bge-base-en-v1.5` (768 dimensions). The collection is created with\nCosine distance on first use and left alone afterwards.\n\n**Ids are deterministic** — a UUIDv5 of `source#index` — so re-ingesting\nthe same document updates its points instead of duplicating them.\n\n**Requires** qdrant and embeddings.",
+        "height": 700,
+        "width": 540
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [-120, 20]
     },
     {
       "parameters": {
-        "content": "## RAG Pipeline Trigger\n\nThis is a template workflow for ingesting documents from a watched folder into Qdrant, then answering questions over the indexed corpus.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "httpMethod": "POST",
+        "path": "ods-rag-ingest",
+        "responseMode": "responseNode",
+        "options": {}
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "webhook-ingest",
+      "name": "Document In",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [460, 340],
+      "webhookId": "2b7a4e91-6d38-4c57-9e10-8a3f5b2d7c69"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1",
+              "leftValue": "={{ $json.body?.text }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-has-text",
+      "name": "Text Present?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 340]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "=http://qdrant:6333/collections/{{ $json.body?.collection || 'ods_docs' }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ vectors: { size: 768, distance: 'Cosine' } }) }}",
+        "options": {
+          "timeout": 30000,
+          "response": {
+            "response": {
+              "neverError": true
+            }
+          }
+        }
+      },
+      "id": "http-ensure-collection",
+      "name": "Ensure Collection",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [920, 240]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Split on paragraph boundaries, packing up to ~1200 characters per chunk\n// with a 150-character overlap so a fact spanning a boundary is still\n// retrievable from at least one chunk.\nconst body = $('Document In').first().json.body || {};\nconst text = String(body.text || '');\nconst source = String(body.source || 'untitled');\nconst collection = String(body.collection || 'ods_docs');\n\nconst MAX = 1200;\nconst OVERLAP = 150;\n\nconst paragraphs = text.split(/\\n\\s*\\n/).map((p) => p.trim()).filter(Boolean);\nconst chunks = [];\nlet current = '';\n\nfor (const paragraph of paragraphs) {\n  if (current && current.length + paragraph.length + 2 > MAX) {\n    chunks.push(current);\n    current = current.slice(Math.max(0, current.length - OVERLAP));\n  }\n  current = current ? current + '\\n\\n' + paragraph : paragraph;\n  while (current.length > MAX) {\n    chunks.push(current.slice(0, MAX));\n    current = current.slice(MAX - OVERLAP);\n  }\n}\nif (current.trim()) chunks.push(current);\n\nreturn chunks.map((chunk, index) => ({\n  json: { collection, source, index, text: chunk },\n}));"
+      },
+      "id": "code-chunk",
+      "name": "Chunk Document",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 240]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://embeddings:80/v1/embeddings",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'BAAI/bge-base-en-v1.5', input: $json.text }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-embed",
+      "name": "Embed Chunk",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1400, 240]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Pair each embedding with the chunk it came from. Both node outputs are\n// in the same order, one item per chunk.\nconst embeddings = $input.all();\nconst chunks = $('Chunk Document').all();\n\nif (embeddings.length !== chunks.length) {\n  throw new Error(\n    `Embedding count ${embeddings.length} does not match chunk count ${chunks.length}`\n  );\n}\n\n// Deterministic point id: UUIDv5 over \"source#index\" in the URL namespace,\n// so re-ingesting a document overwrites its own points instead of piling up\n// duplicates. Implemented inline because the Code node has no uuid import.\nconst crypto = require('crypto');\nconst NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';\n\nfunction uuidv5(name) {\n  const nsBytes = Buffer.from(NAMESPACE_URL.replace(/-/g, ''), 'hex');\n  const hash = crypto\n    .createHash('sha1')\n    .update(Buffer.concat([nsBytes, Buffer.from(name, 'utf8')]))\n    .digest();\n  const bytes = Buffer.from(hash.subarray(0, 16));\n  bytes[6] = (bytes[6] & 0x0f) | 0x50;\n  bytes[8] = (bytes[8] & 0x3f) | 0x80;\n  const hex = bytes.toString('hex');\n  return [\n    hex.slice(0, 8),\n    hex.slice(8, 12),\n    hex.slice(12, 16),\n    hex.slice(16, 20),\n    hex.slice(20),\n  ].join('-');\n}\n\nconst points = embeddings.map((item, i) => {\n  const vector = item.json?.data?.[0]?.embedding;\n  if (!Array.isArray(vector)) {\n    throw new Error(`Embedding ${i} has no vector — check the embeddings service`);\n  }\n  const chunk = chunks[i].json;\n  return {\n    id: uuidv5(`${chunk.source}#${chunk.index}`),\n    vector,\n    payload: {\n      text: chunk.text,\n      source: chunk.source,\n      chunk_index: chunk.index,\n      ingested_at: new Date().toISOString(),\n    },\n  };\n});\n\nreturn [{\n  json: { collection: chunks[0].json.collection, source: chunks[0].json.source, points },\n}];"
+      },
+      "id": "code-points",
+      "name": "Build Points",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1640, 240]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "=http://qdrant:6333/collections/{{ $json.collection }}/points?wait=true",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ points: $json.points }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-upsert",
+      "name": "Upsert To Qdrant",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1880, 240]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ collection: $('Build Points').item.json.collection, source: $('Build Points').item.json.source, chunks_indexed: $('Build Points').item.json.points.length, qdrant_status: $json.status }) }}",
+        "options": {}
+      },
+      "id": "respond-ok",
+      "name": "Return Result",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2120, 240]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: \"Body must include a non-empty 'text' field.\" }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-bad-request",
+      "name": "Return 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [920, 480]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Document In": {
+      "main": [[{ "node": "Text Present?", "type": "main", "index": 0 }]]
+    },
+    "Text Present?": {
+      "main": [
+        [{ "node": "Ensure Collection", "type": "main", "index": 0 }],
+        [{ "node": "Return 400", "type": "main", "index": 0 }]
+      ]
+    },
+    "Ensure Collection": {
+      "main": [[{ "node": "Chunk Document", "type": "main", "index": 0 }]]
+    },
+    "Chunk Document": {
+      "main": [[{ "node": "Embed Chunk", "type": "main", "index": 0 }]]
+    },
+    "Embed Chunk": {
+      "main": [[{ "node": "Build Points", "type": "main", "index": 0 }]]
+    },
+    "Build Points": {
+      "main": [[{ "node": "Upsert To Qdrant", "type": "main", "index": 0 }]]
+    },
+    "Upsert To Qdrant": {
+      "main": [[{ "node": "Return Result", "type": "main", "index": 0 }]]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },


### PR DESCRIPTION
## Summary

`config/n8n/rag-pipeline-trigger.json` was a placeholder — `manualTrigger` +
sticky note + `"connections": {}`. It is now the **ingest** half of RAG; the
query half is the Document Q&A template, reading the same collection.

```
Webhook POST /webhook/ods-rag-ingest  {text, source?, collection?}
  -> Text Present? (IF)      false -> Return 400
  -> Ensure Collection       PUT qdrant:6333/collections/<name>  (768, Cosine)
  -> Chunk Document (Code)   ~1200 chars, 150 overlap, paragraph-aware
  -> Embed Chunk             POST embeddings:80/v1/embeddings   (per chunk)
  -> Build Points (Code)     pair vectors to chunks, deterministic ids
  -> Upsert To Qdrant        PUT .../points?wait=true
  -> Return Result           {chunks_indexed, collection, source}
```

### Three decisions that make re-running it safe

- **Deterministic point ids.** A UUIDv5 of `source#index`, so re-ingesting the
  same document *updates its own points* instead of accumulating a duplicate
  set on every folder re-scan. Implemented inline over `crypto` because the
  Code node has no `uuid` import.
- **Collection creation is idempotent.** `Ensure Collection` runs with
  `neverError: true`, so an existing collection is not a failure. Vector size
  is pinned to **768** to match the bundled TEI serving `BAAI/bge-base-en-v1.5`.
- **The pairing is asserted, not assumed.** `Build Points` throws if the
  embedding count does not equal the chunk count, rather than zipping two lists
  that may have drifted and writing vectors onto the wrong text — a silent
  corruption you would only notice as bad retrieval months later.

Chunking splits on paragraph boundaries and packs up to ~1200 characters with a
150-character overlap, so a fact spanning a boundary stays retrievable from at
least one chunk.

### It also corrects the catalog entry

`dependencies` was `["llama-server", "qdrant"]`. The ingest path **never calls
llama-server**, and it cannot work without the **embeddings** service, which
was not declared at all — and an undeclared dependency is not probed, so the
card showed "ready" on a box with no embeddings service. Now
`["qdrant", "embeddings"]`, with a description that says what it actually does.

## AI Assistance

AI assisted with drafting the node graph, the chunker, and this description. I
confirmed the endpoints and the 768-dimension vector size against
`extensions/services/embeddings/` and `dashboard-api/settings.py`, and executed
both Code-node bodies against fake n8n context objects to check they behave —
results below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(The workflow JSON, plus one entry's `dependencies` and `description` in
`config/n8n/catalog.json`, which the dashboard Workflows page reads.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Validated against the exact node package ODS ships (n8n 2.6.4 -> 2.6.2).

$ node verify.js rag-pipeline-trigger.json
n8n-nodes-base version: 2.6.2
node types loaded: 417
  checked rag-pipeline-trigger.json: 10 nodes

ALL WORKFLOWS VALID

# Both Code-node bodies were executed against fake n8n context objects — not
# merely parsed — with a 12-paragraph document and 768-dim stub vectors:

chunks produced: 4
chunk sizes: 940, 1092, 1092, 1094
chunks over the 1200 cap: 0
overlap present between chunk 0 and 1: true
points built: 4
first id: 1c1a8fa9-0a1f-500e-89eb-fd99401f8330
ids are valid UUIDv5: true
ids are unique: true
ids are deterministic across runs: true
vector length: 768
payload keys: text, source, chunk_index, ingested_at
mismatched counts throw: Embedding count 3 does not match chunk count 4
```

**Caveat:** Docker is not running on my dev host, so I could not ingest against
a live Qdrant + TEI. The chunker and point builder are proven above; what is
not proven end to end is the two HTTP shapes — Qdrant's
`PUT /collections/{name}` and `PUT /collections/{name}/points?wait=true`, and
TEI's OpenAI-compatible `/v1/embeddings` response
(`data[0].embedding`). Those come from the pinned images
(`qdrant/qdrant:v1.16.3`, `text-embeddings-inference:cpu-1.9.1`) and from
`settings.py`, which already treats `http://embeddings:80/v1` as an
OpenAI-compatible base. That is what I would most want checked on a live box.

## Operational Change Check

The workflow JSON is an import payload — nothing in ODS executes it. The
catalog change affects one read path: the Workflows page will now probe qdrant
and embeddings for this entry and stop probing llama-server, which matches what
the workflow uses.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**I removed `llama-server` from this entry's dependencies.** The ingest path
does not call it. If you would rather dependencies describe the *pair* of RAG
templates rather than each one, say so and I will put it back — I would just
rather the card reflect what this workflow actually needs.

**Embedding model is hardcoded** to `BAAI/bge-base-en-v1.5`, matching the
`EMBEDDING_MODEL` default and the 768-dimension collection. If a user changes
`EMBEDDING_MODEL`, both this and the collection size need to change together —
which is exactly why `settings.py` warns that the bundled TEI serves one model
only. Reading it from the environment needs `EMBEDDING_MODEL` passed to n8n,
which `compose.yaml` does not do today; same plumbing question as #2496.

**One chunk per HTTP call.** Simple and readable, but a 200-chunk document
makes 200 requests. TEI accepts an array `input`, so a batched version is
possible — I kept it per-chunk so the pairing logic stays obvious. Happy to
batch it if you prefer.

Part of the series making the 18 stub templates real: #2496, #2497, #2498,
#2499, #2500, #2501, #2502, #2503, #2505.
