### PR TITLE
feat(workflows): make the RAG demo template real

### DIFF
--- a/ods/config/n8n/06-rag-demo.json
+++ b/ods/config/n8n/06-rag-demo.json
@@ -2,27 +2,273 @@
   "name": "RAG Demo",
   "nodes": [
     {
+      "parameters": {
+        "content": "## RAG Demo\n\nBoth halves of retrieval-augmented generation in one runnable workflow.\nPress **Test workflow** and watch it index a tiny corpus, then answer a\nquestion that can only be answered from it.\n\n```\nseed 3 passages -> embed -> Qdrant  (index)\nquestion -> embed -> Qdrant search -> llama-server  (retrieve + answer)\n```\n\nIt uses its own collection, `ods_rag_demo`, so it never touches the\n`ods_docs` collection the real templates use. Re-running is safe: point\nids are deterministic, so a second run updates the same three points.\n\n**The question is deliberately unanswerable without retrieval** — the\nseeded passages contain an invented policy detail no model could know.\nIf the answer comes back right, retrieval genuinely worked. If it comes\nback \"I don't know\", check that qdrant and embeddings are running.\n\nOnce this passes, use *RAG Pipeline Trigger* to index your own documents\nand *Document Q&A* to query them.\n\n**Requires** qdrant, embeddings and llama-server.",
+        "height": 700,
+        "width": 560
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-140, 20]
+    },
+    {
       "parameters": {},
-      "id": "start",
-      "name": "Start",
+      "id": "manual-trigger",
+      "name": "Run Demo",
       "type": "n8n-nodes-base.manualTrigger",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [460, 340]
     },
     {
       "parameters": {
-        "content": "## RAG Demo\n\nThis is a template workflow for retrieval-augmented generation.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "method": "PUT",
+        "url": "http://qdrant:6333/collections/ods_rag_demo",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ vectors: { size: 768, distance: 'Cosine' } }) }}",
+        "options": {
+          "timeout": 30000,
+          "response": {
+            "response": {
+              "neverError": true
+            }
+          }
+        }
       },
-      "id": "note",
-      "name": "Setup Instructions",
+      "id": "http-ensure",
+      "name": "Ensure Demo Collection",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 340]
+    },
+    {
+      "parameters": {
+        "jsCode": "// A tiny corpus with one invented, unguessable fact. If the final answer\n// contains it, retrieval demonstrably worked — a model cannot know this\n// from training data.\nconst passages = [\n  {\n    source: 'handbook.md',\n    text:\n      'Escalation policy. Any incident that stays unresolved for more than ' +\n      'forty minutes is escalated to the Kestrel rota. The Kestrel rota is ' +\n      'staffed on weekday evenings only; outside those hours incidents go ' +\n      'to the on-call duty engineer instead.',\n  },\n  {\n    source: 'handbook.md',\n    text:\n      'Backups. Nightly snapshots run at 02:15 in the cluster timezone and ' +\n      'are retained for fourteen days. Restores are rehearsed once a ' +\n      'quarter against a scratch namespace.',\n  },\n  {\n    source: 'onboarding.md',\n    text:\n      'New starters get read-only access on day one. Write access to ' +\n      'production is granted after the second week, and only once the ' +\n      'escalation drill has been completed with a buddy.',\n  },\n];\n\nreturn passages.map((p, index) => ({\n  json: { collection: 'ods_rag_demo', source: p.source, index, text: p.text },\n}));"
+      },
+      "id": "code-corpus",
+      "name": "Seed Passages",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 340]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://embeddings:80/v1/embeddings",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'BAAI/bge-base-en-v1.5', input: $json.text }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-embed-passages",
+      "name": "Embed Passages",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 340]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Deterministic ids so re-running the demo updates the same three points\n// rather than growing the collection. Same scheme as the RAG Pipeline\n// Trigger template.\nconst crypto = require('crypto');\nconst NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';\n\nfunction uuidv5(name) {\n  const nsBytes = Buffer.from(NAMESPACE_URL.replace(/-/g, ''), 'hex');\n  const hash = crypto\n    .createHash('sha1')\n    .update(Buffer.concat([nsBytes, Buffer.from(name, 'utf8')]))\n    .digest();\n  const bytes = Buffer.from(hash.subarray(0, 16));\n  bytes[6] = (bytes[6] & 0x0f) | 0x50;\n  bytes[8] = (bytes[8] & 0x3f) | 0x80;\n  const hex = bytes.toString('hex');\n  return [\n    hex.slice(0, 8),\n    hex.slice(8, 12),\n    hex.slice(12, 16),\n    hex.slice(16, 20),\n    hex.slice(20),\n  ].join('-');\n}\n\nconst embeddings = $input.all();\nconst passages = $('Seed Passages').all();\n\nif (embeddings.length !== passages.length) {\n  throw new Error(\n    `Embedding count ${embeddings.length} does not match passage count ${passages.length}`\n  );\n}\n\nconst points = embeddings.map((item, i) => {\n  const vector = item.json?.data?.[0]?.embedding;\n  if (!Array.isArray(vector)) {\n    throw new Error(`Embedding ${i} has no vector — check the embeddings service`);\n  }\n  const p = passages[i].json;\n  return {\n    id: uuidv5(`demo:${p.source}#${p.index}`),\n    vector,\n    payload: { text: p.text, source: p.source, chunk_index: p.index },\n  };\n});\n\nreturn [{ json: { points } }];"
+      },
+      "id": "code-points",
+      "name": "Build Demo Points",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 340]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "http://qdrant:6333/collections/ods_rag_demo/points?wait=true",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ points: $json.points }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-upsert",
+      "name": "Index Passages",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1620, 340]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "q1",
+              "name": "question",
+              "value": "After how long does an unresolved incident escalate, and which rota does it go to?",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-question",
+      "name": "Ask The Question",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1860, 340]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://embeddings:80/v1/embeddings",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'BAAI/bge-base-en-v1.5', input: $json.question }) }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "http-embed-question",
+      "name": "Embed Question",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2100, 340]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://qdrant:6333/collections/ods_rag_demo/points/query",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ query: $json.data[0].embedding, limit: 3, with_payload: true }) }}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "neverError": true
+            }
+          }
+        }
+      },
+      "id": "http-search",
+      "name": "Retrieve Passages",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2340, 340]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Accept both Qdrant shapes: /points/query returns { result: { points } },\n// the older /points/search returned { result: [...] }.\nconst payload = $input.first().json || {};\nconst raw = payload.result?.points ?? payload.result ?? [];\nconst hits = Array.isArray(raw) ? raw : [];\n\nconst kept = hits.map((h, i) => ({\n  rank: i + 1,\n  score: typeof h?.score === 'number' ? Number(h.score.toFixed(4)) : null,\n  source: h?.payload?.source ?? 'unknown',\n  text: String(h?.payload?.text ?? ''),\n}));\n\nreturn [{\n  json: {\n    question: $('Ask The Question').first().json.question,\n    retrieved: kept.length,\n    sources: kept.map(({ rank, score, source }) => ({ rank, score, source })),\n    context: kept.map((h) => `[${h.rank}] (${h.source}) ${h.text}`).join('\\n\\n'),\n  },\n}];"
+      },
+      "id": "code-context",
+      "name": "Build Context",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2580, 340]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://llama-server:8080/v1/chat/completions",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'local-model', messages: [ { role: 'system', content: 'Answer using only the numbered context passages. Cite the passages you used as [n]. If the context does not contain the answer, say so.' }, { role: 'user', content: 'Question: ' + $json.question + '\\n\\nContext:\\n' + $json.context } ], temperature: 0.2, max_tokens: 500, stream: false }) }}",
+        "options": {
+          "timeout": 180000
+        }
+      },
+      "id": "http-llama",
+      "name": "Answer From Context",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2820, 340]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "r1",
+              "name": "question",
+              "value": "={{ $('Build Context').item.json.question }}",
+              "type": "string"
+            },
+            {
+              "id": "r2",
+              "name": "answer",
+              "value": "={{ $json.choices[0].message.content }}",
+              "type": "string"
+            },
+            {
+              "id": "r3",
+              "name": "retrieval_worked",
+              "value": "={{ /kestrel/i.test($json.choices[0].message.content) }}",
+              "type": "boolean"
+            },
+            {
+              "id": "r4",
+              "name": "passages_retrieved",
+              "value": "={{ $('Build Context').item.json.retrieved }}",
+              "type": "number"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "set-result",
+      "name": "Demo Result",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [3060, 340]
+    },
+    {
+      "parameters": {
+        "content": "### Reading the result\n\n`retrieval_worked` checks whether the answer mentions **Kestrel** — the\ninvented rota name that appears only in the seeded passages. True means\nthe answer came from the index, not from the model's training data.\n\n`passages_retrieved` should be 3. Zero means Qdrant returned nothing —\ncheck that qdrant and embeddings are both healthy.",
+        "height": 280,
+        "width": 420
+      },
+      "id": "note-result",
+      "name": "Reading the result",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [440, 140]
+      "position": [2980, 520]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Run Demo": {
+      "main": [[{ "node": "Ensure Demo Collection", "type": "main", "index": 0 }]]
+    },
+    "Ensure Demo Collection": {
+      "main": [[{ "node": "Seed Passages", "type": "main", "index": 0 }]]
+    },
+    "Seed Passages": {
+      "main": [[{ "node": "Embed Passages", "type": "main", "index": 0 }]]
+    },
+    "Embed Passages": {
+      "main": [[{ "node": "Build Demo Points", "type": "main", "index": 0 }]]
+    },
+    "Build Demo Points": {
+      "main": [[{ "node": "Index Passages", "type": "main", "index": 0 }]]
+    },
+    "Index Passages": {
+      "main": [[{ "node": "Ask The Question", "type": "main", "index": 0 }]]
+    },
+    "Ask The Question": {
+      "main": [[{ "node": "Embed Question", "type": "main", "index": 0 }]]
+    },
+    "Embed Question": {
+      "main": [[{ "node": "Retrieve Passages", "type": "main", "index": 0 }]]
+    },
+    "Retrieve Passages": {
+      "main": [[{ "node": "Build Context", "type": "main", "index": 0 }]]
+    },
+    "Build Context": {
+      "main": [[{ "node": "Answer From Context", "type": "main", "index": 0 }]]
+    },
+    "Answer From Context": {
+      "main": [[{ "node": "Demo Result", "type": "main", "index": 0 }]]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },

--- a/ods/config/n8n/catalog.json
+++ b/ods/config/n8n/catalog.json
@@ -86,11 +86,12 @@
       "id": "rag-demo",
       "file": "06-rag-demo.json",
       "name": "RAG Demo",
-      "description": "Retrieval-augmented generation example",
+      "description": "End-to-end RAG example: seeds a tiny corpus, then answers from it",
       "icon": "Search",
       "category": "development",
       "dependencies": [
         "qdrant",
+        "embeddings",
         "llama-server"
       ],
       "setupTime": "3 minutes",


### PR DESCRIPTION
## Summary

`config/n8n/06-rag-demo.json` was a placeholder — `manualTrigger` + sticky note
+ `"connections": {}` — behind a catalog card advertising *"Retrieval-augmented
generation example"*.

Pressing **Test workflow** now runs both halves end to end:

```
Run Demo
  -> Ensure Demo Collection   (ods_rag_demo, 768, Cosine)
  -> Seed Passages            3 short passages
  -> Embed Passages -> Build Demo Points -> Index Passages
  -> Ask The Question
  -> Embed Question -> Retrieve Passages -> Build Context
  -> Answer From Context
  -> Demo Result              {answer, retrieval_worked, passages_retrieved}
```

### It proves retrieval instead of asserting it

The seeded corpus contains an **invented** detail — an escalation rota called
**Kestrel** — that appears in no model's training data. The final node sets:

```js
retrieval_worked: /kestrel/i.test(answer)
```

So a user can tell at a glance whether the answer came from the index or from
the model improvising. A demo that just prints a plausible paragraph teaches
you nothing about whether your Qdrant is actually wired up; this one fails
visibly.

`passages_retrieved` should be 3. Zero means Qdrant returned nothing, and a
sticky note next to the result says exactly that and what to check.

### Safe to run, and to re-run

- **Its own collection**, `ods_rag_demo`, so the demo never touches the
  `ods_docs` collection the real templates (#2506, #2508) use.
- **Deterministic point ids** (UUIDv5 of `demo:source#index`), so a second run
  updates the same three points rather than growing the collection.
- Collection creation uses `neverError`, and search does too, so an
  already-existing collection or a missing one surfaces as data rather than a
  red node.

### It also corrects the catalog entry

`dependencies` was `["qdrant", "llama-server"]` — the **embeddings** service was
not declared, and an undeclared dependency is never probed, so the card showed
"ready" without it. Now `["qdrant", "embeddings", "llama-server"]`, with a
description that says what the demo does.

## AI Assistance

AI assisted with drafting the node graph, the seeded corpus, and this
description. I confirmed the endpoints and vector size against the service
manifests, and executed all three Code-node bodies against fake n8n context
objects — results below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(The workflow JSON, plus one entry's `dependencies` and `description` in
`config/n8n/catalog.json`, which the dashboard Workflows page reads.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Validated against the exact node package ODS ships (n8n 2.6.4 -> 2.6.2).

$ node verify.js 06-rag-demo.json
n8n-nodes-base version: 2.6.2
node types loaded: 417
  checked 06-rag-demo.json: 14 nodes

ALL WORKFLOWS VALID

# All three Code-node bodies executed against fake n8n context objects:

passages seeded: 3 | sources: handbook.md, onboarding.md
invented fact present: true
points: 3 | uuidv5: true | unique: true
deterministic across runs: true
vector length: 768
retrieved: 3 | context carries the invented fact: true
sources: [{"rank":1,"score":0.9,"source":"handbook.md"},
          {"rank":2,"score":0.8,"source":"handbook.md"},
          {"rank":3,"score":0.7,"source":"onboarding.md"}]
empty payload -> retrieved: 0
error payload -> retrieved: 0
```

**Caveat:** Docker is not running on my dev host, so I could not run the demo
against live Qdrant + TEI + llama-server. The seeding, id generation and
context assembly are proven above, including the empty and error paths. What is
not proven end to end is the HTTP shapes — TEI `/v1/embeddings` and Qdrant
`v1.16.3` `PUT /collections/{n}` / `PUT .../points?wait=true` /
`POST .../points/query` — and, of course, whether a Tier 0–2 model actually
answers correctly from the retrieved context. This is the workflow where a live
run would be most informative, since it is the one meant to *demonstrate* the
stack works. Happy to get one before merge.

## Operational Change Check

The workflow JSON is an import payload — nothing in ODS executes it. When a
user runs it, it creates and writes a `ods_rag_demo` collection in their
Qdrant, which is new state in a service they installed for this purpose, and
never touches `ods_docs`. The catalog change makes the Workflows page also
probe the embeddings service for this entry.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**"Kestrel" is doing real work here.** If you would rather the demo not rely on
a keyword check, the alternative is to trust the reader to eyeball the answer —
which is what a demo that cannot fail gives you today. I would keep it, but the
word itself is arbitrary and easy to change.

**Nothing cleans up `ods_rag_demo`.** Three points is negligible, and leaving
it lets the user inspect the collection in Qdrant's dashboard afterwards, which
seemed more useful than tidiness. Say if you would rather it delete the
collection at the end.

**The demo does not check `min_score`** the way #2508 does — it always answers
from whatever came back. That is deliberate: the point is to show the pipeline
end to end, and the `retrieval_worked` flag already tells you if it failed.

This completes the batch. Series so far: #2496, #2497, #2498, #2499, #2500,
#2501, #2502, #2503, #2505, #2506, #2508 — 12 of the 18 stub templates now do
something. Remaining stubs need services whose APIs I have not verified
(comfyui, hermes, openclaw, litellm/email) or a data source decision
(daily-digest), so I have left them rather than guess.
