### PR TITLE
fix(token-spy): price Claude 3.x models instead of billing them at zero

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Test Postgres SSE cursor
         run: python -m pytest tests/test_recent_events_cursor_postgres.py -v
 
+      - name: Test provider pricing lookups
+        run: python -m pytest tests/test_provider_pricing.py -v
+
   integration-smoke:
     runs-on: ubuntu-latest
     defaults:

--- a/ods/extensions/services/token-spy/providers/anthropic.py
+++ b/ods/extensions/services/token-spy/providers/anthropic.py
@@ -7,10 +7,19 @@ Handles Anthropic-specific request/response formats including:
 """
 
 import json
+import re
 from typing import Any, Dict, List, Optional
 
 from .base import LLMProvider
 from .registry import register_provider
+
+# Anthropic wrote the generation before the family for Claude 3.x
+# (claude-3-5-haiku-20241022) and after it from Claude 4 on
+# (claude-haiku-4-5-20251001). Normalise the older spelling onto the newer
+# one so a single pricing table covers both.
+_GENERATION_FIRST_RE = re.compile(
+    r"claude-(?P<major>\d+)(?:[-.](?P<minor>\d+))?-(?P<family>opus|sonnet|haiku)"
+)
 
 
 @register_provider("anthropic")
@@ -25,7 +34,11 @@ class AnthropicProvider(LLMProvider):
         "claude-opus-4": {"input": 15.0, "output": 75.0, "cache_read": 1.50, "cache_write": 18.75},
         "claude-sonnet-4": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
         "claude-haiku-4-5": {"input": 1.0, "output": 5.0, "cache_read": 0.10, "cache_write": 1.25},
+        "claude-sonnet-3-7": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
+        "claude-sonnet-3-5": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
+        "claude-opus-3": {"input": 15.0, "output": 75.0, "cache_read": 1.50, "cache_write": 18.75},
         "claude-haiku-3-5": {"input": 0.80, "output": 4.0, "cache_read": 0.08, "cache_write": 1.0},
+        "claude-haiku-3": {"input": 0.25, "output": 1.25, "cache_read": 0.03, "cache_write": 0.30},
         "claude-haiku": {"input": 0.80, "output": 4.0, "cache_read": 0.08, "cache_write": 1.0},
     }
 
@@ -53,9 +66,26 @@ class AnthropicProvider(LLMProvider):
     def api_endpoint(self) -> str:
         return "/v1/messages"
 
+    @staticmethod
+    def normalize_model(model: str) -> str:
+        """Rewrite generation-first model ids into the family-first spelling.
+
+        Anthropic put the generation before the family for Claude 3.x
+        (``claude-3-5-haiku-20241022``) and after it from Claude 4 on
+        (``claude-haiku-4-5-20251001``). COST_TABLE is keyed on the newer
+        spelling, so a 3.x id matched nothing at all and every lookup fell
+        through to zero — a silent "this cost nothing" on the one service
+        whose job is telling you what things cost.
+        """
+        return _GENERATION_FIRST_RE.sub(
+            lambda m: f"claude-{m.group('family')}-{m.group('major')}"
+            + (f"-{m.group('minor')}" if m.group("minor") else ""),
+            model.lower(),
+        )
+
     def get_model_pricing(self, model: str) -> Dict[str, float]:
         """Match model name to pricing table."""
-        model_lower = model.lower()
+        model_lower = self.normalize_model(model)
 
         # Try exact prefix matches (longer prefixes first for specificity)
         for prefix in sorted(self.COST_TABLE.keys(), key=len, reverse=True):

--- a/ods/extensions/services/token-spy/tests/test_provider_pricing.py
+++ b/ods/extensions/services/token-spy/tests/test_provider_pricing.py
@@ -1,0 +1,147 @@
+"""Pricing lookup contracts for the Token Spy providers.
+
+Token Spy exists to tell an operator what their agents cost. A model id that
+matches no pricing row is silently billed at zero, which looks exactly like
+"this was free" — the one failure mode the service must not have.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(TOKEN_SPY_DIR))
+
+
+def _load(relative: str):
+    path = TOKEN_SPY_DIR / relative
+    spec = importlib.util.spec_from_file_location(f"ts_{uuid4().hex}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def anthropic():
+    from providers.anthropic import AnthropicProvider
+
+    return AnthropicProvider()
+
+
+# Every Claude model id Anthropic has shipped, in the spelling the API uses.
+# Generation-first for 3.x, family-first from 4 on.
+CLAUDE_IDS = [
+    "claude-opus-4-6-20260115",
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-1-20250805",
+    "claude-opus-4-20250514",
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-20250514",
+    "claude-haiku-4-5-20251001",
+    "claude-3-7-sonnet-20250219",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-sonnet-20240620",
+    "claude-3-5-haiku-20241022",
+    "claude-3-opus-20240229",
+    "claude-3-haiku-20240307",
+]
+
+
+@pytest.mark.parametrize("model", CLAUDE_IDS)
+def test_every_claude_model_has_a_price(anthropic, model):
+    """A priced model billed at zero is indistinguishable from a free one."""
+    pricing = anthropic.get_model_pricing(model)
+    assert pricing["input"] > 0, f"{model} priced at zero input"
+    assert pricing["output"] > 0, f"{model} priced at zero output"
+
+
+@pytest.mark.parametrize("model", CLAUDE_IDS)
+def test_output_costs_at_least_as_much_as_input(anthropic, model):
+    """Sanity check against a transposed row."""
+    pricing = anthropic.get_model_pricing(model)
+    assert pricing["output"] >= pricing["input"], model
+
+
+@pytest.mark.parametrize("model", CLAUDE_IDS)
+def test_cache_read_is_cheaper_than_input(anthropic, model):
+    """Cache reads are discounted; a row where they are not is a typo."""
+    pricing = anthropic.get_model_pricing(model)
+    assert pricing["cache_read"] < pricing["input"], model
+
+
+# --- Both spellings must resolve to the same tier -------------------------
+
+
+@pytest.mark.parametrize(
+    "generation_first,family_first",
+    [
+        ("claude-3-5-haiku-20241022", "claude-haiku-3-5"),
+        ("claude-3-5-sonnet-20241022", "claude-sonnet-3-5"),
+        ("claude-3-opus-20240229", "claude-opus-3"),
+        ("claude-3-haiku-20240307", "claude-haiku-3"),
+    ],
+)
+def test_generation_first_ids_resolve(anthropic, generation_first, family_first):
+    assert anthropic.normalize_model(generation_first).startswith(family_first)
+    assert (
+        anthropic.get_model_pricing(generation_first)
+        == anthropic.COST_TABLE[family_first]
+    )
+
+
+def test_family_first_ids_are_untouched(anthropic):
+    """Claude 4+ ids already match; normalisation must not disturb them."""
+    for model in ("claude-opus-4-5-20251101", "claude-haiku-4-5-20251001"):
+        assert anthropic.normalize_model(model) == model
+
+
+def test_haiku_3_is_not_priced_as_haiku_3_5(anthropic):
+    """The bare `claude-haiku` catch-all must not swallow Haiku 3."""
+    haiku_3 = anthropic.get_model_pricing("claude-3-haiku-20240307")
+    haiku_35 = anthropic.get_model_pricing("claude-3-5-haiku-20241022")
+    assert haiku_3["input"] < haiku_35["input"]
+
+
+# --- Misses stay misses ----------------------------------------------------
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "llama-3.1-70b", "", "claude"])
+def test_non_claude_models_are_unpriced(anthropic, model):
+    """Normalisation must not start matching things it should not."""
+    assert anthropic.get_model_pricing(model)["input"] == 0.0
+
+
+def test_cost_is_computed_from_the_matched_row(anthropic):
+    """calculate_cost must use the row the lookup returned."""
+    usage = {
+        "input_tokens": 1_000_000,
+        "output_tokens": 1_000_000,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    pricing = anthropic.get_model_pricing("claude-3-5-sonnet-20241022")
+    cost = anthropic.calculate_cost(usage, "claude-3-5-sonnet-20241022")
+    assert cost == pytest.approx(pricing["input"] + pricing["output"])
+    assert cost > 0
+
+
+def test_unpriced_model_costs_zero(anthropic):
+    usage = {"input_tokens": 1_000_000, "output_tokens": 1_000_000}
+    assert anthropic.calculate_cost(usage, "some-unknown-model") == 0.0
+
+
+# --- The OpenAI-compatible table is unaffected -----------------------------
+
+
+def test_openai_table_still_resolves():
+    from providers.openai import OpenAICompatibleProvider
+
+    provider = OpenAICompatibleProvider()
+    for model in ("gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "o1", "kimi-k2"):
+        assert provider.get_model_pricing(model)["input"] > 0, model


### PR DESCRIPTION
## Summary

`get_model_pricing()` matches model ids against `COST_TABLE` by substring. The
table is keyed on Anthropic's **post-Claude-4** spelling, where the family comes
before the generation:

```python
"claude-haiku-4-5": {...}   # matches claude-haiku-4-5-20251001
```

Claude 3.x ids put the **generation first**, so none of them match anything and
every lookup falls through to the zero default. Run against `origin/main`:

```text
  claude-opus-4-5-20251101       in=5.0    out=25.0
  claude-sonnet-4-5-20250929     in=3.0    out=15.0
  claude-haiku-4-5-20251001      in=1.0    out=5.0
  claude-3-5-sonnet-20241022     in=0.0    out=0.0     <-- ZERO COST
  claude-3-5-haiku-20241022      in=0.0    out=0.0     <-- ZERO COST
  claude-3-opus-20240229         in=0.0    out=0.0     <-- ZERO COST
  claude-3-haiku-20240307        in=0.0    out=0.0     <-- ZERO COST
```

Token Spy is the service that tells an operator what their agents cost.
Reporting **$0.00** for a real Claude 3.5 Sonnet session is not a missing
feature — it reads as *"this was free"*, which is the one answer a cost tracker
must never give wrongly. And it fails quietly: nothing in the UI distinguishes
"a local model, genuinely free" from "we could not price this".

The give-away that this is a bug and not a policy choice is already in the
table:

```python
"claude-haiku-3-5": {"input": 0.80, "output": 4.0, "cache_read": 0.08, "cache_write": 1.0},
```

0.80 / 4.00 is exactly Claude 3.5 Haiku's rate — someone priced that tier
deliberately, wrote it in a spelling Anthropic never shipped, and it has been
unreachable ever since.

### Fix

1. **Normalise generation-first ids onto the family-first form** before the
   lookup. `claude-3-5-haiku-20241022` → `claude-haiku-3-5-20241022`, which
   makes the row above reachable without inventing a price. Claude 4+ ids are
   left byte-identical.
2. **Add rows for the tiers that had none:** `sonnet-3-7`, `sonnet-3-5`,
   `opus-3`, `haiku-3`.
3. **`haiku-3` gets its own row** so the bare `claude-haiku` catch-all does not
   swallow it. That catch-all is priced at Haiku 3.5's rate, so without an
   explicit row the fix would have billed Haiku 3 at 0.80/4.00 instead of
   0.25/1.25 — a 3.2× overstatement. Turning a silent undercount into a silent
   overcount would not be an improvement.

After:

```text
  claude-3-7-sonnet-20250219     in=3.0    out=15.0
  claude-3-5-sonnet-20241022     in=3.0    out=15.0
  claude-3-5-haiku-20241022      in=0.8    out=4.0
  claude-3-opus-20240229         in=15.0   out=75.0
  claude-3-haiku-20240307        in=0.25   out=1.25
  gpt-4o                         in=0.0    out=0.0     (still a miss, correctly)
```

### Test

`providers/` had no test coverage — nothing under
`extensions/services/token-spy/tests/` referenced it. Adds
`tests/test_provider_pricing.py`: 52 assertions over every shipped Claude id,
both spellings resolving to the same row, output ≥ input and cache_read < input
as typo guards, the Haiku 3 / 3.5 boundary, that non-Claude ids still miss, and
that `calculate_cost` uses the row the lookup returned. Wired into the existing
token-spy CI job.

## AI Assistance

AI assisted with the normalisation regex, drafting the test matrix, and wording
this description. I found the mismatch by running the shipped table against
real model ids, and the four prices I added are the published rates listed
below for you to check.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(`token-spy` is a bundled extension service. One provider module and its new
tests; CI config is also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 -m py_compile extensions/services/token-spy/providers/anthropic.py
py OK

$ python3 -m pytest tests/test_provider_pricing.py -q
52 passed

$ python3 -m pytest tests/ -q        # whole token-spy suite
72 passed, 1 skipped

# the new suite against origin/main's provider:
19 failed, 33 passed
```

**Caveat — the numbers I added.** These are the published per-1M-token rates I
used, and they are the part of this PR I would most like a second pair of eyes
on, since I am asserting data rather than fixing logic:

| Row | input | output | cache read | cache write |
|---|---|---|---|---|
| `claude-sonnet-3-7` | 3.00 | 15.00 | 0.30 | 3.75 |
| `claude-sonnet-3-5` | 3.00 | 15.00 | 0.30 | 3.75 |
| `claude-opus-3` | 15.00 | 75.00 | 1.50 | 18.75 |
| `claude-haiku-3` | 0.25 | 1.25 | 0.03 | 0.30 |

Sonnet 3.5/3.7 and Opus 3 reuse the rates already in the table for their
same-priced siblings (`claude-sonnet-4`, `claude-opus-4`), so only the Haiku 3
row is a genuinely new figure. If your pricing source says otherwise, change
the numbers — the normalisation and the tests stand independently of them.

## Operational Change Check

`get_model_pricing()` runs inside the `token-spy` container when computing cost
for a recorded event. The change is additive: ids that already matched still
match the same row (asserted by
`test_family_first_ids_are_untouched` and by the OpenAI-table test), and ids
that matched nothing now match. No request path, schema, or database change —
though **historical rows already stored with cost 0 stay 0**; this fixes new
events, not the backfill.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The deeper issue is that a pricing miss is invisible.** Zero is both "free
local model" and "we don't know this one", and the UI cannot tell them apart. A
follow-up worth considering: have `get_model_pricing` report whether it matched,
and surface unpriced models in the usage view instead of summing them as $0. I
did not do it here because it touches the storage and the dashboard, and this
PR is about the models that *should* have priced all along. Say the word and I
will send it.

**The bare `claude-haiku` catch-all is now nearly dead** — every real Haiku id
has an explicit row. I left it rather than remove it, since it is the only
thing that would catch a future Haiku released before someone adds a row. It is
priced at 3.5 rates, so it would guess low for a newer model; if you would
rather it be removed so a new model reports zero and gets noticed, that is a
one-line change.
