### PR TITLE
fix(external-llm): match Ollama models carrying the default :latest tag

### DIFF
--- a/ods/installers/lib/external-services.sh
+++ b/ods/installers/lib/external-services.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 # External Ollama / LM Studio discovery and validation helpers.
 
+# Reduce a provider's model id to a comparable name.
+#
+# Ollama reports names as `<model>:<tag>`. The tag is the default `latest`
+# unless the user asked for a specific one, so `ollama pull qwen3-30b-a3b`
+# is listed as `qwen3-30b-a3b:latest` — the exact model ODS wants, under a
+# name that used to normalize to `qwen3-30b-a3b-latest` and match nothing.
+#
+# Tag handling therefore runs BEFORE the quantization strip: a quant that
+# arrives in the tag position (`qwen3.5-2b:q8_0`) is only recognisable once
+# the colon has become a separator the quant pattern accepts.
 external_llm_normalize_model_name() {
     local value="${1:-}"
     value="${value##*/}"
     value="${value,,}"
     value="${value%.gguf}"
     value="$(printf '%s' "$value" | sed -E \
-        -e 's/[-_.](q[0-9]+([_.][a-z0-9]+)*|iq[0-9]+([_.][a-z0-9]+)*|fp(8|16|32)|bf16)([-_.].*)?$//' \
+        -e 's/:latest$//' \
         -e 's/:/-/' \
+        -e 's/[-_.](q[0-9]+([_.][a-z0-9]+)*|iq[0-9]+([_.][a-z0-9]+)*|fp(8|16|32)|bf16)([-_.].*)?$//' \
         -e 's/[[:space:]_]+/-/g' \
         -e 's/-+/-/g' \
         -e 's/^-|-$//g')"

--- a/ods/tests/test-external-services.sh
+++ b/ods/tests/test-external-services.sh
@@ -43,6 +43,27 @@ assert_eq "$(external_llm_normalize_model_name 'qwen3.5:9b')" \
     "qwen3.5-9b" "normalizes Ollama tags"
 assert_eq "$(external_llm_normalize_model_name 'Qwen3.5-9B-Q4_K_M.gguf')" \
     "qwen3.5-9b" "removes GGUF quantization suffixes"
+# `latest` is Ollama's default tag: `ollama pull qwen3-30b-a3b` is listed by
+# /api/tags as `qwen3-30b-a3b:latest`. Treating that as part of the name meant
+# the commonest case — the user already has exactly the model we want — never
+# matched, and the installer downloaded a duplicate copy.
+assert_eq "$(external_llm_normalize_model_name 'qwen3-30b-a3b:latest')" \
+    "qwen3-30b-a3b" "drops Ollama's default :latest tag"
+assert_eq "$(external_llm_normalize_model_name 'gemma-4-e4b-it:latest')" \
+    "gemma-4-e4b-it" "drops :latest from a hyphenated name"
+# A quantization that arrives in the tag position is still a quantization.
+assert_eq "$(external_llm_normalize_model_name 'qwen3.5-2b:q8_0')" \
+    "qwen3.5-2b" "strips a quantization supplied as an Ollama tag"
+assert_eq "$(external_llm_normalize_model_name 'qwen3.5-9b:iq4_xs')" \
+    "qwen3.5-9b" "strips an IQ quantization tag"
+# A size tag is part of the identity and must survive.
+assert_eq "$(external_llm_normalize_model_name 'qwen3.5:9b')" \
+    "qwen3.5-9b" "keeps a size tag"
+assert_eq "$(external_llm_normalize_model_name 'llama3.2:3b')" \
+    "llama3.2-3b" "keeps a size tag on another family"
+# "latest" only counts as a tag, never as part of the name.
+assert_eq "$(external_llm_normalize_model_name 'my-latest-model')" \
+    "my-latest-model" "does not strip latest from inside a name"
 assert_eq "$(external_llm_container_url 'http://localhost:11434/v1')" \
     "http://host.docker.internal:11434" "normalizes localhost for containers"
 assert_eq "$(external_llm_container_url 'http://[::1]:1234/api/v1')" \
@@ -72,6 +93,24 @@ if external_llm_model_matches "qwen3.5:9b" "llama3.2:3b"; then
     fail "rejects unrelated model families"
 else
     pass "rejects unrelated model families"
+fi
+# The tier map's LLM_MODEL against what /api/tags actually reports for a
+# model the user pulled by bare name.
+assert_true "matches a tier target against Ollama's :latest listing" \
+    external_llm_model_matches "qwen3-30b-a3b" "qwen3-30b-a3b:latest"
+assert_true "matches a hyphenated tier target against :latest" \
+    external_llm_model_matches "gemma-4-e4b-it" "gemma-4-e4b-it:latest"
+assert_true "matches a tier target against a quantization tag" \
+    external_llm_model_matches "qwen3.5-2b" "qwen3.5-2b:q8_0"
+if external_llm_model_matches "qwen3.5-9b" "qwen3.5:4b"; then
+    fail "rejects a different size in the tag"
+else
+    pass "rejects a different size in the tag"
+fi
+if external_llm_model_matches "qwen3-30b-a3b" "qwen3-8b:latest"; then
+    fail "rejects a different model carrying :latest"
+else
+    pass "rejects a different model carrying :latest"
 fi
 
 run_phase_case() {


### PR DESCRIPTION
## Summary

`external_llm_model_matches()` normalises both sides and requires an exact
match. The normaliser translated `:` to `-` **after** stripping quantization
suffixes, so whatever Ollama put in the tag position survived into the name.

Ollama's default tag is `latest` — `ollama pull qwen3-30b-a3b` is reported by
`/api/tags` as `qwen3-30b-a3b:latest`. Against `origin/main`:

```text
  qwen3-30b-a3b:latest             -> qwen3-30b-a3b-latest
  gemma-4-e4b-it:latest            -> gemma-4-e4b-it-latest
  qwen3.5-2b:q8_0                  -> qwen3.5-2b-q8-0

  NO MATCH  qwen3-30b-a3b    <- qwen3-30b-a3b:latest
  NO MATCH  gemma-4-e4b-it   <- gemma-4-e4b-it:latest
  NO MATCH  qwen3.5-2b       <- qwen3.5-2b:q8_0
  MATCH     qwen3.5-9b       <- qwen3.5:9b
```

So the **commonest case there is** — the user already has exactly the model the
tier map wants, pulled by bare name — was declined, and the installer
downloaded a duplicate multi-GB GGUF instead of reusing it. That is the
opposite of what `feat(installer): reuse validated external model services`
exists to do.

The last line is why this survived: a user who happened to pull with an
explicit size tag (`qwen3.5:9b`) matched fine, and that is the case the
existing test covers.

### Fix

Do tag handling **before** the quantization strip:

```sh
-e 's/:latest$//'      # Ollama's default tag is not part of the name
-e 's/:/-/'            # ...then a quant in the tag position is strippable
-e 's/[-_.](q[0-9]+...|iq[0-9]+...|fp(8|16|32)|bf16)([-_.].*)?$//'
```

Two properties I was careful to keep:

- **Size tags are identity and must survive.** `qwen3.5:9b` → `qwen3.5-9b`,
  `llama3.2:3b` → `llama3.2-3b`.
- **`latest` is only ever a tag.** Anchored to `:latest$`, so a model named
  `my-latest-model` is untouched.

After:

```text
  MATCH     qwen3-30b-a3b    <- qwen3-30b-a3b:latest
  MATCH     gemma-4-e4b-it   <- gemma-4-e4b-it:latest
  MATCH     qwen3.5-2b       <- qwen3.5-2b:q8_0
  MATCH     qwen3.5-9b       <- qwen3.5:9b
  MATCH     qwen3.5-9b       <- Qwen3.5-9B-Q4_K_M.gguf

  no match  qwen3.5-9b       <- llama3.2:3b
  no match  qwen3.5-9b       <- qwen3.5:4b
  no match  qwen3-30b-a3b    <- qwen3-8b:latest
```

### Test

Extends `tests/test-external-services.sh` with 12 assertions: every tag shape,
the tier-target-against-Ollama-listing matches, and negative cases so a
different size or a different model carrying `:latest` still does not match.

## AI Assistance

AI assisted with the sed ordering and wording this description. I found the bug
by running the shipped normaliser against the model ids Ollama actually reports
for the models this repo's tier map selects, and checked the false-positive
cases before pushing.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(One sed pipeline in `installers/lib/external-services.sh`, plus assertions in
its existing test.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash -n installers/lib/external-services.sh
syntax OK

$ bash tests/test-external-services.sh
Result: 29 passed, 5 failed

# the same suite with origin/main's normaliser and this PR's assertions:
[FAIL] drops Ollama's default :latest tag (expected 'qwen3-30b-a3b', got 'qwen3-30b-a3b-latest')
[FAIL] drops :latest from a hyphenated name (expected 'gemma-4-e4b-it', got 'gemma-4-e4b-it-latest')
[FAIL] strips a quantization supplied as an Ollama tag (expected 'qwen3.5-2b', got 'qwen3.5-2b-q8-0')
[FAIL] strips an IQ quantization tag (expected 'qwen3.5-9b', got 'qwen3.5-9b-iq4-xs')
[FAIL] matches a tier target against Ollama's :latest listing
[FAIL] matches a hyphenated tier target against :latest
[FAIL] matches a tier target against a quantization tag
Result: 22 passed, 12 failed
```

**Caveat on those 5 remaining failures — they are not mine.** Unmodified
`origin/main` reports `17 passed, 5 failed` on my host; with this PR it is
`29 passed, 5 failed`. The same five fail either way. They are the phase-06
and URL-validation cases that shell out to `python3`, which on my Windows dev
box resolves to the Microsoft Store alias and refuses to run (the same issue
#2368 addresses for two other scripts). CI has a real `python3`. My change adds
12 passing assertions and introduces no new failures.

## Operational Change Check

`external_llm_normalize_model_name` runs during install when ODS probes an
existing Ollama or LM Studio for a model it can reuse. The change makes the
matcher accept ids it previously rejected; it does not make it accept
*different* models — the negative assertions above pin that. The visible effect
is that an install which previously downloaded a duplicate GGUF now reuses the
local copy, which is the documented intent of the feature.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**Why `:latest` gets its own rule rather than falling out of the colon
translation.** Dropping it entirely is right — `latest` carries no identity —
but only in the tag position. Translating first and then trying to strip a
trailing `-latest` would also eat the tail of a model legitimately named
`...-latest`, so the rule is anchored to `:latest$` before the colon is gone.
The `my-latest-model` assertion pins that.

**Tags I deliberately did not touch.** Ollama also uses tags like
`:instruct`, `:text` and `:fp16`. `fp16` is already in the quant pattern and
now reachable through the tag position too. `instruct` stays part of the name
(`qwen3.5:9b-instruct-q4_K_M` → `qwen3.5-9b-instruct`), which is correct —
instruct and base are different models. If your tier targets ever name an
instruct variant, that will match; if they name the base, it will not, which is
the behaviour you want.
