### PR TITLE
fix(settings): route seven editable keys to the service that reads them

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -53,7 +53,15 @@ _TOKEN_SPY_APPLY_KEYS = {
     "TOKEN_SPY_URL", "TOKEN_SPY_API_KEY",
 }
 _PRIVACY_SHIELD_APPLY_KEYS = {
-    "TARGET_API_URL", "PII_CACHE_ENABLED", "SHIELD_PORT",
+    "TARGET_API_URL", "TARGET_API_KEY",
+    "PII_CACHE_ENABLED", "PII_CACHE_SIZE", "PII_CACHE_TTL",
+    "SHIELD_PORT",
+}
+_BRAVE_SEARCH_APPLY_KEYS = {
+    "BRAVE_SEARCH_API_KEY", "BRAVE_SEARCH_PORT",
+}
+_TAILSCALE_APPLY_KEYS = {
+    "TS_AUTHKEY", "TS_EXTRA_ARGS", "TS_HOSTNAME",
 }
 _MANUAL_RESTART_KEYS = {
     "BIND_ADDRESS",
@@ -380,7 +388,9 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "hermes"
     if (
         key in _OPEN_WEBUI_APPLY_KEYS
-        or key.startswith("WEBUI_")
+        # OPEN_WEBUI_* does not start with WEBUI_, so those documented,
+        # editable keys used to match no rule at all.
+        or key.startswith(("WEBUI_", "OPEN_WEBUI_"))
         or key.startswith("OPENAI_API_")
         or key.startswith("SEARXNG_")
     ):
@@ -389,6 +399,10 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "token-spy"
     if key in _PRIVACY_SHIELD_APPLY_KEYS or key.startswith("SHIELD_"):
         return "privacy-shield"
+    if key in _BRAVE_SEARCH_APPLY_KEYS:
+        return "brave-search"
+    if key in _TAILSCALE_APPLY_KEYS:
+        return "tailscale"
     if key.startswith("LITELLM_"):
         return "litellm"
     if key.startswith("LANGFUSE_"):

--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -34,6 +34,7 @@ _SETTINGS_APPLY_ALLOWED_SERVICES = frozenset({
     "hermes", "hermes-proxy", "openclaw", "opencode", "perplexica", "searxng", "qdrant",
     "tts", "whisper", "embeddings", "token-spy", "comfyui",
     "ape", "privacy-shield", "ods-proxy", "model-router",
+    "brave-search",
 })
 _LLAMA_APPLY_KEYS = {
     "CTX_SIZE", "MAX_CONTEXT", "GGUF_FILE", "GGUF_URL", "GGUF_SHA256",
@@ -59,9 +60,6 @@ _PRIVACY_SHIELD_APPLY_KEYS = {
 }
 _BRAVE_SEARCH_APPLY_KEYS = {
     "BRAVE_SEARCH_API_KEY", "BRAVE_SEARCH_PORT",
-}
-_TAILSCALE_APPLY_KEYS = {
-    "TS_AUTHKEY", "TS_EXTRA_ARGS", "TS_HOSTNAME",
 }
 _MANUAL_RESTART_KEYS = {
     "BIND_ADDRESS",
@@ -401,8 +399,6 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "privacy-shield"
     if key in _BRAVE_SEARCH_APPLY_KEYS:
         return "brave-search"
-    if key in _TAILSCALE_APPLY_KEYS:
-        return "tailscale"
     if key.startswith("LITELLM_"):
         return "litellm"
     if key.startswith("LANGFUSE_"):

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1320,3 +1320,91 @@ def test_env_example_keys_are_present_in_schema():
     schema_keys = set(schema.get("properties", {}))
 
     assert documented_keys - schema_keys == set()
+
+
+# --- apply-plan routing ---------------------------------------------------
+
+
+class TestApplyServiceRouting:
+    """Every documented, editable key a compose service reads should name that
+    service, so saving it recreates one container instead of asking the user
+    to restart the whole stack."""
+
+    @pytest.mark.parametrize(
+        "key,service",
+        [
+            # OPEN_WEBUI_* does not start with WEBUI_.
+            ("OPEN_WEBUI_LLM_BASE_URL", "open-webui"),
+            ("OPEN_WEBUI_LLM_API_KEY", "open-webui"),
+            # Siblings of keys that were already routed.
+            ("TARGET_API_KEY", "privacy-shield"),
+            ("PII_CACHE_SIZE", "privacy-shield"),
+            ("PII_CACHE_TTL", "privacy-shield"),
+            # Services that had no rule at all.
+            ("BRAVE_SEARCH_API_KEY", "brave-search"),
+            ("BRAVE_SEARCH_PORT", "brave-search"),
+            ("TS_AUTHKEY", "tailscale"),
+            ("TS_HOSTNAME", "tailscale"),
+            ("TS_EXTRA_ARGS", "tailscale"),
+        ],
+    )
+    def test_key_routes_to_its_service(self, key, service):
+        import settings
+
+        assert settings._match_apply_service(key) == service
+
+    @pytest.mark.parametrize(
+        "key,service",
+        [
+            ("WEBUI_PORT", "open-webui"),
+            ("RAG_EMBEDDING_MODEL", "open-webui"),
+            ("SEARXNG_URL", "hermes"),
+            ("SHIELD_PORT", "privacy-shield"),
+            ("TARGET_API_URL", "privacy-shield"),
+            ("PII_CACHE_ENABLED", "privacy-shield"),
+            ("CTX_SIZE", "llama-server"),
+            ("LLAMA_THREADS", "llama-server"),
+            ("GGUF_FILE", "llama-server"),
+            ("TOKEN_SPY_URL", "token-spy"),
+            ("LITELLM_PORT", "litellm"),
+            ("N8N_PORT", "n8n"),
+            ("COMFYUI_BASE_URL", "open-webui"),
+            ("QDRANT_PORT", "qdrant"),
+            ("APE_STRICT_MODE", "ape"),
+        ],
+    )
+    def test_existing_routing_is_unchanged(self, key, service):
+        import settings
+
+        assert settings._match_apply_service(key) == service
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "BIND_ADDRESS",
+            "DASHBOARD_API_KEY",
+            "DASHBOARD_PORT",
+            "ODS_AGENT_PORT",
+        ],
+    )
+    def test_manual_restart_keys_stay_unrouted(self, key):
+        """These deliberately require a manual stack restart."""
+        import settings
+
+        assert settings._match_apply_service(key) is None
+
+    def test_public_url_keys_stay_unrouted(self):
+        import settings
+
+        assert settings._match_apply_service("WEBUI_PUBLIC_URL") is None
+        assert settings._match_apply_service("ODS_SERVICE_PUBLIC_URLS") is None
+
+    def test_saving_an_open_webui_key_schedules_only_that_service(self):
+        import settings
+
+        plan = settings._compute_env_apply_plan(
+            {"OPEN_WEBUI_LLM_BASE_URL": "http://old:8080/v1"},
+            {"OPEN_WEBUI_LLM_BASE_URL": "http://new:8080/v1"},
+        )
+        assert plan["services"] == ["open-webui"]
+        assert "manual stack restart" not in plan["summary"]

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1343,9 +1343,6 @@ class TestApplyServiceRouting:
             # Services that had no rule at all.
             ("BRAVE_SEARCH_API_KEY", "brave-search"),
             ("BRAVE_SEARCH_PORT", "brave-search"),
-            ("TS_AUTHKEY", "tailscale"),
-            ("TS_HOSTNAME", "tailscale"),
-            ("TS_EXTRA_ARGS", "tailscale"),
         ],
     )
     def test_key_routes_to_its_service(self, key, service):
@@ -1398,6 +1395,34 @@ class TestApplyServiceRouting:
 
         assert settings._match_apply_service("WEBUI_PUBLIC_URL") is None
         assert settings._match_apply_service("ODS_SERVICE_PUBLIC_URLS") is None
+
+    @pytest.mark.parametrize(
+        "key,service",
+        [
+            ("OPEN_WEBUI_LLM_BASE_URL", "open-webui"),
+            ("TARGET_API_KEY", "privacy-shield"),
+            ("PII_CACHE_TTL", "privacy-shield"),
+            ("BRAVE_SEARCH_API_KEY", "brave-search"),
+        ],
+    )
+    def test_routed_key_actually_schedules_the_service(self, key, service):
+        """Routing is only half of it: the service also has to be in
+        _SETTINGS_APPLY_ALLOWED_SERVICES, or the key falls back to a manual
+        stack restart and the routing changes nothing."""
+        import settings
+
+        plan = settings._compute_env_apply_plan({key: "a"}, {key: "b"})
+        assert plan["services"] == [service]
+        assert "manual stack restart" not in plan["summary"]
+
+    def test_tailscale_keys_still_require_a_manual_restart(self):
+        """Recreating tailscale can sever the operator's own access path, so
+        TS_* deliberately stays out of the automatic apply plan."""
+        import settings
+
+        plan = settings._compute_env_apply_plan({"TS_AUTHKEY": "a"}, {"TS_AUTHKEY": "b"})
+        assert plan["services"] == []
+        assert "TS_AUTHKEY" in plan["summary"]
 
     def test_saving_an_open_webui_key_schedules_only_that_service(self):
         import settings


### PR DESCRIPTION
## Summary

`settings._match_apply_service()` maps a changed `.env` key to the service that
needs recreating. A key it does not recognise falls through to the manual
bucket, and the dashboard tells the user *"A manual stack restart is still
required for: …"*.

I cross-checked every documented, editable key against the `${VAR}` references
in each service's compose block. **Seven keys that exactly one service reads
were falling through:**

| Key | Reader | Why it was missed |
|---|---|---|
| `OPEN_WEBUI_LLM_BASE_URL` | open-webui | `OPEN_WEBUI_*` does not start with the `WEBUI_` prefix the rule checks |
| `OPEN_WEBUI_LLM_API_KEY` | open-webui | same |
| `TARGET_API_KEY` | privacy-shield | `TARGET_API_URL` is in the set; this one is not |
| `PII_CACHE_SIZE` | privacy-shield | `PII_CACHE_ENABLED` is in the set; this one is not |
| `PII_CACHE_TTL` | privacy-shield | same |
| `BRAVE_SEARCH_API_KEY` | brave-search | no rule for this service at all |
| `BRAVE_SEARCH_PORT` | brave-search | same |

The privacy-shield rows are the clearest evidence this is oversight rather than
intent: `TARGET_API_URL` and `PII_CACHE_ENABLED` are routed, while the keys
sitting next to them in `.env` are not.

**The effect is downtime, not data loss.** Changing the open-webui upstream or a
privacy-shield cache setting made the dashboard ask for a full stack restart —
every service down — when recreating one container was enough.

I want to be accurate about what this is *not*: the change was never silently
dropped. The apply plan does tell you a manual restart is needed, so nothing was
left in an inconsistent state. This is a worse-than-necessary remedy, not a
missing one.

### Fix

- `key.startswith(("WEBUI_", "OPEN_WEBUI_"))` instead of `"WEBUI_"` alone.
- The three missing privacy-shield keys added to `_PRIVACY_SHIELD_APPLY_KEYS`.
- New `_BRAVE_SEARCH_APPLY_KEYS`, with `brave-search` added to
  `_SETTINGS_APPLY_ALLOWED_SERVICES`.

### The correction in the second commit is the interesting part

Routing a key is only half the job — `_compute_env_apply_plan` schedules a
service only if it is **also** in `_SETTINGS_APPLY_ALLOWED_SERVICES`. My first
pass routed `brave-search` and `tailscale` keys without checking that gate, so
five of the ten I originally touched changed nothing at all:

```text
  BRAVE_SEARCH_API_KEY  services=[]  "A manual stack restart is still required..."
  TS_AUTHKEY            services=[]  "A manual stack restart is still required..."
```

`brave-search` now joins the allowed set — it is an ordinary optional HTTP
service, the same class as `searxng` and `perplexica`, which are already there.

The `TS_*` routing is **removed rather than allowed**. Recreating the tailscale
container can sever the very tailnet connection the operator is using to reach
the dashboard, so promoting it from "restart the stack yourself" to "we will
restart it for you" is your call, not a drive-by. There is a test asserting
`TS_AUTHKEY` still lands in the manual bucket on purpose.

The tests now assert the **end-to-end apply plan** for every routed key, not
just `_match_apply_service` — checking only the router is exactly what let the
gate slip past me.

## AI Assistance

AI assisted with drafting the tests and this description. I built the inventory
by parsing every service's compose block for `${VAR}` references and running
each key through the shipped `_match_apply_service`; I caught the allowed-services
gate by re-running the full apply plan rather than trusting the router alone.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Two key sets, one prefix tuple and one entry in the allowed-services frozenset
in `settings.py`, plus tests.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 -m py_compile extensions/services/dashboard-api/settings.py
py OK

$ python3 -m pytest tests/test_settings_env.py -q
109 passed

# end-to-end apply plan for each routed key:
  OPEN_WEBUI_LLM_BASE_URL  services=['open-webui']
  OPEN_WEBUI_LLM_API_KEY   services=['open-webui']
  TARGET_API_KEY           services=['privacy-shield']
  PII_CACHE_SIZE           services=['privacy-shield']
  PII_CACHE_TTL            services=['privacy-shield']
  BRAVE_SEARCH_API_KEY     services=['brave-search']
  BRAVE_SEARCH_PORT        services=['brave-search']
  TS_AUTHKEY               services=[]              (deliberate)

# the new assertions against origin/main's settings.py:
11 failed, 20 passed
```

The assertions that pass either way are the deliberate ones: fifteen existing
routes (`WEBUI_PORT`, `CTX_SIZE`, `LLAMA_THREADS`, `SEARXNG_URL`, `QDRANT_PORT`,
`APE_STRICT_MODE`, …) asserted unchanged, plus `_MANUAL_RESTART_KEYS` and the
`*_PUBLIC_URL` family asserted to stay unrouted. Those are there so this does
not quietly grow into routing things that genuinely need a manual restart.

## Operational Change Check

`_match_apply_service()` runs when the dashboard saves settings, to build the
apply plan. The change moves seven keys from "restart the whole stack" to
"recreate one container", and adds one service to the set the dashboard is
permitted to recreate. No key moves the other way, and nothing already routed
changes — the fifteen unchanged-route assertions pin that. No write path or
schema change.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**The inventory found more than I fixed, and the rest needs a decision I should
not make alone.** `_match_apply_service` returns a *single* service, but some
keys are read by several:

```text
  BIND_ADDRESS        18 services
  TIMEZONE            hermes, n8n, open-webui
  UID / GID           hermes, n8n, privacy-shield
  EMBEDDING_MODEL     embeddings, open-webui
  ODS_DEVICE_NAME     dashboard-api, ods-proxy, open-webui, tailscale
  LLM_API_URL         llama-server (routed) + open-webui (not)
```

`LLM_API_URL` is the one worth your attention: it *is* routed, to llama-server,
and returns before the open-webui branch — so changing it recreates llama-server
and leaves open-webui pointing at the old URL, **with no manual-restart warning
either**. That is the one genuinely silent case I found, and unlike the rest of
this PR it needs `_match_apply_service` to return a set rather than one service,
which changes the apply plan and its summary text. Say the word and I will send
it separately.

`BIND_ADDRESS` and the port keys are already in `_MANUAL_RESTART_KEYS`, so they
are handled deliberately.

**Tailscale.** If you do want `TS_*` handled automatically, adding `tailscale`
to `_SETTINGS_APPLY_ALLOWED_SERVICES` and restoring a three-line key set is the
whole change — I just did not want to make that trade on your behalf.

**Litellm provider keys** (`ANTHROPIC_API_KEY`, `TOGETHER_API_KEY`,
`MINIMAX_API_KEY`) are also unrouted and read only by litellm in compose. I left
them out because they may be read elsewhere at runtime in cloud mode, and I
could not confirm that from compose alone. Easy to add if you know they are
litellm-only.
