### PR TITLE
fix(token-spy): stop billing OpenAI cached tokens twice

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Test Postgres SSE cursor
         run: python -m pytest tests/test_recent_events_cursor_postgres.py -v
 
+      - name: Test cached-token accounting
+        run: python -m pytest tests/test_cached_token_accounting.py -v
+
   integration-smoke:
     runs-on: ubuntu-latest
     defaults:

--- a/ods/extensions/services/token-spy/providers/openai.py
+++ b/ods/extensions/services/token-spy/providers/openai.py
@@ -153,6 +153,29 @@ class OpenAICompatibleProvider(LLMProvider):
 
         return body
 
+    @staticmethod
+    def _split_cached(prompt_tokens: Any, cached_tokens: Any) -> tuple[int, int]:
+        """Return (uncached_input, cached) from OpenAI's overlapping fields.
+
+        OpenAI's ``prompt_tokens`` is the total and *includes*
+        ``prompt_tokens_details.cached_tokens``. Anthropic's ``input_tokens``
+        excludes its cache counters, and ``calculate_cost`` bills every
+        ``*_tokens`` field independently — so reporting OpenAI's total verbatim
+        charges the cached tokens twice, once at the input rate and again at
+        the cache-read rate. Subtract them so the two fields are disjoint, the
+        way the base class already assumes.
+        """
+        try:
+            total = int(prompt_tokens or 0)
+        except (TypeError, ValueError):
+            total = 0
+        try:
+            cached = int(cached_tokens or 0)
+        except (TypeError, ValueError):
+            cached = 0
+        cached = max(0, min(cached, total))
+        return total - cached, cached
+
     def extract_usage_from_response(self, response: Dict[str, Any]) -> Dict[str, Any]:
         """Extract usage from non-streaming response."""
         usage = response.get("usage", {})
@@ -163,10 +186,15 @@ class OpenAICompatibleProvider(LLMProvider):
         if choices:
             stop_reason = choices[0].get("finish_reason")
 
+        input_tokens, cache_read_tokens = self._split_cached(
+            usage.get("prompt_tokens", 0),
+            (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0),
+        )
+
         return {
-            "input_tokens": usage.get("prompt_tokens", 0),
+            "input_tokens": input_tokens,
             "output_tokens": usage.get("completion_tokens", 0),
-            "cache_read_tokens": usage.get("prompt_tokens_details", {}).get("cached_tokens", 0),
+            "cache_read_tokens": cache_read_tokens,
             "cache_write_tokens": 0,  # OpenAI doesn't expose cache write stats
             "stop_reason": stop_reason,
         }
@@ -200,13 +228,14 @@ class OpenAICompatibleProvider(LLMProvider):
         # Check for usage in final chunk
         usage = data.get("usage", {})
         if usage:
-            result["input_tokens"] = usage.get("prompt_tokens", 0)
+            details = usage.get("prompt_tokens_details") or {}
+            input_tokens, cache_read_tokens = self._split_cached(
+                usage.get("prompt_tokens", 0), details.get("cached_tokens", 0)
+            )
+            result["input_tokens"] = input_tokens
             result["output_tokens"] = usage.get("completion_tokens", 0)
-
-            # OpenAI may include cache stats in prompt_tokens_details
-            details = usage.get("prompt_tokens_details", {})
             if details:
-                result["cache_read_tokens"] = details.get("cached_tokens", 0)
+                result["cache_read_tokens"] = cache_read_tokens
 
         # Check for stop reason in choices
         choices = data.get("choices", [])

--- a/ods/extensions/services/token-spy/tests/test_cached_token_accounting.py
+++ b/ods/extensions/services/token-spy/tests/test_cached_token_accounting.py
@@ -1,0 +1,143 @@
+"""Cached-token accounting contracts.
+
+``LLMProvider.calculate_cost`` bills every ``*_tokens`` field independently:
+
+    input_tokens * input + output_tokens * output
+  + cache_read_tokens * cache_read + cache_write_tokens * cache_write
+
+so the fields a provider reports must be disjoint. Anthropic's API already
+returns them that way; OpenAI's ``prompt_tokens`` is a total that *includes*
+``prompt_tokens_details.cached_tokens``, and passing it through unchanged bills
+the cached half twice.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(TOKEN_SPY_DIR))
+
+
+@pytest.fixture(scope="module")
+def openai():
+    from providers.openai import OpenAICompatibleProvider
+
+    return OpenAICompatibleProvider()
+
+
+@pytest.fixture(scope="module")
+def anthropic():
+    from providers.anthropic import AnthropicProvider
+
+    return AnthropicProvider()
+
+
+def _response(prompt_tokens, cached, completion=0):
+    usage = {"prompt_tokens": prompt_tokens, "completion_tokens": completion}
+    if cached is not None:
+        usage["prompt_tokens_details"] = {"cached_tokens": cached}
+    return {"usage": usage, "choices": [{"finish_reason": "stop"}]}
+
+
+# --- the fields must not overlap ------------------------------------------
+
+
+def test_cached_tokens_are_excluded_from_input(openai):
+    usage = openai.extract_usage_from_response(_response(1000, 800))
+    assert usage["input_tokens"] == 200
+    assert usage["cache_read_tokens"] == 800
+
+
+def test_input_plus_cache_reconstructs_the_reported_total(openai):
+    usage = openai.extract_usage_from_response(_response(1234, 567))
+    assert usage["input_tokens"] + usage["cache_read_tokens"] == 1234
+
+
+def test_cost_matches_a_hand_computed_bill(openai):
+    """1M prompt tokens, 90% cached, on gpt-4o."""
+    usage = openai.extract_usage_from_response(_response(1_000_000, 900_000))
+    rates = openai.get_model_pricing("gpt-4o")
+    expected = (100_000 * rates["input"] + 900_000 * rates["cache_read"]) / 1_000_000
+    assert openai.calculate_cost(usage, "gpt-4o") == pytest.approx(expected)
+
+
+def test_stream_usage_excludes_cached_from_input(openai):
+    line = "data: " + json.dumps(
+        {
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 50,
+                "prompt_tokens_details": {"cached_tokens": 800},
+            },
+        }
+    )
+    result = openai.extract_usage_from_stream(line)
+    assert result["input_tokens"] == 200
+    assert result["cache_read_tokens"] == 800
+    assert result["output_tokens"] == 50
+
+
+# --- the no-cache and malformed paths are unchanged ------------------------
+
+
+def test_no_cache_details_reports_the_full_prompt_as_input(openai):
+    usage = openai.extract_usage_from_response(_response(500, None))
+    assert usage["input_tokens"] == 500
+    assert usage["cache_read_tokens"] == 0
+
+
+def test_zero_cached_tokens_reports_the_full_prompt_as_input(openai):
+    usage = openai.extract_usage_from_response(_response(500, 0))
+    assert usage["input_tokens"] == 500
+    assert usage["cache_read_tokens"] == 0
+
+
+def test_null_prompt_tokens_details_is_tolerated(openai):
+    response = {"usage": {"prompt_tokens": 400, "prompt_tokens_details": None}, "choices": []}
+    usage = openai.extract_usage_from_response(response)
+    assert usage["input_tokens"] == 400
+    assert usage["cache_read_tokens"] == 0
+
+
+@pytest.mark.parametrize("cached", [1500, -5, "many", None])
+def test_impossible_cached_counts_never_produce_negative_input(openai, cached):
+    """A cache count larger than the total, or non-numeric, must not make the
+    bill negative or crash the recorder."""
+    usage = openai.extract_usage_from_response(_response(1000, cached))
+    assert usage["input_tokens"] >= 0
+    assert usage["cache_read_tokens"] >= 0
+    assert usage["input_tokens"] + usage["cache_read_tokens"] <= 1000
+    assert openai.calculate_cost(usage, "gpt-4o") >= 0
+
+
+def test_missing_usage_block_is_tolerated(openai):
+    usage = openai.extract_usage_from_response({"choices": []})
+    assert usage["input_tokens"] == 0
+    assert usage["cache_read_tokens"] == 0
+
+
+# --- the two providers agree on the convention -----------------------------
+
+
+def test_both_providers_report_disjoint_fields(openai, anthropic):
+    """Same conversation shape through each provider's response format."""
+    oai = openai.extract_usage_from_response(_response(1000, 900))
+    ant = anthropic.extract_usage_from_response(
+        {
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 0,
+                "cache_read_input_tokens": 900,
+                "cache_creation_input_tokens": 0,
+            }
+        }
+    )
+    assert oai["input_tokens"] == ant["input_tokens"] == 100
+    assert oai["cache_read_tokens"] == ant["cache_read_tokens"] == 900


### PR DESCRIPTION
## Summary

`LLMProvider.calculate_cost()` bills every `*_tokens` field independently:

```python
return (
    usage.get("input_tokens", 0) * rates.get("input", 0) / 1_000_000 +
    usage.get("output_tokens", 0) * rates.get("output", 0) / 1_000_000 +
    usage.get("cache_read_tokens", 0) * rates.get("cache_read", 0) / 1_000_000 +
    usage.get("cache_write_tokens", 0) * rates.get("cache_write", 0) / 1_000_000
)
```

so the fields a provider reports **must be disjoint**. Anthropic's API returns
them that way — `input_tokens` excludes `cache_read_input_tokens` — and the
Anthropic provider passes them straight through.

OpenAI's `prompt_tokens` is a **total that includes**
`prompt_tokens_details.cached_tokens`, and the provider reported it verbatim:

```python
"input_tokens": usage.get("prompt_tokens", 0),
"cache_read_tokens": usage.get("prompt_tokens_details", {}).get("cached_tokens", 0),
```

Every cached token was therefore charged twice — once at the full input rate,
once again at the cache-read rate.

Measured on `gpt-4o`, 1M prompt tokens at a 90% cache hit rate:

```text
OpenAI response usage: {'input_tokens': 1000000, 'cache_read_tokens': 900000}
  reported cost = $3.6250
  correct cost  = $1.3750   (uncached 100k @ 2.5, cached 900k @ 1.25)
  overstated by 2.64x

Anthropic response usage: {'input_tokens': 100000, 'cache_read_tokens': 900000}
  reported cost = $0.5700
  correct cost  = $0.5700  <- matches
```

The same codebase getting it right for one provider and wrong for the other is
what convinced me this is a bug rather than a convention I had misread.

**The error grows with how well caching is working.** Prompt caching pays off
precisely when the hit rate is high, so a user who tunes their prompts for cache
reuse watches their reported spend *increase*. For a service whose whole purpose
is telling you what your agents cost, that is the wrong direction to be wrong
in — and it is wrong on the cheap path, not the expensive one.

### Fix

A small `_split_cached()` helper subtracts the cached count from the total, in
both the response and stream paths, so the two fields stop overlapping. The
count is clamped to `0..total`, so an impossible or non-numeric `cached_tokens`
cannot produce a negative input count or a negative bill.

```text
after:
  usage:  {'input_tokens': 100000, 'output_tokens': 0, 'cache_read_tokens': 900000}
  cost:   $1.3750
  stream: {'input_tokens': 200, 'output_tokens': 50, 'cache_read_tokens': 800}
  no-cache response: input_tokens=500, cache_read_tokens=0   (unchanged)
```

### Test

Adds `tests/test_cached_token_accounting.py` — 13 assertions: the split, a
hand-computed bill, the streaming path, the no-cache and `null`-details paths
asserted unchanged, impossible cached counts (`1500` of `1000`, `-5`,
`"many"`, `None`), a missing `usage` block, and a cross-provider check that
OpenAI and Anthropic now report the same disjoint numbers for the same
conversation. Wired into the token-spy CI job.

## AI Assistance

AI assisted with the clamping helper, the test matrix, and wording this
description. I found it by reading `calculate_cost` and asking what each
provider's `input_tokens` actually contains, then computing the bill both ways
against the shipped code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(`token-spy` is a bundled extension service. One provider module and its new
tests; CI config is also touched.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 -m py_compile extensions/services/token-spy/providers/openai.py
py OK

$ python3 -m pytest tests/test_cached_token_accounting.py -q
13 passed

$ python3 -m pytest tests/ -q          # whole token-spy suite
33 passed, 1 skipped

# the new suite against origin/main's provider:
FAILED test_cached_tokens_are_excluded_from_input
FAILED test_input_plus_cache_reconstructs_the_reported_total
FAILED test_cost_matches_a_hand_computed_bill
FAILED test_stream_usage_excludes_cached_from_input
FAILED test_null_prompt_tokens_details_is_tolerated
FAILED test_impossible_cached_counts_never_produce_negative_input[1500]
FAILED test_impossible_cached_counts_never_produce_negative_input[-5]
FAILED test_impossible_cached_counts_never_produce_negative_input[many]
FAILED test_both_providers_report_disjoint_fields
9 failed, 4 passed
```

The four that pass either way are the no-cache paths, which is the point — this
must not disturb a response without cache details.

## Operational Change Check

`extract_usage_from_response` / `extract_usage_from_stream` run inside the
`token-spy` container when recording a completion. The change alters the
recorded `input_tokens` for OpenAI-compatible responses that carry cache
details, and therefore the computed cost — downward, to the correct figure.
Responses without `prompt_tokens_details` are byte-identical to before.

Two things worth knowing:

- **Rows already stored keep their old numbers.** This fixes new events; it is
  not a backfill. Historical OpenAI-with-cache costs remain overstated.
- **Anyone reconstructing a prompt total from stored rows must now add
  `input_tokens + cache_read_tokens`.** That was already true for Anthropic
  rows, so this makes the two consistent rather than introducing a new rule —
  but if a dashboard query assumes `input_tokens` is the total, it will now
  under-report for OpenAI. I grepped the token-spy dashboard and report code and
  did not find such a query; worth a second look from someone who knows those
  views better than I do.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

**`cache_write` stays 0 for OpenAI** — the API does not expose a cache-write
count, and the table prices it at 0.0 for every OpenAI row, so nothing changes
there.

**DeepSeek and Moonshot go through this same provider** and both report
OpenAI-shaped usage with cache fields. DeepSeek's `prompt_cache_hit_tokens` /
`prompt_cache_miss_tokens` are a *different* pair of keys that this code does
not read at all, so DeepSeek caching is currently invisible rather than
double-counted. That is a separate gap and I did not fix it here — say the word
and I will send it, since the pricing rows for `deepseek-chat` and
`deepseek-reasoner` already carry cache_read rates that nothing can currently
reach.

**Related:** #2511 fixes the Claude 3.x rows in the Anthropic pricing table.
Different file, no overlap.
