### PR TITLE
fix(dashboard): validate llama introspection payloads

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -539,18 +539,42 @@ async def get_loaded_model() -> Optional[str]:
         # authoritative source for which model is actually loaded.
         if LLM_BACKEND == "lemonade":
             resp = await client.get(f"http://{host}:{port}{_LLM_API_PREFIX}/health")
-            loaded = resp.json().get("model_loaded")
-            return loaded if loaded else None
+            payload = resp.json()
+            if not isinstance(payload, dict):
+                raise ValueError("Lemonade health response is not an object")
+            loaded = payload.get("model_loaded")
+            return loaded if isinstance(loaded, str) and loaded else None
 
         # llama.cpp: /v1/models returns the loaded model with status info.
         resp = await client.get(f"http://{host}:{port}{_LLM_API_PREFIX}/models")
-        models = resp.json().get("data", [])
+        payload = resp.json()
+        if not isinstance(payload, dict):
+            raise ValueError("llama-server models response is not an object")
+        models = payload.get("data", [])
+        if not isinstance(models, list):
+            raise ValueError("llama-server models data is not a list")
         for m in models:
+            if not isinstance(m, dict):
+                continue
             status = m.get("status", {})
-            if isinstance(status, dict) and status.get("value") == "loaded":
-                return m.get("id")
-        if models:
-            return models[0].get("id")
+            model_id = m.get("id")
+            if (
+                isinstance(model_id, str)
+                and model_id
+                and isinstance(status, dict)
+                and status.get("value") == "loaded"
+            ):
+                return model_id
+        return next(
+            (
+                model_id
+                for model in models
+                if isinstance(model, dict)
+                and isinstance((model_id := model.get("id")), str)
+                and model_id
+            ),
+            None,
+        )
     except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as e:
         logger.debug("get_loaded_model failed: %s", e)
     return None
@@ -573,8 +597,17 @@ async def get_llama_context_size(model_hint: Optional[str] = None) -> Optional[i
             url += f"?model={loaded}"
         client = await _get_httpx_client()
         resp = await client.get(url)
-        n_ctx = resp.json().get("default_generation_settings", {}).get("n_ctx")
-        return int(n_ctx) if n_ctx else None
+        payload = resp.json()
+        if not isinstance(payload, dict):
+            raise ValueError("llama-server props response is not an object")
+        settings = payload.get("default_generation_settings", {})
+        if not isinstance(settings, dict):
+            raise ValueError("llama-server generation settings are not an object")
+        n_ctx = settings.get("n_ctx")
+        if isinstance(n_ctx, bool) or n_ctx is None:
+            return None
+        context_size = int(n_ctx)
+        return context_size if context_size > 0 else None
     except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as e:
         logger.debug("get_llama_context_size failed: %s", e)
         return None

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -752,6 +752,24 @@ class TestGetLoadedModel:
         result = await get_loaded_model()
         assert result is None
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [
+        [],
+        {"data": {}},
+        {"data": [None, {"id": None, "status": []}]},
+    ])
+    async def test_returns_none_for_invalid_models_payload(self, monkeypatch, payload):
+        monkeypatch.setattr("helpers.SERVICES", {
+            "llama-server": {"host": "localhost", "port": 8080},
+        })
+        mock_response = MagicMock()
+        mock_response.json.return_value = payload
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        assert await get_loaded_model() is None
+
 
 # --- get_llama_context_size ---
 
@@ -802,6 +820,25 @@ class TestGetLlamaContextSize:
 
         result = await get_llama_context_size(model_hint="test-model")
         assert result is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [
+        [],
+        {"default_generation_settings": []},
+        {"default_generation_settings": {"n_ctx": True}},
+        {"default_generation_settings": {"n_ctx": 0}},
+    ])
+    async def test_returns_none_for_invalid_props_payload(self, monkeypatch, payload):
+        monkeypatch.setattr("helpers.SERVICES", {
+            "llama-server": {"host": "localhost", "port": 8080},
+        })
+        mock_response = MagicMock()
+        mock_response.json.return_value = payload
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        assert await get_llama_context_size(model_hint="test-model") is None
 
 
 # --- get_disk_usage ---


### PR DESCRIPTION
## Summary
- validate Lemonade health and llama.cpp model-list payload shapes before reading fields
- ignore malformed model entries while preserving the first usable fallback model
- reject invalid, boolean, and non-positive context sizes from `/props`

## Test plan
- `python -m pytest tests/test_helpers.py -q` (111 passed, 2 skipped)

Generated with Codex