### PR TITLE
fix(auth): validate magic-link store shape

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -237,8 +237,22 @@ def _ensure_store() -> dict:
     if not store_path.exists():
         return {"tokens": []}
     try:
-        return json.loads(store_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        store = json.loads(store_path.read_text(encoding="utf-8"))
+        if not isinstance(store, dict):
+            raise ValueError("store root must be an object")
+        tokens = store.get("tokens")
+        if not isinstance(tokens, list):
+            raise ValueError("store tokens must be a list")
+        valid_tokens = [record for record in tokens if isinstance(record, dict)]
+        if len(valid_tokens) != len(tokens):
+            logger.warning(
+                "Dropped %d invalid magic-link record(s) from %s",
+                len(tokens) - len(valid_tokens),
+                store_path,
+            )
+        store["tokens"] = valid_tokens
+        return store
+    except (OSError, json.JSONDecodeError, ValueError):
         # Corrupted store — start fresh rather than blocking generation.
         logger.exception("magic-link store unreadable at %s; starting fresh", store_path)
         return {"tokens": []}

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -13,6 +13,7 @@ Covers:
 """
 
 import importlib
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -109,6 +110,27 @@ def test_redeem_is_public(magic_link_client):
     )
     # Bogus token → 404 (constant-shape failure), not 401.
     assert resp.status_code == 404
+
+
+@pytest.mark.parametrize("payload", [[], {"tokens": {}}, {"unexpected": []}])
+def test_store_rejects_valid_json_with_invalid_shape(
+    magic_link_module, payload
+):
+    store_path = magic_link_module._writable_store_path()
+    store_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert magic_link_module._ensure_store() == {"tokens": []}
+
+
+def test_store_drops_non_object_records(magic_link_module):
+    store_path = magic_link_module._writable_store_path()
+    valid_record = {"token_hash": "abc"}
+    store_path.write_text(
+        json.dumps({"tokens": [None, "invalid", valid_record]}),
+        encoding="utf-8",
+    )
+
+    assert magic_link_module._ensure_store() == {"tokens": [valid_record]}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- reject syntactically valid magic-link stores whose root or `tokens` field has the wrong type
- discard non-object token records before lifecycle code can dereference them
- preserve valid records and log the number of malformed entries removed

## Test plan
- `python -m pytest tests/test_magic_link.py -q` (70 passed)

Generated with Codex