### PR TITLE
fix(auth): fail closed on invalid magic-link expiry

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -302,8 +302,14 @@ def _is_expired(token_record: dict, now: Optional[datetime] = None) -> bool:
     if token_record["token_type"] == "owner" or not token_record.get("expires_at"):
         return False
     now = now or datetime.now(timezone.utc)
-    expires_at = datetime.fromisoformat(token_record["expires_at"])
-    return now >= expires_at
+    try:
+        expires_at = datetime.fromisoformat(token_record["expires_at"])
+        return now >= expires_at
+    except (TypeError, ValueError):
+        logger.warning(
+            "Treating magic-link record with invalid expires_at as expired"
+        )
+        return True
 
 
 def _prune(store: dict) -> dict:

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -977,6 +977,28 @@ def test_redeem_expired_token(magic_link_client, magic_link_module):
     assert resp.json()["detail"] == "Invalid or expired magic link"
 
 
+@pytest.mark.parametrize("expires_at", ["not-a-date", 123, "2026-01-01T00:00:00"])
+def test_redeem_treats_invalid_expiry_as_expired(
+    magic_link_client, magic_link_module, expires_at
+):
+    gen = magic_link_client.post(
+        "/api/auth/magic-link/generate",
+        json={"target_username": "alice"},
+        headers=magic_link_client.auth_headers,
+    )
+    token = gen.json()["token"]
+    store = magic_link_module._ensure_store()
+    store["tokens"][0]["expires_at"] = expires_at
+    magic_link_module._write_store(store)
+
+    resp = magic_link_client.get(
+        f"/auth/magic-link/{token}", follow_redirects=False
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Invalid or expired magic link"
+
+
 def test_redeem_revoked_token(magic_link_client, magic_link_module):
     gen = magic_link_client.post(
         "/api/auth/magic-link/generate",


### PR DESCRIPTION
## Summary
- treat malformed, non-string, and timezone-naive guest expiry values as expired
- keep corrupt records from turning redemption and pruning into HTTP 500 failures
- preserve the opaque 404 response used for invalid and expired links

## Test plan
- `python -m pytest tests/test_magic_link.py -q` (69 passed)

Generated with Codex