### PR TITLE
fix(oauth): confine credential discovery to roots

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
@@ -174,6 +174,16 @@ def _credential_status(provider: dict) -> tuple[bool, list[str]]:
             continue
         for root in _credential_roots():
             candidate = root / filename
+            try:
+                candidate.resolve(strict=False).relative_to(
+                    root.resolve(strict=False)
+                )
+            except (OSError, ValueError):
+                logger.warning(
+                    "Ignoring OAuth credential path outside configured root: %s",
+                    filename,
+                )
+                break
             if candidate.is_file():
                 found.append(f"{root.name}/{filename}")
                 break

--- a/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
@@ -515,3 +515,31 @@ def test_oauth_providers_reports_credential_status(oauth_client, monkeypatch):
     assert by_id["google"]["configured"] is True
     assert by_id["spotify"]["configured"] is False
     assert by_id["google"]["found_credentials"] == ["hermes/google_client_secret.json"]
+
+
+def test_oauth_providers_rejects_credential_path_traversal(
+    oauth_client, monkeypatch
+):
+    registry = oauth_client.tmp / "providers.json"
+    registry.write_text(json.dumps({
+        "schema_version": "ods.oauth-providers.v1",
+        "providers": [{
+            "id": "escaped",
+            "credential_files": ["../outside-secret.json"],
+        }],
+    }))
+    data_dir = oauth_client.tmp / "data"
+    hermes_dir = data_dir / "hermes"
+    hermes_dir.mkdir(parents=True)
+    (data_dir / "outside-secret.json").write_text("{}")
+    monkeypatch.setenv("ODS_OAUTH_PROVIDERS_FILE", str(registry))
+    monkeypatch.setenv("ODS_DATA_DIR", str(data_dir))
+
+    resp = oauth_client.get(
+        "/api/oauth/providers", headers=oauth_client.auth_headers
+    )
+
+    assert resp.status_code == 200
+    provider = resp.json()["providers"][0]
+    assert provider["configured"] is False
+    assert provider["found_credentials"] == []


### PR DESCRIPTION
## Summary
- resolve every registry credential path before checking whether it exists
- reject traversal and symlink escapes outside each configured credential root
- prevent unrelated files from falsely marking an OAuth provider configured

## Test plan
- `python -m pytest tests/test_oauth_passthrough.py -q` (47 passed, 2 skipped)

Generated with Codex