### PR TITLE
fix(gpu): validate persisted state payloads

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -516,8 +516,16 @@ def read_gpu_topology() -> Optional[dict]:
         logger.warning("Topology file not found at %s", topo_path)
         return None
     try:
-        return _json.loads(topo_path.read_text())
-    except (OSError, _json.JSONDecodeError) as exc:
+        topology = _json.loads(topo_path.read_text(encoding="utf-8"))
+        if not isinstance(topology, dict):
+            raise ValueError("topology root must be an object")
+        gpus = topology.get("gpus", [])
+        if not isinstance(gpus, list) or any(
+            not isinstance(gpu, dict) for gpu in gpus
+        ):
+            raise ValueError("topology gpus must be a list of objects")
+        return topology
+    except (OSError, _json.JSONDecodeError, ValueError) as exc:
         logger.warning("Failed to read topology file %s: %s", topo_path, exc)
         return None
 
@@ -535,8 +543,26 @@ def decode_gpu_assignment() -> Optional[dict]:
     if not b64:
         return None
     try:
-        return _json.loads(base64.b64decode(b64.strip()).decode("utf-8"))
-    except (base64.binascii.Error, _json.JSONDecodeError, UnicodeDecodeError):
+        assignment = _json.loads(
+            base64.b64decode(b64.strip()).decode("utf-8")
+        )
+        if not isinstance(assignment, dict):
+            raise ValueError("assignment root must be an object")
+        body = assignment.get("gpu_assignment")
+        if not isinstance(body, dict):
+            raise ValueError("gpu_assignment must be an object")
+        services = body.get("services", {})
+        if not isinstance(services, dict) or any(
+            not isinstance(service, dict) for service in services.values()
+        ):
+            raise ValueError("assignment services must be an object map")
+        return assignment
+    except (
+        base64.binascii.Error,
+        _json.JSONDecodeError,
+        UnicodeDecodeError,
+        ValueError,
+    ):
         return None
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -60,6 +60,15 @@ class TestReadGpuTopology:
         monkeypatch.setenv("ODS_INSTALL_DIR", str(tmp_path))
         assert read_gpu_topology() is None
 
+    def test_returns_none_on_invalid_payload_shape(self, monkeypatch, tmp_path):
+        topo_file = tmp_path / "config" / "gpu-topology.json"
+        topo_file.parent.mkdir()
+        monkeypatch.setenv("ODS_INSTALL_DIR", str(tmp_path))
+
+        for payload in ([], {"gpus": {}}, {"gpus": [None]}):
+            topo_file.write_text(json.dumps(payload), encoding="utf-8")
+            assert read_gpu_topology() is None
+
 
 # ============================================================================
 # decode_gpu_assignment
@@ -110,6 +119,19 @@ class TestDecodeGpuAssignment:
         bad = base64.b64encode(b"not valid json {").decode()
         monkeypatch.setenv("GPU_ASSIGNMENT_JSON_B64", bad)
         assert decode_gpu_assignment() is None
+
+    def test_returns_none_on_invalid_payload_shape(self, monkeypatch):
+        invalid_payloads = (
+            [],
+            {},
+            {"gpu_assignment": []},
+            {"gpu_assignment": {"services": []}},
+            {"gpu_assignment": {"services": {"llama": None}}},
+        )
+
+        for payload in invalid_payloads:
+            monkeypatch.setenv("GPU_ASSIGNMENT_JSON_B64", _make_assignment_b64(payload))
+            assert decode_gpu_assignment() is None
 
     def test_live_empty_assignment_does_not_fall_back_to_stale_container_env(
         self,


### PR DESCRIPTION
## Summary
- validate topology files as objects with an object-list `gpus` field
- validate decoded GPU assignments before downstream service mapping uses them
- return the existing unavailable state for syntactically valid but structurally corrupt documents

## Test plan
- `python -m pytest tests/test_gpu_detailed.py -q` (35 passed)

Generated with Codex