### PR TITLE
fix(usage): validate Token Spy report payload

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -382,7 +382,7 @@ async def _fetch_token_spy_report(start: str, end: str) -> dict[str, Any]:
             end,
             detail=f"Token Spy returned HTTP {exc.code}: {detail[:160]}",
         )
-    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
         return _empty_report(start, end, detail=f"Token Spy unavailable: {exc}")
 
 
@@ -392,6 +392,8 @@ def _request_token_spy_report(start: str, end: str, headers: dict[str, str]) -> 
     request = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(request, timeout=10) as response:
         payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Token Spy report response must be an object")
     payload["source"] = {
         "name": "token-spy",
         "status": "ok",

--- a/ods/extensions/services/dashboard-api/tests/test_usage.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -244,6 +245,27 @@ def test_usage_report_returns_token_spy_payload(test_client, monkeypatch):
     assert data["summary"]["spend_usd"] == 1.25
     assert data["source"]["status"] == "ok"
     fetch.assert_awaited_once_with("2026-05-01", "2026-05-31")
+
+
+def test_token_spy_invalid_report_degrades_to_unavailable(monkeypatch):
+    import routers.usage as usage_router
+
+    monkeypatch.setattr(usage_router, "TOKEN_SPY_URL", "http://token-spy:8080")
+    monkeypatch.setattr(
+        usage_router,
+        "_request_token_spy_report",
+        lambda *_args: (_ for _ in ()).throw(
+            ValueError("Token Spy report response must be an object")
+        ),
+    )
+
+    report = asyncio.run(
+        usage_router._fetch_token_spy_report("2026-05-01", "2026-05-31")
+    )
+
+    assert report["source"]["status"] == "unavailable"
+    assert report["summary"]["requests"] == 0
+    assert "must be an object" in report["source"]["detail"]
 
 
 def test_usage_report_returns_honest_empty_payload_when_token_spy_disabled(


### PR DESCRIPTION
## Summary
- require Token Spy report responses to be JSON objects before annotating them
- classify malformed JSON and wrong-shape payloads as an unavailable telemetry source
- return the existing honest zeroed report instead of an API 500

## Test plan
- `python -m pytest tests/test_usage.py -q` (22 passed)

Generated with Codex