### PR TITLE
fix(privacy): validate IP address candidates

### DIFF
--- a/ods/extensions/services/privacy-shield/pii_scrubber.py
+++ b/ods/extensions/services/privacy-shield/pii_scrubber.py
@@ -5,6 +5,7 @@ Detects and replaces PII with tokens, restores on reverse.
 """
 
 import codecs
+import ipaddress
 import re
 import hashlib
 import secrets
@@ -86,6 +87,15 @@ class PIIDetector:
                 # Credit card: validate with Luhn to reduce false positives
                 if pii_type == 'credit_card' and not self._luhn_check(match):
                     continue
+
+                # The regex identifies IPv4/IPv6-shaped candidates, but it
+                # deliberately does not encode numeric range rules. Avoid
+                # scrubbing version-like values such as 999.999.999.999.
+                if pii_type == 'ip_address':
+                    try:
+                        ipaddress.ip_address(match)
+                    except ValueError:
+                        continue
 
                 # Check if we've seen this PII before
                 existing_token = None

--- a/ods/extensions/services/privacy-shield/tests/test_pii_scrubber.py
+++ b/ods/extensions/services/privacy-shield/tests/test_pii_scrubber.py
@@ -117,6 +117,15 @@ class TestIPDetection:
         result = detector.scrub(text)
         assert "2001:0db8:85a3:0000:0000:8a2e:0370:7334" not in result
 
+    @pytest.mark.parametrize(
+        "candidate",
+        ["999.999.999.999", "256.1.1.1", "192.168.1.999"],
+    )
+    def test_invalid_ipv4_candidate_is_not_scrubbed(self, detector, candidate):
+        text = f"Version-like value: {candidate}"
+
+        assert detector.scrub(text) == text
+
 
 # ── API key detection ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- validate regex-matched IP candidates with Python's address parser
- keep impossible IPv4 octets from being treated as sensitive network addresses
- preserve existing scrubbing for valid IPv4 and IPv6 values

## Test plan
- `python -m pytest tests/test_pii_scrubber.py -q` (32 passed)

Generated with Codex