### PR TITLE
fix(auth): require integer session TTLs

### DIFF
--- a/ods/extensions/services/dashboard-api/session_signer.py
+++ b/ods/extensions/services/dashboard-api/session_signer.py
@@ -103,8 +103,9 @@ def _sign(payload: str) -> str:
 def issue(ttl_seconds: int = 12 * 3600) -> str:
     """Mint a new signed cookie value valid for ``ttl_seconds`` seconds.
 
-    Raises ``RuntimeError`` if ODS_SESSION_SECRET is not configured —
-    we refuse to issue cookies that can't be verified.
+    Raises ``RuntimeError`` if ODS_SESSION_SECRET is not configured and
+    ``TypeError`` if ``ttl_seconds`` is not an integer. We refuse to issue
+    cookies that can't be verified.
     """
     if not _SECRET:
         raise RuntimeError(
@@ -112,6 +113,8 @@ def issue(ttl_seconds: int = 12 * 3600) -> str:
             "unsignable session cookie. Set it in .env (32+ random bytes) "
             "and restart dashboard-api."
         )
+    if isinstance(ttl_seconds, bool) or not isinstance(ttl_seconds, int):
+        raise TypeError("ttl_seconds must be an integer")
     if ttl_seconds < 1:
         raise ValueError(f"ttl_seconds must be positive, got {ttl_seconds}")
 

--- a/ods/extensions/services/dashboard-api/tests/test_session_signer.py
+++ b/ods/extensions/services/dashboard-api/tests/test_session_signer.py
@@ -48,6 +48,11 @@ class TestIssue:
         c2 = session_signer.issue(ttl_seconds=60)
         assert c1.split(".")[0] != c2.split(".")[0]
 
+    @pytest.mark.parametrize("ttl", [True, 1.5, "60", None])
+    def test_rejects_non_integer_ttl_before_minting_cookie(self, ttl):
+        with pytest.raises(TypeError, match="must be an integer"):
+            session_signer.issue(ttl_seconds=ttl)
+
 
 # ---------------------------------------------------------------------------
 # is_configured()


### PR DESCRIPTION
## Summary
- reject boolean, float, string, and null TTLs before signing a session cookie
- prevent minting cookies whose fractional expiry cannot be parsed by the verifier
- document the stricter session-signing contract

## Test plan
- `python -m pytest tests/test_session_signer.py -q` (25 passed)

Generated with Codex