### PR TITLE
fix(lemonade): classify transcription failures

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -256,6 +256,12 @@ class LemonadeClient:
                 status_code=exc.response.status_code,
                 payload=payload,
             ) from exc
+        except httpx.TimeoutException as exc:
+            raise LemonadeClientError("timeout", str(exc)) from exc
+        except httpx.RequestError as exc:
+            raise LemonadeClientError("provider_unreachable", str(exc)) from exc
+        except ValueError as exc:
+            raise LemonadeClientError("invalid_response", str(exc)) from exc
 
 
 def _json_payload(response: httpx.Response) -> dict[str, Any]:

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -171,3 +171,42 @@ async def test_explicit_timeout_override_is_applied():
     await client.aclose()
 
     assert seen["timeout"].get("read") == 5.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "kind"),
+    [
+        (httpx.ReadTimeout("slow transcription"), "timeout"),
+        (httpx.ConnectError("provider offline"), "provider_unreachable"),
+    ],
+)
+async def test_transcription_classifies_transport_errors(failure, kind):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        failure.request = request
+        raise failure
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.transcribe_wav("whisper", b"RIFF")
+
+    assert exc.value.kind == kind
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transcription_classifies_invalid_json():
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, content=b"not-json")
+        )
+    )
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.transcribe_wav("whisper", b"RIFF")
+
+    assert exc.value.kind == "invalid_response"
+    await client.aclose()


### PR DESCRIPTION
## Summary
- map transcription timeouts and connection failures to `LemonadeClientError`
- classify malformed transcription JSON consistently with other Lemonade calls
- add regression coverage for all three failure classes

## Test plan
- [x] `pytest -q tests/test_lemonade_client.py`

Generated with Codex