### PR TITLE
fix(lemonade): classify speech failures

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -226,14 +226,27 @@ class LemonadeClient:
 
     async def speech(self, model: str, text: str, *, voice: str = "af_heart") -> bytes:
         client = await self._ensure_client()
-        response = await client.post(
-            self.api_url("audio/speech"),
-            json={"model": model, "input": text, "voice": voice},
-            headers=self.auth_headers(),
-            timeout=self.settings.timeout,
-        )
-        response.raise_for_status()
-        return response.content
+        try:
+            response = await client.post(
+                self.api_url("audio/speech"),
+                json={"model": model, "input": text, "voice": voice},
+                headers=self.auth_headers(),
+                timeout=self.settings.timeout,
+            )
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPStatusError as exc:
+            payload = _json_payload(exc.response)
+            raise LemonadeClientError(
+                classify_status(exc.response.status_code),
+                _payload_message(payload) or exc.response.text or str(exc),
+                status_code=exc.response.status_code,
+                payload=payload,
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise LemonadeClientError("timeout", str(exc)) from exc
+        except httpx.RequestError as exc:
+            raise LemonadeClientError("provider_unreachable", str(exc)) from exc
 
     async def transcribe_wav(self, model: str, wav_bytes: bytes, *, filename: str = "audio.wav") -> dict[str, Any]:
         client = await self._ensure_client()

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -171,3 +171,38 @@ async def test_explicit_timeout_override_is_applied():
     await client.aclose()
 
     assert seen["timeout"].get("read") == 5.0
+
+
+@pytest.mark.asyncio
+async def test_speech_classifies_provider_http_error():
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                503, json={"error": {"message": "voice model unavailable"}}
+            )
+        )
+    )
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.speech("kokoro", "hello")
+
+    assert exc.value.kind == "provider_error"
+    assert exc.value.status_code == 503
+    assert "voice model unavailable" in str(exc.value)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_speech_classifies_transport_error():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("slow speech", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    with pytest.raises(LemonadeClientError) as exc:
+        await adapter.speech("kokoro", "hello")
+
+    assert exc.value.kind == "timeout"
+    await client.aclose()


### PR DESCRIPTION
## Summary
- Classify speech HTTP, timeout, and transport failures through LemonadeClientError.
- Add focused regression coverage.

## Test plan
- [x] pytest -q tests/test_lemonade_client.py

Generated with Codex