### PR TITLE
fix(lemonade): encode model ids in request paths

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence
+from urllib.parse import quote
 
 import httpx
 
@@ -189,7 +190,8 @@ class LemonadeClient:
         return data if isinstance(data, list) else []
 
     async def model(self, model_id: str) -> dict[str, Any]:
-        return await self._request_json("GET", f"models/{model_id}")
+        encoded_model_id = quote(model_id, safe="")
+        return await self._request_json("GET", f"models/{encoded_model_id}")
 
     async def chat_completion(
         self,

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -106,6 +106,24 @@ async def test_models_returns_data_list():
 
 
 @pytest.mark.asyncio
+async def test_model_percent_encodes_identifier_as_one_path_segment():
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["raw_path"] = request.url.raw_path
+        return httpx.Response(200, json={"id": "org/model name"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = LemonadeClient(client=client)
+
+    payload = await adapter.model("org/model name")
+
+    assert payload["id"] == "org/model name"
+    assert seen["raw_path"] == b"/api/v1/models/org%2Fmodel%20name"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_http_status_errors_are_classified():
     async def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Summary
- Percent-encode model identifiers so slashes and spaces remain one API path segment.
- Add focused regression coverage.

## Test plan
- [x] pytest -q tests/test_lemonade_client.py

Generated with Codex