### PR TITLE
fix(agent): reject non-finite request timeouts

### DIFF
--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import errno
 import json
+import math
 import threading
 import time
 from typing import Any
@@ -99,9 +100,12 @@ def _headers() -> dict[str, str]:
 
 
 def _timeout(read_seconds: float) -> httpx.Timeout:
+    read_timeout = float(read_seconds)
+    if not math.isfinite(read_timeout):
+        raise ValueError("Host-agent read timeout must be finite")
     return httpx.Timeout(
         connect=5.0,
-        read=max(0.1, float(read_seconds)),
+        read=max(0.1, read_timeout),
         write=30.0,
         pool=5.0,
     )

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
@@ -225,6 +225,25 @@ def test_timeout_is_distinct_from_unavailable(monkeypatch):
         client.close()
 
 
+@pytest.mark.parametrize("timeout", [float("nan"), float("inf"), float("-inf")])
+def test_request_rejects_non_finite_timeout_before_transport(monkeypatch, timeout):
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.Client(base_url="http://agent", transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(agent_client, "_sync_client", client)
+    try:
+        with pytest.raises(ValueError, match="must be finite"):
+            agent_client.request_json("GET", "/health", timeout=timeout)
+        assert calls == 0
+    finally:
+        client.close()
+
+
 @pytest.mark.asyncio
 async def test_async_request_and_shutdown_close_both_pools(monkeypatch):
     async_client = httpx.AsyncClient(


### PR DESCRIPTION
## Summary
- Reject NaN and infinite host-agent read timeouts before transport execution.
- Add focused regression coverage.

## Test plan
- [x] pytest -q tests/test_host_agent_client.py

Generated with Codex