### PR TITLE
fix(talk): trim backend URL settings

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -152,7 +152,7 @@ def _vision_backend_base_url() -> str:
         os.environ.get("ODS_TALK_VISION_URL")
         or os.environ.get("LLM_API_URL")
         or "http://llama-server:8080"
-    ).rstrip("/")
+    ).strip().rstrip("/")
     if raw.endswith("/v1") or raw.endswith("/api/v1"):
         return raw
 
@@ -277,11 +277,15 @@ async def _service_state(service_id: str) -> dict[str, Any]:
 
 
 def _whisper_url() -> str:
-    return (os.environ.get("WHISPER_URL") or "http://whisper:8000").rstrip("/")
+    return (os.environ.get("WHISPER_URL") or "http://whisper:8000").strip().rstrip("/")
 
 
 def _tts_url() -> str:
-    return (os.environ.get("KOKORO_URL") or os.environ.get("TTS_URL") or "http://tts:8880").rstrip("/")
+    return (
+        os.environ.get("KOKORO_URL")
+        or os.environ.get("TTS_URL")
+        or "http://tts:8880"
+    ).strip().rstrip("/")
 
 
 def _stt_model() -> str:

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from routers import talk
+
 
 @pytest.fixture()
 def signed_talk_cookie(monkeypatch):
@@ -1186,3 +1188,11 @@ def test_ods_talk_hermes_timeout_is_env_configurable(monkeypatch):
 
     monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", "5")
     assert hermes_bridge._request_timeout() == 10
+def test_talk_backend_urls_ignore_surrounding_env_whitespace(monkeypatch):
+    monkeypatch.setenv("ODS_TALK_VISION_URL", "  http://vision:8080/v1/  ")
+    monkeypatch.setenv("WHISPER_URL", "  http://whisper:8000/  ")
+    monkeypatch.setenv("KOKORO_URL", "  http://kokoro:8880/  ")
+
+    assert talk._vision_backend_base_url() == "http://vision:8080/v1"
+    assert talk._whisper_url() == "http://whisper:8000"
+    assert talk._tts_url() == "http://kokoro:8880"


### PR DESCRIPTION
﻿## Summary
- Normalize surrounding whitespace in vision, transcription, and speech backend URLs.
- Add focused regression coverage.

## Test plan
- [x] pytest -q tests/test_talk.py

Generated with Codex


## Why this matters
Operator-edited URL environment values can carry surrounding whitespace; without normalization, Talk constructs syntactically invalid vision, STT, or TTS request URLs and reports the backend as unavailable.

## Overlap check
Searched the existing tang-vu PR history by title and changed files. No other open PR normalizes these three Talk backend URL helpers.
