### PR TITLE
fix(config): confine generated contract paths

### DIFF
--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -43,6 +43,16 @@ def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def resolve_repo_path(issues: Issues, value: str, path: str) -> Path | None:
+    candidate = (ROOT / value).resolve()
+    try:
+        candidate.relative_to(ROOT)
+    except ValueError:
+        issues.add(path, f"path must stay within the repository: {value}")
+        return None
+    return candidate
+
+
 def resolve_json_path(data: Any, dotted_path: str) -> Any:
     current = data
     for part in dotted_path.split("."):
@@ -99,7 +109,9 @@ def validate_writers(issues: Issues, value: Any, path: str) -> set[str]:
             platforms.append(platform)
         if nonempty_string(target):
             targets.add(str(target))
-            issues.require((ROOT / target).exists(), f"{writer_path}.path", f"file does not exist: {target}")
+            target_path = resolve_repo_path(issues, str(target), f"{writer_path}.path")
+            if target_path is not None:
+                issues.require(target_path.exists(), f"{writer_path}.path", f"file does not exist: {target}")
     return targets
 
 
@@ -116,7 +128,9 @@ def validate_invariant(issues: Issues, invariant: Any, path: str) -> None:
     if not nonempty_string(target):
         return
 
-    target_path = ROOT / str(target)
+    target_path = resolve_repo_path(issues, str(target), f"{path}.path")
+    if target_path is None:
+        return
     issues.require(target_path.exists(), f"{path}.path", f"file does not exist: {target}")
     if not target_path.exists():
         return

--- a/ods/tests/test-generated-config-contracts.sh
+++ b/ods/tests/test-generated-config-contracts.sh
@@ -8,7 +8,8 @@ python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$ROOT_DIR/config/gene
 
 missing_writer_contract="$(mktemp)"
 missing_lemonade_writer_contract="$(mktemp)"
-trap 'rm -f "$missing_writer_contract" "$missing_lemonade_writer_contract"' EXIT
+escaping_path_contract="$(mktemp)"
+trap 'rm -f "$missing_writer_contract" "$missing_lemonade_writer_contract" "$escaping_path_contract"' EXIT
 python3 - "$ROOT_DIR/config/generated-config-contracts.json" "$missing_writer_contract" <<'PY'
 import json
 import sys
@@ -48,6 +49,22 @@ target.write_text(json.dumps(contract), encoding="utf-8")
 PY
 if python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$missing_lemonade_writer_contract" >/dev/null 2>&1; then
     echo "[FAIL] Lemonade writer validation accepted an incomplete ownership inventory" >&2
+    exit 1
+fi
+
+python3 - "$ROOT_DIR/config/generated-config-contracts.json" "$escaping_path_contract" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+contract = json.loads(source.read_text(encoding="utf-8"))
+contract["surfaces"][0]["invariants"][0]["path"] = "../README.md"
+target.write_text(json.dumps(contract), encoding="utf-8")
+PY
+if python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$escaping_path_contract" >/dev/null 2>&1; then
+    echo "[FAIL] generated config validation accepted a path outside the repository" >&2
     exit 1
 fi
 


### PR DESCRIPTION
﻿## Summary
- Reject generated-config writer and invariant paths that resolve outside the repository.
- Add focused regression coverage.

## Test plan
- [x] python scripts/validate-generated-configs.py config/generated-config-contracts.json

Generated with Codex


## Why this matters
The release contract validator should prove facts about files inside the ODS checkout. Without confinement, an accidental ../ path or absolute path can make the gate validate an unrelated host file and produce a false pass.

## Overlap check
Distinct from #2536 and #2537: this PR only governs generated-config writer and invariant paths in validate-generated-configs.py.
