### PR TITLE
fix(release): confine golden path files

### DIFF
--- a/ods/scripts/validate-golden-paths.py
+++ b/ods/scripts/validate-golden-paths.py
@@ -47,6 +47,22 @@ def nonempty_string(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
+def resolve_repo_path(
+    issues: Issues,
+    value: str,
+    path: str,
+    *,
+    boundary: Path = ROOT,
+) -> Path | None:
+    candidate = (ROOT / value).resolve()
+    try:
+        candidate.relative_to(boundary)
+    except ValueError:
+        issues.add(path, f"path must stay within the repository: {value}")
+        return None
+    return candidate
+
+
 def validate_string_list(issues: Issues, value: Any, path: str) -> list[str]:
     if not isinstance(value, list):
         issues.add(path, "must be an array")
@@ -140,7 +156,14 @@ def validate_scenario(issues: Issues, scenario: Any, path: str) -> str | None:
         entrypoint = installer.get("entrypoint")
         issues.require(nonempty_string(entrypoint), f"{path}.installer.entrypoint", "must be a non-empty string")
         if nonempty_string(entrypoint):
-            issues.require((ROOT / entrypoint).exists(), f"{path}.installer.entrypoint", f"file does not exist: {entrypoint}")
+            entrypoint_path = resolve_repo_path(
+                issues,
+                str(entrypoint),
+                f"{path}.installer.entrypoint",
+                boundary=ROOT.parent,
+            )
+            if entrypoint_path is not None:
+                issues.require(entrypoint_path.exists(), f"{path}.installer.entrypoint", f"file does not exist: {entrypoint}")
         issues.require(nonempty_string(installer.get("mode")), f"{path}.installer.mode", "must be a non-empty string")
         issues.require(nonempty_string(installer.get("ci_simulation")), f"{path}.installer.ci_simulation", "must be a non-empty string")
         validate_string_list(issues, installer.get("dry_run_args"), f"{path}.installer.dry_run_args")
@@ -158,7 +181,11 @@ def validate_scenario(issues: Issues, scenario: Any, path: str) -> str | None:
 
     compose_files = validate_string_list(issues, expected.get("compose_files"), f"{path}.expected.compose_files")
     for compose_file in compose_files:
-        issues.require((ROOT / compose_file).exists(), f"{path}.expected.compose_files", f"compose file does not exist: {compose_file}")
+        compose_path = resolve_repo_path(
+            issues, compose_file, f"{path}.expected.compose_files"
+        )
+        if compose_path is not None:
+            issues.require(compose_path.exists(), f"{path}.expected.compose_files", f"compose file does not exist: {compose_file}")
 
     core_services = validate_string_list(issues, expected.get("core_services"), f"{path}.expected.core_services")
     recommended_services = validate_string_list(issues, expected.get("recommended_services"), f"{path}.expected.recommended_services")

--- a/ods/tests/test-golden-paths.sh
+++ b/ods/tests/test-golden-paths.sh
@@ -6,4 +6,22 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 python3 -m py_compile "$ROOT_DIR/scripts/validate-golden-paths.py"
 python3 "$ROOT_DIR/scripts/validate-golden-paths.py" "$ROOT_DIR/config/golden-paths.json"
 
+escaping_contract="$(mktemp)"
+trap 'rm -f "$escaping_contract"' EXIT
+python3 - "$ROOT_DIR/config/golden-paths.json" "$escaping_contract" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+contract = json.loads(source.read_text(encoding="utf-8"))
+contract["scenarios"][0]["installer"]["entrypoint"] = "../../install.sh"
+target.write_text(json.dumps(contract), encoding="utf-8")
+PY
+if python3 "$ROOT_DIR/scripts/validate-golden-paths.py" "$escaping_contract" >/dev/null 2>&1; then
+    echo "[FAIL] golden path validator accepted an entrypoint outside the repository" >&2
+    exit 1
+fi
+
 echo "[PASS] golden path validator test"


### PR DESCRIPTION
﻿## Summary
- Constrain golden-path installer and compose references to their intended repository boundaries.
- Add focused regression coverage.

## Test plan
- [x] python scripts/validate-golden-paths.py config/golden-paths.json

Generated with Codex


## Why this matters
Golden-path scenarios legitimately reference both ods/ files and the outer wrapper installers. Explicit boundaries preserve those supported references while rejecting accidental escapes beyond the repository.

## Overlap check
Distinct from #2535 and #2537: this PR is limited to installer/compose references in validate-golden-paths.py and preserves the existing ../install.ps1 contract.
