### PR TITLE
fix(deps): confine dependency lock paths

### DIFF
--- a/ods/scripts/check-dependency-pins.py
+++ b/ods/scripts/check-dependency-pins.py
@@ -218,6 +218,16 @@ def _arg_default_present(path: Path, arg: str, default: str) -> bool:
     return expected in path.read_text(encoding="utf-8")
 
 
+def _resolve_locked_path(root: Path, value: str) -> Path | None:
+    root = root.resolve()
+    candidate = (root / value).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
 def _validate_lock_shape(lock: dict[str, object], root: Path) -> list[str]:
     errors: list[str] = []
     if lock.get("version") != 1:
@@ -242,7 +252,10 @@ def _validate_lock_shape(lock: dict[str, object], root: Path) -> list[str]:
         if (path, value) in entry_keys:
             errors.append(f"duplicate lock entry path/value: {path} -> {value}")
         entry_keys.add((path, value))
-        file_path = root / path
+        file_path = _resolve_locked_path(root, path)
+        if file_path is None:
+            errors.append(f"lock entry path escapes repository root: {path}")
+            continue
         if not file_path.exists():
             errors.append(f"lock entry points at missing file: {path}")
             continue
@@ -263,7 +276,10 @@ def _validate_lock_shape(lock: dict[str, object], root: Path) -> list[str]:
             if (path, value) in seen:
                 errors.append(f"duplicate {list_name} entry: {path} -> {value}")
             seen.add((path, value))
-            file_path = root / path
+            file_path = _resolve_locked_path(root, path)
+            if file_path is None:
+                errors.append(f"{list_name} path escapes repository root: {path}")
+                continue
             if not file_path.exists():
                 errors.append(f"{list_name} entry points at missing file: {path}")
                 continue

--- a/ods/tests/test-dependency-pins.py
+++ b/ods/tests/test-dependency-pins.py
@@ -178,6 +178,33 @@ def test_extension_library_sha_tags_are_rejected() -> None:
     )
 
 
+def test_lock_paths_cannot_escape_repository_root() -> None:
+    module = load_module()
+    with TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        root = workspace / "repo"
+        root.mkdir()
+        outside = workspace / "compose.yaml"
+        outside.write_text("image: example/runtime:1.0\n", encoding="utf-8")
+        lock = {
+            "version": 1,
+            "entries": [
+                {
+                    "id": "escape",
+                    "path": "../compose.yaml",
+                    "value": "example/runtime:1.0",
+                }
+            ],
+            "allow_latest": [],
+            "allow_local_images": [],
+            "allow_variable_refs": [],
+        }
+
+        errors = module._validate_lock_shape(lock, root)
+
+    assert any("path escapes repository root" in error for error in errors)
+
+
 def main() -> int:
     tests = [
         test_repo_dependency_lock_passes,
@@ -187,6 +214,7 @@ def main() -> int:
         test_ephemeral_sha256_length_tags_are_rejected,
         test_sha256_digest_pins_are_allowed,
         test_extension_library_sha_tags_are_rejected,
+        test_lock_paths_cannot_escape_repository_root,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
﻿## Summary
- Reject dependency-lock entries and allowlist paths that escape the scanned repository.
- Add focused regression coverage.

## Test plan
- [x] python tests/test-dependency-pins.py

Generated with Codex


## Why this matters
Dependency pin checks must be reproducible from the checkout. Resolving a lock entry outside the scanned root can validate a developer-machine file that CI or another clone does not have.

## Overlap check
Distinct from #2535 and #2536: this PR only confines dependency-lock entries and allowlists in check-dependency-pins.py.
