### PR TITLE
fix(extensions): reject duplicate catalog ids

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -100,6 +100,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Manifest schema source of truth ==="
 	@bash tests/test-validate-manifest-schema.sh
+	@python3 tests/test-generate-extensions-catalog.py
 	@echo ""
 	@echo "=== macOS ods config show secret-mask ==="
 	@bash tests/test-macos-config-show-secret-mask.sh

--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -127,6 +127,7 @@ def generate_catalog(library_dir: Path) -> list[dict]:
         sys.exit(1)
 
     entries = []
+    entry_sources: dict[str, Path] = {}
     for service_dir in sorted(library_dir.iterdir()):
         if not service_dir.is_dir():
             continue
@@ -143,7 +144,15 @@ def generate_catalog(library_dir: Path) -> list[dict]:
         if entry is None:
             continue
 
+        service_id = entry["id"]
+        previous = entry_sources.get(service_id)
+        if previous is not None:
+            raise ValueError(
+                f"duplicate service id {service_id!r} in {previous} and {manifest_path}"
+            )
+
         entries.append(entry)
+        entry_sources[service_id] = manifest_path
 
     entries.sort(key=lambda e: e["id"])
     return entries

--- a/ods/tests/test-generate-extensions-catalog.py
+++ b/ods/tests/test-generate-extensions-catalog.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Regression tests for extension catalog generation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate-extensions-catalog.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("generate_extensions_catalog", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(path: Path, service_id: str) -> None:
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "schema_version: ods.services.v1\n"
+        "service:\n"
+        f"  id: {service_id}\n"
+        f"  name: {service_id}\n",
+        encoding="utf-8",
+    )
+
+
+def test_duplicate_service_ids_are_rejected() -> None:
+    module = load_module()
+    with TemporaryDirectory() as tmp:
+        library = Path(tmp)
+        _write_manifest(library / "first" / "manifest.yaml", "duplicate")
+        _write_manifest(library / "second" / "manifest.yaml", "duplicate")
+
+        with pytest.raises(ValueError, match="duplicate service id 'duplicate'"):
+            module.generate_catalog(library)
+
+
+if __name__ == "__main__":
+    test_duplicate_service_ids_are_rejected()
+    print("[PASS] extension catalog generator tests")


### PR DESCRIPTION
﻿## Summary
- Fail catalog generation when two manifests claim the same service id.
- Add focused regression coverage.

## Test plan
- [x] python tests/test-generate-extensions-catalog.py

Generated with Codex


## Why this matters
Duplicate service IDs make the generated extension catalog ambiguous: two independent manifests become indistinguishable to dashboard consumers. Failing generation identifies both source manifests before publishing the catalog.

## Overlap check
Searched the existing tang-vu PR history by title and changed files. No other open PR rejects duplicate IDs during extension catalog generation.
