### PR TITLE
fix(release): parse structured version files

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -88,6 +88,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py
+	@python3 tests/test-check-version-consistency.py
 	@echo ""
 	@echo "=== Bash 3.2 guard contracts ==="
 	@bash tests/test-bash32-guards.sh

--- a/ods/scripts/check-version-consistency.py
+++ b/ods/scripts/check-version-consistency.py
@@ -44,9 +44,14 @@ def optional_version_file() -> str | None:
         data = json.loads(raw)
     except json.JSONDecodeError:
         return raw
-    if isinstance(data, dict) and data.get("version"):
-        return str(data["version"])
-    return raw
+    if isinstance(data, str):
+        return data.strip() or None
+    if isinstance(data, dict):
+        version = data.get("version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+        raise ValueError(".version JSON object must contain a non-empty string version")
+    raise ValueError(".version JSON must be a string or an object with a version field")
 
 
 def add_regex_check(
@@ -132,9 +137,12 @@ def main() -> int:
         r"^> Version ([0-9]+\.[0-9]+\.[0-9]+)\s+\|",
     )
 
-    version_file = optional_version_file()
-    if version_file is not None:
-        checks.append((".version version", version_file))
+    try:
+        version_file = optional_version_file()
+        if version_file is not None:
+            checks.append((".version version", version_file))
+    except ValueError as exc:
+        errors.append(str(exc))
 
     try:
         changelog_version, changelog_date = latest_changelog_release()

--- a/ods/tests/test-check-version-consistency.py
+++ b/ods/tests/test-check-version-consistency.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Unit tests for version authority parsing."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-version-consistency.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_version_consistency", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse(contents: str):
+    module = load_module()
+    with TemporaryDirectory() as tmp:
+        module.ROOT = Path(tmp)
+        (module.ROOT / ".version").write_text(contents, encoding="utf-8")
+        return module.optional_version_file()
+
+
+def test_plain_version_is_supported() -> None:
+    assert _parse("3.4.0\n") == "3.4.0"
+
+
+def test_json_string_version_is_unwrapped() -> None:
+    assert _parse('"3.4.0"\n') == "3.4.0"
+
+
+def test_json_object_version_is_unwrapped() -> None:
+    assert _parse('{"version": "3.4.0"}\n') == "3.4.0"
+
+
+def test_json_object_requires_string_version() -> None:
+    try:
+        _parse('{"version": 340}\n')
+    except ValueError as exc:
+        assert "non-empty string version" in str(exc)
+    else:
+        raise AssertionError("numeric JSON version must be rejected")
+
+
+if __name__ == "__main__":
+    test_plain_version_is_supported()
+    test_json_string_version_is_unwrapped()
+    test_json_object_version_is_unwrapped()
+    test_json_object_requires_string_version()
+    print("[PASS] version consistency tests")


### PR DESCRIPTION
## Summary
- Correctly unwrap JSON string and object .version formats and reject invalid structured values.
- Add focused regression coverage.

## Test plan
- [x] python tests/test-check-version-consistency.py; python scripts/check-version-consistency.py

Generated with Codex