### PR TITLE
fix(backup): stop rsync --delete from wiping live data on restore

### DIFF
--- a/ods/lib/rsync.sh
+++ b/ods/lib/rsync.sh
@@ -18,10 +18,21 @@
 #   $1 - source path
 #   $2 - destination path
 #   $3 - optional label (default: "Copying")
+#   $4 - optional extra rsync flags, e.g. "--delete" (default: none)
+#
+# --delete is NOT enabled by default. It makes the destination an exact
+# mirror of the source, removing anything under dest that isn't in src —
+# including files that were created in a live dest directory *after* the
+# source snapshot was taken. ods-restore.sh's restore_user_data() rsyncs an
+# (older) backup dir over a live data dir; with --delete this silently
+# deleted any file the user created since the backup ran, contradicting the
+# function's own "preserve files created after backup" comment. Pass
+# "--delete" explicitly only at call sites that truly want a mirror sync.
 rsync_with_progress() {
     local src="$1"
     local dest="$2"
     local label="${3:-Copying}"
+    local extra_flags="${4:-}"
 
     # Prefer the caller's styled logger when it exists. log_info is a *function*
     # in the scripts that source this lib (ods-backup.sh, ods-restore.sh), so it
@@ -33,12 +44,18 @@ rsync_with_progress() {
         echo "[INFO] $label..."
     fi
 
+    local -a extra_args=()
+    if [[ -n "$extra_flags" ]]; then
+        # shellcheck disable=SC2206  # intentional word-splitting of flag string
+        extra_args=($extra_flags)
+    fi
+
     # Use --info=progress2 for compact single-line progress updates
     # Fallback to basic rsync if progress2 not supported
     if rsync --help 2>/dev/null | grep -q "info=progress2"; then
-        rsync -a --delete --info=progress2 "$src" "$dest"
+        rsync -a "${extra_args[@]}" --info=progress2 "$src" "$dest"
     else
         # Fallback: use --progress for older rsync versions
-        rsync -a --delete --progress "$src" "$dest" 2>/dev/null || rsync -a --delete "$src" "$dest"
+        rsync -a "${extra_args[@]}" --progress "$src" "$dest" 2>/dev/null || rsync -a "${extra_args[@]}" "$src" "$dest"
     fi
 }

--- a/ods/tests/test-backup-restore-roundtrip.sh
+++ b/ods/tests/test-backup-restore-roundtrip.sh
@@ -45,9 +45,20 @@ BACKUP_ID=$(ls -1 "$SRC/.backups" | head -n 1)
 [[ -n "$BACKUP_ID" ]] || fail "No backup created"
 pass "Backup created: $BACKUP_ID"
 
-# Create destination ODS directory (empty)
+# Create destination ODS directory with pre-existing live data: a sibling
+# service dir not in this backup (data/qdrant), AND a file inside
+# data/open-webui itself that was created *after* the backup was taken.
+# Regression: restore_user_data() used to rsync with --delete. Since the
+# restored dir (open-webui) already exists live with a newer file not
+# present in the (older) backup, --delete removes it — confirmed via direct
+# rsync testing: `rsync -a --delete backup/open-webui live/data/` deletes
+# any file under live/data/open-webui that isn't in the backup, even though
+# the code's own comment says restore must preserve files added since backup.
 DST="$TMP/dst"
-mkdir -p "$DST/data"
+mkdir -p "$DST/data/qdrant"
+echo "live-qdrant-data" > "$DST/data/qdrant/existing.txt"
+mkdir -p "$DST/data/open-webui"
+echo "created-after-backup" > "$DST/data/open-webui/post-backup-file.txt"
 mkdir -p "$DST/.backups"
 mkdir -p "$DST/lib"
 cp "$SCRIPT_DIR/../lib/rsync.sh" "$DST/lib/"
@@ -81,6 +92,17 @@ pass "All expected files/dirs present after restore"
 [[ "$(cat "$DST/data/open-webui/data.txt")" == "user-data-file" ]] || fail "data/open-webui/data.txt content mismatch"
 
 pass "All file contents match after restore"
+
+# Regression: restore_user_data() used to rsync with --delete.
+info "Verifying restore did not delete unrelated live sibling data"
+[[ -f "$DST/data/qdrant/existing.txt" ]] || fail "restore deleted live data/qdrant (--delete regression)"
+[[ "$(cat "$DST/data/qdrant/existing.txt")" == "live-qdrant-data" ]] || fail "live data/qdrant content mismatch after restore"
+pass "restore preserved unrelated live data directories"
+
+info "Verifying restore did not delete a file created after the backup"
+[[ -f "$DST/data/open-webui/post-backup-file.txt" ]] || fail "restore deleted a file created after the backup (--delete regression)"
+[[ "$(cat "$DST/data/open-webui/post-backup-file.txt")" == "created-after-backup" ]] || fail "post-backup file content mismatch after restore"
+pass "restore preserved a file created in the live dir after the backup was taken"
 
 # ── Compressed round-trip ─────────────────────────────────────────────
 # extract_backup's stdout is command-substituted into the backup path, so a


### PR DESCRIPTION
## Summary

`rsync_with_progress()` in `ods/lib/rsync.sh` hardcoded `--delete` on every
call. I verified with direct rsync testing (not just reading the code) that
`restore_user_data()` restoring an older backup over a live `data/` dir
deletes any file created there since the backup was taken — the opposite of
its own "preserve files created after backup" comment.

I also checked the "backup loop wipes prior services" / "config wipes data"
theory from the issue by reproducing the exact rsync invocations in
isolation; that specific mechanism did not reproduce (rsync's `--delete`
scope stays within the transferred subtree when the source has no trailing
slash, so sibling directories under a shared backup dir are untouched).
The restore-clobbering-live-data path is real and reproducible, so that's
what this PR fixes and tests.

Fix: `--delete` becomes an explicit opt-in (`rsync_with_progress src dest
label "--delete"`), default off. No existing call site passes it — none of
them actually want mirror-sync semantics.

## AI Assistance

Used an AI coding assistant to investigate the issue, write the fix, and add
regression tests. I reviewed the diff, verified the fix and both backup/
restore tests against real `rsync` (WSL/Ubuntu), and confirmed the added
test fails on the old code and passes on the new code before opening this PR.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Tests only
- [ ] Installer / bootstrap / lifecycle (backup/restore scripts source this lib, but the change is contained to `lib/rsync.sh`'s shared helper)

## Risk And Validation

- Risk level: Medium (backup/restore correctness)
- Validation run:
  - [x] Focused tests listed below
  - [ ] Not required because: n/a

Commands/results:

```text
bash -n ods/lib/rsync.sh                         # syntax OK
bash ods/tests/test-backup-restore-roundtrip.sh  # PASS (incl. 2 new regression checks)
bash ods/tests/test-backup-integrity.sh          # PASS (unaffected)

# Confirmed the new restore regression checks fail against the pre-fix
# lib/rsync.sh (git show HEAD:ods/lib/rsync.sh) and pass against the fix.
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

## Notes For Reviewers

The issue's root-cause writeup for the *backup*-side loop is not accurate
per my rsync testing (details above) — I'm not fixing a bug that doesn't
reproduce there, just noting it in case it's useful for triage. The
restore-side data-loss bug is real, reproduced, and fixed here.
