### PR TITLE
fix(bootstrap): refuse to rm -rf a dangerous ODS_INSTALL_DIR

### DIFF
--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -361,6 +361,42 @@ fi
 
 # GPU pre-check already done above — real detection happens in the installer
 
+# ── Guard against a dangerous ODS_INSTALL_DIR before any destructive op ──
+# INSTALL_DIR is used below by remove_install_dir() (rm -rf) and by the
+# post-clone copy/cleanup steps. A mistyped ODS_INSTALL_DIR (e.g. "~",
+# unset HOME resolving to "/", or "/home") must never be treated as an
+# ODS install location just because it happens to exist and lack a .env file.
+resolve_absolute_path() {
+    local p="$1"
+    (cd "$p" 2>/dev/null && pwd -P) || echo "$p"
+}
+
+is_unsafe_install_dir() {
+    local resolved="$1"
+    local home_resolved=""
+
+    [[ -n "${HOME:-}" ]] && home_resolved="$(resolve_absolute_path "$HOME")"
+
+    [[ "$resolved" == "/" ]] && return 0
+    [[ -n "$home_resolved" && "$resolved" == "$home_resolved" ]] && return 0
+
+    case "$resolved" in
+        /root|/home|/usr|/etc|/var|/opt|/bin|/sbin|/boot|/dev|/proc|/sys|/lib|/lib64|/mnt|/media|/srv|/tmp)
+            return 0 ;;
+    esac
+
+    # Reject direct children of root ("/foo") — an ODS install should
+    # always be nested at least two levels deep.
+    local without_root="${resolved#/}"
+    [[ "$without_root" != */* ]] && return 0
+
+    return 1
+}
+
+if [[ -e "$INSTALL_DIR" ]] && is_unsafe_install_dir "$(resolve_absolute_path "$INSTALL_DIR")"; then
+    error "ODS_INSTALL_DIR ('$INSTALL_DIR') resolves to a system or home directory, not a dedicated ODS install location. Refusing to continue — set ODS_INSTALL_DIR to a subdirectory, e.g. \$HOME/ods."
+fi
+
 # ── Check for existing installation ──────────────────
 if [[ -d "$INSTALL_DIR" ]]; then
     if [[ -f "$INSTALL_DIR/.env" ]]; then

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -233,6 +233,29 @@ assert_contains "$bootstrap" 'Re-run with --force to remove it automatically' "b
 assert_contains "$bootstrap" 'remove_install_dir()' "bootstrap should centralize incomplete install cleanup"
 assert_contains "$bootstrap" 'sudo -n rm -rf -- "\$target_dir"' "bootstrap --force should retry root-owned container data cleanup with sudo -n"
 assert_contains "$bootstrap" 'root-owned container data' "bootstrap sudo fallback should explain root-owned Docker data cleanup"
+assert_contains "$bootstrap" 'is_unsafe_install_dir' "bootstrap should validate ODS_INSTALL_DIR before any rm -rf"
+
+echo "[contract] public bootstrap refuses to rm -rf a dangerous ODS_INSTALL_DIR"
+danger_home="$tmpdir/danger-home"
+mkdir -p "$danger_home"
+echo "must-survive" > "$danger_home/important-user-file.txt"
+
+# ODS_INSTALL_DIR resolving to $HOME itself (e.g. a mistyped "~") is exactly
+# the "incomplete install, no .env" shape remove_install_dir() used to
+# rm -rf without question. It must refuse instead of wiping $HOME.
+if HOME="$danger_home" \
+    ODS_BOOTSTRAP_ROOT="$danger_home" \
+    ODS_INSTALL_DIR="$danger_home" \
+    OSTYPE=linux-gnu \
+    bash get-ods.sh --force --non-interactive >"$tmpdir/bootstrap-danger.out" 2>&1; then
+  echo "[FAIL] bootstrap should refuse an ODS_INSTALL_DIR that resolves to \$HOME"
+  cat "$tmpdir/bootstrap-danger.out"
+  exit 1
+fi
+assert_contains "$tmpdir/bootstrap-danger.out" "system or home directory" "bootstrap did not explain why it refused the dangerous install dir"
+[[ -f "$danger_home/important-user-file.txt" ]] \
+  || { echo "[FAIL] bootstrap deleted files outside the ODS install dir"; cat "$tmpdir/bootstrap-danger.out"; exit 1; }
+echo "[PASS] bootstrap refuses a dangerous ODS_INSTALL_DIR without deleting anything"
 
 echo "[contract] public bootstrap can install from an exact commit SHA"
 sha_repo="$tmpdir/sha-ref-repo"


### PR DESCRIPTION
## Summary

`get-ods.sh` treats an existing `INSTALL_DIR` that lacks a `.env` file as an
"incomplete install" and removes it with `rm -rf` (automatically with
`--force`, or after a `[y/N]` prompt) with no check that the resolved path
isn't `/`, `$HOME`, or another system directory.

I reproduced this directly rather than just reading the code: with
`HOME=ODS_INSTALL_DIR=/tmp/danger-home` and `--force`, the entire directory
was deleted mid-run, and the script itself then crashed because its own
working directory (which it `cd`s into at startup) had just been removed
out from under it.

Fix: resolve `INSTALL_DIR` to an absolute path once, right after it's set
and before any destructive branch can run, and refuse to continue if it's
`/`, `$HOME` itself, a handful of top-level system directories (`/etc`,
`/usr`, `/var`, `/tmp`, ...), or any direct child of root. Normal installs
(the default `$HOME/ods`, or any other subdirectory) are unaffected —
verified by running the full default-path flow in a sandboxed `$HOME`.

## AI Assistance

Used an AI coding assistant to investigate, implement the guard, and add a
regression test. I reviewed the diff and personally reproduced both the bug
(old code deletes `$HOME`) and the fix (refuses cleanly, file survives) by
running the actual script end-to-end in a sandboxed WSL environment, not
just reading code.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer / bootstrap / lifecycle

## Risk And Validation

- Risk level: High (this is exactly the surface that can delete user data)
- Validation run:
  - [x] Focused tests listed below
  - [ ] Not required because: n/a

Commands/results:

```text
bash -n ods/get-ods.sh                                        # syntax OK
bash ods/tests/contracts/test-installer-hardening.sh          # PASS (full suite, incl. new contract)

# Direct end-to-end reproduction (not just the test suite):
#  - Old get-ods.sh + HOME=ODS_INSTALL_DIR=<tmp dir> --force --non-interactive
#    => entire directory rm -rf'd, script then crashes (cwd gone)
#  - New get-ods.sh, same inputs
#    => refuses with a clear error, directory and its contents untouched
#  - New get-ods.sh + normal default install dir ($HOME/ods)
#    => proceeds past the guard exactly as before, reaches the real
#       install.sh unaffected
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

## Notes For Reviewers

This only guards `get-ods.sh`'s own `INSTALL_DIR` handling (the public
bootstrap entry point named in the issue). I did not touch
`remove_install_dir()` itself, since every call site already goes through
the new guard — keeping the check in one place per the "functional core"
convention in this repo's `installers/lib/` vs `installers/phases/` split.
