### PR TITLE
ci: add least-privilege permissions to 10 workflows

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -12,6 +12,9 @@ concurrency:
   group: issue-triage-${{ github.event.issue.number }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     name: Triage Issue

--- a/.github/workflows/autonomous-code-scanner.yml
+++ b/.github/workflows/autonomous-code-scanner.yml
@@ -23,6 +23,9 @@ concurrency:
   group: autonomous-code-scanner
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   # Job 1: Pre-Flight Security Check (10 min)
   security-check:

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -12,6 +12,9 @@ concurrency:
   group: issue-to-pr-${{ github.event.issue.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ============================================================
   # Job 1: Validate — bot filter, secrets, duplicate PR check
@@ -20,6 +23,8 @@ jobs:
     name: Validate Issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      pull-requests: read
     if: >-
       github.event.label.name == 'ai-implement' &&
       github.event.issue.user.login != 'claude[bot]' &&
@@ -322,6 +327,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       pr_number: ${{ steps.create.outputs.pull-request-number }}
       pr_url: ${{ steps.create.outputs.pull-request-url }}

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   powershell-lint:
     strategy:

--- a/.github/workflows/nightly-code-review.yml
+++ b/.github/workflows/nightly-code-review.yml
@@ -22,11 +22,17 @@ concurrency:
   group: nightly-code-review
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   preflight:
     name: Pre-flight Checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has_changes: ${{ steps.detect.outputs.has_changes }}
       skip: ${{ steps.dedup.outputs.skip }}

--- a/.github/workflows/nightly-docs-update.yml
+++ b/.github/workflows/nightly-docs-update.yml
@@ -22,11 +22,17 @@ concurrency:
   group: nightly-docs-update
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     name: Detect Doc-Affecting Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       affected_docs: ${{ steps.check.outputs.affected_docs }}
@@ -162,6 +168,9 @@ jobs:
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -18,6 +18,9 @@ concurrency:
   group: release-notes
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   generate:
     name: Generate Release Notes

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   token-spy-postgres:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   env-schema:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`dashboard.yml`, `issue-to-pr.yml`, `lint-powershell.yml`,
`nightly-docs-update.yml`, `nightly-code-review.yml`, `ai-issue-triage.yml`,
`autonomous-code-scanner.yml`, `release-notes.yml`, `test-linux.yml`, and
`validate-env.yml` had no `permissions:` block, so `GITHUB_TOKEN` ran with
the repo's default (broader) privileges rather than what each job actually
uses. Nine other workflows already set `permissions: contents: read` at the
top level (`secret-scan.yml`, `lint-shell.yml`, ...) — this brings the
remaining 10 in line with that convention.

Added a top-level `permissions: contents: read` to all 10. For jobs that
call `gh pr list`, create PRs, or comment on issues and didn't already have
their own scoped block, I read every `gh`/API call site in that job and
added a job-level override with exactly what it uses — a job-level
`permissions:` block **replaces** the workflow default for that job, so
under-scoping would silently break the job (e.g. `gh pr list` returning 403)
rather than just being a lint nit:

- `issue-to-pr.yml`: `validate` → `pull-requests: read` (for `gh pr list`
  dedup check); `create-pr` → `contents: write, pull-requests: write,
  issues: write` (pushes a branch, opens a draft PR, comments on the issue)
- `nightly-docs-update.yml`: `detect-changes` → `contents: read,
  pull-requests: read`; `update-and-create-pr` → `contents: write,
  pull-requests: write`
- `nightly-code-review.yml`: `preflight` → `contents: read, pull-requests:
  read`

Jobs that already declared their own permissions — `ai-issue-triage`'s
`triage`, `nightly-code-review`'s `create-pr`, `autonomous-code-scanner`'s
`create-prs`, `release-notes`'s `generate` — are untouched; they already
scope correctly for what they do today.

## AI Assistance

Used an AI coding assistant to audit each workflow's job-by-job API/`gh`
usage and add the permissions blocks. I reviewed every added block against
the actual steps in that job (not just applied a blanket `contents: read`
everywhere), and validated all 10 files parse correctly and the intended
permissions landed on the intended jobs (script output pasted below).

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [ ] Docs only
- [x] Dependencies / runtime wiring (CI workflow permissions)

## Risk And Validation

- Risk level: Medium (getting a job's scope wrong breaks that automation,
  e.g. a draft-PR workflow silently losing the ability to push)
- Validation run:
  - [x] Focused tests listed below
  - [ ] Not required because: n/a

Commands/results:

```text
python3 -c "import yaml; ..." — parsed all 10 modified workflow files and
printed the resolved top-level + job-level permissions for each, confirming:
  - every job with a gh/API write call has an explicit scoped block
  - no job that previously worked (relying on default perms) lost access
    it actually uses
```

I don't have a way to actually execute these workflows outside GitHub
Actions, so this is static verification (reading every step against the
granted scopes), not a live run. Flagging that explicitly for reviewers —
please double check the `issue-to-pr` and `nightly-docs-update` PR-creation
paths on the next real trigger.

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

## Notes For Reviewers

Two adjacent gaps I noticed while reading these files but did **not** fix
here (out of scope for "add the missing permissions block", and each needs
its own verification):

1. `autonomous-code-scanner.yml`'s `create-prs` job calls
   `github.rest.actions.listWorkflowRuns` / `listJobsForWorkflowRun` in its
   "Create issue for consecutive no-change runs" step, but its existing
   permissions block (`contents: write, pull-requests: write, issues:
   write`) has no `actions: read`. That looks like it may already be
   failing today, independent of this PR.
2. `release-notes.yml`'s `claude_args` allow the model to run `gh pr list`,
   but the job's existing permissions block only grants `contents: write`
   — `gh pr list` would need `pull-requests: read` too.

Happy to open follow-up PRs for those if useful — didn't want to bundle
unrelated fixes into this one.
