### PR TITLE
fix(cli): strip CR and quotes when comparing preset env values

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3368,16 +3368,37 @@ META
                 # used (which missed _PASS, _SALT, email admin fields, etc.).
                 _cmd_config_load_secret_schema
 
-                # Parse both env files
+                # Parse both env files. Strip a trailing CR (CRLF .env files
+                # from Windows editors/installer — see lib/safe-env.sh) and a
+                # single matching pair of surrounding quotes, so e.g.
+                # PORT=8080\r in one preset and PORT=8080 in the other don't
+                # show up as a spurious diff, and KEY="value" doesn't display
+                # its quotes literally.
                 declare -A env1 env2
                 while IFS='=' read -r key value; do
                     [[ "$key" =~ ^[[:space:]]*# ]] && continue
                     [[ -z "$key" ]] && continue
+                    value="${value%$'\r'}"
+                    if [[ "$value" == '"'*'"' ]]; then
+                        value="${value#\"}"
+                        value="${value%\"}"
+                    elif [[ "$value" == "'"*"'" ]]; then
+                        value="${value#\'}"
+                        value="${value%\'}"
+                    fi
                     env1["$key"]="$value"
                 done < "$dir1/env"
                 while IFS='=' read -r key value; do
                     [[ "$key" =~ ^[[:space:]]*# ]] && continue
                     [[ -z "$key" ]] && continue
+                    value="${value%$'\r'}"
+                    if [[ "$value" == '"'*'"' ]]; then
+                        value="${value#\"}"
+                        value="${value%\"}"
+                    elif [[ "$value" == "'"*"'" ]]; then
+                        value="${value#\'}"
+                        value="${value%\'}"
+                    fi
                     env2["$key"]="$value"
                 done < "$dir2/env"
 

--- a/ods/tests/test-preset-diff.sh
+++ b/ods/tests/test-preset-diff.sh
@@ -122,6 +122,51 @@ test_diff_masks_secrets() {
     fi
 }
 
+# Test 7: Diff ignores a trailing CR (CRLF env file) when comparing values
+# Regression: env parsing used to leave a trailing \r attached to the value,
+# so PORT=8080\r (Windows-edited preset) vs PORT=8080 (Linux) showed up as a
+# spurious difference even though the values are identical.
+test_diff_ignores_crlf() {
+    local presets_dir="$ODS_DIR/presets"
+    mkdir -p "$presets_dir/test-preset-i" "$presets_dir/test-preset-j"
+    printf 'TIER=3\r\n' > "$presets_dir/test-preset-i/env"
+    printf 'TIER=3\n' > "$presets_dir/test-preset-j/env"
+    echo "enabled:llama-server" > "$presets_dir/test-preset-i/extensions.list"
+    echo "enabled:llama-server" > "$presets_dir/test-preset-j/extensions.list"
+
+    # Check for a changed-value bullet on TIER specifically — "no differences"
+    # also appears in the unrelated Service State section above, so it isn't
+    # a reliable signal on its own.
+    local output
+    output=$("$ODS_CLI" preset diff test-preset-i test-preset-j 2>&1 || true)
+    if echo "$output" | grep -q "TIER.*→"; then
+        fail "Diff should treat TIER=3\\r and TIER=3 as identical"
+    else
+        pass "Diff ignores a trailing CR (CRLF env file)"
+    fi
+}
+
+# Test 8: Diff treats a quoted value the same as its unquoted equivalent
+# Regression: env parsing didn't strip surrounding quotes, so KEY="3" vs
+# KEY=3 (same effective value) showed up as a spurious difference, and a
+# changed quoted value displayed its quote characters literally.
+test_diff_strips_quotes() {
+    local presets_dir="$ODS_DIR/presets"
+    mkdir -p "$presets_dir/test-preset-k" "$presets_dir/test-preset-l"
+    echo 'TIER="3"' > "$presets_dir/test-preset-k/env"
+    echo "TIER=3" > "$presets_dir/test-preset-l/env"
+    echo "enabled:llama-server" > "$presets_dir/test-preset-k/extensions.list"
+    echo "enabled:llama-server" > "$presets_dir/test-preset-l/extensions.list"
+
+    local output
+    output=$("$ODS_CLI" preset diff test-preset-k test-preset-l 2>&1 || true)
+    if echo "$output" | grep -q "TIER.*→"; then
+        fail "Diff should treat TIER=\"3\" and TIER=3 as identical"
+    else
+        pass "Diff treats a quoted value the same as its unquoted equivalent"
+    fi
+}
+
 # Run tests
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Preset Diff Tests"
@@ -134,6 +179,8 @@ test_diff_identical
 test_diff_env_changes
 test_diff_service_changes
 test_diff_masks_secrets
+test_diff_ignores_crlf
+test_diff_strips_quotes
 cleanup
 
 # Summary


### PR DESCRIPTION
## Summary

`ods preset diff` parses each preset's `env` file with `IFS='=' read -r key
value` (`ods-cli` ~line 3373). #2297 claims this truncates values at the
first `=`, corrupting comparisons of base64 secrets / URLs with query
strings.

**I checked this directly before touching anything** (after getting burned
assuming a similar audit-issue claim was accurate in an earlier PR): bash's
`read` does *not* truncate here. When there are more fields than names, the
last named variable absorbs the entire remainder, embedded delimiters
included. Verified:

```
$ line="TOKEN=abc=def=ghi"; IFS='=' read -r key value <<< "$line"; echo "[$key] [$value]"
[TOKEN] [abc=def=ghi]
```

So that specific claim doesn't reproduce, and I'm not fixing a bug that
isn't there.

What **is** real: the parser doesn't strip a trailing CR or surrounding
quotes, unlike `lib/safe-env.sh`'s `load_env_file` (which explicitly does
both, with a comment calling out CRLF `.env` files from Windows editors /
the Windows installer). Reproduced directly:

- `TIER=3` in a CRLF-saved preset vs `TIER=3` in an LF one → diff shows
  `~ TIER: 3 → 3` (looks identical, isn't — the CR is invisible)
- `TIER="3"` vs `TIER=3` (same effective value) → also shown as a false
  difference, and a genuinely changed quoted value would print its quote
  characters literally

Fix: apply the same CR-strip + matching-quote-strip `lib/safe-env.sh`
already uses, to both `env1`/`env2` parse loops in the diff command.

## AI Assistance

Used an AI coding assistant to investigate the filed issue, discovered
during that investigation that its stated root cause doesn't reproduce
(verified with direct `read` tests, shown above), then identified and fixed
the actual CR/quote gap. I reviewed the diff and independently confirmed
both the false-positive-diff bug and the fix by running the CLI directly,
not just the test suite.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Tests only — actually: `ods-cli` (CLI) + tests. (No installer/compose/auth surface touched.)

## Risk And Validation

- Risk level: Low (display/comparison logic in a diagnostic command, not a
  code path that mutates anything)
- Validation run:
  - [x] Focused tests listed below

Commands/results:

```text
bash -n ods/ods-cli && bash -n ods/tests/test-preset-diff.sh   # syntax OK
bash ods/tests/test-preset-diff.sh                             # 8/8 PASS on the fix

# Confirmed the 2 new regression tests actually discriminate:
#  - against the pre-fix ods-cli (git show HEAD:ods/ods-cli): 6 passed, 2 failed
#    (the CRLF and quote tests fail, as expected)
#  - against the fix: 8/8 passed
```

## Operational Change Check

- [x] This is not an operational change.

## Notes For Reviewers

If the maintainers want #2297 fully closed by this PR that's fine, but I
used "Relates to" rather than "Fixes" in the commit trailer since the
issue's literal claim (truncation at first `=`) doesn't reproduce — happy
to discuss if I'm missing a case where it would.
