### PR TITLE
fix(backup): recognize multi-segment user-named backup IDs

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -148,7 +148,12 @@ collect_backups() {
     local entry base
     while IFS= read -r -d '' entry; do
         base=$(basename "$entry")
-        [[ "$base" =~ ^([A-Za-z0-9_]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
+        # Prefix allows internal hyphens (e.g. "dashboard-my-name-") so
+        # multi-segment user-named backups created via the host-agent
+        # (whose BACKUP_ID_RE in bin/ods-host-agent.py permits
+        # [A-Za-z0-9_-]) are still recognized here instead of silently
+        # skipped by list/retention while remaining on disk and deletable.
+        [[ "$base" =~ ^([A-Za-z0-9_-]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
         COLLECTED_BACKUPS+=("$entry")
     done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
 }

--- a/ods/tests/test-backup-integrity.sh
+++ b/ods/tests/test-backup-integrity.sh
@@ -106,3 +106,21 @@ info "Deleting a compressed backup by bare ID"
 echo y | ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$LIFECYCLE_DIR" -d 20260601-120000 >/dev/null
 [[ ! -f "$LIFECYCLE_DIR/20260601-120000.tar.gz" ]] || fail "delete left the compressed backup behind"
 pass "delete removes compressed backups by bare ID"
+
+# ── Multi-segment user-named backup IDs must be recognized, not just deletable ──
+# bin/ods-host-agent.py's BACKUP_ID_RE allows [A-Za-z0-9_-]+, so a
+# dashboard-triggered named backup like "dashboard-my-name-20260715-143022"
+# lands in BACKUP_ROOT with multiple hyphens before the timestamp. The old
+# collect_backups() glob only allowed a single hyphenated prefix segment, so
+# such a backup was invisible to --list/retention (though still deletable).
+
+NAMED_DIR="$TMP_ROOT/named-backups"
+mkdir -p "$NAMED_DIR/dashboard-my-name-20260715-143022"
+echo '{"backup_type": "user-data", "description": "named"}' \
+  > "$NAMED_DIR/dashboard-my-name-20260715-143022/manifest.json"
+
+info "Listing a multi-segment user-named backup ID"
+named_list_out=$(ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$NAMED_DIR" --list)
+echo "$named_list_out" | grep -q "dashboard-my-name-20260715-143022" \
+  || fail "--list does not show a multi-segment user-named backup ID"
+pass "--list recognizes multi-segment user-named backup IDs"


### PR DESCRIPTION
## Summary

`collect_backups()` in `ods-backup.sh` used
`^([A-Za-z0-9_]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$` — the optional prefix
group allows only **one** hyphenated segment (the character class doesn't
include `-`). The host-agent's own `BACKUP_ID_RE`
(`bin/ods-host-agent.py:115`) is `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` —
explicitly permitting multiple hyphenated segments, for dashboard-triggered
named backups like `dashboard-my-name-20260715-143022`.

That kind of ID lands in `BACKUP_ROOT` fine, but `collect_backups()`'s glob
can't match a multi-hyphen prefix, so `list_backups()` /
`apply_retention()` silently skip it — invisible to `ods-backup.sh --list`
and to retention counting, while still present on disk and still
individually deletable by exact ID (the `-d <id>` path doesn't go through
`collect_backups()`).

Fix: widen the prefix character class to include `-`, while keeping the
required trailing `YYYYMMDD-HHMMSS` anchor so arbitrary non-backup
directories are still excluded — verified against the repo's existing
`my-notes` directory test case, which still correctly stays hidden.

I did **not** copy the host-agent's regex verbatim (it has no timestamp
requirement at all — `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` would also match a
plain directory like `my-notes`), since that would reintroduce a different
bug: `--list` showing arbitrary non-backup debris, which an existing test
explicitly guards against.

## AI Assistance

Used an AI coding assistant to trace the regex mismatch between
`ods-backup.sh` and the host-agent, and to implement + test the fix. I
reviewed the diff and specifically checked that the widened regex doesn't
regress the existing "skip non-backup directories" guarantee.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Tests only — practically: `ods-backup.sh` (operational script) + tests.

## Risk And Validation

- Risk level: Low (widens what a display/retention regex recognizes; keeps
  the timestamp anchor that prevents false positives)
- Validation run:
  - [x] Focused tests listed below

Commands/results:

```text
bash -n ods/ods-backup.sh && bash -n ods/tests/test-backup-integrity.sh   # syntax OK
bash ods/tests/test-backup-integrity.sh                                   # PASS, incl. new check

# Confirmed the new check discriminates:
#  - against pre-fix ods-backup.sh (git show HEAD:...): fails with
#    "--list does not show a multi-segment user-named backup ID"
#  - against the fix: passes
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.
