### PR TITLE
fix(remote-provider): log SSH tunnel plan argv ValueError

### DIFF
--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
@@ -301,7 +301,14 @@ class SshProcessSupervisor:
             self._notice_exited_locked(now)
             try:
                 argv = _combined_ssh_argv(plan)
-            except ValueError:
+            except ValueError as exc:
+                # _combined_ssh_argv only raises with static, non-sensitive
+                # messages describing a malformed plan shape (e.g. "missing
+                # a local forward") — never argv contents or secrets — so
+                # it's safe and useful to log the message itself, unlike
+                # the exc.__class__.__name__-only convention used below for
+                # OSError from process start (which can carry paths).
+                LOGGER.warning("ssh plan argv invalid: %s", exc)
                 self._stop_process_locked()
                 self._last_payload = _health_from_plan(
                     _error_plan("ssh_plan_unavailable", secret_dir=self.secret_dir),

--- a/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
+++ b/ods/tests/contracts/test-remote-provider-ssh-tunnel-service.py
@@ -342,6 +342,41 @@ def test_supervisor_uses_restart_cooldown_after_child_exit() -> None:
     assert_true(restarted["status"] == "starting", "restarted child should enter grace period")
 
 
+def test_supervisor_logs_invalid_ssh_plan_argv() -> None:
+    # Regression: reconcile() used to catch _combined_ssh_argv's ValueError
+    # and discard it entirely, so a malformed tunnel plan (e.g. missing the
+    # -L forward) silently transitioned to "ssh_plan_unavailable" with no
+    # log line explaining why — operators had nothing to diagnose.
+    with tempfile.TemporaryDirectory() as tmp:
+        route_path, secret_dir = _ready_supervisor_fixture(Path(tmp))
+        supervisor, _factory, _clock = _new_fake_supervisor(route_path, secret_dir)
+        ssh_app = _health_app()
+        warnings: list[tuple[object, ...]] = []
+        original_plan_fn = ssh_app._supervisor_plan_for_paths
+        original_warning = ssh_app.LOGGER.warning
+        # Bypass real plan generation entirely: return a plan that is
+        # "ready to start" but structurally invalid (no tunnels), which is
+        # exactly what _combined_ssh_argv rejects with a ValueError.
+        ssh_app._supervisor_plan_for_paths = (
+            lambda _route_path, _secret_dir: {"readyToStart": True, "tunnels": []}
+        )
+        ssh_app.LOGGER.warning = lambda *args: warnings.append(args)
+        try:
+            payload = supervisor.reconcile()
+        finally:
+            ssh_app._supervisor_plan_for_paths = original_plan_fn
+            ssh_app.LOGGER.warning = original_warning
+    assert_true(payload["status"] == "invalid", "invalid plan argv should report an invalid plan status")
+    assert_true(payload["reason"] == "ssh_plan_unavailable", "invalid plan argv reason drifted")
+    assert_true(payload["process"]["status"] == "stopped", "invalid plan argv must stop any running process")
+    assert_true(len(warnings) == 1, "reconcile must log exactly one warning for invalid ssh plan argv")
+    assert_true(warnings[0][0] == "ssh plan argv invalid: %s", "warning message format drifted")
+    assert_true(
+        "SSH supervisor plan has no tunnels" in str(warnings[0][1]),
+        "warning should include the underlying ValueError detail",
+    )
+
+
 def test_service_source_avoids_public_secret_names() -> None:
     for path, text in _walk_service_source():
         for key in PUBLIC_SSH_SECRET_ENV:
@@ -365,6 +400,7 @@ def main() -> int:
         test_supervisor_stops_process_when_secret_custody_disappears,
         test_supervisor_restarts_process_when_route_argv_changes,
         test_supervisor_uses_restart_cooldown_after_child_exit,
+        test_supervisor_logs_invalid_ssh_plan_argv,
         test_service_source_avoids_public_secret_names,
     ]
     for test in tests:


### PR DESCRIPTION
## Summary

`SshProcessSupervisor.reconcile()` (`extensions/services/remote-provider-ssh-tunnel/app/main.py`)
catches `_combined_ssh_argv(plan)`'s `ValueError`, stops the process, and
transitions the health payload to `{"status": "invalid", "reason":
"ssh_plan_unavailable"}` — but discards the exception object entirely
(`except ValueError:` with no `as exc`, nothing logged). A corrupted
`routing-state.json` (e.g. a tunnel entry missing its `-L` forward, per the
issue's repro) leaves operators staring at that health JSON with nothing in
the container logs to say *why* the plan was rejected.

Every message `_combined_ssh_argv` raises is a static, non-sensitive
description of the malformed plan shape (`"SSH supervisor plan has no
tunnels"`, `"SSH tunnel argv is missing a local forward"`, etc.) — never
argv contents or secret material — so logging it directly is safe. That's
different from this file's existing convention for `OSError` out of process
start (`LOGGER.warning("failed to start SSH tunnel process: %s",
exc.__class__.__name__)`), which deliberately logs only the class name
since `OSError` messages can carry filesystem paths.

Fix: `except ValueError as exc:` + `LOGGER.warning("ssh plan argv invalid:
%s", exc)`, matching the exact log line the issue asked for.

## AI Assistance

Used an AI coding assistant to locate the code (via a background research
pass) and implement the fix + test. I reviewed the diff and specifically
checked that none of `_combined_ssh_argv`'s raise sites interpolate
argv/secret content into the message before confirming it's safe to log
directly.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Model routing / Hermes / capabilities (remote-provider SSH tunnel is
  part of the remote model-routing path)

## Risk And Validation

- Risk level: Low (adds a log line on an already-existing error path; no
  control-flow change — process still stops, health payload is identical)
- Validation run:
  - [x] Focused tests listed below

Commands/results:

```text
python3 -m py_compile extensions/services/remote-provider-ssh-tunnel/app/main.py \
  tests/contracts/test-remote-provider-ssh-tunnel-service.py
python3 tests/contracts/test-remote-provider-ssh-tunnel-service.py
  # [PASS] x12, including the new test_supervisor_logs_invalid_ssh_plan_argv

# Confirmed the new test discriminates:
#  - against pre-fix main.py (git show HEAD:...): fails (no warning logged)
#  - against the fix: passes
```

## Operational Change Check

- [x] This is not an operational change.
