### PR TITLE
fix(context): validate model discovery payloads

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -180,11 +180,15 @@ def _loaded_model(llm_port: int = 8080) -> str | None:
         except Exception:
             continue
         loaded = data.get("all_models_loaded") if isinstance(data, dict) else None
-        if isinstance(loaded, list) and loaded:
-            return loaded[0].get("model_name")
+        if isinstance(loaded, list):
+            for item in loaded:
+                if isinstance(item, dict) and isinstance(item.get("model_name"), str):
+                    return item["model_name"]
         models = data.get("data") if isinstance(data, dict) else None
-        if isinstance(models, list) and models:
-            return models[0].get("id")
+        if isinstance(models, list):
+            for item in models:
+                if isinstance(item, dict) and isinstance(item.get("id"), str):
+                    return item["id"]
     return None
 
 

--- a/ods/tests/test-build-installation-context.py
+++ b/ods/tests/test-build-installation-context.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Regression tests for the installation-context HTTP boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-installation-context.py"
+
+
+class Response(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("build_installation_context", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def response(payload: object) -> Response:
+    return Response(json.dumps(payload).encode("utf-8"))
+
+
+def main() -> int:
+    module = load_module()
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            response({"all_models_loaded": [None, {"model_name": "qwen-local"}]}),
+        ],
+    ):
+        assert module._loaded_model() == "qwen-local"
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            response({"all_models_loaded": ["invalid"]}),
+            response({"data": [7, {"id": "openai-compatible"}]}),
+        ],
+    ):
+        assert module._loaded_model() == "openai-compatible"
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[response({"all_models_loaded": [False]}), response({"data": [None]})],
+    ):
+        assert module._loaded_model() is None
+
+    print("[PASS] installation-context model payload tests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- validate Lemonade and OpenAI-compatible model list entries before reading fields
- skip malformed entries while preserving the first valid discovered model
- add HTTP-boundary regression coverage for mixed and fully malformed payloads

## Why this matters
The installer invokes `build-installation-context.py` on Linux, macOS, and Windows to generate the runtime SOUL context. A reachable but malformed model endpoint could return a non-object list entry and abort context generation with `AttributeError`, leaving Hermes without refreshed installation facts.

## Overlap check
Searched open and closed PRs for `installation context`, `model payload`, and the production file `build-installation-context.py`. Open PRs #2436 and #2218 only make the output write atomic; closed PR #1335 introduced the context builder. This scope is independent because it changes only HTTP response validation and adds payload regression coverage.

## Test plan
- [x] `uv run --no-project python ods/tests/test-build-installation-context.py`
- [x] `git diff --check`

Generated with Codex