### PR TITLE
fix(schema): confine mirror contract paths

### DIFF
--- a/ods/scripts/sync-manifest-schema.py
+++ b/ods/scripts/sync-manifest-schema.py
@@ -17,7 +17,15 @@ LIBRARY_SCHEMA = ROOT_DIR / "extensions" / "library" / "schema" / "service-manif
 def canonical_schema_path() -> Path:
     manifest = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
     relative_path = manifest["contracts"]["extensions"]["serviceManifestSchema"]
+    if not isinstance(relative_path, str):
+        raise TypeError("manifest schema contract path must be a string")
     schema_path = (ROOT_DIR / relative_path).resolve()
+    try:
+        schema_path.relative_to(ROOT_DIR.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            f"declared manifest schema escapes the repository: {relative_path}"
+        ) from exc
     if not schema_path.is_file():
         raise FileNotFoundError(f"declared manifest schema not found: {relative_path}")
     return schema_path

--- a/ods/tests/test-validate-manifest-schema.sh
+++ b/ods/tests/test-validate-manifest-schema.sh
@@ -33,6 +33,31 @@ assert_success() {
 
 assert_success "generated library schema mirror is current" \
     python3 "$ROOT_DIR/scripts/sync-manifest-schema.py" --check
+
+ESCAPE_ROOT="$TMP_DIR/schema-escape"
+mkdir -p "$ESCAPE_ROOT/repo/scripts" "$ESCAPE_ROOT/repo/extensions/library/schema" \
+    "$ESCAPE_ROOT/outside"
+cp "$ROOT_DIR/scripts/sync-manifest-schema.py" "$ESCAPE_ROOT/repo/scripts/"
+printf '{}\n' > "$ESCAPE_ROOT/outside/schema.json"
+cat > "$ESCAPE_ROOT/repo/manifest.json" <<'JSON'
+{
+  "contracts": {
+    "extensions": {
+      "serviceManifestSchema": "../outside/schema.json"
+    }
+  }
+}
+JSON
+if python3 "$ESCAPE_ROOT/repo/scripts/sync-manifest-schema.py" --check \
+    >"$TMP_DIR/schema-escape.log" 2>&1; then
+    fail "schema mirror accepted a contract path outside the repository"
+fi
+grep -q "escapes the repository" "$TMP_DIR/schema-escape.log" || {
+    cat "$TMP_DIR/schema-escape.log" >&2
+    fail "schema mirror path error was not actionable"
+}
+pass "schema mirror rejects contract paths outside the repository"
+
 assert_success "bundled and library manifests validate together" \
     bash "$VALIDATOR"
 assert_success "standalone library validator accepts all library manifests" \


### PR DESCRIPTION
## Summary
- require the manifest schema contract path to be a string
- reject resolved schema paths outside the ODS repository before reading or mirroring them
- exercise the public `--check` entry point with an escaping contract fixture

## Why this matters
`sync-manifest-schema.py --check` is a release gate and the write mode updates the standalone extension-library schema. An accidental absolute or `..` contract path in repository metadata could make the gate compare against an unrelated host file or copy that file into the generated mirror, producing non-reproducible release artifacts.

## Overlap check
Searched open and closed PRs for `manifest schema mirror`, `sync-manifest-schema`, and schema-path changes. No open PR covers this behavior. The existing generated-config/golden-path/dependency-lock confinement PRs (#2535-#2537) validate different contracts and production files; this scope is limited to the schema mirror generator.

## Test plan
- [x] `uv run --no-project python ods/scripts/sync-manifest-schema.py --check`
- [x] `uv run --no-project python -m py_compile ods/scripts/sync-manifest-schema.py`
- [x] `git diff --check`
- [ ] `bash tests/test-validate-manifest-schema.sh` (runs in Linux CI; Bash is unavailable in this Windows host)

Generated with Codex