### PR TITLE
fix(release): confine compatibility contract paths

### DIFF
--- a/ods/scripts/check-compatibility.sh
+++ b/ods/scripts/check-compatibility.sh
@@ -3,7 +3,8 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="${ODS_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+ROOT_DIR="$(cd "$ROOT_DIR" && pwd -P)"
 MANIFEST_FILE="${ROOT_DIR}/manifest.json"
 
 RED='\033[0;31m'
@@ -15,6 +16,23 @@ fail() { echo -e "${RED}[FAIL]${NC} $1"; exit 1; }
 pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 
+contract_file() {
+  local label="$1"
+  local relative="$2"
+  local candidate parent resolved
+
+  [[ -n "$relative" && "$relative" != "null" && "$relative" != /* ]] \
+    || fail "invalid ${label} path: ${relative}"
+  candidate="${ROOT_DIR}/${relative}"
+  test -f "$candidate" || fail "missing ${label}: ${relative}"
+  parent="$(cd "$(dirname "$candidate")" && pwd -P)"
+  resolved="${parent}/$(basename "$candidate")"
+  case "$resolved" in
+    "$ROOT_DIR"/*) printf '%s\n' "$resolved" ;;
+    *) fail "${label} escapes the repository: ${relative}" ;;
+  esac
+}
+
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 test -f "$MANIFEST_FILE" || fail "manifest.json not found"
 
@@ -25,27 +43,27 @@ pass "manifest structure"
 # Compose contract files
 while IFS= read -r file; do
   file="${file%$'\r'}"
-  test -f "${ROOT_DIR}/${file}" || fail "missing compose contract file: ${file}"
+  contract_file "compose contract file" "$file" >/dev/null
 done < <(jq -r '.contracts.compose.canonical[]' "$MANIFEST_FILE")
 pass "compose canonical files"
 
 # Workflow catalog canonical path
 workflow_path="$(jq -r '.contracts.workflowCatalog.canonicalPath' "$MANIFEST_FILE")"
 workflow_path="${workflow_path%$'\r'}"
-test -f "${ROOT_DIR}/${workflow_path}" || fail "missing canonical workflow catalog: ${workflow_path}"
+contract_file "canonical workflow catalog" "$workflow_path" >/dev/null
 pass "workflow catalog canonical path"
 
 # Extension schema contract
 schema_path="$(jq -r '.contracts.extensions.serviceManifestSchema' "$MANIFEST_FILE")"
 schema_path="${schema_path%$'\r'}"
-test -f "${ROOT_DIR}/${schema_path}" || fail "missing extension schema: ${schema_path}"
+contract_file "extension schema" "$schema_path" >/dev/null
 pass "extension schema contract"
 
 # Port contract
 ports_path="$(jq -r '.contracts.ports.canonicalPath' "$MANIFEST_FILE")"
 ports_path="${ports_path%$'\r'}"
-test -f "${ROOT_DIR}/${ports_path}" || fail "missing canonical ports contract: ${ports_path}"
-jq -e '.version and (.ports | type=="array" and length>0)' "${ROOT_DIR}/${ports_path}" >/dev/null \
+ports_file="$(contract_file "canonical ports contract" "$ports_path")"
+jq -e '.version and (.ports | type=="array" and length>0)' "$ports_file" >/dev/null \
   || fail "invalid ports contract structure: ${ports_path}"
 pass "ports contract"
 

--- a/ods/tests/test-compatibility-contract-paths.sh
+++ b/ods/tests/test-compatibility-contract-paths.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FIXTURE="$TMP_DIR/repo"
+mkdir -p "$FIXTURE/contracts" "$TMP_DIR/outside"
+printf '{}\n' > "$FIXTURE/contracts/workflows.json"
+printf '{}\n' > "$FIXTURE/contracts/schema.json"
+printf '{"version":1,"ports":[8080]}\n' > "$FIXTURE/contracts/ports.json"
+printf 'services: {}\n' > "$TMP_DIR/outside/base.yml"
+cat > "$FIXTURE/manifest.json" <<'JSON'
+{
+  "manifestVersion": 1,
+  "release": {"version": "1.0.0"},
+  "compatibility": {"os": {"macos": {"supported": true}}},
+  "contracts": {
+    "compose": {"canonical": ["../outside/base.yml"]},
+    "workflowCatalog": {"canonicalPath": "contracts/workflows.json"},
+    "extensions": {"serviceManifestSchema": "contracts/schema.json"},
+    "ports": {"canonicalPath": "contracts/ports.json"}
+  }
+}
+JSON
+
+if ODS_ROOT="$FIXTURE" bash "$ROOT_DIR/scripts/check-compatibility.sh" \
+    >"$TMP_DIR/output.log" 2>&1; then
+  echo "[FAIL] compatibility gate accepted an escaping contract path" >&2
+  exit 1
+fi
+grep -q "escapes the repository" "$TMP_DIR/output.log"
+echo "[PASS] compatibility gate confines contract paths"


### PR DESCRIPTION
## Summary
- resolve compatibility contract files through one POSIX-portable confinement helper
- reject absolute paths, missing values, traversal, and symlinked parent escapes
- add a public-entry-point regression fixture covering an escaping compose contract

## Why this matters
`check-compatibility.sh` runs in the release gate and CI. Its manifest-owned paths are supposed to identify versioned ODS contracts; accepting a file outside the checkout can make release validation depend on unrelated host state and pass in one environment while failing in a clean clone.

## Overlap check
Searched open and closed PRs for `compatibility contract`, `check-compatibility`, and contract path validation. No open PR covers these production paths. PRs #2535-#2537 validate separate JSON contract families; this change is limited to the compatibility gate's compose, workflow, extension-schema, and ports references.

## Test plan
- [x] `wsl.exe bash -n scripts/check-compatibility.sh`
- [x] `wsl.exe bash -n tests/test-compatibility-contract-paths.sh`
- [x] `wsl.exe bash tests/test-compatibility-contract-paths.sh`
- [x] `git diff --check`

Generated with Codex