### PR TITLE
fix(card): reject unusable onboarding URLs

### DIFF
--- a/ods/scripts/generate-setup-card.py
+++ b/ods/scripts/generate-setup-card.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 # Card geometry — 4×6 inches @ 300 DPI = 1200×1800px portrait.
 CARD_W = 1200
@@ -331,6 +332,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _valid_card_url(value: str) -> bool:
+    try:
+        parsed = urlsplit(value)
+        return parsed.scheme in {"http", "https"} and bool(parsed.hostname)
+    except ValueError:
+        return False
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
@@ -342,6 +351,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     if args.mode == "factory-owner" and not args.owner_url:
         print("error: --owner-url is required in factory-owner mode", file=sys.stderr)
+        return 2
+    card_url = args.setup_url if args.mode == "setup" else args.owner_url
+    if card_url is not None and not _valid_card_url(card_url):
+        option = "--setup-url" if args.mode == "setup" else "--owner-url"
+        print(f"error: {option} must be an absolute HTTP(S) URL", file=sys.stderr)
         return 2
 
     try:

--- a/ods/tests/test_setup_card.py
+++ b/ods/tests/test_setup_card.py
@@ -218,6 +218,27 @@ def test_cli_requires_owner_url_in_factory_owner_mode(tmp_path):
     assert "owner-url" in result.stderr.lower() or "owner_url" in result.stderr.lower()
 
 
+@pytest.mark.parametrize(
+    ("mode_args", "url_option"),
+    [
+        (["--setup-url", "javascript:alert(1)"], "setup-url"),
+        (["--setup-url", "/setup"], "setup-url"),
+        (["--mode", "factory-owner", "--owner-url", "http://[invalid"], "owner-url"),
+    ],
+)
+def test_cli_rejects_unusable_card_urls(tmp_path, mode_args, url_option):
+    out = tmp_path / "card.png"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--ssid", "ODS", *mode_args, "--output", str(out)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert url_option in result.stderr.lower()
+    assert not out.exists()
+
+
 def test_cli_help_works_without_pillow():
     """Argparse help shouldn't require Pillow; helpful when an operator is
     checking flags before installing deps."""


### PR DESCRIPTION
## Summary
- require setup and owner QR targets to be absolute HTTP(S) URLs with a hostname
- reject relative, non-web, and malformed URL inputs before loading rendering dependencies or writing output
- cover both setup and factory-owner CLI modes end to end

## Why this matters
The fulfillment CLI prints and packages onboarding cards for shipped ODS units. It previously accepted values such as relative setup paths or non-web schemes, producing a successful image whose QR code cannot take the buyer to the device onboarding page; discovering that after printing wastes cards and blocks first-run setup.

## Overlap check
Searched open and closed PRs for setup card, setup-url, owner-url, and generate-setup-card.py. Open PRs #2447 and #2387 only address atomic output writes. This scope is independent because it validates the QR destination contract before rendering.

## Test plan
- [x] Focused setup-card URL pytest cases (5 passed)
- [x] git diff --check

Generated with Codex