### PR TITLE
fix(healthcheck): bound expected HTTP statuses

### DIFF
--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -121,6 +121,12 @@ def _parse_host_port(raw: str) -> Tuple[str, int]:
 
 def _parse_expected_status(expr: str) -> Set[int]:
     """Parse '200,204,3xx,401-403' => allowed status codes set."""
+    def status_code(raw: str) -> int:
+        value = int(raw)
+        if not 100 <= value <= 599:
+            raise ValueError(f"HTTP status out of range (100-599): {value}")
+        return value
+
     allowed: Set[int] = set()
     for part in (p.strip() for p in expr.split(",") if p.strip()):
         if part.endswith("xx") and len(part) == 3 and part[0].isdigit():
@@ -129,13 +135,13 @@ def _parse_expected_status(expr: str) -> Set[int]:
             continue
         if "-" in part:
             lo_s, hi_s = (x.strip() for x in part.split("-", 1))
-            lo = int(lo_s)
-            hi = int(hi_s)
+            lo = status_code(lo_s)
+            hi = status_code(hi_s)
             if lo > hi:
                 lo, hi = hi, lo
             allowed.update(range(lo, hi + 1))
             continue
-        allowed.add(int(part))
+        allowed.add(status_code(part))
 
     if not allowed:
         raise ValueError("--expect-status produced empty set")

--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -131,6 +131,8 @@ def _parse_expected_status(expr: str) -> Set[int]:
     for part in (p.strip() for p in expr.split(",") if p.strip()):
         if part.endswith("xx") and len(part) == 3 and part[0].isdigit():
             base = int(part[0]) * 100
+            if not 100 <= base <= 500:
+                raise ValueError(f"HTTP status class out of range (1xx-5xx): {part}")
             allowed.update(range(base, base + 100))
             continue
         if "-" in part:

--- a/ods/tests/test-healthcheck-status.py
+++ b/ods/tests/test-healthcheck-status.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Regression tests for universal healthcheck status parsing."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "healthcheck.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("ods_healthcheck", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    module = load_module()
+    assert module._parse_expected_status("200,204,3xx,401-403") >= {200, 204, 399, 401, 403}
+
+    for expression in ("99", "600", "1-999999999", "700-200"):
+        try:
+            module._parse_expected_status(expression)
+        except ValueError as exc:
+            assert "100-599" in str(exc)
+        else:
+            raise AssertionError(f"accepted invalid HTTP status expression: {expression}")
+
+    assert module.main(
+        ["http://127.0.0.1/health", "--expect-status", "1-999999999", "--json"]
+    ) == 2
+    print("[PASS] healthcheck status bounds")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test-healthcheck-status.py
+++ b/ods/tests/test-healthcheck-status.py
@@ -24,11 +24,11 @@ def main() -> int:
     module = load_module()
     assert module._parse_expected_status("200,204,3xx,401-403") >= {200, 204, 399, 401, 403}
 
-    for expression in ("99", "600", "1-999999999", "700-200"):
+    for expression in ("99", "600", "0xx", "6xx", "1-999999999", "700-200"):
         try:
             module._parse_expected_status(expression)
         except ValueError as exc:
-            assert "100-599" in str(exc)
+            assert "range" in str(exc)
         else:
             raise AssertionError(f"accepted invalid HTTP status expression: {expression}")
 


### PR DESCRIPTION
## Summary
- validate individual expected status codes against the HTTP 100-599 domain
- validate range endpoints before expanding them into the allowed-status set
- cover valid expressions, invalid singles/ranges, and the CLI JSON error boundary

## Why this matters
The universal healthcheck is embedded in service probes. Previously an accidental expression such as 1-999999999 attempted to materialize an enormous Python set before any request, consuming memory instead of returning the documented usage error and potentially destabilizing a minimal service container.

## Overlap check
Searched open and closed PRs for expect-status, healthcheck status, and healthcheck.py. Open PR #2480 validates timeout finiteness only. No PR covers status-domain validation or pre-expansion range bounds, so this scope is independent.

## Test plan
- [x] uv run --no-project python ods/tests/test-healthcheck-status.py
- [x] git diff --check

Generated with Codex