### PR TITLE
fix(healthcheck): support bracketed IPv6 targets

### DIFF
--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -98,8 +98,8 @@ def _parse_target(raw: str) -> Tuple[str, str]:
     if raw.startswith("tcp://"):
         return ("tcp", raw[len("tcp://") :])
 
-    # host:port shorthand
-    if ":" in raw and not raw.startswith("["):
+    # host:port shorthand, including bracketed IPv6 literals.
+    if ":" in raw and (not raw.startswith("[") or "]:" in raw):
         return ("tcp", raw)
 
     raise ValueError("target must be http(s) URL, tcp://host:port, or host:port")
@@ -108,6 +108,8 @@ def _parse_target(raw: str) -> Tuple[str, str]:
 def _parse_host_port(raw: str) -> Tuple[str, int]:
     host, port_s = raw.rsplit(":", 1)
     host = host.strip()
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
     if not host:
         raise ValueError("host is empty")
     try:

--- a/ods/tests/test-healthcheck-ipv6.py
+++ b/ods/tests/test-healthcheck-ipv6.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Regression tests for IPv6 healthcheck targets."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "healthcheck.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("ods_healthcheck_ipv6", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    module = load_module()
+    for target in ("[::1]:8080", "tcp://[2001:db8::5]:443"):
+        kind, normalized = module._parse_target(target)
+        assert kind == "tcp"
+        host, port = module._parse_host_port(normalized)
+        assert "[" not in host and "]" not in host
+        assert port in {443, 8080}
+
+    with patch.object(module.socket, "create_connection") as connect:
+        connect.return_value.__enter__.return_value = object()
+        assert module.main(["tcp://[::1]:8080", "--retries", "0"]) == 0
+        connect.assert_called_once_with(("::1", 8080), timeout=5.0)
+
+    print("[PASS] healthcheck IPv6 target tests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- accept bracketed IPv6 literals in host:port shorthand
- strip RFC-style brackets before passing the host to socket.create_connection
- cover shorthand, tcp URL, and the full CLI-to-socket boundary

## Why this matters
ODS uses the universal healthcheck for service probes. Operators using IPv6 literals could not express the standard [address]:port form, and the accepted tcp:// form passed brackets to name resolution, marking a reachable IPv6 service unhealthy.

## Overlap check
Searched open and closed PRs for healthcheck IPv6 and bracketed targets; no matches were found. PR #2577 changes expected-status parsing in the same script but touches a separate parser and has no behavioral overlap.

## Test plan
- [x] uv run --no-project python ods/tests/test-healthcheck-ipv6.py
- [x] git diff --check

Generated with Codex