### PR TITLE
fix(resources): validate container stats payloads

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -67,7 +67,14 @@ def _fetch_container_stats() -> list[dict]:
     """Fetch container stats from host agent."""
     try:
         data = request_agent_json("GET", "/v1/service/stats", timeout=10)
-        return data.get("containers", [])
+        if not isinstance(data, dict):
+            logger.warning("Host agent stats response root is not an object")
+            return []
+        containers = data.get("containers", [])
+        if not isinstance(containers, list):
+            logger.warning("Host agent stats containers field is not a list")
+            return []
+        return [item for item in containers if isinstance(item, dict)]
     except (AgentClientError, OSError):
         logger.debug("Could not fetch container stats from host agent")
         return []

--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -83,6 +83,19 @@ class TestFetchContainerStats:
             result = _fetch_container_stats()
         assert result == containers
 
+    def test_malformed_response_shapes_are_rejected(self):
+        for payload in ([], {"containers": {}}, {"containers": [None, "bad"]}):
+            with patch("routers.resources.request_agent_json", return_value=payload):
+                assert _fetch_container_stats() == []
+
+    def test_malformed_entries_do_not_hide_valid_stats(self):
+        valid = {"container_name": "ods-llama", "cpu_percent": 45.0}
+        with patch(
+            "routers.resources.request_agent_json",
+            return_value={"containers": [None, valid, 7]},
+        ):
+            assert _fetch_container_stats() == [valid]
+
     def test_host_agent_unreachable(self):
         """URLError (host agent unreachable) returns empty list."""
         with patch(


### PR DESCRIPTION
## Summary
- require the host-agent stats response root to be an object
- require containers to be a list and discard malformed entries while retaining valid stats
- add focused boundary tests for wrong roots, wrong fields, mixed lists, and valid responses

## Why this matters
GET /api/services/resources feeds the dashboard resource view. A protocol-valid JSON response with an unexpected shape previously raised AttributeError in the fetch helper or later attempted .get on a scalar, turning a transient host-agent protocol mismatch into a dashboard API 500.

## Overlap check
Searched open and closed PRs for container stats payload and resources metrics. PR #2007 handles null numeric metric values after a valid dictionary payload; it does not validate response or entry shapes. This PR is independent and preserves that PR's metric-value scope.

## Test plan
- [x] Focused TestFetchContainerStats suite: 6 passed
- [x] git diff --check

Generated with Codex