### PR TITLE
fix(gpu): validate host metrics response root

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -377,6 +377,8 @@ def _get_windows_host_gpu_payload() -> Optional[dict]:
         return None
     try:
         payload = request_agent_json("GET", "/v1/gpu/metrics", timeout=10)
+        if not isinstance(payload, dict):
+            return None
         if payload.get("schema_version") != "ods.host-gpu-metrics.v1":
             return None
         return payload

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -142,6 +142,14 @@ class TestGetGpuInfoNvidia:
 
 class TestWindowsHostGpuInfo:
 
+    def test_rejects_non_object_host_agent_payload(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
+        monkeypatch.setattr("gpu.request_agent_json", lambda *args, **kwargs: [])
+
+        assert get_gpu_info_windows_host() is None
+        assert get_gpu_info_windows_host_detailed() is None
+
     def test_maps_valid_host_agent_payload(self, monkeypatch):
         monkeypatch.setenv("GPU_BACKEND", "amd")
         monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")


### PR DESCRIPTION
## Summary
- require Windows host GPU metrics to have a JSON object root before schema inspection
- preserve the existing fail-closed fallback for malformed host-agent protocol data
- cover both aggregate and per-adapter callers with the malformed root fixture

## Why this matters
On Windows AMD host inference, dashboard GPU endpoints read /v1/gpu/metrics from the host agent. A valid JSON array or scalar previously raised AttributeError before the fallback path, turning a transient protocol mismatch into an API 500 instead of reporting GPU metrics as unavailable.

## Overlap check
Searched open and closed PRs for GPU metrics payload and Windows host GPU response shape. No matching PR was found. PR #2526 validates persisted GPU state, not the live host-agent metrics endpoint, so this scope is independent.

## Test plan
- [x] TestWindowsHostGpuInfo suite: 7 passed
- [x] git diff --check

Generated with Codex