### PR TITLE
fix(health): validate host-agent payload roots

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -141,6 +141,8 @@ async def _check_tailscale_health(service_id: str, config: dict) -> ServiceStatu
     except AgentClientError:
         return _service_status_from_config(service_id, config, "not_deployed")
 
+    if not isinstance(payload, dict):
+        return _service_status_from_config(service_id, config, "not_deployed")
     if not payload.get("running"):
         return _service_status_from_config(service_id, config, "not_deployed")
     if payload.get("authenticated"):
@@ -171,6 +173,8 @@ async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceSt
     except AgentClientError:
         return _service_status_from_config(service_id, config, "down")
 
+    if not isinstance(payload, dict):
+        return _service_status_from_config(service_id, config, "down")
     status = "healthy" if payload.get("reachable") else "not_deployed"
     return ServiceStatus(
         id=service_id,
@@ -703,6 +707,8 @@ async def get_all_services() -> list[ServiceStatus]:
 
     try:
         snapshot = await request_agent_json("GET", "/v1/service/health", timeout=15)
+        if not isinstance(snapshot, dict):
+            raise ValueError("host service-health response must be an object")
         if snapshot.get("schema_version") != "ods.host-service-health.v1":
             raise ValueError("unsupported host service-health schema")
         containers = snapshot.get("containers")

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -527,11 +527,39 @@ class TestCheckServiceHealth:
         result = await check_service_health("tailscale", config)
         assert result.status == "healthy"
 
+    @pytest.mark.asyncio
+    async def test_tailscale_rejects_non_object_agent_payload(self, monkeypatch):
+        config = {
+            "name": "Tailscale", "port": 0, "external_port": 0,
+            "health": "/health", "host": "localhost", "host_network": True,
+        }
+        monkeypatch.setattr("helpers.request_agent_json", AsyncMock(return_value=[]))
+
+        result = await check_service_health("tailscale", config)
+        assert result.status == "not_deployed"
+
 
 # --- get_all_services ---
 
 
 class TestGetAllServices:
+
+    @pytest.mark.asyncio
+    async def test_non_object_host_snapshot_preserves_probe_status(self, monkeypatch):
+        fake_services = {"svc": {"name": "Service", "port": 8001, "external_port": 8001}}
+        monkeypatch.setattr("helpers.SERVICES", fake_services)
+
+        async def degraded(service_id, config):
+            return ServiceStatus(
+                id=service_id, name=config["name"], port=config["port"],
+                external_port=config["external_port"], status="degraded",
+            )
+
+        monkeypatch.setattr("helpers.check_service_health", degraded)
+        monkeypatch.setattr("helpers.request_agent_json", AsyncMock(return_value=[]))
+
+        statuses = await get_all_services()
+        assert statuses[0].status == "degraded"
 
     @pytest.mark.asyncio
     async def test_returns_all_statuses(self, monkeypatch):
@@ -1012,6 +1040,17 @@ class TestCheckServiceHealthSystemd:
         result = await check_service_health("opencode", config)
         assert result.status == "not_deployed"
         assert result.response_time_ms == 2.0
+
+    @pytest.mark.asyncio
+    async def test_host_systemd_rejects_non_object_agent_payload(self, monkeypatch):
+        monkeypatch.setattr("helpers.request_agent_json", AsyncMock(return_value=[]))
+        config = {
+            "name": "opencode", "port": 3003, "external_port": 3003,
+            "health": "/health", "host": "localhost", "type": "host-systemd",
+        }
+
+        result = await check_service_health("opencode", config)
+        assert result.status == "down"
 
 
 # --- get_model_info error branch ---


### PR DESCRIPTION
## Summary
- validate host-agent response roots for Tailscale and host-systemd port health probes
- validate the service-health reconciliation snapshot before schema inspection
- preserve each probe's existing unavailable/down semantics for malformed protocol data

## Why this matters
The dashboard aggregates these helpers into service health APIs. Valid JSON arrays or scalars from a mismatched host agent previously raised AttributeError, allowing one malformed health response to turn the aggregate endpoint into a 500 instead of showing the affected service as unavailable.

## Overlap check
Searched open and closed PRs for host agent health payload and service-health response shape. No matching PR was found. Tailscale router PR #2082 validates its proxy response, while this change covers the shared health helper and separate host-agent endpoints.

## Test plan
- [x] Three focused malformed-root async tests passed
- [x] git diff --check

Generated with Codex