### PR TITLE
fix(models): validate agent status response root

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -1560,6 +1560,8 @@ def _get_agent_model_status(timeout: int = 5) -> Optional[dict]:
             status = request_agent_json("GET", "/v1/model/status", timeout=timeout)
         except AgentClientError:
             status = None
+        if not isinstance(status, dict):
+            status = None
 
         _agent_model_status_cache_value = status
         _agent_model_status_cache_at = time.monotonic()

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -868,6 +868,18 @@ def test_agent_model_status_collapses_concurrent_poll_bursts(monkeypatch):
     assert results == [{"status": "downloading", "percent": 42}] * 16
 
 
+def test_agent_model_status_rejects_non_object_payload(monkeypatch):
+    import routers.models as models_router
+
+    monkeypatch.setattr(models_router, "request_agent_json", lambda *args, **kwargs: [])
+    monkeypatch.setattr(models_router, "_AGENT_MODEL_STATUS_CACHE_TTL_SECONDS", 0.0)
+    monkeypatch.setattr(models_router, "_agent_model_status_cache_at", 0.0)
+    monkeypatch.setattr(models_router, "_agent_model_status_cache_value", {"status": "stale"})
+
+    assert models_router._get_agent_model_status() is None
+    assert models_router._agent_model_status_cache_value is None
+
+
 def test_agent_model_status_and_actions_share_transport(monkeypatch):
     import routers.models as models_router
 


### PR DESCRIPTION
## Summary
- require /v1/model/status responses to have an object root
- cache malformed JSON shapes as unavailable instead of poisoning the short-lived status cache
- preserve the endpoint's existing persisted-file and bootstrap fallback path

## Why this matters
The model download-status endpoint immediately reads fields from the cached host-agent response. A valid JSON array or scalar previously caused AttributeError and was cached, making repeated dashboard polling return 500 until the cache expired rather than falling back to local progress state.

## Overlap check
Searched open and closed PRs for model status payload and host-agent model status. No matching PR was found. Existing model introspection PRs #2520 and #2376 cover llama/model catalog HTTP responses, not /v1/model/status or this cache.

## Test plan
- [x] Four focused agent_model_status tests passed
- [x] git diff --check

Generated with Codex