### PR TITLE
feat(healthcheck): add quiet success output

### DIFF
--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -27,6 +27,7 @@ Options
   --expect-body-regex REGEX      Regex to match in response body (GET only)
   --user-agent UA                Custom user-agent
   --json                         Emit machine-readable JSON result
+  --quiet                        Suppress successful human-readable output
 
 Exit codes
 ----------
@@ -287,6 +288,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         help="User-Agent header",
     )
     p.add_argument("--json", action="store_true", help="Emit JSON result")
+    p.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress successful human-readable output (JSON is never suppressed)",
+    )
     return p.parse_args(argv)
 
 
@@ -394,7 +400,7 @@ def main(argv: Sequence[str]) -> int:
 
     if args.json:
         print(res.to_json())
-    else:
+    elif not (args.quiet and res.ok):
         if res.ok:
             status_part = f" status={res.status}" if res.status is not None else ""
             print(f"[PASS] {res.kind} {res.target}{status_part} ({res.elapsed_ms}ms)")

--- a/ods/tests/test-healthcheck-quiet.py
+++ b/ods/tests/test-healthcheck-quiet.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""CLI coverage for healthcheck quiet output."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "healthcheck.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("ods_healthcheck_quiet", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def invoke(module, result, *extra: str) -> tuple[int, str]:
+    output = io.StringIO()
+    with patch.object(module, "check_tcp", return_value=result), contextlib.redirect_stdout(output):
+        code = module.main(["localhost:8080", "--retries", "0", *extra])
+    return code, output.getvalue()
+
+
+def main() -> int:
+    module = load_module()
+    code, output = invoke(module, (True, "tcp connect ok"), "--quiet")
+    assert code == 0 and output == ""
+
+    code, output = invoke(module, (False, "tcp connection refused"), "--quiet")
+    assert code == 1 and "[FAIL]" in output
+
+    code, output = invoke(module, (True, "tcp connect ok"), "--quiet", "--json")
+    assert code == 0 and json.loads(output)["ok"] is True
+    print("[PASS] healthcheck quiet output")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a --quiet option that suppresses successful human-readable healthcheck output
- keep failure diagnostics visible and preserve JSON output when --json is requested
- cover success, failure, and quiet-plus-JSON CLI behavior

## Why this matters
The universal healthcheck runs repeatedly inside service containers. Operators who only need exit status can now avoid repetitive success lines in orchestrator logs without losing failures or machine-readable output.

## Overlap check
Searched open and closed PRs for healthcheck quiet output; no matches were found. Open PRs #2577 and #2578 modify status and IPv6 parsing in the same tool but do not add output controls.

## Test plan
- [x] uv run --no-project python ods/tests/test-healthcheck-quiet.py
- [x] git diff --check

Generated with Codex