### PR TITLE
feat(models): emit offline readiness JSON

### DIFF
--- a/ods/scripts/validate-models.py
+++ b/ods/scripts/validate-models.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import os
 import re
 import sys
@@ -206,7 +208,10 @@ def installer_command(platform_name: str | None = None) -> str:
     return r".\install.ps1" if (platform_name or os.name) == "nt" else "./install.sh"
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable readiness report")
+    args = parser.parse_args(argv)
     root = ods_root()
     results: list[tuple[str, bool | None, str]] = []
 
@@ -248,16 +253,23 @@ def main() -> int:
     else:
         results.append(("Embedding model", None, "Skipped: service is not active"))
 
-    print("=" * 72)
-    print("ODS Offline Mode - Model Validation")
-    print("=" * 72)
     missing: list[str] = []
+    report: list[dict[str, object]] = []
     for description, ok, detail in results:
         status = "OK" if ok is True else "MISSING" if ok is False else "SKIP"
-        print(f"[{status:7s}] {description:30s} {detail}")
+        report.append({"name": description, "status": status.lower(), "detail": detail})
         if ok is False:
             missing.append(description)
 
+    if args.json:
+        print(json.dumps({"ready": not missing, "models": report}, sort_keys=True))
+        return 0 if not missing else 1
+
+    print("=" * 72)
+    print("ODS Offline Mode - Model Validation")
+    print("=" * 72)
+    for item in report:
+        print(f"[{str(item['status']).upper():7s}] {str(item['name']):30s} {item['detail']}")
     print("=" * 72)
 
     if not missing:

--- a/ods/tests/test-offline-model-validation.py
+++ b/ods/tests/test-offline-model-validation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib.util
+import json
 import os
 import shutil
 import subprocess
@@ -100,10 +101,10 @@ def build_ready_root(
     return root
 
 
-def run_validator(root: Path) -> subprocess.CompletedProcess[str]:
+def run_validator(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     env = dict(os.environ, ODS_ROOT=str(root), PYTHONIOENCODING="utf-8")
     return subprocess.run(
-        [sys.executable, str(VALIDATE_PY)],
+        [sys.executable, str(VALIDATE_PY), *args],
         capture_output=True,
         text=True,
         env=env,
@@ -213,6 +214,15 @@ def main() -> int:
             "Kokoro host voice file is not required",
             not (root / "data" / "kokoro" / "voices" / "af_heart.pt").exists()
             and run_validator(root).returncode == 0,
+        )
+        json_result = run_validator(root, "--json")
+        json_report = json.loads(json_result.stdout)
+        check(
+            "JSON readiness report describes every model check",
+            json_result.returncode == 0
+            and json_report["ready"] is True
+            and len(json_report["models"]) == 4,
+            output(json_result),
         )
 
     with temp_root() as root:


### PR DESCRIPTION
## Summary
- add --json to the offline model validator
- report overall readiness plus status and detail for each active/skipped model check
- preserve existing text output and exit-code behavior

## Why this matters
Provisioning and fleet automation can now consume offline-readiness results without scraping a human-formatted table, while operators retain the existing remediation output by default.

## Overlap check
Searched open and closed PRs for offline model JSON and validate-models JSON output; no matches were found. Existing offline validation PR #2379 changes env precedence rather than adding a reporting interface.

## Test plan
- [x] Full offline model contract suite: 44 passed
- [x] git diff --check

Generated with Codex