### PR TITLE
feat(deps): emit dependency pin JSON

### DIFF
--- a/ods/scripts/check-dependency-pins.py
+++ b/ods/scripts/check-dependency-pins.py
@@ -8,6 +8,7 @@ drift explicit in review instead of discovering it during an install.
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -351,8 +352,14 @@ def check(path: Path = LOCK_PATH, root: Path = ROOT) -> list[str]:
     return errors
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable validation report")
+    args = parser.parse_args(argv)
     errors = check()
+    if args.json:
+        print(json.dumps({"ok": not errors, "error_count": len(errors), "errors": errors}, sort_keys=True))
+        return 1 if errors else 0
     if errors:
         for error in errors:
             print(f"[FAIL] {error}", file=sys.stderr)

--- a/ods/tests/test-dependency-pins.py
+++ b/ods/tests/test-dependency-pins.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import json
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -178,6 +181,16 @@ def test_extension_library_sha_tags_are_rejected() -> None:
     )
 
 
+def test_json_report_is_machine_readable() -> None:
+    module = load_module()
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        return_code = module.main(["--json"])
+    report = json.loads(output.getvalue())
+    assert return_code == 0
+    assert report == {"ok": True, "error_count": 0, "errors": []}
+
+
 def main() -> int:
     tests = [
         test_repo_dependency_lock_passes,
@@ -187,6 +200,7 @@ def main() -> int:
         test_ephemeral_sha256_length_tags_are_rejected,
         test_sha256_digest_pins_are_allowed,
         test_extension_library_sha_tags_are_rejected,
+        test_json_report_is_machine_readable,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary
- add --json to the dependency pin release validator
- emit stable ok, error_count, and errors fields
- preserve existing human output and exit codes

## Why this matters
Release bots and downstream forks can consume dependency drift results directly instead of parsing prefixed stderr lines, making it easier to publish annotations or aggregate gates.

## Overlap check
Searched open and closed PRs for dependency pins JSON and machine-readable pin reports; no matches were found. Existing dependency-lock PRs #2537 and #2116 change validation rules, not the reporting interface.

## Test plan
- [x] python tests/test-dependency-pins.py
- [x] git diff --check

Generated with Codex