### PR TITLE
feat(release): emit version consistency JSON

### DIFF
--- a/ods/scripts/check-version-consistency.py
+++ b/ods/scripts/check-version-consistency.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -62,7 +63,10 @@ def add_regex_check(
         errors.append(str(exc))
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable consistency report")
+    args = parser.parse_args(argv)
     errors: list[str] = []
     manifest_path = ROOT / "manifest.json"
 
@@ -73,6 +77,9 @@ def main() -> int:
         release_version = str(release.get("version", "")).strip()
         release_date = str(release.get("date", "")).strip()
     except Exception as exc:  # noqa: BLE001 - gate should report cleanly
+        if args.json:
+            print(json.dumps({"ok": False, "expected": None, "errors": [str(exc)]}, sort_keys=True))
+            return 1
         print(f"[FAIL] version consistency: cannot read manifest.json: {exc}")
         return 1
 
@@ -149,6 +156,10 @@ def main() -> int:
     for label, value in checks:
         if value != expected:
             errors.append(f"{label} {value!r} != manifest.json ods_version {expected!r}")
+
+    if args.json:
+        print(json.dumps({"ok": not errors, "expected": expected, "errors": errors}, sort_keys=True))
+        return 1 if errors else 0
 
     if errors:
         print("[FAIL] version consistency")

--- a/ods/tests/test-version-consistency.py
+++ b/ods/tests/test-version-consistency.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Public CLI coverage for version consistency JSON output."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-version-consistency.py"
+
+
+def main() -> int:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    report = json.loads(result.stdout)
+    assert result.returncode == 0, report
+    assert report["ok"] is True
+    assert report["expected"]
+    assert report["errors"] == []
+    print("[PASS] version consistency JSON report")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add --json to the version consistency release gate
- expose overall status, canonical expected version, and drift errors
- preserve existing human output and exit behavior

## Why this matters
Release automation can now aggregate version authority checks without scraping console text, and can display the canonical target version alongside any drift.

## Overlap check
Searched open and closed PRs for version consistency JSON; no matches were found. Existing version PRs #1799 and closed #2539 change error handling/parsing rather than add a reporting contract.

## Test plan
- [x] uv run --no-project python ods/tests/test-version-consistency.py
- [x] git diff --check

Generated with Codex