### PR TITLE
feat(catalog): add native freshness check

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -32,15 +32,5 @@ jobs:
       - name: Install PyYAML
         run: pip install pyyaml
 
-      - name: Regenerate catalog and diff
-        run: |
-          cp ods/config/extensions-catalog.json /tmp/catalog-before.json
-          python ods/scripts/generate-extensions-catalog.py
-          # Compare ignoring generated_at timestamp (changes every run)
-          jq 'del(.generated_at)' /tmp/catalog-before.json > /tmp/a.json
-          jq 'del(.generated_at)' ods/config/extensions-catalog.json > /tmp/b.json
-          if ! diff -q /tmp/a.json /tmp/b.json >/dev/null 2>&1; then
-            diff /tmp/a.json /tmp/b.json || true
-            echo "::error::extensions-catalog.json is out of date. Run: python ods/scripts/generate-extensions-catalog.py"
-            exit 1
-          fi
+      - name: Check catalog freshness
+        run: python ods/scripts/generate-extensions-catalog.py --check

--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -41,6 +41,11 @@ def parse_args() -> argparse.Namespace:
         default=script_dir / ".." / "config" / "extensions-catalog.json",
         help="Output path for the catalog JSON",
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if the output catalog does not match manifests (ignores generated_at)",
+    )
     return parser.parse_args()
 
 
@@ -149,24 +154,47 @@ def generate_catalog(library_dir: Path) -> list[dict]:
     return entries
 
 
-def main() -> None:
+def main() -> int:
     args = parse_args()
     library_dir = args.library_dir.resolve()
     output_path = args.output.resolve()
 
     entries = generate_catalog(library_dir)
 
-    catalog = {
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    expected = {
         "schema_version": CATALOG_SCHEMA_VERSION,
         "extensions": entries,
+    }
+
+    if args.check:
+        try:
+            actual = json.loads(output_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"ERROR: Cannot read catalog for checking: {exc}", file=sys.stderr)
+            return 1
+        if isinstance(actual, dict):
+            actual = {key: value for key, value in actual.items() if key != "generated_at"}
+        if actual != expected:
+            print(
+                "ERROR: extensions catalog is out of date; run "
+                "python scripts/generate-extensions-catalog.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Extensions catalog is current: {output_path}")
+        return 0
+
+    catalog = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        **expected,
     }
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
     print(f"Generated catalog with {len(entries)} extensions at {output_path}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/ods/tests/test-catalog-check.py
+++ b/ods/tests/test-catalog-check.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""CLI coverage for extension catalog drift checking."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate-extensions-catalog.py"
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True)
+
+
+def main() -> int:
+    current = run("--check")
+    assert current.returncode == 0, current.stderr
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        stale = Path(temp_dir) / "catalog.json"
+        stale.write_text("{}\n", encoding="utf-8")
+        result = run("--output", str(stale), "--check")
+        assert result.returncode == 1
+        assert "out of date" in result.stderr
+        assert stale.read_text(encoding="utf-8") == "{}\n"
+
+    print("[PASS] extension catalog native check")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a native --check mode to the extension catalog generator
- compare manifest-derived content while intentionally ignoring generated_at
- replace the workflow's temporary files, jq, and diff pipeline with the public command

## Why this matters
Contributors and downstream forks can run the exact catalog freshness gate locally on every platform. Check mode never rewrites the catalog, which makes CI intent clearer and avoids timestamp-only worktree changes.

## Overlap check
Searched open and closed PRs for catalog --check and catalog freshness. No PR adds this interface; #1953 addresses atomic writes in normal generation mode.

## Test plan
- [x] uv run --no-project --with pyyaml python ods/tests/test-catalog-check.py
- [x] git diff --check

Generated with Codex