### PR TITLE
feat(release): emit golden path JSON

### DIFF
--- a/ods/scripts/validate-golden-paths.py
+++ b/ods/scripts/validate-golden-paths.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -179,13 +180,23 @@ def validate_scenario(issues: Issues, scenario: Any, path: str) -> str | None:
 
 
 def main(argv: list[str]) -> int:
-    path = Path(argv[0]) if argv else DEFAULT_PATH
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=DEFAULT_PATH)
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable validation report")
+    args = parser.parse_args(argv)
+    path = args.path
     if not path.exists():
+        if args.json:
+            print(json.dumps({"ok": False, "path": str(path), "errors": ["file not found"]}, sort_keys=True))
+            return 1
         print(f"[FAIL] golden path file not found: {path}")
         return 1
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "path": str(path), "errors": [f"invalid JSON: {exc}"]}, sort_keys=True))
+            return 1
         print(f"[FAIL] invalid JSON in {path}: {exc}")
         return 1
 
@@ -193,6 +204,9 @@ def main(argv: list[str]) -> int:
     root = as_dict(data)
     if root is None:
         issues.add("$", "must be an object")
+        if args.json:
+            print(json.dumps({"ok": False, "path": str(path), "errors": issues.items}, sort_keys=True))
+            return 1
         issues.exit_if_any()
         return 1
 
@@ -211,6 +225,9 @@ def main(argv: list[str]) -> int:
         expected_ids = {"linux-nvidia", "windows-wsl2-nvidia", "windows-wsl2-amd-lemonade", "apple-silicon"}
         issues.require(set(seen) == expected_ids, "$.scenarios", f"must define exactly {sorted(expected_ids)}")
 
+    if args.json:
+        print(json.dumps({"ok": not issues.items, "path": str(path), "errors": issues.items}, sort_keys=True))
+        return 1 if issues.items else 0
     issues.exit_if_any()
     print("[PASS] golden path contracts")
     return 0

--- a/ods/tests/test-golden-paths-json.py
+++ b/ods/tests/test-golden-paths-json.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""CLI coverage for golden-path JSON reports."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "validate-golden-paths.py"
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True)
+
+
+def main() -> int:
+    valid = run("--json")
+    valid_report = json.loads(valid.stdout)
+    assert valid.returncode == 0 and valid_report["ok"] is True
+    assert valid_report["errors"] == []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        invalid_path = Path(temp_dir) / "golden.json"
+        invalid_path.write_text("[]\n", encoding="utf-8")
+        invalid = run(str(invalid_path), "--json")
+        invalid_report = json.loads(invalid.stdout)
+        assert invalid.returncode == 1 and invalid_report["ok"] is False
+        assert invalid_report["errors"] == ["$: must be an object"]
+
+    print("[PASS] golden-path JSON report")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add --json to the golden-path release validator
- emit stable ok, path, and errors fields for success and failure paths
- preserve existing human-readable diagnostics and validation rules

## Why this matters
Release dashboards and fleet-validation automation can consume golden-path contract failures directly instead of parsing indented console messages.

## Overlap check
Searched open and closed PRs for golden path JSON reports; no matches were found. PR #2536 changes path confinement, not the reporting interface.

## Test plan
- [x] uv run --no-project python ods/tests/test-golden-paths-json.py
- [x] git diff --check

Generated with Codex