### PR TITLE
feat(config): emit contract validation JSON

### DIFF
--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -183,19 +184,32 @@ def validate_surface(issues: Issues, surface: Any, path: str) -> str | None:
 
 
 def main(argv: list[str]) -> int:
-    path = Path(argv[0]) if argv else DEFAULT_PATH
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=DEFAULT_PATH)
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable validation report")
+    args = parser.parse_args(argv)
+    path = args.path
     if not path.exists():
+        if args.json:
+            print(json.dumps({"ok": False, "path": str(path), "errors": ["file not found"]}, sort_keys=True))
+            return 1
         print(f"[FAIL] generated config contract file not found: {path}")
         return 1
     try:
         data = load_json(path)
     except json.JSONDecodeError as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "path": str(path), "errors": [f"invalid JSON: {exc}"]}, sort_keys=True))
+            return 1
         print(f"[FAIL] invalid JSON in {path}: {exc}")
         return 1
 
     issues = Issues()
     if not isinstance(data, dict):
         issues.add("$", "must be an object")
+        if args.json:
+            print(json.dumps({"ok": False, "path": str(path), "errors": issues.items}, sort_keys=True))
+            return 1
         issues.exit_if_any()
         return 1
     issues.require(data.get("version") == 1, "$.version", "must be 1")
@@ -224,6 +238,9 @@ def main(argv: list[str]) -> int:
         }
         issues.require(set(surface_ids) == required, "$.surfaces", f"must define exactly {sorted(required)}")
 
+    if args.json:
+        print(json.dumps({"ok": not issues.items, "path": str(path), "errors": issues.items}, sort_keys=True))
+        return 1 if issues.items else 0
     issues.exit_if_any()
     print("[PASS] generated config contracts")
     return 0

--- a/ods/tests/test-generated-configs-json.py
+++ b/ods/tests/test-generated-configs-json.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""CLI coverage for generated-config JSON reports."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "validate-generated-configs.py"
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True)
+
+
+def main() -> int:
+    valid = run("--json")
+    valid_report = json.loads(valid.stdout)
+    assert valid.returncode == 0 and valid_report["ok"] is True
+    assert valid_report["errors"] == []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        invalid_path = Path(temp_dir) / "contracts.json"
+        invalid_path.write_text("[]\n", encoding="utf-8")
+        invalid = run(str(invalid_path), "--json")
+        invalid_report = json.loads(invalid.stdout)
+        assert invalid.returncode == 1 and invalid_report["ok"] is False
+        assert invalid_report["errors"] == ["$: must be an object"]
+
+    print("[PASS] generated-config JSON report")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add --json to generated runtime-config contract validation
- report stable ok, path, and errors fields across success and failure paths
- retain existing human diagnostics and contract rules

## Why this matters
Release and downstream-fork automation can surface exact generated-config contract failures without parsing console indentation, alongside the source contract path.

## Overlap check
Searched open and closed PRs for generated config JSON reports; no matches were found. PR #2535 confines contract paths but does not add machine-readable output.

## Test plan
- [x] uv run --no-project python ods/tests/test-generated-configs-json.py
- [x] git diff --check

Generated with Codex