### PR TITLE
feat(schema): support custom mirror output

### DIFF
--- a/ods/scripts/sync-manifest-schema.py
+++ b/ods/scripts/sync-manifest-schema.py
@@ -32,18 +32,25 @@ def main() -> int:
         action="store_true",
         help="fail if the generated mirror differs instead of updating it",
     )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=LIBRARY_SCHEMA,
+        help="write or check an alternate mirror path",
+    )
     args = parser.parse_args()
+    output = args.output.resolve()
 
     try:
         source = canonical_schema_path()
         expected = source.read_bytes()
-        actual = LIBRARY_SCHEMA.read_bytes() if LIBRARY_SCHEMA.exists() else None
+        actual = output.read_bytes() if output.exists() else None
     except (KeyError, OSError, TypeError, json.JSONDecodeError) as exc:
         print(f"ERROR: cannot resolve manifest schema contract: {exc}", file=sys.stderr)
         return 2
 
     if actual == expected:
-        print(f"Manifest schema mirror is current: {LIBRARY_SCHEMA.relative_to(ROOT_DIR)}")
+        print(f"Manifest schema mirror is current: {output}")
         return 0
 
     if args.check:
@@ -54,11 +61,11 @@ def main() -> int:
         )
         return 1
 
-    LIBRARY_SCHEMA.parent.mkdir(parents=True, exist_ok=True)
-    LIBRARY_SCHEMA.write_bytes(expected)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(expected)
     print(
         "Updated generated manifest schema mirror from "
-        f"{source.relative_to(ROOT_DIR)}"
+        f"{source.relative_to(ROOT_DIR)} at {output}"
     )
     return 0
 

--- a/ods/tests/test-validate-manifest-schema.sh
+++ b/ods/tests/test-validate-manifest-schema.sh
@@ -33,6 +33,12 @@ assert_success() {
 
 assert_success "generated library schema mirror is current" \
     python3 "$ROOT_DIR/scripts/sync-manifest-schema.py" --check
+CUSTOM_MIRROR="$TMP_DIR/custom-schema.json"
+assert_success "custom schema mirror can be generated" \
+    python3 "$ROOT_DIR/scripts/sync-manifest-schema.py" --output "$CUSTOM_MIRROR"
+cmp "$SCHEMA" "$CUSTOM_MIRROR" || fail "custom schema mirror differs from canonical schema"
+assert_success "custom schema mirror can be checked" \
+    python3 "$ROOT_DIR/scripts/sync-manifest-schema.py" --check --output "$CUSTOM_MIRROR"
 assert_success "bundled and library manifests validate together" \
     bash "$VALIDATOR"
 assert_success "standalone library validator accepts all library manifests" \


### PR DESCRIPTION
## Summary
- add an `--output` option to the manifest schema mirror generator
- support both generation and freshness checks at a caller-selected path
- cover the custom-output workflow in the public schema validation suite

## Why this matters
Downstream packaging and release jobs can now stage the generated schema in an isolated directory without modifying the repository checkout, while still using the repository's canonical contract and freshness check.

## Overlap check
Searched open and closed upstream PRs for `schema mirror output` and found no matching work. PR #2574 touches schema contract path confinement, but does not add caller-selected output or the associated generation/check workflow.

## Test plan
- `bash ods/tests/test-validate-manifest-schema.sh` (19 checks passed)