### PR TITLE
feat(audit): emit GitHub annotations

### DIFF
--- a/ods/scripts/audit-extensions.py
+++ b/ods/scripts/audit-extensions.py
@@ -97,10 +97,16 @@ def parse_args() -> argparse.Namespace:
         default=default_project,
         help="ODS project directory (defaults to the repo root).",
     )
-    parser.add_argument(
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument(
         "--json",
         action="store_true",
         help="Emit JSON instead of the human-readable report.",
+    )
+    output_group.add_argument(
+        "--github-annotations",
+        action="store_true",
+        help="Emit issues as GitHub Actions workflow annotations.",
     )
     parser.add_argument(
         "--strict",
@@ -849,6 +855,29 @@ def print_human_report(payload: dict[str, Any]) -> None:
     )
 
 
+def escape_workflow_data(value: Any) -> str:
+    return str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def escape_workflow_property(value: Any) -> str:
+    return escape_workflow_data(value).replace(":", "%3A").replace(",", "%2C")
+
+
+def print_github_annotations(payload: dict[str, Any]) -> None:
+    issues = list(payload["global_issues"])
+    for service in payload["services"]:
+        issues.extend(service["issues"])
+
+    for issue in issues:
+        properties = [f"title={escape_workflow_property(issue['code'])}"]
+        if issue.get("path"):
+            properties.insert(0, f"file={escape_workflow_property(issue['path'])}")
+        print(
+            f"::{issue['severity']} {','.join(properties)}::"
+            f"{escape_workflow_data(issue['message'])}"
+        )
+
+
 def main() -> int:
     args = parse_args()
     project_dir = args.project_dir.resolve()
@@ -869,6 +898,8 @@ def main() -> int:
     if args.json:
         json.dump(payload, sys.stdout, indent=2)
         sys.stdout.write("\n")
+    elif args.github_annotations:
+        print_github_annotations(payload)
     else:
         print_human_report(payload)
 

--- a/ods/tests/test-extension-audit.sh
+++ b/ods/tests/test-extension-audit.sh
@@ -257,6 +257,14 @@ if assert_json_value "$report2" "any(issue['code'] == 'dependency-missing' for s
 else
     fail "missing dependency code was not reported"
 fi
+annotations=$(mktemp)
+if run_audit "$root2" --github-annotations > "$annotations" 2>/dev/null; then
+    fail "annotation output should preserve audit failure status"
+elif grep -q '^::error file=.*manifest.yaml,title=dependency-missing::depends_on references unknown service' "$annotations"; then
+    pass "GitHub annotation output includes the issue path, code, and message"
+else
+    fail "GitHub annotation output did not contain the dependency error"
+fi
 
 header "3" "Alias Collisions Are Rejected"
 root3=$(make_fixture_root)


### PR DESCRIPTION
## Summary
- add a GitHub Actions annotation output mode to the extension auditor
- emit error and warning commands with escaped file, code, and message fields
- preserve audit exit semantics and make annotation mode mutually exclusive with JSON

## Why this matters
CI users can surface extension contract failures directly on affected manifest and compose files instead of searching a long textual log, improving the feedback loop for extension authors.

## Overlap check
Searched open and closed upstream PRs for `extension audit annotations` and found no matching work. Existing audit PRs and tests cover contract rules, not a GitHub Actions-native reporting interface.

## Test plan
- `bash ods/tests/test-extension-audit.sh` (16 passed, 0 failed)
- `python -m py_compile ods/scripts/audit-extensions.py`