### PR TITLE
fix(dashboard-api): add safe float timeout parsing in host_agent_client.py

### DIFF
--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -99,9 +99,13 @@ def _headers() -> dict[str, str]:
 
 
 def _timeout(read_seconds: float) -> httpx.Timeout:
+    try:
+        read_val = max(0.1, float(read_seconds))
+    except (ValueError, TypeError):
+        read_val = 5.0
     return httpx.Timeout(
         connect=5.0,
-        read=max(0.1, float(read_seconds)),
+        read=read_val,
         write=30.0,
         pool=5.0,
     )


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/host_agent_client.py`, `_timeout()` accepts a `read_seconds` parameter and calculates `max(0.1, float(read_seconds))`. If a `None` or unparseable value is provided, `float()` raises `TypeError` or `ValueError`.

## Fix

Wrap `float(read_seconds)` conversion inside a `try...except (ValueError, TypeError)` block, falling back safely to `5.0` seconds on conversion errors.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/host_agent_client.py`. `git diff --check` passed cleanly.