### PR TITLE
fix(dashboard-api): use _positive_number for regex param matches in model_memory.py

### DIFF
--- a/ods/extensions/services/dashboard-api/model_memory.py
+++ b/ods/extensions/services/dashboard-api/model_memory.py
@@ -34,10 +34,10 @@ def estimated_param_billions(model: dict[str, Any]) -> float:
         model.get("gguf"),
         model.get("gguf_file"),
     ):
-        numbers.extend(
-            float(match)
-            for match in re.findall(r"(\d+(?:\.\d+)?)\s*b", str(text or ""), re.I)
-        )
+        for match in re.findall(r"(\d+(?:\.\d+)?)\s*b", str(text or ""), re.I):
+            val = _positive_number(match)
+            if val:
+                numbers.append(val)
     if numbers:
         return max(numbers)
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/model_memory.py`, `estimated_param_billions()` extracts model parameter scales from model names and filenames using `re.findall(r"(\d+(?:\.\d+)?)\s*b", ...)`. Directly mapping matches with `float(match)` could raise a `ValueError` on malformed match groups.

## Fix

Use the existing `_positive_number()` helper function to validate regex parameter scale matches safely before adding them to candidate scale numbers.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/model_memory.py`. `git diff --check` passed cleanly.