### PR TITLE
fix(gpu): add safe float parsing for memory_free_gb in assign_gpus.py

### DIFF
--- a/ods/scripts/assign_gpus.py
+++ b/ods/scripts/assign_gpus.py
@@ -79,7 +79,10 @@ def parse_gpus(topology: dict) -> list:
         total_mb = float(g["memory_gb"]) * 1024
         scheduling_mb = total_mb
         if g.get("memory_free_gb") is not None:
-            scheduling_mb = max(float(g["memory_free_gb"]) * 1024, 0.0)
+            try:
+                scheduling_mb = max(float(g["memory_free_gb"]) * 1024, 0.0)
+            except (ValueError, TypeError):
+                scheduling_mb = total_mb
         gpus.append(GPU(
             index=g["index"],
             uuid=g["uuid"],


### PR DESCRIPTION
## Problem

In `ods/scripts/assign_gpus.py`, `parse_gpus()` parses available VRAM from topology payloads using `float(g["memory_free_gb"])`. If the topology file passes non-numeric values or invalid strings for `memory_free_gb`, `float()` raises an unhandled `ValueError`.

## Fix

Wrap `float(g["memory_free_gb"])` in a `try...except (ValueError, TypeError)` block, defaulting `scheduling_mb` back to `total_mb` on parsing errors.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/assign_gpus.py`. `git diff --check` passed cleanly.