### PR TITLE
fix(catalog): handle decode errors in load_manifest in generate-extensions-catalog.py

### DIFF
--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -57,7 +57,7 @@ def load_manifest(manifest_path: Path) -> dict | None:
     """Load and validate a single manifest file. Returns None on failure."""
     try:
         data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-    except (yaml.YAMLError, OSError) as e:
+    except (yaml.YAMLError, OSError, UnicodeDecodeError, ValueError) as e:
         print(f"WARNING: Failed to read {manifest_path}: {e}", file=sys.stderr)
         return None
 


### PR DESCRIPTION
## Problem

In `ods/scripts/generate-extensions-catalog.py`, `load_manifest()` opens service extension manifest YAML files via `manifest_path.read_text(encoding="utf-8")`. If a manifest file contains non-UTF-8 bytes or decode errors occur during parsing, a `UnicodeDecodeError` or `ValueError` could escape the exception handler block.

## Fix

Include `UnicodeDecodeError` and `ValueError` in the exception handler block in `load_manifest()`, logging a warning to stderr and returning `None` gracefully.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/generate-extensions-catalog.py`. `git diff --check` passed cleanly.