### PR TITLE
feat(healthcheck): support custom request headers

### DIFF
--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -25,6 +25,7 @@ Options
   --method {HEAD,GET}            HTTP method (default: HEAD, with GET fallback)
   --expect-status 200,204,3xx    Allowed HTTP status codes/ranges
   --expect-body-regex REGEX      Regex to match in response body (GET only)
+  --header NAME:VALUE            HTTP request header (repeatable)
   --user-agent UA                Custom user-agent
   --json                         Emit machine-readable JSON result
 
@@ -142,6 +143,22 @@ def _parse_expected_status(expr: str) -> Set[int]:
     return allowed
 
 
+def _parse_headers(values: Sequence[str]) -> List[Tuple[str, str]]:
+    """Parse repeatable NAME:VALUE arguments without accepting header injection."""
+    headers: List[Tuple[str, str]] = []
+    for value in values:
+        if "\r" in value or "\n" in value:
+            raise ValueError("header values must not contain newlines")
+        if ":" not in value:
+            raise ValueError(f"header must use NAME:VALUE syntax: {value!r}")
+        name, raw_value = value.split(":", 1)
+        name = name.strip()
+        if not re.fullmatch(r"[!#$%&'*+.^_`|~0-9A-Za-z-]+", name):
+            raise ValueError(f"invalid header name: {name!r}")
+        headers.append((name, raw_value.strip()))
+    return headers
+
+
 # -----------------------------
 # Check implementations
 # -----------------------------
@@ -166,9 +183,12 @@ def _http_request(
     method: str,
     timeout: float,
     user_agent: str,
+    headers: Sequence[Tuple[str, str]],
 ) -> urllib.response.addinfourl:
     req = urllib.request.Request(url, method=method)
     req.add_header("User-Agent", user_agent)
+    for name, value in headers:
+        req.add_header(name, value)
     return urllib.request.urlopen(req, timeout=timeout)  # nosec B310
 
 
@@ -180,6 +200,7 @@ def check_http(
     allowed_status: Optional[Set[int]],
     body_regex: Optional[re.Pattern[str]],
     user_agent: str,
+    headers: Sequence[Tuple[str, str]],
 ) -> Tuple[bool, str, Optional[int]]:
     """Check HTTP endpoint matches expected status and optional body regex."""
 
@@ -198,7 +219,13 @@ def check_http(
 
     for m in try_methods:
         try:
-            with _http_request(url, method=m, timeout=timeout, user_agent=user_agent) as resp:
+            with _http_request(
+                url,
+                method=m,
+                timeout=timeout,
+                user_agent=user_agent,
+                headers=headers,
+            ) as resp:
                 status = getattr(resp, "status", None)
 
                 # Status validation
@@ -286,6 +313,13 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         default="ODS-Healthcheck/1.0",
         help="User-Agent header",
     )
+    p.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        metavar="NAME:VALUE",
+        help="HTTP request header (repeatable)",
+    )
     p.add_argument("--json", action="store_true", help="Emit JSON result")
     return p.parse_args(argv)
 
@@ -302,6 +336,24 @@ def main(argv: Sequence[str]) -> int:
         kind, norm = _parse_target(args.target)
     except ValueError as exc:
         res = Result(ok=False, target=args.target, kind="unknown", detail=str(exc))
+        if args.json:
+            print(res.to_json())
+        else:
+            print(f"[FAIL] {res.detail}")
+        return 2
+
+    try:
+        headers = _parse_headers(args.header)
+    except ValueError as exc:
+        res = Result(ok=False, target=args.target, kind=kind, detail=f"invalid --header: {exc}")
+        if args.json:
+            print(res.to_json())
+        else:
+            print(f"[FAIL] {res.detail}")
+        return 2
+
+    if kind != "http" and headers:
+        res = Result(ok=False, target=args.target, kind=kind, detail="--header requires an HTTP target")
         if args.json:
             print(res.to_json())
         else:
@@ -379,6 +431,7 @@ def main(argv: Sequence[str]) -> int:
                 allowed_status=allowed_status,
                 body_regex=body_re,
                 user_agent=args.user_agent,
+                headers=headers,
             ),
             retries=args.retries,
         )

--- a/ods/tests/test_healthcheck_headers.py
+++ b/ods/tests/test_healthcheck_headers.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Public CLI coverage for authenticated universal health probes."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "healthcheck.py"
+
+
+class _AuthenticatedHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.headers.get("Authorization") != "Bearer test-token":
+            self.send_response(401)
+            self.end_headers()
+            return
+        if self.headers.get("X-ODS-Probe") != "integration":
+            self.send_response(400)
+            self.end_headers()
+            return
+        self.send_response(204)
+        self.end_headers()
+
+    def log_message(self, *_args: object) -> None:
+        return
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_repeatable_headers_reach_authenticated_endpoint() -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _AuthenticatedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        result = _run(
+            f"http://127.0.0.1:{server.server_port}/health",
+            "--method",
+            "GET",
+            "--header",
+            "Authorization: Bearer test-token",
+            "--header",
+            "X-ODS-Probe:integration",
+            "--expect-status",
+            "204",
+            "--retries",
+            "0",
+            "--json",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["status"] == 204
+
+
+def test_header_rejects_newline_injection() -> None:
+    result = _run("http://localhost:1", "--header", "X-Test:ok\r\nInjected: yes", "--json")
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "newlines" in payload["detail"]
+
+
+def test_header_rejects_tcp_targets() -> None:
+    result = _run("localhost:1", "--header", "Authorization:test", "--json")
+
+    assert result.returncode == 2
+    assert "requires an HTTP target" in json.loads(result.stdout)["detail"]


### PR DESCRIPTION
## Summary
- add repeatable `--header NAME:VALUE` arguments to the dependency-free HTTP healthcheck
- forward custom headers across HEAD-to-GET fallback and retry attempts
- reject malformed names, newline injection, and headers on TCP targets before connecting
- cover the public CLI against a local authenticated HTTP endpoint

## Why this matters
Operators use `scripts/healthcheck.py` for container and deployment probes, but protected health endpoints could not be checked without replacing the bundled helper with curl/wget. Repeatable headers make API-key and bearer-token probes possible while preserving the dependency-free runtime path and keeping header values out of result output.

## Overlap check
Searched open and closed Osmantic/ODS PR titles for `healthcheck custom request headers` and PR bodies for `ods/scripts/healthcheck.py`. No PR provides repeatable authenticated request headers; the scope is independent of existing healthcheck timeout/status/JSON changes.

## Test plan
- [x] `python -m pytest -q ods/tests/test_healthcheck_headers.py`
- [x] `python -m py_compile ods/scripts/healthcheck.py`
- [x] `git diff --check`

Generated with Codex