### PR TITLE
feat(mode): preview mode switches

### DIFF
--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -2,7 +2,7 @@
 # ============================================================================
 # ODS Mode Switch
 # ============================================================================
-# Usage: ./mode-switch.sh <local|cloud|hybrid> [--status]
+# Usage: ./mode-switch.sh <local|cloud|hybrid> [--dry-run]
 #
 # Switches ODS between local/cloud/hybrid modes by updating .env.
 # This is the backend for `ods mode <mode>`.
@@ -58,6 +58,7 @@ show_status() {
 
 switch_mode() {
     local mode="$1"
+    local dry_run="${2:-false}"
 
     # Validate
     case "$mode" in
@@ -73,16 +74,29 @@ switch_mode() {
         error "External LLM routing is installer-managed. Run './install.sh --no-external-llm' first, then retry the mode switch."
     fi
 
+    local target_url="http://litellm:4000"
+    [[ "$mode" == "local" ]] && target_url="http://llama-server:8080"
+    local litellm_cf="$SCRIPT_DIR/extensions/services/litellm/compose.yaml"
+    local litellm_disabled="${litellm_cf}.disabled"
+
+    if [[ "$dry_run" == "true" ]]; then
+        log "Dry run: no files will be changed."
+        echo "Would set ODS_MODE=$mode"
+        echo "Would set LLM_API_URL=$target_url"
+        if [[ "$mode" != "local" && -f "$litellm_disabled" && ! -f "$litellm_cf" ]]; then
+            echo "Would enable litellm: $litellm_disabled -> $litellm_cf"
+        fi
+        return 0
+    fi
+
     # Update .env
     env_set "ODS_MODE" "$mode"
 
     if [[ "$mode" == "local" ]]; then
-        env_set "LLM_API_URL" "http://llama-server:8080"
+        env_set "LLM_API_URL" "$target_url"
     else
-        env_set "LLM_API_URL" "http://litellm:4000"
+        env_set "LLM_API_URL" "$target_url"
         # Auto-enable litellm extension
-        local litellm_cf="$SCRIPT_DIR/extensions/services/litellm/compose.yaml"
-        local litellm_disabled="${litellm_cf}.disabled"
         if [[ -f "$litellm_disabled" && ! -f "$litellm_cf" ]]; then
             mv "$litellm_disabled" "$litellm_cf"
             success "Auto-enabled litellm for $mode mode"
@@ -98,8 +112,14 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     case "${1:---status}" in
         --status|-s|status) show_status ;;
         --help|-h|help)
-            echo "Usage: mode-switch.sh <local|cloud|hybrid|--status>"
+            echo "Usage: mode-switch.sh <local|cloud|hybrid> [--dry-run]"
+            echo "       mode-switch.sh --status"
             ;;
-        *) switch_mode "${1:-}" ;;
+        *)
+            if [[ $# -gt 2 || ( $# -eq 2 && "$2" != "--dry-run" ) ]]; then
+                error "Usage: mode-switch.sh <local|cloud|hybrid> [--dry-run]"
+            fi
+            switch_mode "${1:-}" "$( [[ "${2:-}" == "--dry-run" ]] && echo true || echo false )"
+            ;;
     esac
 fi

--- a/ods/tests/test-mode-switch-status.sh
+++ b/ods/tests/test-mode-switch-status.sh
@@ -145,6 +145,25 @@ check_contains "unknown mode explains itself" "Unknown mode" "$(run_mode "$ROOT"
 ROOT="$(new_root)"
 check_eq "switching without .env exits 1" "1" "$(run_rc "$ROOT" cloud)"
 
+# 8. Dry run previews every mutation without changing files.
+ROOT="$(new_root)"
+mkdir -p "$ROOT/extensions/services/litellm"
+printf 'disabled compose\n' > "$ROOT/extensions/services/litellm/compose.yaml.disabled"
+printf 'ODS_MODE=local\nLLM_API_URL=http://llama-server:8080\n' > "$ROOT/.env"
+BEFORE="$(cat "$ROOT/.env")"
+OUT="$(run_mode "$ROOT" cloud --dry-run)"
+check_eq "dry run exits 0" "0" "$(run_rc "$ROOT" cloud --dry-run)"
+check_contains "dry run previews mode" "Would set ODS_MODE=cloud" "$OUT"
+check_contains "dry run previews routing URL" "Would set LLM_API_URL=http://litellm:4000" "$OUT"
+check_contains "dry run previews extension enable" "Would enable litellm:" "$OUT"
+check_eq "dry run leaves .env unchanged" "$BEFORE" "$(cat "$ROOT/.env")"
+if [[ -f "$ROOT/extensions/services/litellm/compose.yaml.disabled" && ! -e "$ROOT/extensions/services/litellm/compose.yaml" ]]; then
+    pass "dry run leaves litellm compose disabled"
+else
+    fail "dry run leaves litellm compose disabled" "compose file was moved"
+fi
+check_eq "unknown second argument exits 1" "1" "$(run_rc "$ROOT" cloud --preview)"
+
 # ── Summary ───────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary
- add `--dry-run` to the documented mode-switch backend
- preview both `.env` assignments and the conditional LiteLLM compose enable
- reuse the computed routing target for preview and apply paths
- reject stray second arguments and prove the preview leaves both files untouched

## Why this matters
Switching local/cloud/hybrid mode changes routing configuration and may enable the LiteLLM compose fragment. Operators can now inspect the exact mutation plan before changing a running installation, including whether an extension file would move.

## Overlap check
Searched open/closed PR titles for `mode switch dry run preview` and bodies referencing `ods/scripts/mode-switch.sh`. PR #2616 changes atomic `.env` writes and #2467 changes duplicate-key reads; neither exposes a preview contract. This PR does not modify `env_set` or duplicate-key selection and has an independently reachable `mode-switch.sh <mode> --dry-run` boundary.

## Test plan
- [x] `bash ods/tests/test-mode-switch-status.sh` (27 assertions)
- [x] `bash -n ods/scripts/mode-switch.sh`
- [x] `bash -n ods/tests/test-mode-switch-status.sh`
- [x] `git diff --check`

Generated with Codex