### PR TITLE
feat(cold-storage): configure retention age

### DIFF
--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -4,7 +4,7 @@
 #
 # Part of ODS tooling.
 #
-# Models not accessed in 7+ days are moved to cold storage on a backup drive.
+# Models not accessed for the configured retention period are moved to cold storage.
 # A symlink replaces the original so HuggingFace cache resolution still works.
 # Models can be restored manually or are auto-detected if a process loads them.
 #
@@ -14,13 +14,14 @@
 #   ./llm-cold-storage.sh --restore <name> # Restore a specific model
 #   ./llm-cold-storage.sh --restore-all    # Restore all archived models
 #   ./llm-cold-storage.sh --status         # Show archive status
+#   ./llm-cold-storage.sh --max-idle-days 30 [--execute]
 #
 set -uo pipefail
 
 HF_CACHE="${HF_CACHE:-$HOME/.cache/huggingface/hub}"
 COLD_DIR="${COLD_DIR:-$HOME/llm-cold-storage}"
 LOG_FILE="${LOG_FILE:-$HOME/.local/log/llm-cold-storage.log}"
-MAX_IDLE_DAYS=7
+MAX_IDLE_DAYS="${MAX_IDLE_DAYS:-7}"
 
 # Ensure the log directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -224,30 +225,64 @@ show_status() {
     echo "Cold storage total: $(du -sh "$COLD_DIR" 2>/dev/null | cut -f1)"
 }
 
-case "${1:-}" in
-    --execute)
-        do_archive false
-        ;;
-    --restore)
-        [[ -n "${2:-}" ]] || { echo "Usage: $0 --restore <model-name>"; exit 1; }
-        do_restore "$2"
-        ;;
-    --restore-all)
-        do_restore_all
-        ;;
-    --status)
-        show_status
-        ;;
-    --help|-h)
+ACTION="archive-dry-run"
+RESTORE_NAME=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --execute)
+            ACTION="archive"
+            shift
+            ;;
+        --max-idle-days)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --max-idle-days requires a value" >&2; exit 2; }
+            MAX_IDLE_DAYS="$2"
+            shift 2
+            ;;
+        --restore)
+            [[ -n "${2:-}" ]] || { echo "Usage: $0 --restore <model-name>"; exit 1; }
+            ACTION="restore"
+            RESTORE_NAME="$2"
+            shift 2
+            ;;
+        --restore-all)
+            ACTION="restore-all"
+            shift
+            ;;
+        --status)
+            ACTION="status"
+            shift
+            ;;
+        --help|-h)
+            ACTION="help"
+            shift
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! "$MAX_IDLE_DAYS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --max-idle-days must be a non-negative integer" >&2
+    exit 2
+fi
+
+case "$ACTION" in
+    archive) do_archive false ;;
+    archive-dry-run) do_archive true ;;
+    restore) do_restore "$RESTORE_NAME" ;;
+    restore-all) do_restore_all ;;
+    status) show_status ;;
+    help)
         echo "Usage: $0 [--execute|--restore <name>|--restore-all|--status|--help]"
         echo ""
         echo "  (no args)            Dry-run: show what would be archived"
-        echo "  --execute            Archive idle models (>$MAX_IDLE_DAYS days)"
+        echo "  --execute            Archive idle models (default: $MAX_IDLE_DAYS days)"
+        echo "  --max-idle-days N    Override the archive age threshold (may precede --execute)"
         echo "  --restore <name>     Restore model from cold storage"
         echo "  --restore-all        Restore all archived models"
         echo "  --status             Show current hot/cold status"
-        ;;
-    *)
-        do_archive true
         ;;
 esac

--- a/ods/tests/test-llm-cold-storage-retention.sh
+++ b/ods/tests/test-llm-cold-storage-retention.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Public CLI coverage for configurable cold-storage retention.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/llm-cold-storage.sh"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+contains() {
+    local label="$1" needle="$2" haystack="$3"
+    [[ "$haystack" == *"$needle"* ]] && pass "$label" || fail "$label" "missing $needle"
+}
+
+HF_CACHE="$WORKDIR/cache"
+COLD_DIR="$WORKDIR/cold"
+LOG_FILE="$WORKDIR/logs/cold-storage.log"
+mkdir -p "$HF_CACHE/models--Fixture--Unused" "$COLD_DIR"
+
+run_script() {
+    HF_CACHE="$HF_CACHE" COLD_DIR="$COLD_DIR" LOG_FILE="$LOG_FILE" \
+        bash "$SCRIPT" "$@" 2>&1
+}
+
+OUT="$(run_script --max-idle-days 10000)"
+contains "custom threshold keeps younger candidates" "SKIP (recent, 9999d)" "$OUT"
+
+OUT="$(run_script --max-idle-days 9000)"
+contains "custom threshold selects older candidates" "WOULD ARCHIVE: models--Fixture--Unused" "$OUT"
+if [[ -d "$HF_CACHE/models--Fixture--Unused" && ! -L "$HF_CACHE/models--Fixture--Unused" ]]; then
+    pass "dry run leaves the model in hot storage"
+else
+    fail "dry run leaves the model in hot storage" "model moved"
+fi
+
+run_script --max-idle-days nope >/dev/null
+RC=$?
+[[ "$RC" -eq 2 ]] && pass "invalid threshold exits 2" || fail "invalid threshold exits 2" "got $RC"
+
+OUT="$(run_script --help)"
+contains "help documents retention override" "--max-idle-days N" "$OUT"
+
+echo "Passed: $PASS  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- add repeatable-order CLI parsing for `--max-idle-days N`
- support the retention override for dry-run and execute scans
- retain `MAX_IDLE_DAYS` as an environment-level deployment default
- reject unknown arguments and non-integer thresholds with usage exit code 2
- exercise selection and non-mutation at the script boundary

## Why this matters
The production cold-storage script previously hard-coded every installation to seven days. Operators with scarce NVMe or slower backup media can now choose an explicit retention policy and preview the exact candidates before executing an archive.

## Overlap check
Searched open/closed PR titles for `cold storage max idle days` and bodies referencing `ods/scripts/llm-cold-storage.sh`. PR #2365 repairs archive-path behavior but does not make retention configurable. This scope changes CLI policy selection and its public dry-run boundary, independently of that path fix.

## Test plan
- [x] `bash ods/tests/test-llm-cold-storage-retention.sh` (5 assertions)
- [x] `bash -n ods/scripts/llm-cold-storage.sh`
- [x] `bash -n ods/tests/test-llm-cold-storage-retention.sh`
- [x] `git diff --check`

Generated with Codex