### PR TITLE
feat(demo): add service-only health snapshot

### DIFF
--- a/ods/scripts/first-boot-demo.sh
+++ b/ods/scripts/first-boot-demo.sh
@@ -2,7 +2,7 @@
 # ODS First Boot Demo
 # Shows off what your local AI stack can do in under 2 minutes
 #
-# Usage: ./first-boot-demo.sh [--all] [--quick]
+# Usage: ./first-boot-demo.sh [--all] [--quick] [--health-only]
 # Mission: M5 (Clonable ODS Setup Server)
 
 set -euo pipefail
@@ -43,15 +43,18 @@ DEMO_MODEL="${LLM_MODEL:-Qwen/Qwen2.5-32B-Instruct-AWQ}"
 
 QUICK_MODE=false
 ALL_MODE=false
+HEALTH_ONLY=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --quick) QUICK_MODE=true; shift ;;
         --all) ALL_MODE=true; shift ;;
+        --health-only) HEALTH_ONLY=true; QUICK_MODE=true; shift ;;
         -h|--help) 
-            echo "Usage: $0 [--quick] [--all]"
+            echo "Usage: $0 [--quick] [--all] [--health-only]"
             echo "  --quick  Skip slow demos, just show what's available"
             echo "  --all    Run all demos including voice (requires audio files)"
+            echo "  --health-only  Check service availability without running prompts"
             exit 0
             ;;
         *) shift ;;
@@ -59,7 +62,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Dependency check — jq is required for parsing API responses.
-if ! command -v jq >/dev/null 2>&1; then
+if [[ "$HEALTH_ONLY" != "true" ]] && ! command -v jq >/dev/null 2>&1; then
     echo "Error: 'jq' is required for first-boot-demo.sh but was not found in PATH."
     echo "Install it with:  sudo apt install jq   (Debian/Ubuntu)"
     echo "                  brew install jq        (macOS)"
@@ -186,6 +189,15 @@ fi
 
 echo ""
 echo -e "${BOLD}Services: ${SERVICES_OK}/${SERVICES_TOTAL} running${NC}"
+
+if [[ "$HEALTH_ONLY" == "true" ]]; then
+    if [[ "$LLM_AVAILABLE" == "true" && "$SERVICES_OK" -eq "$SERVICES_TOTAL" ]]; then
+        success "Core services are ready."
+        exit 0
+    fi
+    fail "One or more core services are unavailable."
+    exit 1
+fi
 
 if [[ "$LLM_AVAILABLE" != "true" ]]; then
     echo -e "\n${RED}LLM (llama-server) is required for demos. Is it still loading?${NC}"

--- a/ods/tests/test-first-boot-demo-health-only.sh
+++ b/ods/tests/test-first-boot-demo-health-only.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Public CLI coverage for the non-interactive first-boot health snapshot.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/first-boot-demo.sh"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+mkdir -p "$WORKDIR/bin" "$WORKDIR/root/scripts"
+cp "$SCRIPT" "$WORKDIR/root/scripts/first-boot-demo.sh"
+SCRIPT="$WORKDIR/root/scripts/first-boot-demo.sh"
+
+cat > "$WORKDIR/bin/clear" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$WORKDIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CURL_LOG"
+case "$*" in
+  *http://llm.test/health*|*http://webui.test/*) exit 0 ;;
+  *) exit 22 ;;
+esac
+EOF
+chmod +x "$WORKDIR/bin/clear" "$WORKDIR/bin/curl"
+cat > "$WORKDIR/bin/jq" <<'EOF'
+#!/usr/bin/env bash
+echo called >> "$JQ_LOG"
+exit 99
+EOF
+chmod +x "$WORKDIR/bin/jq"
+
+export CURL_LOG="$WORKDIR/curl.log"
+export JQ_LOG="$WORKDIR/jq.log"
+OUT="$(
+    PATH="$WORKDIR/bin:/usr/bin:/bin" \
+    LLM_URL="http://llm.test" WEBUI_URL="http://webui.test" \
+    WHISPER_URL="http://whisper.test" PIPER_URL="http://tts.test" \
+    N8N_URL="http://n8n.test" \
+        bash "$SCRIPT" --health-only 2>&1
+)"
+RC=$?
+
+[[ "$RC" -eq 0 ]] || { echo "[FAIL] health-only exit: $RC"; exit 1; }
+[[ "$OUT" == *"Core services are ready"* ]] || { echo "[FAIL] readiness summary missing"; exit 1; }
+if grep -q '/v1/chat/completions' "$CURL_LOG"; then
+    echo "[FAIL] health-only sent a model prompt"
+    exit 1
+fi
+if [[ -e "$JQ_LOG" ]]; then
+    echo "[FAIL] health-only invoked jq"
+    exit 1
+fi
+
+echo "[PASS] health-only checks services without jq, prompts, or interaction"


### PR DESCRIPTION
## Summary
- add `--health-only` to the first-boot demo
- probe core and optional service availability without sending model prompts or pausing for input
- return nonzero when a core service is unavailable
- skip the jq dependency entirely for the health-only path
- cover the CLI with isolated curl/clear/jq shims

## Why this matters
Installers and operators often need to verify that the freshly started stack is ready without consuming inference time or entering an interactive showcase. The new mode turns the production first-boot script into a quick, non-interactive readiness snapshot while retaining meaningful exit status.

## Overlap check
Searched open/closed PR titles for `first boot demo service filter` and bodies referencing `ods/scripts/first-boot-demo.sh`. Only merged jq/strict/model fixes were found; no open PR adds a non-interactive health-only boundary.

## Test plan
- [x] `bash ods/tests/test-first-boot-demo-health-only.sh`
- [x] `bash -n ods/scripts/first-boot-demo.sh`
- [x] `bash -n ods/tests/test-first-boot-demo-health-only.sh`
- [x] `git diff --check`

Generated with Codex