### PR TITLE
feat(compose): emit structured resolution plans

### DIFF
--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -6,6 +6,7 @@ TIER="1"
 GPU_BACKEND="nvidia"
 PROFILE_OVERLAYS=""
 ENV_MODE="false"
+JSON_MODE="false"
 SKIP_BROKEN="false"
 GPU_COUNT="1"
 ODS_MODE="${ODS_MODE:-local}"
@@ -35,6 +36,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --env)
             ENV_MODE="true"
+            shift
+            ;;
+        --json)
+            JSON_MODE="true"
             shift
             ;;
         --gpu-count)
@@ -73,7 +78,7 @@ if ! "$PYTHON_CMD" -c 'import yaml' >/dev/null 2>&1; then
     exit 2
 fi
 
-"$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" "$ODS_MODE" "$SKIP_GPU_OVERLAYS" <<'PY'
+"$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" "$ODS_MODE" "$SKIP_GPU_OVERLAYS" "$JSON_MODE" <<'PY'
 import os
 import pathlib
 import platform
@@ -93,6 +98,7 @@ skip_gpu_overlays = {
     for x in (sys.argv[9] or os.environ.get("ODS_SKIP_GPU_OVERLAYS", "")).split(",")
     if x.strip()
 }
+json_mode = (sys.argv[10] or "false").lower() == "true"
 lemonade_external = (
     os.environ.get("LEMONADE_EXTERNAL", "").lower() in {"1", "true", "yes", "on"}
     or (
@@ -760,7 +766,17 @@ def to_flags(files):
 
 resolved_flags = to_flags(resolved)
 
-if env_mode:
+if json_mode:
+    print(json.dumps({
+        "primary_file": primary,
+        "files": resolved,
+        "flags": resolved_flags,
+        "tier": tier,
+        "gpu_backend": gpu_backend,
+        "gpu_count": gpu_count,
+        "ods_mode": ods_mode,
+    }, separators=(",", ":")))
+elif env_mode:
     def out(key, value):
         safe = str(value).replace("\\", "\\\\").replace('"', '\\"')
         print(f'{key}="{safe}"')

--- a/ods/tests/test-resolve-compose-json.sh
+++ b/ods/tests/test-resolve-compose-json.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Public CLI coverage for structured compose resolution plans.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORT="$(mktemp)"
+trap 'rm -f "$REPORT"' EXIT
+
+bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$ROOT_DIR" \
+    --tier 1 \
+    --gpu-backend nvidia \
+    --gpu-count 1 \
+    --ods-mode local \
+    --json > "$REPORT"
+
+python3 - "$REPORT" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    report = json.load(handle)
+
+assert report["primary_file"] == "docker-compose.nvidia.yml"
+assert report["files"][:2] == ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
+assert report["tier"] == "1"
+assert report["gpu_backend"] == "nvidia"
+assert report["gpu_count"] == 1
+assert report["ods_mode"] == "local"
+assert report["flags"] == " ".join(f"-f {path}" for path in report["files"])
+PY
+
+echo "[PASS] compose resolver emits a self-consistent JSON plan"


### PR DESCRIPTION
## Summary
- add `--json` to the production compose-stack resolver
- expose primary file, ordered layers, exact flags, tier, backend, GPU count, and ODS mode
- preserve the existing shell-flags and `--env` contracts unchanged
- verify that the JSON file order and reconstructed flags are self-consistent

## Why this matters
Installers, support tooling, and automation currently parse a shell fragment to understand the resolved Compose stack. The JSON plan provides the same authoritative resolution with ordered layer metadata, avoiding shell parsing and making backend/mode decisions auditable.

## Overlap check
Searched open/closed PR titles for `resolve compose stack json` and bodies referencing `ods/scripts/resolve-compose-stack.sh`. PR #2287 changes script-root selection and #2494 changes GPU overlay selection; neither provides structured output. This PR only adds an output mode after resolution and does not alter selection logic.

## Test plan
- [x] `bash ods/tests/test-resolve-compose-json.sh`
- [x] `bash -n ods/scripts/resolve-compose-stack.sh`
- [x] `bash -n ods/tests/test-resolve-compose-json.sh`
- [x] `git diff --check`

Generated with Codex