### PR TITLE
feat(models): expose legacy inventory as JSON

### DIFF
--- a/ods/scripts/upgrade-model.sh
+++ b/ods/scripts/upgrade-model.sh
@@ -269,16 +269,41 @@ start_llm() {
 #-----------------------------------------------------------------------------
 
 cmd_list() {
+    local json_output="${1:-false}"
+    local current
+    current=$(get_current_model)
+
+    if [[ "$json_output" == "true" ]]; then
+        local models='[]'
+        if [[ -d "$MODELS_DIR" ]]; then
+            for model_dir in "$MODELS_DIR"/*/; do
+                [[ -f "${model_dir}config.json" ]] || continue
+                local model_name size active
+                model_name=$(basename "$model_dir")
+                size=$(du -sh "$model_dir" 2>/dev/null | cut -f1)
+                active=false
+                [[ "$model_name" == "$current" ]] && active=true
+                models=$(jq -c \
+                    --arg name "$model_name" \
+                    --arg size "$size" \
+                    --argjson active "$active" \
+                    '. + [{name: $name, size: $size, active: $active}]' <<< "$models")
+            done
+        fi
+        jq -cn --arg current "$current" --argjson models "$models" \
+            '{current: (if $current == "" then null else $current end), models: $models}'
+        return 0
+    fi
+
     echo -e "${CYAN}Available Models:${NC}"
     echo ""
     
     if [[ -d "$MODELS_DIR" ]]; then
         for model_dir in "$MODELS_DIR"/*/; do
             if [[ -f "${model_dir}config.json" ]]; then
-                local model_name size current
+                local model_name size
                 model_name=$(basename "$model_dir")
                 size=$(du -sh "$model_dir" 2>/dev/null | cut -f1)
-                current=$(get_current_model)
                 
                 if [[ "$model_name" == "$current" ]]; then
                     echo -e "  ${GREEN}● $model_name${NC} ($size) [ACTIVE]"
@@ -423,7 +448,11 @@ cmd_rollback() {
 main() {
     case "${1:-}" in
         --list|-l)
-            cmd_list
+            if [[ -n "${2:-}" && "${2:-}" != "--json" ]]; then
+                error "Unknown list option: $2"
+                exit 1
+            fi
+            cmd_list "$( [[ "${2:-}" == "--json" ]] && echo true || echo false )"
             ;;
         --current|-c)
             cmd_current
@@ -437,7 +466,7 @@ ODS Model Upgrade
 
 Usage:
   $0 <model-name>        Upgrade to specified model
-  $0 --list              List available models
+  $0 --list [--json]     List available models
   $0 --current           Show current model
   $0 --rollback          Rollback to previous model
   $0 --help              Show this help

--- a/ods/tests/test-upgrade-model-list-json.sh
+++ b/ods/tests/test-upgrade-model-list-json.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Public CLI coverage for legacy model inventory JSON.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+mkdir -p "$WORKDIR/models/alpha" "$WORKDIR/models/beta"
+printf '{}\n' > "$WORKDIR/models/alpha/config.json"
+printf '{}\n' > "$WORKDIR/models/beta/config.json"
+printf '{"current":"beta","previous":"alpha"}\n' > "$WORKDIR/model-state.json"
+
+REPORT="$WORKDIR/report.json"
+ODS_DIR="$WORKDIR" MODELS_DIR="$WORKDIR/models" \
+    bash "$ROOT_DIR/scripts/upgrade-model.sh" --list --json > "$REPORT"
+
+jq -e '
+    .current == "beta" and
+    (.models | length) == 2 and
+    (.models | map(.name)) == ["alpha", "beta"] and
+    (.models | map(select(.active) | .name)) == ["beta"] and
+    (.models | all(.size | type == "string" and length > 0))
+' "$REPORT" >/dev/null
+
+echo "[PASS] model inventory JSON identifies every model and the active selection"


### PR DESCRIPTION
## Summary
- add `--list --json` to the legacy model-directory upgrade helper
- emit the current model plus sorted inventory entries with name, disk size, and active state
- represent an unset current model as JSON null
- preserve the existing human inventory unchanged
- validate the public CLI against a two-model fixture

## Why this matters
Older ODS installations still use this production helper for directory-based model upgrades. Automation and migration tooling can now inspect available and active models without scraping colored table output before deciding whether to invoke an upgrade.

## Overlap check
Searched open/closed PR titles for `upgrade model json list` and bodies referencing `ods/scripts/upgrade-model.sh`. PRs #2613, #2404, and #2266 change compose/state/env mutation paths; none changes the read-only inventory command. This PR is isolated to `cmd_list` and its CLI option.

## Test plan
- [x] `bash ods/tests/test-upgrade-model-list-json.sh`
- [x] `bash -n ods/scripts/upgrade-model.sh`
- [x] `bash -n ods/tests/test-upgrade-model-list-json.sh`
- [x] `git diff --check`

Generated with Codex