### PR TITLE
feat(offline): select pre-download components

### DIFF
--- a/ods/scripts/pre-download.sh
+++ b/ods/scripts/pre-download.sh
@@ -261,22 +261,39 @@ verify_cache() {
     echo "Found: $found cached | Missing: $missing required"
 }
 
+has_component() {
+    local components=",$1," component="$2"
+    [[ "$components" == *",$component,"* ]]
+}
+
 download_tier() {
     local tier="$1"
-    local include_voice="${2:-false}"
+    local components="${2:-llm}"
+    local plan_only="${3:-false}"
     
-    if [[ -z "${TIER_MODELS[$tier]:-}" ]]; then
+    if has_component "$components" llm && [[ -z "${TIER_MODELS[$tier]:-}" ]]; then
         error "Unknown tier: $tier"
         echo "Available tiers: nano, edge, pro, cluster"
         exit 1
     fi
     
-    local model="${TIER_MODELS[$tier]}"
-    local size="${MODEL_SIZES_GB[$tier]}"
+    local model=""
+    local size="0"
+    if has_component "$components" llm; then
+        model="${TIER_MODELS[$tier]}"
+        size="${MODEL_SIZES_GB[$tier]}"
+    fi
     
-    echo -e "\n${BOLD}Downloading ${tier} tier models${NC}"
-    echo -e "LLM: $model (~${size}GB)"
+    echo -e "\n${BOLD}Selected offline artifacts${NC}"
+    has_component "$components" llm && echo -e "LLM ($tier): $model (~${size}GB)"
+    has_component "$components" stt && echo -e "STT: $STT_MODEL (~3GB)"
+    has_component "$components" tts && echo -e "TTS: $TTS_MODEL (~0.2GB)"
     echo ""
+
+    if [[ "$plan_only" == "true" ]]; then
+        success "Download plan ready; no network requests were made."
+        return 0
+    fi
     
     # Estimate time
     local est_minutes
@@ -292,12 +309,14 @@ download_tier() {
     fi
     
     # Download LLM
-    download_model "$model" "LLM ($tier tier)" || exit 1
+    if has_component "$components" llm; then
+        download_model "$model" "LLM ($tier tier)" || exit 1
+    fi
     
-    # Download voice components if requested
-    if [[ "$include_voice" == "true" ]]; then
-        echo ""
+    if has_component "$components" stt; then
         download_model "$STT_MODEL" "STT (Whisper)" || warn "STT download failed (optional)"
+    fi
+    if has_component "$components" tts; then
         download_model "$TTS_MODEL" "TTS (Kokoro)" || warn "TTS download failed (optional)"
     fi
     
@@ -337,7 +356,9 @@ interactive_menu() {
     local include_voice="false"
     [[ $voice_choice =~ ^[Yy]$ ]] && include_voice="true"
     
-    download_tier "$tier_choice" "$include_voice"
+    local components="llm"
+    [[ "$include_voice" == "true" ]] && components="llm,stt,tts"
+    download_tier "$tier_choice" "$components" false
 }
 
 #=============================================================================
@@ -353,6 +374,8 @@ Usage: $0 [options]
 Options:
   --tier TIER      Download models for specific tier (nano/edge/pro/cluster)
   --with-voice     Also download STT and TTS models
+  --component NAME Download only a selected component: llm, stt, or tts (repeatable)
+  --plan           Print the selected artifacts without installing dependencies or downloading
   --list           List available models and sizes
   --verify         Check which models are already cached
   --help           Show this help message
@@ -361,6 +384,7 @@ Examples:
   $0                      # Interactive mode (auto-detect tier)
   $0 --tier pro           # Download pro tier models
   $0 --tier edge --with-voice  # Download edge tier + voice models
+  $0 --component stt --component tts --plan  # Preview a voice-only cache plan
   $0 --verify             # Check cache status
 EOF
 }
@@ -368,6 +392,8 @@ EOF
 main() {
     local tier=""
     local include_voice="false"
+    local components=""
+    local plan_only="false"
     local action="interactive"
     
     while [[ $# -gt 0 ]]; do
@@ -379,6 +405,20 @@ main() {
                 ;;
             --with-voice)
                 include_voice="true"
+                shift
+                ;;
+            --component)
+                case "${2:-}" in
+                    llm|stt|tts) ;;
+                    *) error "--component must be one of: llm, stt, tts"; exit 1 ;;
+                esac
+                components="${components:+$components,}$2"
+                action="download"
+                shift 2
+                ;;
+            --plan)
+                plan_only="true"
+                action="download"
                 shift
                 ;;
             --list)
@@ -407,8 +447,16 @@ main() {
             ;;
         download)
             print_banner
-            check_dependencies
-            download_tier "$tier" "$include_voice"
+            if [[ "$include_voice" == "true" && -n "$components" ]]; then
+                error "--with-voice cannot be combined with --component"
+                exit 1
+            fi
+            if [[ -z "$components" ]]; then
+                components="llm"
+                [[ "$include_voice" == "true" ]] && components="llm,stt,tts"
+            fi
+            [[ "$plan_only" == "true" ]] || check_dependencies
+            download_tier "$tier" "$components" "$plan_only"
             ;;
         list)
             print_banner

--- a/ods/tests/test-pre-download-components.sh
+++ b/ods/tests/test-pre-download-components.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Public CLI coverage for selective offline-cache plans.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/pre-download.sh"
+
+OUT="$(bash "$SCRIPT" --component stt --component tts --plan)"
+[[ "$OUT" == *"STT: Systran/faster-whisper-large-v3"* ]]
+[[ "$OUT" == *"TTS: hexgrad/Kokoro-82M"* ]]
+[[ "$OUT" != *"LLM ("* ]]
+[[ "$OUT" == *"no network requests were made"* ]]
+
+OUT="$(bash "$SCRIPT" --tier edge --component llm --plan)"
+[[ "$OUT" == *"LLM (edge): Qwen/Qwen2.5-7B-Instruct"* ]]
+[[ "$OUT" != *"STT:"* ]]
+
+if bash "$SCRIPT" --component llm --plan >/dev/null 2>&1; then
+    echo "[FAIL] LLM component accepted without a tier"
+    exit 1
+fi
+if bash "$SCRIPT" --component video --plan >/dev/null 2>&1; then
+    echo "[FAIL] unknown component accepted"
+    exit 1
+fi
+
+echo "[PASS] pre-download plans target only the requested offline components"


### PR DESCRIPTION
## Summary
- add repeatable `--component llm|stt|tts` selection to the offline pre-download tool
- support voice-only cache preparation without requiring an LLM tier
- add `--plan` to inspect exact repositories without dependency installation or network access
- keep `--with-voice` backward compatible and reject ambiguous mixed selection
- cover targeted LLM, voice-only, missing-tier, and invalid-component boundaries

## Why this matters
Offline and metered installations may need only speech assets, only an LLM, or a staged subset. Operators can now download exactly the required cache components and inspect the plan before any pip install or Hugging Face request, reducing bandwidth and storage use.

## Overlap check
Searched open/closed PR titles for `pre download component selection` and bodies referencing `ods/scripts/pre-download.sh`. No open PR changes component selection or adds a network-free plan; unrelated resolver references do not touch this behavior.

## Test plan
- [x] `bash ods/tests/test-pre-download-components.sh`
- [x] `bash -n ods/scripts/pre-download.sh`
- [x] `bash -n ods/tests/test-pre-download-components.sh`
- [x] `git diff --check`

Generated with Codex