### PR TITLE
feat(context): emit installation snapshots as JSON

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -377,6 +377,28 @@ def build_compact_soul(env_path: Path) -> str:
     ])
 
 
+def build_context_snapshot(env_path: Path) -> dict[str, object]:
+    """Return the detected install facts without the persona prose wrapper."""
+    env = _read_env(env_path)
+    repo_root = env_path.resolve().parent
+    running = sorted(_running_services(repo_root))
+    device = env.get("ODS_DEVICE_NAME") or socket.gethostname() or "this machine"
+    model = _loaded_model() or env.get("LLM_MODEL") or env.get("GGUF_FILE")
+    context = env.get("CTX_SIZE") or env.get("MAX_CONTEXT")
+    return {
+        "host": device,
+        "gpu_backend": _humanize_gpu(env),
+        "model": model,
+        "context_size": int(context) if context and context.isdigit() else None,
+        "services": running,
+        "urls": {
+            "dashboard": f"http://{device}.local",
+            "talk": f"http://talk.{device}.local",
+            "chat": f"http://chat.{device}.local",
+        },
+    }
+
+
 def build_soul(
     template_path: Path,
     env_path: Path,
@@ -461,13 +483,25 @@ def main(argv: list[str] | None = None) -> int:
         default="full",
         help="Prompt profile to render. local-lemonade keeps Windows AMD prompts compact.",
     )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format for --check (default: markdown).",
+    )
     args = parser.parse_args(argv)
 
     if args.check:
-        ctx = build_compact_soul(args.env) if args.profile == "local-lemonade" else build_context_block(args.env)
-        sys.stdout.write(ctx)
-        sys.stdout.write("\n")
+        if args.format == "json":
+            print(json.dumps(build_context_snapshot(args.env), separators=(",", ":")))
+        else:
+            ctx = build_compact_soul(args.env) if args.profile == "local-lemonade" else build_context_block(args.env)
+            sys.stdout.write(ctx)
+            sys.stdout.write("\n")
         return 0
+
+    if args.format != "markdown":
+        parser.error("--format json requires --check")
 
     if not args.template.exists():
         print(f"ERROR: template not found at {args.template}", file=sys.stderr)

--- a/ods/tests/test_installation_context_json.py
+++ b/ods/tests/test_installation_context_json.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "build-installation-context.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("build_installation_context", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_json_reports_detected_install_facts(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_module()
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "ODS_DEVICE_NAME=lab-node\n"
+        "GPU_BACKEND=nvidia\n"
+        "LLM_MODEL=catalog/fallback\n"
+        "CTX_SIZE=32768\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "_running_services", lambda _root: {"n8n", "comfyui"})
+    monkeypatch.setattr(module, "_loaded_model", lambda: "runtime/model")
+
+    result = module.main(["--env", str(env_path), "--check", "--format", "json"])
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "host": "lab-node",
+        "gpu_backend": "NVIDIA GPU (CUDA via llama.cpp)",
+        "model": "runtime/model",
+        "context_size": 32768,
+        "services": ["comfyui", "n8n"],
+        "urls": {
+            "dashboard": "http://lab-node.local",
+            "talk": "http://talk.lab-node.local",
+            "chat": "http://chat.lab-node.local",
+        },
+    }


### PR DESCRIPTION
## Summary
- add `--check --format json` to the installation-context builder
- expose detected host, GPU/backend, live model, numeric context size, running services, and local URLs
- keep the existing Markdown/full/compact persona formats unchanged
- reject JSON format on the file-writing path to keep output semantics explicit
- test the CLI parser/output with deterministic runtime probes

## Why this matters
The installer already gathers an authoritative snapshot of the running ODS environment for Hermes. Support tools and dashboards can now consume those same facts directly without parsing persona Markdown or duplicating Docker/model detection.

## Overlap check
Searched open/closed PR titles for structured installation context and bodies referencing `ods/scripts/build-installation-context.py`. PRs #2218 and #2436 change atomic SOUL file writes; this PR only adds the read-only `--check` JSON boundary and does not touch write/replace behavior.

## Test plan
- [x] `python -m pytest -q ods/tests/test_installation_context_json.py`
- [x] `python -m py_compile ods/scripts/build-installation-context.py`
- [x] `git diff --check`

Generated with Codex