### PR TITLE
fix(dashboard-api): handle UnicodeDecodeError in ClusterStatus.refresh in agent_monitor.py

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -74,7 +74,7 @@ class ClusterStatus:
             logger.debug("Cluster proxy health check timed out after 5s")
         except OSError as e:
             logger.debug("Cluster proxy connection failed: %s", e)
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
             logger.warning("Cluster proxy returned invalid JSON: %s", e)
 
     def to_dict(self) -> dict:


### PR DESCRIPTION
### Issue Context

When querying status metrics from the cluster proxy, `ClusterStatus.refresh()` in `agent_monitor.py` decodes process stdout via `stdout.decode()`. If non-UTF-8 payload bytes or malformed content are received from proxy responses, a `UnicodeDecodeError` or `ValueError` could escape the exception handler block.

### Code Modifications

Expanded the exception handling tuple in `ClusterStatus.refresh()` to catch `UnicodeDecodeError` and `ValueError` alongside `json.JSONDecodeError`.

### Testing & Verification

Checked Python compilation cleanly using `python3 -m py_compile ods/extensions/services/dashboard-api/agent_monitor.py`. Formatting verified via `git diff --check`.