### PR TITLE
fix(installer): write setup-complete.json atomically in 13-summary.sh

### DIFF
--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -56,12 +56,18 @@ if ! $DRY_RUN; then
     _setup_config_dir="${INSTALL_DIR}/data/config"
     _setup_complete_file="${_setup_config_dir}/setup-complete.json"
     _completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    if mkdir -p "${_setup_config_dir}" 2>/dev/null \
-        && printf '{"completed_at": "%s", "version": "1.0.0"}\n' "${_completed_at}" > "${_setup_complete_file}" 2>/dev/null \
-        && chmod 644 "${_setup_complete_file}" 2>/dev/null; then
-        log "Setup wizard pre-marked complete at ${_setup_complete_file}"
-    else
-        ai_warn "Could not write ${_setup_complete_file} (non-fatal)"
+    if mkdir -p "${_setup_config_dir}" 2>/dev/null; then
+        _tmp_setup_complete=$(mktemp "${_setup_config_dir}/setup-complete.XXXXXX.tmp" 2>/dev/null || echo "")
+        if [[ -n "${_tmp_setup_complete}" ]]; then
+            if printf '{"completed_at": "%s", "version": "1.0.0"}\n' "${_completed_at}" > "${_tmp_setup_complete}" \
+                && chmod 644 "${_tmp_setup_complete}" \
+                && mv -f "${_tmp_setup_complete}" "${_setup_complete_file}" 2>/dev/null; then
+                log "Setup wizard pre-marked complete at ${_setup_complete_file}"
+            else
+                rm -f "${_tmp_setup_complete}"
+                ai_warn "Could not write ${_setup_complete_file} (non-fatal)"
+            fi
+        fi
     fi
 fi
 


### PR DESCRIPTION
### Issue Context

During phase 13 of installation (`13-summary.sh`), setup completion state is saved using direct output redirection (`printf ... > ${_setup_complete_file}`). If process execution is interrupted by a system termination signal or disk error during installer cleanup, `setup-complete.json` can be left zero-byte truncated or partially populated.

### Code Modifications

Updated `13-summary.sh` to write completion JSON data to a temporary file created via `mktemp` inside `_setup_config_dir` and atomically swap it into place using `mv -f`.

### Testing & Verification

Syntax validated cleanly using `bash -n ods/installers/phases/13-summary.sh`. Workspace formatting verified via `git diff --check`.