### PR TITLE
fix(healthcheck): improve status range parsing error diagnostics in healthcheck.py

### DIFF
--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -122,20 +122,23 @@ def _parse_host_port(raw: str) -> Tuple[str, int]:
 def _parse_expected_status(expr: str) -> Set[int]:
     """Parse '200,204,3xx,401-403' => allowed status codes set."""
     allowed: Set[int] = set()
-    for part in (p.strip() for p in expr.split(",") if p.strip()):
-        if part.endswith("xx") and len(part) == 3 and part[0].isdigit():
-            base = int(part[0]) * 100
-            allowed.update(range(base, base + 100))
-            continue
-        if "-" in part:
-            lo_s, hi_s = (x.strip() for x in part.split("-", 1))
-            lo = int(lo_s)
-            hi = int(hi_s)
-            if lo > hi:
-                lo, hi = hi, lo
-            allowed.update(range(lo, hi + 1))
-            continue
-        allowed.add(int(part))
+    try:
+        for part in (p.strip() for p in expr.split(",") if p.strip()):
+            if part.endswith("xx") and len(part) == 3 and part[0].isdigit():
+                base = int(part[0]) * 100
+                allowed.update(range(base, base + 100))
+                continue
+            if "-" in part:
+                lo_s, hi_s = (x.strip() for x in part.split("-", 1))
+                lo = int(lo_s)
+                hi = int(hi_s)
+                if lo > hi:
+                    lo, hi = hi, lo
+                allowed.update(range(lo, hi + 1))
+                continue
+            allowed.add(int(part))
+    except ValueError as exc:
+        raise ValueError(f"invalid status code specification '{expr}': {exc}") from exc
 
     if not allowed:
         raise ValueError("--expect-status produced empty set")


### PR DESCRIPTION
### Issue Context

In `ods/scripts/healthcheck.py`, `_parse_expected_status()` parses status code specifications like `200,204,3xx,401-403` using `int()`. If invalid status strings or range bounds are passed via `--expect-status` (such as `200-abc`), Python raises an uncaught `ValueError` with standard traceback rather than structured CLI usage context.

### Code Modifications

Wrapped integer parsing within `_parse_expected_status()` in a `try...except ValueError` block that re-raises a clear, contextual `ValueError(f"invalid status code specification '{expr}': {exc}")`.

### Testing & Verification

Verified syntax with `python3 -m py_compile ods/scripts/healthcheck.py`. `git diff --check` passed cleanly.