### PR TITLE
fix(uninstall): prime sudo credentials before the first timeout-wrapped call

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -286,6 +286,15 @@ unset _ods_uninstall_orphan_pids _pid
 # Remove system-mode ods-host-agent unit (migrated from --user mode).
 # Idempotent — no-op if the unit was never installed (e.g. older user-mode installs).
 if systemctl is-enabled ods-host-agent.service >/dev/null 2>&1; then
+    # Prime the sudo credential cache with a clean, unwrapped prompt before
+    # any timeout-wrapped sudo call below. If `timeout` signals sudo while
+    # it's still mid-password-entry (slow typing, or a long-running
+    # systemctl call eating into the budget), sudo can be killed before it
+    # restores the terminal's echo setting — leaving the next keystroke's
+    # input, including a retried password, visible in plaintext.
+    if command -v sudo >/dev/null 2>&1; then
+        sudo -v || log_warn "sudo authentication failed; systemd cleanup below may be skipped"
+    fi
     if ! timeout 20s sudo systemctl disable --now ods-host-agent.service 2>/dev/null; then
         log_warn "ods-host-agent did not stop cleanly; forcing service shutdown"
         sudo systemctl kill -s SIGKILL ods-host-agent.service 2>/dev/null || true

--- a/ods/tests/test-linux-host-agent-stop.sh
+++ b/ods/tests/test-linux-host-agent-stop.sh
@@ -27,6 +27,19 @@ grep -q 'systemctl kill -s SIGKILL ods-host-agent.service' "$UNINSTALL" \
   || fail "uninstall must force-kill a stuck host-agent service after bounded stop"
 pass "uninstall has bounded stop plus force-kill fallback"
 
+# Regression (#2623): a bare `timeout 20s sudo ...` as the FIRST sudo call
+# can have sudo signaled mid-password-entry, leaving the terminal's echo
+# setting uncleaned — the reported symptom was the sudo password appearing
+# in plaintext. `sudo -v` must prime the credential cache in an unwrapped
+# call before any timeout-wrapped sudo invocation.
+sudo_v_line="$(grep -n '^\s*sudo -v' "$UNINSTALL" | head -1 | cut -d: -f1 || true)"
+first_timeout_sudo_line="$(grep -n 'timeout 20s sudo systemctl disable --now ods-host-agent.service' "$UNINSTALL" | head -1 | cut -d: -f1 || true)"
+[[ -n "$sudo_v_line" ]] \
+  || fail "uninstall must prime sudo credentials with 'sudo -v' before timeout-wrapped sudo calls"
+[[ -n "$first_timeout_sudo_line" && "$sudo_v_line" -lt "$first_timeout_sudo_line" ]] \
+  || fail "'sudo -v' priming must run before the first timeout-wrapped sudo call"
+pass "sudo credentials are primed before any timeout-wrapped sudo call"
+
 grep -q 'def _request_server_shutdown' "$AGENT" \
   || fail "host-agent must expose async-safe shutdown helper"
 grep -q 'target=server.shutdown' "$AGENT" \

--- a/ods/tests/test-uninstall-sudo-priming.sh
+++ b/ods/tests/test-uninstall-sudo-priming.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Regression checks for sudo credential priming during uninstall (#2623).
+# Hermetic: stubs sudo/systemctl/docker/pgrep, fake HOME/INSTALL_DIR — no
+# real systemd mutation, runs on Linux CI.
+#
+# Background: ods-uninstall.sh's first sudo call was
+# `timeout 20s sudo systemctl disable --now ods-host-agent.service`. If
+# `timeout` signals sudo while it's still reading the password (slow
+# typing, or systemctl itself running long), sudo can be killed before it
+# restores the terminal's echo setting, and the reported symptom was the
+# sudo password appearing in plaintext. The fix primes the sudo credential
+# cache with a clean, unwrapped `sudo -v` before any timeout-wrapped call.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/ods-uninstall.sh"
+TMP_DIR=""
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+make_stub_bin() {
+    local stub_dir="$1"
+    local sudo_log="$2"
+    local sudo_v_exit="${3:-0}"
+
+    cat > "$stub_dir/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat > "$stub_dir/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    cat > "$stub_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+echo Linux
+EOF
+    cat > "$stub_dir/systemctl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "is-enabled" ]]; then
+    exit 0
+fi
+exit 0
+EOF
+    # Logs every invocation. `sudo -v` exits with SUDO_V_EXIT (simulating
+    # auth success/failure); every other sudo call succeeds.
+    cat > "$stub_dir/sudo" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${sudo_log}"
+if [[ "\${1:-}" == "-v" ]]; then
+    exit ${sudo_v_exit}
+fi
+exit 0
+EOF
+    chmod +x "$stub_dir"/*
+}
+
+make_install() {
+    local install_dir="$1"
+
+    mkdir -p "$install_dir/lib"
+    cp "$TARGET" "$install_dir/ods-uninstall.sh"
+    cp "$ROOT_DIR/lib/safe-env.sh" "$install_dir/lib/safe-env.sh"
+    touch "$install_dir/ods-cli"
+}
+
+run_uninstall() {
+    local install_dir="$1"
+    local home_dir="$2"
+    local stub_dir="$3"
+    local out_file="$4"
+
+    HOME="$home_dir" \
+    INSTALL_DIR="$install_dir" \
+    PATH="$stub_dir:$PATH" \
+        bash "$install_dir/ods-uninstall.sh" --force > "$out_file" 2>&1
+}
+
+main() {
+    [[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+    TMP_DIR="$(mktemp -d -t ods-uninstall-sudo-test-XXXXXX)"
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
+    # ── Scenario 1: sudo -v primes the cache before the first timeout-wrapped call ──
+    local install1="$TMP_DIR/install1" home1="$TMP_DIR/home1" stub1="$TMP_DIR/bin1"
+    make_install "$install1"
+    mkdir -p "$home1" "$stub1"
+    local sudo_log1="$TMP_DIR/sudo1.log"
+    : > "$sudo_log1"
+    make_stub_bin "$stub1" "$sudo_log1" 0
+    run_uninstall "$install1" "$home1" "$stub1" "$TMP_DIR/out1.log" \
+        || fail "uninstall must succeed when sudo authenticates cleanly"
+
+    first_call="$(head -1 "$sudo_log1")"
+    [[ "$first_call" == "-v" ]] \
+        || fail "the first sudo invocation must be 'sudo -v' (got: '$first_call')"
+    grep -qF "systemctl disable --now ods-host-agent.service" "$sudo_log1" \
+        || fail "uninstall must still call sudo systemctl disable --now after priming"
+    pass "sudo -v primes the credential cache before the first timeout-wrapped sudo call"
+
+    # ── Scenario 2: sudo -v failing (no auth) must not abort the uninstall ──
+    local install2="$TMP_DIR/install2" home2="$TMP_DIR/home2" stub2="$TMP_DIR/bin2"
+    make_install "$install2"
+    mkdir -p "$home2" "$stub2"
+    local sudo_log2="$TMP_DIR/sudo2.log"
+    : > "$sudo_log2"
+    make_stub_bin "$stub2" "$sudo_log2" 1
+    run_uninstall "$install2" "$home2" "$stub2" "$TMP_DIR/out2.log" \
+        || fail "a failed sudo -v must not abort the whole uninstall (set -euo pipefail trap)"
+    grep -qi "sudo authentication failed" "$TMP_DIR/out2.log" \
+        || fail "a failed sudo -v must produce a warning"
+    pass "a failed sudo -v warns and lets the uninstall continue"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

`ods-uninstall.sh`'s first `sudo` invocation is
`timeout 20s sudo systemctl disable --now ods-host-agent.service`, run
right after "Reaping any orphan host-managed processes..." — matching the
exact log sequence in the report. `timeout` wrapping a `sudo` call that may
need to prompt interactively is risky: `sudo` reads the password with
terminal echo disabled (via `tcsetattr`) and re-enables it afterward. If
`timeout` signals `sudo` while it's still mid-read (slow typing, or the
combined `systemctl` operation running long), `sudo` can be killed before
it gets to restore the terminal's echo setting — which matches the
reported symptom of the password appearing in plaintext right after the
`[sudo] password for ...:` prompt.

Fix: add a plain, unwrapped `sudo -v` immediately before that first
`timeout`-wrapped call. This is the standard pattern for this exact
problem — priming the sudo credential cache in a clean, uninterruptible
context, so the actual password prompt (if needed) can't be cut short, and
subsequent `sudo` calls in the script (including the `timeout`-wrapped
ones) reuse the cached ticket within its normal validity window instead of
re-prompting. Guarded with `|| log_warn ...` so a failed/declined
authentication doesn't abort the whole uninstall under `set -euo
pipefail` — it warns and lets cleanup continue.

## AI Assistance

Used an AI coding assistant to investigate and fix this. I want to be
upfront about a limitation: I don't have a way to reproduce the exact
terminal-echo corruption interactively in this environment (it requires a
real TTY + a slow/interrupted sudo prompt), so the root-cause mechanism
above is the most plausible explanation I could construct from reading the
code and the report's exact log sequence, not a live reproduction. What
*is* verified: the fix follows a well-established, documented pattern for
exactly this class of bug (priming sudo before any timeout/xargs/parallel
wrapper), and the two new tests confirm the priming call happens in the
right place and that a failed `sudo -v` doesn't break the uninstall.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer / bootstrap / lifecycle (uninstall path)

## Risk And Validation

- Risk level: Low (adds one extra `sudo -v` call on an already-privileged
  path; behavior is a no-op if sudo isn't installed, and a failure just
  warns instead of aborting)
- Validation run:
  - [x] Focused tests listed below
  - [ ] Not required because: n/a — I could not validate the actual
    terminal-echo behavior live (see AI Assistance note above); the tests
    below validate the fix's structure and safety, not the original
    symptom directly.

Commands/results:

```text
bash -n ods-uninstall.sh tests/test-linux-host-agent-stop.sh tests/test-uninstall-sudo-priming.sh
bash tests/test-linux-host-agent-stop.sh       # 4/4 OK, incl. new "sudo -v primed first" check
bash tests/test-uninstall-sudo-priming.sh      # 2/2 PASS (hermetic, stubs sudo/systemctl/docker)

# Confirmed both new checks fail against pre-fix ods-uninstall.sh
# (git show HEAD:...) and pass against the fix.
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above,
  with the caveat noted twice above: I could not reproduce the original
  terminal-echo symptom live in this environment.

## Notes For Reviewers

Given I couldn't reproduce the exact symptom, I'd appreciate it if someone
who can reproduce (or a maintainer familiar with the actual mechanism)
double-checks this actually resolves it before merge — happy to iterate if
the real cause turns out to be something else.
