### PR TITLE
fix(gpu): fail closed when LLAMA_SERVER_GPU_UUIDS is unset

### DIFF
--- a/ods/docker-compose.multigpu-nvidia.yml
+++ b/ods/docker-compose.multigpu-nvidia.yml
@@ -1,7 +1,12 @@
 services:
   llama-server:
     environment:
-      NVIDIA_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_UUIDS:-all}"
+      # This overlay is only merged in when gpu_count > 1 (see
+      # scripts/resolve-compose-stack.sh), so LLAMA_SERVER_GPU_UUIDS must
+      # already be set by the installer/gpu-reassign flow. Falling back to
+      # "all" here would silently hand llama-server every GPU on the host
+      # instead of the assigned subset — fail closed instead.
+      NVIDIA_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_UUIDS:?LLAMA_SERVER_GPU_UUIDS must be set when the multigpu-nvidia overlay is active}"
       LLAMA_ARG_SPLIT_MODE: "${LLAMA_ARG_SPLIT_MODE:-none}"
       LLAMA_ARG_TENSOR_SPLIT: "${LLAMA_ARG_TENSOR_SPLIT:-}"
     deploy:

--- a/ods/tests/test-multigpu-nvidia-gpu-isolation.sh
+++ b/ods/tests/test-multigpu-nvidia-gpu-isolation.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Regression (#2298): docker-compose.multigpu-nvidia.yml used to default
+# NVIDIA_VISIBLE_DEVICES to "all" when LLAMA_SERVER_GPU_UUIDS was unset
+# (manual compose runs, or the transient window during `ods gpu-reassign`
+# which explicitly unsets it) — silently handing llama-server every GPU on
+# the host instead of the assigned subset. This overlay is only merged in
+# when gpu_count > 1 (scripts/resolve-compose-stack.sh), so the var must
+# always be set whenever this file is actually part of the stack; failing
+# closed is correct, not overly strict.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}✓${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1"; exit 1; }
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    echo "  (skipped — docker compose not available)"
+    exit 0
+fi
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Minimal env satisfying every other required variable in the base stack,
+# so any failure below is unambiguously about LLAMA_SERVER_GPU_UUIDS.
+cat > "$TMPDIR_TEST/compose-test.env" << 'MINENV'
+LLM_MODEL=test
+GGUF_FILE=test.gguf
+MAX_CONTEXT=4096
+GPU_BACKEND=nvidia
+WEBUI_PORT=3000
+WEBUI_SECRET=test
+OLLAMA_PORT=11434
+WHISPER_PORT=9000
+TTS_PORT=8880
+N8N_PORT=5678
+QDRANT_PORT=6333
+QDRANT_GRPC_PORT=6334
+QDRANT_API_KEY=test
+LITELLM_PORT=4000
+LITELLM_KEY=test
+OPENCLAW_PORT=7860
+OPENCLAW_TOKEN=test
+SEARXNG_PORT=8888
+DASHBOARD_API_KEY=test
+LIVEKIT_API_KEY=test
+LIVEKIT_API_SECRET=test
+OPENCODE_SERVER_PASSWORD=test
+OPENCODE_PORT=3003
+N8N_USER=admin
+N8N_PASS=test
+N8N_HOST=localhost
+N8N_WEBHOOK_URL=http://localhost:5678
+WEBUI_AUTH=true
+ENABLE_WEB_SEARCH=true
+WEB_SEARCH_ENGINE=searxng
+WHISPER_MODEL=base
+TTS_VOICE=en_US-lessac-medium
+TIMEZONE=UTC
+ODS_MODE=local
+LLM_API_URL=http://llama-server:8080/v1
+CTX_SIZE=4096
+LANGFUSE_PORT=3006
+LANGFUSE_ENABLED=false
+LANGFUSE_NEXTAUTH_SECRET=test
+LANGFUSE_SALT=test
+LANGFUSE_ENCRYPTION_KEY=test
+LANGFUSE_DB_PASSWORD=test
+LANGFUSE_CLICKHOUSE_PASSWORD=test
+LANGFUSE_REDIS_PASSWORD=test
+LANGFUSE_MINIO_ACCESS_KEY=test
+LANGFUSE_MINIO_SECRET_KEY=test
+LANGFUSE_PROJECT_PUBLIC_KEY=test
+LANGFUSE_PROJECT_SECRET_KEY=test
+LANGFUSE_INIT_PROJECT_ID=test
+LANGFUSE_INIT_USER_EMAIL=test@test.com
+LANGFUSE_INIT_USER_PASSWORD=test
+MINENV
+
+COMPOSE_ARGS=(--env-file "$TMPDIR_TEST/compose-test.env" -f docker-compose.base.yml -f docker-compose.nvidia.yml -f docker-compose.multigpu-nvidia.yml)
+
+echo "── multigpu-nvidia GPU isolation ──"
+
+# Unset LLAMA_SERVER_GPU_UUIDS must fail closed, not default to "all".
+unset LLAMA_SERVER_GPU_UUIDS 2>/dev/null || true
+error_output="$(docker compose "${COMPOSE_ARGS[@]}" config --quiet 2>&1)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    fail "compose config succeeded with LLAMA_SERVER_GPU_UUIDS unset (should fail closed)"
+elif ! echo "$error_output" | grep -q "LLAMA_SERVER_GPU_UUIDS"; then
+    fail "compose config failed for an unrelated reason: $error_output"
+else
+    pass "compose config refuses to start with LLAMA_SERVER_GPU_UUIDS unset"
+fi
+
+# A set value must be passed through exactly — never silently widened to "all".
+rendered="$(LLAMA_SERVER_GPU_UUIDS="GPU-aaa,GPU-bbb" docker compose "${COMPOSE_ARGS[@]}" config 2>/dev/null | grep 'NVIDIA_VISIBLE_DEVICES:')"
+if [[ "$rendered" == *"GPU-aaa,GPU-bbb"* ]]; then
+    pass "compose config passes through the assigned GPU UUIDs"
+else
+    fail "compose config did not render the assigned GPU UUIDs (got: $rendered)"
+fi
+if [[ "$rendered" == *": all"* ]]; then
+    fail "compose config resolved NVIDIA_VISIBLE_DEVICES to 'all' despite an explicit assignment"
+fi
+
+echo ""
+echo "  All checks passed"


### PR DESCRIPTION
## Summary

`docker-compose.multigpu-nvidia.yml` had `NVIDIA_VISIBLE_DEVICES:
"${LLAMA_SERVER_GPU_UUIDS:-all}"` — whenever the variable was unset (a
manual `docker compose` run, or the transient window during `ods
gpu-reassign` which explicitly `unset`s it before recomputing the
assignment — see `ods-cli`'s `_gpu_reassign_reload_env`), llama-server
would get **every** GPU on the host, ignoring `GPU_ASSIGNMENT_JSON_B64` and
per-service GPU isolation.

This overlay is only merged into the compose stack when `gpu_count > 1`
(`scripts/resolve-compose-stack.sh`), so whenever it's actually part of a
running stack, the assignment flow must already have set this variable —
an unset value here is never a legitimate "use everything" default, only a
bug. Changed the fallback from `:-all` to `:?...`, so Compose refuses to
render the config at all instead of silently widening GPU access.

## AI Assistance

Used an AI coding assistant to implement and verify this fix. Verification
was done against real Docker (Docker Desktop, available on this Windows
host) — not simulated: `docker compose config` was run with the actual
`docker-compose.base.yml` + `docker-compose.nvidia.yml` +
`docker-compose.multigpu-nvidia.yml` stack, confirming (a) the pre-fix
file really does resolve `NVIDIA_VISIBLE_DEVICES` to the literal string
`all` when the var is unset, (b) the fix refuses to render with a clear
"required variable ... is missing a value" error, and (c) a real UUID
list passes through unchanged when the var is set. I reviewed the diff and
this verification output myself.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Docker Compose / service manifests

## Risk And Validation

- Risk level: Medium (a stack that was relying on the old silent
  all-GPUs fallback — e.g. someone running `docker compose -f ... -f
  docker-compose.multigpu-nvidia.yml up` by hand without going through
  `ods-cli`'s GPU assignment flow — will now get a hard failure instead of
  starting. That's the intended behavior change; flagging it explicitly
  since it's a compose file used directly by some operators.)
- Validation run:
  - [x] Focused tests listed below

Commands/results:

```text
docker compose --env-file <minimal-complete-env> \
  -f docker-compose.base.yml -f docker-compose.nvidia.yml \
  -f docker-compose.multigpu-nvidia.yml config --quiet
  # unset LLAMA_SERVER_GPU_UUIDS: exit 1, "required variable
  #   LLAMA_SERVER_GPU_UUIDS is missing a value: ..."
  # LLAMA_SERVER_GPU_UUIDS=GPU-abc,GPU-def: renders
  #   NVIDIA_VISIBLE_DEVICES: GPU-abc,GPU-def (not "all")
  # pre-fix file (git show HEAD:...) with the var unset: renders
  #   NVIDIA_VISIBLE_DEVICES: all — confirms this is a real, reproducible bug

bash tests/test-multigpu-nvidia-gpu-isolation.sh
  # new hermetic test wrapping the same checks; PASS on the fix,
  # first check FAILs on pre-fix (confirmed by testing both)
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above
  (real `docker compose config` runs against the actual overlay stack).
