### PR TITLE
fix(embeddings): make the TEI compose platform pin configurable

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -448,6 +448,11 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # RAG_OPENAI_API_KEY=              # only for authenticated external providers
 # Larger models such as BAAI/bge-m3 may need a higher container memory limit.
 # EMBEDDINGS_MEMORY_LIMIT=4G
+# TEI ships no arm64 image, so the embeddings service defaults to linux/amd64
+# (works via Rosetta 2 on Apple Silicon). On native arm64 Linux hosts (e.g.
+# Raspberry Pi, Graviton), which have no Rosetta, set this to linux/arm64 or
+# an arm64-capable image, or the service will run under slow QEMU emulation.
+# EMBEDDINGS_PLATFORM=linux/amd64
 
 # Image generation (ComfyUI + SDXL Lightning)
 # ENABLE_IMAGE_GENERATION=true

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -860,6 +860,11 @@
       "default": "4G",
       "pattern": "^[1-9][0-9]*([bBkKmMgG]|[kKmMgG][bB])?$"
     },
+    "EMBEDDINGS_PLATFORM": {
+      "type": "string",
+      "description": "Docker platform for the bundled TEI embeddings service. TEI ships no arm64 image, so this defaults to linux/amd64 (works via Rosetta 2 on Apple Silicon). Set to linux/arm64 (or an arm64-capable image) on native arm64 Linux hosts, which have no Rosetta.",
+      "default": "linux/amd64"
+    },
     "EMBEDDING_URL": {
       "type": "string",
       "description": "Embedding service URL used by dashboard-api functional diagnostics. Leave empty for the bundled embeddings service."

--- a/ods/extensions/services/embeddings/compose.yaml
+++ b/ods/extensions/services/embeddings/compose.yaml
@@ -1,7 +1,12 @@
 services:
   embeddings:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1
-    platform: linux/amd64  # TEI has no arm64 image -- Rosetta 2 on Apple Silicon
+    # TEI ships no arm64 image. Default pins x86, relying on Rosetta 2 on
+    # Apple Silicon; native arm64 Linux hosts (Raspberry Pi 5, Graviton,
+    # aarch64 Colima, most ARM SBCs) have no Rosetta and would otherwise run
+    # this under slow QEMU emulation or fail to start. Override with
+    # EMBEDDINGS_PLATFORM=linux/arm64 (or an arm64-capable image) on those hosts.
+    platform: ${EMBEDDINGS_PLATFORM:-linux/amd64}
     container_name: ods-embeddings
     restart: unless-stopped
     security_opt:

--- a/ods/tests/test-embeddings-platform-override.sh
+++ b/ods/tests/test-embeddings-platform-override.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Regression (#2302): embeddings compose hardcoded platform: linux/amd64.
+# TEI has no arm64 image; the comment cited Rosetta 2 (macOS), but native
+# arm64 Linux hosts (Raspberry Pi 5, Graviton, aarch64 Colima, most ARM
+# SBCs) have no Rosetta and would run the container under slow QEMU
+# emulation or fail to start. EMBEDDINGS_PLATFORM makes it configurable
+# while keeping the same default.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}✓${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1"; exit 1; }
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    echo "  (skipped — docker compose not available)"
+    exit 0
+fi
+
+COMPOSE_FILE="extensions/services/embeddings/compose.yaml"
+
+echo "── embeddings platform override ──"
+
+rendered_default="$(unset EMBEDDINGS_PLATFORM 2>/dev/null; docker compose -f "$COMPOSE_FILE" config 2>/dev/null | grep 'platform:')"
+if [[ "$rendered_default" == *"linux/amd64"* ]]; then
+    pass "default platform is unchanged (linux/amd64)"
+else
+    fail "default platform changed unexpectedly (got: $rendered_default)"
+fi
+
+rendered_override="$(EMBEDDINGS_PLATFORM=linux/arm64 docker compose -f "$COMPOSE_FILE" config 2>/dev/null | grep 'platform:')"
+if [[ "$rendered_override" == *"linux/arm64"* ]]; then
+    pass "EMBEDDINGS_PLATFORM overrides the default"
+else
+    fail "EMBEDDINGS_PLATFORM override was not applied (got: $rendered_override)"
+fi
+
+# validate-env.sh must accept the new key, not flag it as unknown.
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+echo "EMBEDDINGS_PLATFORM=linux/arm64" > "$TMPDIR_TEST/test.env"
+validate_out="$(bash scripts/validate-env.sh "$TMPDIR_TEST/test.env" .env.schema.json 2>&1 || true)"
+if echo "$validate_out" | grep -qi "EMBEDDINGS_PLATFORM"; then
+    fail "validate-env.sh flags EMBEDDINGS_PLATFORM as unknown/invalid: $validate_out"
+else
+    pass "EMBEDDINGS_PLATFORM is a recognized schema key"
+fi
+
+echo ""
+echo "  All checks passed"


### PR DESCRIPTION
## Summary

`extensions/services/embeddings/compose.yaml` hardcoded `platform:
linux/amd64` with a comment citing Rosetta 2 for Apple Silicon. On native
arm64 Linux hosts — Raspberry Pi 5, AWS Graviton, aarch64 Colima, most ARM
SBCs — there is no Rosetta, so Docker either runs the container under slow
QEMU emulation or fails to start, blocking the embeddings service on
hardware that otherwise runs the rest of the stack fine.

Added `EMBEDDINGS_PLATFORM` (default unchanged: `linux/amd64`) so arm64
Linux hosts can opt out with `EMBEDDINGS_PLATFORM=linux/arm64` (or point at
an arm64-capable image). Registered the key in `.env.schema.json` — this
repo's `validate-env.sh` hard-fails on unknown `.env` keys, so skipping
that step would make setting this override break `ods` install/update
validation — and documented it in `.env.example`.

## AI Assistance

Used an AI coding assistant to implement this and verify it against real
Docker: confirmed the default is unchanged, the override is respected, and
`validate-env.sh` accepts the new schema key (rather than assuming it
would — this repo's validator hard-fails on unrecognized keys, so I
checked). I reviewed the diff.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Docker Compose / service manifests

## Risk And Validation

- Risk level: Low (default behavior is byte-for-byte unchanged; only adds
  an opt-in override)
- Validation run:
  - [x] Focused tests listed below

Commands/results:

```text
docker compose -f extensions/services/embeddings/compose.yaml config
  # unset EMBEDDINGS_PLATFORM: platform: linux/amd64 (unchanged)
  # EMBEDDINGS_PLATFORM=linux/arm64: platform: linux/arm64

bash scripts/validate-env.sh <env-with-EMBEDDINGS_PLATFORM> .env.schema.json
  # no "unknown key" error

python3 -c "import json; json.load(open('.env.schema.json'))"  # valid JSON

bash tests/test-embeddings-platform-override.sh   # 3/3 PASS on the fix

# Confirmed the override-application check fails against the pre-fix
# compose.yaml (git show HEAD:...) and passes against the fix.
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above
  (real `docker compose config` + `validate-env.sh` runs).
