### PR TITLE
fix(macos): reinstall llama-server when the on-disk build is stale

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2079,6 +2079,22 @@ else
 
         # Download llama.cpp Metal build
         LLAMA_ZIP="/tmp/${LLAMA_CPP_MACOS_ASSET}"
+
+        # A present binary alone doesn't mean the RIGHT binary: a prior
+        # install pinned an older LLAMA_CPP_RELEASE_TAG (e.g. a qwen-profile
+        # install at b8210), and a later profile swap (e.g. to gemma4, which
+        # overrides the tag to a newer build the older binary can't serve)
+        # used to log "llama-server already present" and never fetch the
+        # required build — the model then fails at runtime with
+        # "unknown model architecture" instead of at install time. Track
+        # which tag is actually on disk and force a reinstall on mismatch.
+        LLAMA_SERVER_TAG_FILE="${LLAMA_SERVER_DIR}/.llama-cpp-release-tag"
+        LLAMA_SERVER_INSTALLED_TAG=""
+        [[ -f "$LLAMA_SERVER_TAG_FILE" ]] && LLAMA_SERVER_INSTALLED_TAG="$(cat "$LLAMA_SERVER_TAG_FILE" 2>/dev/null || true)"
+        if [[ -x "$LLAMA_SERVER_BIN" ]] && [[ "$LLAMA_SERVER_INSTALLED_TAG" != "$LLAMA_CPP_RELEASE_TAG" ]]; then
+            ai_warn "Installed llama-server (${LLAMA_SERVER_INSTALLED_TAG:-unknown build}) does not match the build required for this model profile (${LLAMA_CPP_RELEASE_TAG}) — reinstalling"
+            rm -f "$LLAMA_SERVER_BIN"
+        fi
         if [[ ! -x "$LLAMA_SERVER_BIN" ]]; then
             if [[ ! -f "$LLAMA_ZIP" ]]; then
                 download_with_progress "$LLAMA_CPP_MACOS_URL" "$LLAMA_ZIP" \
@@ -2145,8 +2161,15 @@ else
             # Remove quarantine attribute (macOS Gatekeeper)
             xattr -rd com.apple.quarantine "$LLAMA_SERVER_BIN" 2>/dev/null || true
             xattr -rd com.apple.quarantine "$LLAMA_SERVER_DIR"/*.dylib 2>/dev/null || true
+
+            # Record which tag is now on disk. The Homebrew fallback doesn't
+            # actually guarantee this exact tag (brew tracks its own current
+            # version), but no worse than the total absence of tracking
+            # before this fix, and correctly triggers a reinstall the next
+            # time a pinned-build profile requires a specific tag.
+            printf '%s' "$LLAMA_CPP_RELEASE_TAG" > "$LLAMA_SERVER_TAG_FILE" 2>/dev/null || true
         else
-            ai_ok "llama-server already present"
+            ai_ok "llama-server already present (${LLAMA_CPP_RELEASE_TAG})"
         fi
 
         # Start native llama-server with Metal

--- a/ods/tests/test-macos-native-llama-launch-cwd.sh
+++ b/ods/tests/test-macos-native-llama-launch-cwd.sh
@@ -108,4 +108,24 @@ grep -qF 'write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES"' "$bootstrap" 
     || fail "macOS native hot-swap failure must report real downloaded bytes"
 pass "macOS native hot-swap failure is reported as failed"
 
+# Regression (#2351 bug 3): the installer used to treat a present
+# llama-server binary as sufficient, with no check that it's actually the
+# build the current model profile requires. A prior qwen-profile install
+# pinned at LLAMA_CPP_RELEASE_TAG=b8210 survived a later gemma4-profile
+# swap (which overrides the tag to a newer build) untouched — the model
+# then failed at RUNTIME with "unknown model architecture" instead of at
+# install time with an actionable message.
+llama_block="$(awk '/LLAMA_ZIP="\/tmp\/\$\{LLAMA_CPP_MACOS_ASSET\}"/,/Start native llama-server with Metal/' "$installer")"
+[[ -n "$llama_block" ]] || fail "could not locate the native llama-server install block"
+
+echo "$llama_block" | grep -qF 'LLAMA_SERVER_TAG_FILE=' \
+    || fail "macOS installer must track which llama.cpp tag is on disk"
+echo "$llama_block" | grep -qF '"$LLAMA_SERVER_INSTALLED_TAG" != "$LLAMA_CPP_RELEASE_TAG"' \
+    || fail "macOS installer must compare the on-disk tag against the required tag, not just check presence"
+echo "$llama_block" | grep -qF 'rm -f "$LLAMA_SERVER_BIN"' \
+    || fail "macOS installer must remove a stale-tag binary before reinstalling"
+echo "$llama_block" | grep -qF 'printf '"'"'%s'"'"' "$LLAMA_CPP_RELEASE_TAG" > "$LLAMA_SERVER_TAG_FILE"' \
+    || fail "macOS installer must persist the newly installed tag for future comparisons"
+pass "macOS installer detects a stale llama.cpp build and reinstalls instead of assuming presence means correctness"
+
 echo "[OK] macOS native llama launch cwd contract holds"


### PR DESCRIPTION
## Summary

The macOS native installer decided whether to (re)install `llama-server`
with `[[ ! -x "$LLAMA_SERVER_BIN" ]]` — presence only, no check that the
binary is actually the build the current model profile requires. A prior
`qwen`-profile install pins `LLAMA_CPP_RELEASE_TAG=b8210`
(`installers/macos/lib/constants.sh`); a later `gemma4`-profile swap
overrides that to a newer build via
`LLAMA_CPP_RELEASE_TAG_OVERRIDE=b9014` (`installers/macos/lib/tier-map.sh`,
per PR #855) — a build the old binary can't serve. Re-running the
installer over the existing install logged `[OK] llama-server already
present` and never fetched the required build. The model then fails at
**runtime** with `unknown model architecture: 'gemma4'` instead of
succeeding, or at minimum failing loudly, at install time.

Fix: track which tag is actually on disk in a small marker file next to
the binary (`bin/.llama-cpp-release-tag`), and force a reinstall on
mismatch instead of trusting mere presence. The download/extract logic
itself is unchanged — on a mismatch, the stale binary is removed first so
the existing "binary doesn't exist" path runs exactly as it already did
for a fresh install.

Third of three bugs from #2351. The other two — stale catalog checksums
(fixed separately, PR #2672) and a missing pre-swap warning when a
user-supplied custom GGUF needs a newer llama.cpp than what's pinned at
install time — are tracked as separate PRs; not bundling unrelated changes
into one review.

## AI Assistance

Used an AI coding assistant to investigate and implement this. I don't
have macOS hardware to run the actual installer end-to-end, so this is
verified via the same static-assertion approach this repo's own macOS
installer tests already use (`tests/test-macos-native-llama-launch-cwd.sh` —
none of the macOS installer tests execute the real script, since it can't
run on Linux CI; they all check the script text for the expected control
flow). I traced the logic change carefully by hand — the download/extract
code path itself is untouched, only the decision of whether to enter it —
and reviewed the diff myself.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer / bootstrap / lifecycle

## Risk And Validation

- Risk level: Medium (macOS-only install path; I could not run this
  end-to-end — see AI Assistance note. The change is scoped narrowly: it
  only affects the branch condition for whether llama-server gets
  reinstalled, not the download/extract mechanics themselves.)
- Validation run:
  - [x] Focused tests listed below
  - [ ] Not required because: n/a — no macOS hardware available to
    validate live; flagging explicitly per the note above.

Commands/results:

```text
bash -n installers/macos/install-macos.sh tests/test-macos-native-llama-launch-cwd.sh

bash tests/test-macos-native-llama-launch-cwd.sh   # all checks PASS on the fix

# Confirmed the new check fails against the pre-fix installer
# (git show HEAD:...): "[FAIL] macOS installer must track which
# llama.cpp tag is on disk"
```

## Operational Change Check

- [x] This is an operational change. Validation is the static-assertion
  approach noted above (consistent with how this repo already tests its
  macOS installer, since it can't execute on Linux CI) — not a live
  macOS run. Flagging for a maintainer with real macOS hardware to
  smoke-test before release, same caveat as the linked issue's own report.

## Notes For Reviewers

This is the piece I'm least able to independently verify in this batch —
happy to iterate if the marker-file approach doesn't match how you'd
rather track installed build versions.
