### PR TITLE
fix(macos): escape sed metacharacters in upsert_env_value

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -71,7 +71,17 @@ upsert_env_value() {
     local key="$2"
     local value="$3"
     if grep -qE "^${key}=" "$env_path" 2>/dev/null; then
-        sed -i '' "s|^${key}=.*|${key}=${value}|" "$env_path"
+        # Escape sed's replacement-text metacharacters (& = whole match,
+        # \ = escape, and | = our chosen delimiter) before interpolating
+        # value into the substitution. Unescaped, a value containing '&'
+        # (common in OAuth-style URLs with query strings, e.g.
+        # RAG_OPENAI_API_BASE_URL) duplicates the matched line into the
+        # output instead of replacing it, and a value containing '|'
+        # breaks the sed expression outright — which aborts the caller
+        # under set -euo pipefail.
+        local escaped_value
+        escaped_value="$(printf '%s' "$value" | sed 's/[&/\|]/\\&/g')"
+        sed -i '' "s|^${key}=.*|${key}=${escaped_value}|" "$env_path"
     else
         printf '%s=%s\n' "$key" "$value" >> "$env_path"
     fi

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -394,7 +394,16 @@ upsert_env_value() {
     local key="$2"
     local value="$3"
     if grep -qE "^${key}=" "$env_file" 2>/dev/null; then
-        sed -i '' "s|^${key}=.*|${key}=${value}|" "$env_file"
+        # Escape sed's replacement-text metacharacters (& = whole match,
+        # \ = escape, and | = our chosen delimiter) before interpolating
+        # value into the substitution — see the matching fix in
+        # installers/macos/lib/env-generator.sh for the failure modes
+        # (values containing '&' silently duplicate the line instead of
+        # replacing it; values containing '|' break the sed expression
+        # outright, aborting the caller under set -euo pipefail).
+        local escaped_value
+        escaped_value="$(printf '%s' "$value" | sed 's/[&/\|]/\\&/g')"
+        sed -i '' "s|^${key}=.*|${key}=${escaped_value}|" "$env_file"
     else
         printf '%s=%s\n' "$key" "$value" >> "$env_file"
     fi

--- a/ods/tests/test-macos-upsert-env-value-sed-escape.sh
+++ b/ods/tests/test-macos-upsert-env-value-sed-escape.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Regression: upsert_env_value() (installers/macos/lib/env-generator.sh and
+# installers/macos/ods-macos.sh — duplicated implementations) interpolated
+# the raw value into a sed replacement with no escaping. A value containing
+# '&' (sed's "whole match" token — common in OAuth-style URLs with query
+# strings, e.g. RAG_OPENAI_API_BASE_URL) silently duplicated the matched
+# line into the .env file instead of replacing it; a value containing '|'
+# (the chosen sed delimiter) broke the sed expression outright, aborting
+# the caller under set -euo pipefail.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { printf "  ${GREEN}✓ PASS${NC} %s\n" "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf "  ${RED}✗ FAIL${NC} %s\n" "$1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "=== upsert_env_value sed-escaping tests ==="
+echo ""
+
+check_source() {
+    local target="$1" label="$2"
+
+    # Extract just upsert_env_value so nothing else in the file runs.
+    local src
+    src="$(sed -n '/^upsert_env_value()/,/^}/p' "$target")"
+    if [[ -z "$src" ]]; then
+        fail "$label: could not extract upsert_env_value"
+        return
+    fi
+    eval "$src"
+
+    # This function's `sed -i ''` is BSD sed syntax — correct (and the only
+    # option) on real macOS, where these scripts actually run, but GNU sed
+    # (this CI runner) parses `-i ''` differently. Shim it locally so the
+    # test exercises the function's actual escaping logic instead of
+    # failing on an unrelated platform difference in sed's -i flag.
+    if sed --version 2>/dev/null | grep -q GNU; then
+        sed() {
+            if [[ "${1:-}" == "-i" && "${2-unset}" == "" ]]; then
+                shift 2
+                command sed -i "$@"
+            else
+                command sed "$@"
+            fi
+        }
+    fi
+
+    local tmp
+    tmp="$(mktemp -d)"
+
+    # Value containing '&' must not duplicate the line.
+    printf 'RAG_OPENAI_API_BASE_URL=http://embeddings:80/v1\n' > "$tmp/env"
+    upsert_env_value "$tmp/env" "RAG_OPENAI_API_BASE_URL" \
+        "https://api.example.com/v1?api-version=2024&region=us"
+    local ampersand_result
+    ampersand_result="$(grep '^RAG_OPENAI_API_BASE_URL=' "$tmp/env")"
+    if [[ "$ampersand_result" == "RAG_OPENAI_API_BASE_URL=https://api.example.com/v1?api-version=2024&region=us" ]]; then
+        pass "$label: value containing '&' round-trips without duplicating the line"
+    else
+        fail "$label: value containing '&' corrupted the line (got: $ampersand_result)"
+    fi
+    [[ "$(wc -l < "$tmp/env" | tr -d ' ')" == "1" ]] \
+        && pass "$label: '&' value does not inject an extra line" \
+        || fail "$label: '&' value injected an extra line"
+
+    # Value containing '|' (the sed delimiter) must not break the expression.
+    printf 'TARGET_API_KEY=old\n' > "$tmp/env2"
+    if upsert_env_value "$tmp/env2" "TARGET_API_KEY" "sk-abc|def" 2>"$tmp/err"; then
+        local pipe_result
+        pipe_result="$(grep '^TARGET_API_KEY=' "$tmp/env2")"
+        if [[ "$pipe_result" == "TARGET_API_KEY=sk-abc|def" ]]; then
+            pass "$label: value containing '|' round-trips without breaking sed"
+        else
+            fail "$label: value containing '|' produced wrong content (got: $pipe_result)"
+        fi
+    else
+        fail "$label: value containing '|' broke the sed expression: $(cat "$tmp/err")"
+    fi
+
+    rm -rf "$tmp"
+}
+
+check_source "$ROOT_DIR/installers/macos/lib/env-generator.sh" "env-generator.sh"
+check_source "$ROOT_DIR/installers/macos/ods-macos.sh" "ods-macos.sh"
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

`upsert_env_value()` — duplicated in `installers/macos/lib/env-generator.sh`
and `installers/macos/ods-macos.sh` — interpolated the raw value straight
into a sed replacement with no escaping:

```bash
sed -i '' "s|^${key}=.*|${key}=${value}|" "$env_path"
```

Both callers pass genuinely variable data through this: `env-generator.sh`
upserts `RAG_OPENAI_API_BASE_URL`/`RAG_OPENAI_API_KEY` (`.env.example`
documents these as "only for authenticated external providers" — arbitrary
third-party URLs and keys), and `ods-macos.sh` calls it on every local
rerun for several keys.

**Reproduced directly, not just inferred from reading the code:**

```
$ value="https://api.example.com/v1?api-version=2024&region=us"
$ sed -i "s|^${key}=.*|${key}=${value}|" env.test
$ cat env.test
RAG_OPENAI_API_BASE_URL=https://api.example.com/v1?api-version=2024RAG_OPENAI_API_BASE_URL=http://embeddings:80/v1region=us
```

The `&` in the value expands to sed's "whole matched line" token, silently
duplicating/corrupting the `.env` line. Separately, a value containing `|`
(the chosen sed delimiter) breaks the substitution outright with `sed: -e
expression #1, char 44: unknown option to 's'` — and since both
`install-macos.sh` and `ods-macos.sh` run under `set -euo pipefail`, that
aborts the whole install/CLI command with a cryptic sed error.

Fix: escape sed's replacement-text metacharacters (`&`, `\`, and the `|`
delimiter) before interpolating, matching the `_sed_escape()` pattern
`installers/phases/06-directories.sh` already uses for the identical
problem when patching OpenClaw's config.

This wasn't filed as a GitHub issue — found it via code review while
working through #2351 (a nearby macOS installer issue), noticed the
codebase already has the fix pattern established elsewhere for exactly
this class of bug, and it was small/self-contained enough to fix directly
rather than just file a report.

## AI Assistance

Used an AI coding assistant to find and fix this during a broader review
pass. The corruption and the sed-delimiter break were both reproduced
directly (shown above) before writing the fix, and the regression test was
verified to fail against the pre-fix functions and pass against the fix. I
reviewed the diff.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer / bootstrap / lifecycle

## Risk And Validation

- Risk level: Medium (touches `.env` mutation on every macOS local rerun,
  but the change is narrowly scoped to escaping — the sed command
  structure and all call sites are unchanged)
- Validation run:
  - [x] Focused tests listed below

Commands/results:

```text
bash -n installers/macos/lib/env-generator.sh installers/macos/ods-macos.sh \
  tests/test-macos-upsert-env-value-sed-escape.sh

bash tests/test-macos-upsert-env-value-sed-escape.sh   # 6/6 PASS on the fix
bash tests/test-macos-env-quote-strip.sh               # 9/9 PASS, unaffected
bash tests/test-macos-native-llama-launch-cwd.sh       # unaffected

# Confirmed 4/6 checks fail against the pre-fix functions (git show
# HEAD:...), with the exact corruption/error reproduced above.
```

Note: `upsert_env_value`'s `sed -i ''` is BSD-sed syntax, correct on real
macOS (the only place these scripts run) but not runnable as-is under GNU
sed. The test extracts just the function via `sed -n '/^upsert_env_value()/,/^}/p'`
+ `eval` (the same pattern `tests/test-macos-env-quote-strip.sh` already
uses for `read_ods_env`) and shims `sed -i ''` → GNU-compatible `-i` only
inside the test process, so it validates the actual escaping logic without
needing real macOS hardware.

## Operational Change Check

- [x] This is an operational change and validation is recorded above.
