### PR TITLE
fix(privacy-shield): log chmod failure instead of silent pass

### DIFF
--- a/ods/extensions/services/privacy-shield/key_management.py
+++ b/ods/extensions/services/privacy-shield/key_management.py
@@ -31,8 +31,14 @@ def persist_key(path: str, key: str) -> None:
         try:
             os.chmod(path, 0o600)
         except Exception:
-            # Best-effort only (may fail on some mounts/platforms)
-            pass
+            # Best-effort only (may fail on some mounts/platforms), but the
+            # key is left world-readable if this silently fails — log it so
+            # the gap is visible instead of invisible.
+            logging.warning(
+                "Failed to chmod 0600 %s; the key file may be readable by "
+                "other local users on this host",
+                path,
+            )
     except Exception:
         logging.exception("Failed to persist generated SHIELD_API_KEY")
 

--- a/ods/extensions/services/privacy-shield/tests/test_key_management.py
+++ b/ods/extensions/services/privacy-shield/tests/test_key_management.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 # Allow running this test from repo root without installing the service as a package.
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -29,6 +30,26 @@ class TestKeyManagement(unittest.TestCase):
             self.assertTrue(isinstance(key, str) and len(key) > 0)
             with open(key_path, "r", encoding="utf-8") as f:
                 self.assertEqual(f.read().strip(), key)
+
+    def test_chmod_failure_is_logged_not_silently_swallowed(self):
+        # Regression: persist_key() wrapped os.chmod in `except Exception:
+        # pass` with no log call — a verbatim match for the pattern
+        # CLAUDE.md forbids ("Never except Exception: pass"). If chmod
+        # fails (some bind-mount configurations, SELinux-labeled mounts,
+        # permission races), the generated SHIELD_API_KEY is left
+        # world-readable with zero operator-visible signal.
+        with tempfile.TemporaryDirectory() as d:
+            key_path = os.path.join(d, "shield_api_key")
+            with patch("os.chmod", side_effect=OSError("simulated chmod failure")):
+                with self.assertLogs(level="WARNING") as captured:
+                    persist_key(key_path, "some-key")
+            self.assertTrue(
+                any("chmod" in message.lower() for message in captured.output),
+                f"expected a chmod-failure warning, got: {captured.output}",
+            )
+            # The key itself must still be written even though chmod failed.
+            with open(key_path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read().strip(), "some-key")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`persist_key()` in `extensions/services/privacy-shield/key_management.py`
wrapped the `os.chmod(path, 0o600)` hardening step in `except Exception:
pass` with no log call at all — a verbatim match for the pattern
`CLAUDE.md` explicitly forbids: *"Never `except Exception: pass`"*.

`persist_key()` is called from `resolve_shield_api_key()` whenever
`SHIELD_API_KEY` isn't set in `.env`: it generates a fresh key and writes
it to a host-bind-mounted file (`compose.yaml` mounts
`$INSTALL_DIR/data/privacy-shield/shield_api_key` into the container) with
the process umask (typically `022`, i.e. world-readable via `open(path,
"w")`). The `chmod` is what's supposed to lock the file down to
owner-only. If it fails for any reason — some bind-mount configurations,
SELinux-labeled `:z` mounts, permission races — the auto-generated
`SHIELD_API_KEY`, which authenticates cross-service calls to the Privacy
Shield PII-scrubbing proxy, is left world-readable on the host filesystem
with zero operator-visible signal that hardening didn't apply.

Fix: log a warning when `chmod` fails instead of silently swallowing it.
The key is still written either way (this doesn't change behavior, only
observability) — the point is an operator can now actually see the
hardening gap instead of it being invisible.

Not a filed GitHub issue — found while reviewing this repo's own
`CLAUDE.md` error-handling rules (rule 1 explicitly names this exact
pattern as forbidden) against the codebase for other batches in this
session.

## AI Assistance

Used an AI coding assistant to find and fix this, then add a regression
test. I reviewed the diff and the test, which mocks `os.chmod` to raise and
asserts a warning is logged via `assertLogs` — verified to fail against
the pre-fix code (no warning) and pass against the fix.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Network exposure / auth / proxy (this is the credential file backing
  Privacy Shield's cross-service auth)

## Risk And Validation

- Risk level: Low (adds a log line on an already-existing best-effort
  failure path; no control-flow change — the key is still written and
  returned exactly as before)
- Validation run:
  - [x] Focused tests listed below

Commands/results:

```text
python3 -m py_compile key_management.py tests/test_key_management.py
python3 -m pytest tests/test_key_management.py -v
  # 4/4 PASS on the fix (3 existing + 1 new)

# Confirmed the new test fails against the pre-fix key_management.py
# (git show HEAD:...): "AssertionError: no logs of level WARNING or
# higher triggered on root"
```

## Operational Change Check

- [x] This is not an operational change (application-level logging only;
  no installer/compose/lifecycle surface touched).
