### PR TITLE
fix(macos): detect a dead native llama-server instead of waiting out the timeout

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -645,6 +645,25 @@ start_native_llama() {
             ai_ok "Native llama-server healthy"
             return
         fi
+        # A crash (e.g. "unknown model architecture" for a GGUF newer than
+        # the installed llama.cpp build supports — see LLAMA_CPP_RELEASE_TAG)
+        # exits almost immediately, not gradually. Polling /health alone
+        # can't tell "still loading" apart from "already dead", so the old
+        # code waited out the full 60s and reported a misleading "may still
+        # be loading" even when the process was long gone. Check liveness
+        # too and surface the real failure right away.
+        if ! kill -0 "$pid" 2>/dev/null; then
+            ai_err "Native llama-server exited before becoming healthy (PID ${pid})"
+            if [[ -f "$LLAMA_SERVER_LOG" ]]; then
+                ai "Last log lines (${LLAMA_SERVER_LOG}):"
+                tail -n 20 "$LLAMA_SERVER_LOG"
+            fi
+            ai "If the log mentions an unknown/unsupported model architecture, "
+            ai "the installed llama.cpp build (LLAMA_CPP_RELEASE_TAG) is too old "
+            ai "for this GGUF — re-run the installer for this model's profile, "
+            ai "or set LLAMA_CPP_RELEASE_TAG_OVERRIDE to a build that supports it."
+            return
+        fi
     done
     ai_warn "llama-server may still be loading model..."
 }

--- a/ods/tests/test-macos-native-llama-crash-detection.sh
+++ b/ods/tests/test-macos-native-llama-crash-detection.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Regression (#2351 bug 1): start_native_llama()'s health-wait loop polled
+# /health for up to 60s with no check that the process was still alive. A
+# crash (e.g. "unknown model architecture" for a GGUF newer than the
+# installed llama.cpp build supports) exits almost immediately, not
+# gradually — so the old code waited out the full 60s and then reported a
+# misleading "llama-server may still be loading model..." even though the
+# process had been dead the whole time, with the real crash reason left
+# sitting unseen in the log file.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$ROOT_DIR/installers/macos/ods-macos.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { printf "  ${GREEN}✓ PASS${NC} %s\n" "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf "  ${RED}✗ FAIL${NC} %s\n" "$1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "=== native llama-server crash detection ==="
+echo ""
+
+if bash -n "$CLI" 2>/dev/null; then
+    pass "ods-macos.sh passes bash -n"
+else
+    fail "ods-macos.sh bash -n failed"
+    echo "Result: $PASSED passed, $FAILED failed"
+    exit 1
+fi
+
+# Extract just start_native_llama so the CLI's dispatch never runs.
+START_NATIVE_LLAMA_SRC="$(sed -n '/^start_native_llama()/,/^}/p' "$CLI")"
+if [[ -z "$START_NATIVE_LLAMA_SRC" ]]; then
+    fail "could not extract start_native_llama from ods-macos.sh"
+    echo "Result: $PASSED passed, $FAILED failed"
+    exit 1
+fi
+
+# start_native_llama() calls several other CLI functions for setup
+# (reading .env, configuring the Colima bridge, checking current status).
+# Stub them so the function under test reaches its actual launch/health
+# logic without needing the rest of the CLI's environment.
+read_ods_env() {
+    ENV_GGUF_FILE="$GGUF_FILE"
+    ENV_ODS_MODE="local"
+    ENV_CTX_SIZE=4096
+    ENV_ODS_NATIVE_LLAMA_PORT=18099
+    ENV_BIND_ADDRESS=127.0.0.1
+    ENV_LLAMA_REASONING="off"
+}
+macos_configure_llm_bridge_from_env() { return 0; }
+get_native_llama_status() { NATIVE_LLAMA_RUNNING=false; NATIVE_LLAMA_HEALTHY=false; }
+macos_bind_probe_host() { printf '%s' "$1"; }
+ai() { printf 'ai: %s\n' "$*"; }
+ai_ok() { printf 'ai_ok: %s\n' "$*"; }
+ai_err() { printf 'ai_err: %s\n' "$*"; }
+ai_warn() { printf 'ai_warn: %s\n' "$*"; }
+# curl must never actually hit the network in this test — a dead process
+# means nothing is listening, but stubbing keeps the test deterministic
+# and fast regardless of port availability.
+curl() { return 1; }
+
+eval "$START_NATIVE_LLAMA_SRC"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INSTALL_DIR="$TMP_DIR"
+mkdir -p "$INSTALL_DIR/data/models"
+GGUF_FILE="gemma-4-E4B-it-Q4_K_M.gguf"
+touch "$INSTALL_DIR/data/models/$GGUF_FILE"
+LLAMA_SERVER_PID_FILE="$TMP_DIR/llama-server.pid"
+LLAMA_SERVER_LOG="$TMP_DIR/llama-server.log"
+
+# Fake llama-server binary that crashes immediately, the way a real
+# architecture-mismatch failure does, and writes the real error to its log.
+LLAMA_SERVER_BIN="$TMP_DIR/fake-llama-server"
+cat > "$LLAMA_SERVER_BIN" <<'EOF'
+#!/usr/bin/env bash
+echo "llama_model_load: error loading model architecture: unknown model architecture: 'gemma4'"
+exit 1
+EOF
+chmod +x "$LLAMA_SERVER_BIN"
+
+output="$(start_native_llama 2>&1)"
+
+if echo "$output" | grep -q "exited before becoming healthy"; then
+    pass "crash is detected instead of waiting out the full timeout"
+else
+    fail "crash was not detected (output: $output)"
+fi
+
+if echo "$output" | grep -q "may still be loading"; then
+    fail "misleading 'may still be loading' message was shown despite the process being dead"
+else
+    pass "misleading 'may still be loading' message is not shown for a dead process"
+fi
+
+if echo "$output" | grep -q "unknown model architecture"; then
+    pass "the real crash reason from the log is surfaced to the operator"
+else
+    fail "the real crash reason was not surfaced (output: $output)"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

`start_native_llama()`'s health-wait loop polled `/health` for up to 60
seconds with no check that the process was still alive. A crash — e.g.
`unknown model architecture: 'gemma4'` for a GGUF newer than the installed
llama.cpp build supports (`LLAMA_CPP_RELEASE_TAG`) — exits almost
immediately, not gradually. The old code waited out the full 60s
regardless and then reported a misleading `llama-server may still be
loading model...` even though the process had been dead the whole time,
with the real crash reason left sitting unseen in the log file.

I scoped this narrower than the issue's own two "fix ideas" (predicting
required llama.cpp versions ahead of a swap by tracking them per model
family, or storing/checking a version table). A custom, manually-placed
GGUF — the exact repro in the report — isn't necessarily a catalog entry
at all, so there's no reliable way to predict the requirement in advance
without parsing GGUF architecture metadata directly (a much bigger,
riskier change I can't fully verify without real macOS + real GGUF
files). Instead: detect the failure the moment it happens and make it
loud and actionable, rather than trying to prevent it.

Fix: check process liveness (`kill -0 "$pid"`) alongside the health poll;
on an early exit, stop waiting immediately and surface the tail of the log
plus a pointer at `LLAMA_CPP_RELEASE_TAG` when the failure looks like an
unsupported architecture. This generalizes to *any* fast llama-server
startup crash, not just architecture mismatches.

First of three bugs from #2351; the other two (stale catalog checksums,
installer skipping the binary version check on existing installs) are
separate PRs — #2672 and #2673.

## AI Assistance

Used an AI coding assistant to investigate and implement this. I don't
have macOS hardware, so verification used the same extraction approach
this repo's other macOS CLI tests already use
(`tests/test-macos-env-quote-strip.sh`'s pattern): extract just
`start_native_llama()` via `sed -n '/^fn()/,/^}/p'` + `eval`, stub its
handful of CLI-internal dependencies (`read_ods_env`,
`macos_configure_llm_bridge_from_env`, `get_native_llama_status`,
`macos_bind_probe_host`), and run it against a fake `llama-server` binary
that exits immediately with the exact `unknown model architecture`
message from the report. I ran this myself and confirmed the pre-fix code
genuinely waits the full 60s and shows the misleading message, and the
fix detects the crash within one 2s poll interval.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer / bootstrap / lifecycle

## Risk And Validation

- Risk level: Medium (macOS-only path; I could not run this end-to-end on
  real hardware — see AI Assistance note. The change only affects
  diagnostics in the health-wait loop; the launch/health-check mechanics
  themselves are unchanged, and a healthy startup takes the exact same
  path as before.)
- Validation run:
  - [x] Focused tests listed below
  - [ ] Not required because: n/a — no macOS hardware available; flagging
    explicitly.

Commands/results:

```text
bash -n installers/macos/ods-macos.sh tests/test-macos-native-llama-crash-detection.sh

bash tests/test-macos-native-llama-crash-detection.sh
  # 4/4 PASS on the fix — crash detected within ~2s, real error surfaced

# Against the pre-fix ods-macos.sh (git show HEAD:...): the SAME test
# waits the full ~60s timeout and then fails 3/4 checks — the process
# exit is never noticed, and the operator only sees "may still be
# loading model...", matching the reported symptom exactly.

bash tests/test-macos-native-llama-launch-cwd.sh   # unaffected, still green
```

## Operational Change Check

- [x] This is an operational change. Validation is the extraction-based
  approach noted above (this repo's own established way of testing macOS
  CLI logic without macOS hardware) plus a real 60-second timing
  comparison between pre-fix and post-fix behavior — not a live macOS run.
  Flagging for a maintainer with real macOS hardware to smoke-test before
  release.

## Notes For Reviewers

Same caveat as #2673: this is the piece I'm least able to independently
verify end-to-end. Happy to iterate on the exact wording of the operator
guidance message if you'd word it differently.
