### PR TITLE
fix(installer): escape sed metacharacters in systemd unit templates

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -380,15 +380,23 @@ if [[ -f "$INSTALL_DIR/bin/ods-host-agent.py" ]]; then
                     cp "$INSTALL_DIR/scripts/systemd/ods-host-agent.service" "$svc_tmp"
                     # Substitute placeholders — use sed directly with | delimiter
                     # (paths contain / but never |, so | is a safe delimiter).
-                    # Dual-form for BSD/GNU sed compatibility.
-                    sed -i "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp"
-                    sed -i "s|__HOME__|${HOME}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__HOME__|${HOME}|g" "$svc_tmp"
-                    sed -i "s|__PYTHON3__|${AGENT_PYTHON}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__PYTHON3__|${AGENT_PYTHON}|g" "$svc_tmp"
-                    sed -i "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp"
+                    # Dual-form for BSD/GNU sed compatibility. Escape sed special
+                    # chars in the *values* (same as the opencode-web.service
+                    # block above) — an unescaped '&' in INSTALL_DIR/HOME/the
+                    # install user re-inserts the whole matched line instead of
+                    # the intended value, corrupting the rendered unit.
+                    _install_dir_esc=$(printf '%s\n' "$INSTALL_DIR" | sed 's/[&/\]/\\&/g')
+                    _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&/\]/\\&/g')
+                    _agent_python_esc=$(printf '%s\n' "$AGENT_PYTHON" | sed 's/[&/\]/\\&/g')
+                    _agent_user_esc=$(printf '%s\n' "$_agent_user" | sed 's/[&/\]/\\&/g')
+                    sed -i "s|__INSTALL_DIR__|${_install_dir_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__INSTALL_DIR__|${_install_dir_esc}|g" "$svc_tmp"
+                    sed -i "s|__HOME__|${_home_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__HOME__|${_home_esc}|g" "$svc_tmp"
+                    sed -i "s|__PYTHON3__|${_agent_python_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__PYTHON3__|${_agent_python_esc}|g" "$svc_tmp"
+                    sed -i "s|__INSTALL_USER__|${_agent_user_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__INSTALL_USER__|${_agent_user_esc}|g" "$svc_tmp"
                     # Verify placeholders were actually rendered
                     if grep -q '__INSTALL_DIR__\|__HOME__\|__PYTHON3__\|__INSTALL_USER__' "$svc_tmp"; then
                         ai_warn "Host agent systemd unit has unrendered placeholders — check $svc_tmp"
@@ -506,14 +514,20 @@ if [[ -f "$INSTALL_DIR/bin/ods-mdns.py" ]] && [[ "$(uname -s)" == "Linux" ]]; th
             ai_warn "Failed to create secure temp file for ods-mdns.service; skipping systemd unit install"
         else
             cp "$INSTALL_DIR/scripts/systemd/ods-mdns.service" "$svc_tmp"
-            sed -i "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp"
-            sed -i "s|__HOME__|${HOME}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__HOME__|${HOME}|g" "$svc_tmp"
-            sed -i "s|__PYTHON3__|${MDNS_PYTHON}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__PYTHON3__|${MDNS_PYTHON}|g" "$svc_tmp"
-            sed -i "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp"
+            # Escape sed special chars in the values — see the matching fix
+            # in the ods-host-agent.service block above.
+            _install_dir_esc=$(printf '%s\n' "$INSTALL_DIR" | sed 's/[&/\]/\\&/g')
+            _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&/\]/\\&/g')
+            _mdns_python_esc=$(printf '%s\n' "$MDNS_PYTHON" | sed 's/[&/\]/\\&/g')
+            _agent_user_esc=$(printf '%s\n' "$_agent_user" | sed 's/[&/\]/\\&/g')
+            sed -i "s|__INSTALL_DIR__|${_install_dir_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__INSTALL_DIR__|${_install_dir_esc}|g" "$svc_tmp"
+            sed -i "s|__HOME__|${_home_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__HOME__|${_home_esc}|g" "$svc_tmp"
+            sed -i "s|__PYTHON3__|${_mdns_python_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__PYTHON3__|${_mdns_python_esc}|g" "$svc_tmp"
+            sed -i "s|__INSTALL_USER__|${_agent_user_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__INSTALL_USER__|${_agent_user_esc}|g" "$svc_tmp"
             if grep -q '__INSTALL_DIR__\|__HOME__\|__PYTHON3__\|__INSTALL_USER__' "$svc_tmp"; then
                 ai_warn "ods-mdns systemd unit has unrendered placeholders — check $svc_tmp"
             else

--- a/ods/tests/test-devtools-systemd-template-escaping.sh
+++ b/ods/tests/test-devtools-systemd-template-escaping.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Regression: 07-devtools.sh rendered the ods-host-agent.service and
+# ods-mdns.service systemd units by interpolating INSTALL_DIR/HOME/the
+# resolved agent user/python path directly into a sed replacement with no
+# escaping — inconsistent with the opencode-web.service block 30 lines
+# above it in the same file, which explicitly escapes for exactly this
+# reason ("Escape sed special chars to prevent injection from path
+# values"). An unescaped '&' in any of those values (e.g. a custom
+# INSTALL_DIR) re-inserts the whole matched line into the rendered unit
+# instead of the real value.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/installers/phases/07-devtools.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { echo -e "  ${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "=== 07-devtools.sh systemd template escaping ==="
+echo ""
+
+[[ -f "$TARGET" ]] || { fail "missing $TARGET"; exit 1; }
+if bash -n "$TARGET"; then
+    pass "07-devtools.sh passes bash -n"
+else
+    fail "07-devtools.sh bash -n failed"
+fi
+
+# Static check: both the host-agent and mdns unit substitutions must use an
+# escaped variable, not the raw INSTALL_DIR/HOME/etc.
+for marker in '_install_dir_esc=$(printf' '_home_esc=$(printf' '_agent_python_esc=$(printf' '_agent_user_esc=$(printf' '_mdns_python_esc=$(printf'; do
+    if grep -qF "$marker" "$TARGET"; then
+        pass "found escaping for: ${marker%%=*}"
+    else
+        fail "missing escaping for: ${marker%%=*}"
+    fi
+done
+
+for substitution in '__INSTALL_DIR__|${_install_dir_esc}' '__HOME__|${_home_esc}' '__PYTHON3__|${_agent_python_esc}' '__INSTALL_USER__|${_agent_user_esc}'; do
+    count="$(grep -cF "$substitution" "$TARGET" || true)"
+    if [[ "${count:-0}" -ge 1 ]]; then
+        pass "sed substitution uses escaped value: $substitution"
+    else
+        fail "sed substitution does not use escaped value: $substitution"
+    fi
+done
+
+# Direct reproduction of the escaping expression itself (pure, self-contained
+# string transform — no need to extract anything from the file).
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+printf 'ExecStart=__PYTHON3__ __INSTALL_DIR__/bin/agent.py\nWorkingDirectory=__INSTALL_DIR__\nUser=__INSTALL_USER__\n' > "$TMP_DIR/unit.rendered"
+
+install_dir_with_amp='/opt/my&installs/ods'
+install_dir_esc=$(printf '%s\n' "$install_dir_with_amp" | sed 's/[&/\]/\\&/g')
+sed -i "s|__INSTALL_DIR__|${install_dir_esc}|g" "$TMP_DIR/unit.rendered" 2>/dev/null || \
+    sed -i '' "s|__INSTALL_DIR__|${install_dir_esc}|g" "$TMP_DIR/unit.rendered"
+
+rendered_line="$(grep '^WorkingDirectory=' "$TMP_DIR/unit.rendered")"
+if [[ "$rendered_line" == "WorkingDirectory=${install_dir_with_amp}" ]]; then
+    pass "a value containing '&' round-trips correctly through the escaped substitution"
+else
+    fail "a value containing '&' was corrupted (got: $rendered_line)"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

`07-devtools.sh` renders `ods-host-agent.service`/`ods-mdns.service` by sed-interpolating `INSTALL_DIR`, `HOME`, the resolved python path, and the resolved install user with no escaping — unlike the `opencode-web.service` block 30 lines above it in the same file, which explicitly escapes for exactly this reason. An unescaped `&` in any of those values re-inserts the whole matched line into the rendered unit instead of the real value, corrupting `ExecStart`/`WorkingDirectory`/`User`.

Fix: escape both substitution sites the same way the existing `opencode-web.service` block does.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this. Verified the escaping expression directly (round-tripped a value containing `&` through the actual substitution logic) and confirmed the new test fails against the pre-fix file and passes against the fix.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Installer / bootstrap / lifecycle

## Risk And Validation
- Risk level: Low (escaping-only change; substitution mechanism and call sites unchanged)
- Validation: `bash -n`, plus a new test that reproduces the corruption directly and confirms the fix resolves it (fails pre-fix, passes post-fix — verified both ways).

## Operational Change Check
- [x] Operational change; validation above.
