### PR TITLE
fix(mode-switch): stop env_set() leaking a stray .tmp file on awk failure

### DIFF
--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -30,9 +30,16 @@ error() { echo -e "${RED}✗${NC} $1" >&2; exit 1; }
 env_set() {
     local key="$1" val="$2"
     if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
-        awk -v k="$key" -v v="$val" '{
+        local tmp
+        tmp="$(mktemp "${ENV_FILE}.XXXXXX")"
+        if awk -v k="$key" -v v="$val" '{
             if (index($0, k "=") == 1) print k "=" v; else print
-        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
+        }' "$ENV_FILE" > "$tmp"; then
+            mv "$tmp" "$ENV_FILE"
+        else
+            rm -f "$tmp"
+            error "Failed to update ${key} in $ENV_FILE"
+        fi
     else
         echo "${key}=${val}" >> "$ENV_FILE"
     fi

--- a/ods/tests/test-mode-switch-env-set-tmpfile.sh
+++ b/ods/tests/test-mode-switch-env-set-tmpfile.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# ============================================================================
+# Test: scripts/mode-switch.sh's env_set() does not leak a stray .tmp file
+#       (or silently continue) when the awk rewrite fails partway through.
+# ============================================================================
+# Regression for: env_set() piped awk's output straight to a fixed
+# "${ENV_FILE}.tmp" path and only removed it via `&&`, so any awk failure
+# (disk full, permission error, etc.) left the partial .tmp file on disk
+# forever and the caller got no diagnostic.
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MODE_SWITCH="$REPO_ROOT/scripts/mode-switch.sh"
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+extract_env_set() {
+    sed -n '/^env_set() {/,/^}$/p' "$MODE_SWITCH"
+}
+
+TMP_DIR="$(mktemp -d)"
+FAKE_BIN="$TMP_DIR/fakebin"
+mkdir -p "$FAKE_BIN"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# A fake `awk` that writes partial output then fails, simulating a
+# mid-rewrite crash (disk full, permission revoked mid-write, etc.).
+cat > "$FAKE_BIN/awk" << 'EOF'
+#!/bin/sh
+echo "PARTIAL_LINE_FROM_FAILED_AWK"
+exit 1
+EOF
+chmod +x "$FAKE_BIN/awk"
+
+ENV_SET_SRC="$(extract_env_set)"
+
+run_env_set() {
+    local env_file="$1" key="$2" val="$3" use_fake_awk="$4"
+    (
+        error() { echo "ERROR: $1" >&2; return 1; }
+        ENV_FILE="$env_file"
+        if [[ "$use_fake_awk" == "true" ]]; then
+            PATH="$FAKE_BIN:$PATH"
+        fi
+        eval "$ENV_SET_SRC"
+        env_set "$key" "$val"
+    )
+}
+
+echo "== awk fails partway through the rewrite =="
+ENV_FILE_FAIL="$TMP_DIR/fail.env"
+cat > "$ENV_FILE_FAIL" << 'EOF'
+ODS_MODE=local
+OTHER_KEY=unrelated
+EOF
+run_env_set "$ENV_FILE_FAIL" "ODS_MODE" "cloud" "true"
+RC=$?
+check "env_set reports failure instead of continuing silently" "$RC" "1"
+LEFTOVER_COUNT=$(find "$TMP_DIR" -maxdepth 1 -name 'fail.env.*' | wc -l | tr -d ' ')
+check "no stray tmp file left behind after a failed rewrite" "$LEFTOVER_COUNT" "0"
+check "original .env is untouched when the rewrite fails" "$(cat "$ENV_FILE_FAIL")" "$(printf 'ODS_MODE=local\nOTHER_KEY=unrelated')"
+
+echo "== normal successful update (no regression) =="
+ENV_FILE_OK="$TMP_DIR/ok.env"
+cat > "$ENV_FILE_OK" << 'EOF'
+ODS_MODE=local
+OTHER_KEY=unrelated
+EOF
+run_env_set "$ENV_FILE_OK" "ODS_MODE" "cloud" "false"
+RC_OK=$?
+check "env_set succeeds on the normal path" "$RC_OK" "0"
+check "key is actually updated" "$(grep '^ODS_MODE=' "$ENV_FILE_OK")" "ODS_MODE=cloud"
+check "unrelated key is preserved" "$(grep '^OTHER_KEY=' "$ENV_FILE_OK")" "OTHER_KEY=unrelated"
+LEFTOVER_OK=$(find "$TMP_DIR" -maxdepth 1 -name 'ok.env.*' | wc -l | tr -d ' ')
+check "no stray tmp file left behind after a successful rewrite" "$LEFTOVER_OK" "0"
+
+echo "== appending a brand-new key (no regression) =="
+ENV_FILE_NEW="$TMP_DIR/new.env"
+cat > "$ENV_FILE_NEW" << 'EOF'
+ODS_MODE=local
+EOF
+run_env_set "$ENV_FILE_NEW" "BRAND_NEW_KEY" "value123" "false"
+check "new key is appended" "$(grep '^BRAND_NEW_KEY=' "$ENV_FILE_NEW")" "BRAND_NEW_KEY=value123"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`env_set()` (the backend for `ods mode <mode>`) rewrote `.env` by piping awk's output to a fixed `"${ENV_FILE}.tmp"` path and only removing it via a `&&` chain:

```bash
awk ... > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
```

If awk fails partway (disk full, permission error, etc.), the `&&` chain short-circuits and `rm -f` never runs — the partial `.tmp` file is left on disk indefinitely, and the caller gets no diagnostic at all.

Fix: use `mktemp` for a unique temp file, `mv` it into place on success, and explicitly clean up + call `error()` on failure.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this. Verified directly: extracted `env_set()` from both the pre-fix file (`git show HEAD`) and the current one, ran each against a fake `awk` that writes partial output and exits 1. Confirmed the pre-fix version leaves a `fail.env.tmp` file behind on disk; the post-fix version leaves nothing and reports the failure instead of continuing silently. Also verified the normal update/append paths are unaffected.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] CLI / scripts

## Risk And Validation
- Risk level: Low (same rewrite-then-replace strategy, just atomic and with cleanup; happy path behavior unchanged)
- Validation: `bash -n`, plus a new test exercising failure (fake failing awk) and success (update + append) paths.

```text
bash -n scripts/mode-switch.sh tests/test-mode-switch-env-set-tmpfile.sh

bash tests/test-mode-switch-env-set-tmpfile.sh
  # 8/8 PASS

# Manually confirmed against pre-fix code (git show HEAD): same fake-awk
# failure leaves fail.env.tmp on disk; post-fix leaves nothing.
```

## Operational Change Check
- [x] Operational change; validation above.
