### PR TITLE
fix(installer): stop _phase11_env_set() leaking a stray .tmp file on awk failure

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -213,13 +213,18 @@ else
     _phase11_env_set() {
         local key="$1" value="$2" env_file="$INSTALL_DIR/.env" tmp_file
         [[ -f "$env_file" ]] || return 0
-        tmp_file="${env_file}.tmp.$$"
-        awk -v k="$key" -v v="$value" '
+        tmp_file="$(mktemp "${env_file}.XXXXXX")"
+        if awk -v k="$key" -v v="$value" '
             BEGIN { found = 0 }
             index($0, k "=") == 1 { print k "=" v; found = 1; next }
             { print }
             END { if (!found) print k "=" v }
-        ' "$env_file" > "$tmp_file" && cat "$tmp_file" > "$env_file" && rm -f "$tmp_file"
+        ' "$env_file" > "$tmp_file"; then
+            mv "$tmp_file" "$env_file"
+        else
+            rm -f "$tmp_file"
+            error "Failed to write ${key} to $env_file"
+        fi
     }
 
     _phase11_env_get() {

--- a/ods/tests/test-phase11-env-set-tmpfile.sh
+++ b/ods/tests/test-phase11-env-set-tmpfile.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# ============================================================================
+# Test: installers/phases/11-services.sh's _phase11_env_set() does not leak
+#       a stray .tmp file (or continue silently) when the awk rewrite fails.
+# ============================================================================
+# Regression for: _phase11_env_set() piped awk's output to a fixed
+# "${env_file}.tmp.$$" path and only removed it via a `&&` chain, so any awk
+# failure (disk full, permission error, etc.) left the partial .tmp file on
+# disk forever with no diagnostic — this runs during service startup, so a
+# silently dropped GPU_BACKEND/ODS_MODE/LLM_API_URL write could leave the
+# stack misconfigured.
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PHASE_FILE="$REPO_ROOT/installers/phases/11-services.sh"
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+extract_phase11_env_set() {
+    sed -n '/^    _phase11_env_set() {/,/^    }$/p' "$PHASE_FILE"
+}
+
+TMP_DIR="$(mktemp -d)"
+FAKE_BIN="$TMP_DIR/fakebin"
+mkdir -p "$FAKE_BIN"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat > "$FAKE_BIN/awk" << 'EOF'
+#!/bin/sh
+echo "PARTIAL_LINE_FROM_FAILED_AWK"
+exit 1
+EOF
+chmod +x "$FAKE_BIN/awk"
+
+ENV_SET_SRC="$(extract_phase11_env_set)"
+
+run_env_set() {
+    local install_dir="$1" key="$2" val="$3" use_fake_awk="$4"
+    (
+        error() { echo "ERROR: $1" >&2; return 1; }
+        INSTALL_DIR="$install_dir"
+        if [[ "$use_fake_awk" == "true" ]]; then
+            PATH="$FAKE_BIN:$PATH"
+        fi
+        eval "$ENV_SET_SRC"
+        _phase11_env_set "$key" "$val"
+    )
+}
+
+echo "== awk fails partway through the rewrite =="
+INSTALL_DIR_FAIL="$TMP_DIR/fail-install"
+mkdir -p "$INSTALL_DIR_FAIL"
+cat > "$INSTALL_DIR_FAIL/.env" << 'EOF'
+GPU_BACKEND=nvidia
+OTHER_KEY=unrelated
+EOF
+run_env_set "$INSTALL_DIR_FAIL" "GPU_BACKEND" "amd" "true"
+RC=$?
+check "_phase11_env_set reports failure instead of continuing silently" "$RC" "1"
+LEFTOVER_COUNT=$(find "$INSTALL_DIR_FAIL" -maxdepth 1 -name '.env.*' | wc -l | tr -d ' ')
+check "no stray tmp file left behind after a failed rewrite" "$LEFTOVER_COUNT" "0"
+check "original .env is untouched when the rewrite fails" \
+    "$(cat "$INSTALL_DIR_FAIL/.env")" "$(printf 'GPU_BACKEND=nvidia\nOTHER_KEY=unrelated')"
+
+echo "== normal successful update (no regression) =="
+INSTALL_DIR_OK="$TMP_DIR/ok-install"
+mkdir -p "$INSTALL_DIR_OK"
+cat > "$INSTALL_DIR_OK/.env" << 'EOF'
+GPU_BACKEND=nvidia
+OTHER_KEY=unrelated
+EOF
+run_env_set "$INSTALL_DIR_OK" "GPU_BACKEND" "amd" "false"
+RC_OK=$?
+check "_phase11_env_set succeeds on the normal path" "$RC_OK" "0"
+check "key is actually updated" "$(grep '^GPU_BACKEND=' "$INSTALL_DIR_OK/.env")" "GPU_BACKEND=amd"
+check "unrelated key is preserved" "$(grep '^OTHER_KEY=' "$INSTALL_DIR_OK/.env")" "OTHER_KEY=unrelated"
+LEFTOVER_OK=$(find "$INSTALL_DIR_OK" -maxdepth 1 -name '.env.*' | wc -l | tr -d ' ')
+check "no stray tmp file left behind after a successful rewrite" "$LEFTOVER_OK" "0"
+
+echo "== appending a brand-new key (no regression) =="
+INSTALL_DIR_NEW="$TMP_DIR/new-install"
+mkdir -p "$INSTALL_DIR_NEW"
+cat > "$INSTALL_DIR_NEW/.env" << 'EOF'
+GPU_BACKEND=nvidia
+EOF
+run_env_set "$INSTALL_DIR_NEW" "BRAND_NEW_KEY" "value123" "false"
+check "new key is appended" "$(grep '^BRAND_NEW_KEY=' "$INSTALL_DIR_NEW/.env")" "BRAND_NEW_KEY=value123"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Same bug as #2684, in the installer's own phase code: `_phase11_env_set()` in Phase 11 (Starting Services) writes `GPU_BACKEND`, `ODS_MODE`, `LLM_API_URL`, `LLM_MODEL`, `LLAMA_SERVER_IMAGE`, etc. into `.env` by piping awk's output to a fixed `"${env_file}.tmp.$$"` path and only removing it via a `&&` chain:

```bash
awk ... "$env_file" > "$tmp_file" && cat "$tmp_file" > "$env_file" && rm -f "$tmp_file"
```

Any awk failure partway through leaves the partial `.tmp.$$` file on disk indefinitely with no diagnostic — this runs during service startup, so a silently dropped config write could leave the stack misconfigured with no indication why.

Fix: use `mktemp` for the temp file, `mv` it into place on success, and explicitly clean up + call `error()` on failure — the same fix already applied to `scripts/mode-switch.sh`'s `env_set()`.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this. Verified directly: extracted `_phase11_env_set()` from both the pre-fix file (`git show HEAD`) and the current one, ran each against a fake `awk` that writes partial output and exits 1. Confirmed the pre-fix version leaves `.env.tmp.<pid>` behind on disk; the post-fix version leaves nothing and reports the failure instead of continuing silently. Also verified the normal update/append paths are unaffected.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Installer / bootstrap / lifecycle

## Risk And Validation
- Risk level: Low (same rewrite-then-replace strategy, just atomic and with cleanup; happy path behavior unchanged)
- Validation: `bash -n`, plus a new test exercising failure (fake failing awk) and success (update + append) paths.

```text
bash -n installers/phases/11-services.sh tests/test-phase11-env-set-tmpfile.sh

bash tests/test-phase11-env-set-tmpfile.sh
  # 8/8 PASS

# Manually confirmed against pre-fix code (git show HEAD): same fake-awk
# failure leaves .env.tmp.<pid> on disk; post-fix leaves nothing.
```

## Operational Change Check
- [x] Operational change; validation above.
