### PR TITLE
fix(installer): close symlink race in background-tasks.sh registry creation

### DIFF
--- a/ods/installers/lib/background-tasks.sh
+++ b/ods/installers/lib/background-tasks.sh
@@ -23,11 +23,30 @@ bg_task_start() {
     local description="$3"
     local log_file="$4"
     
-    # Create registry if it doesn't exist
-    if [[ ! -f "$BG_TASK_REGISTRY" ]]; then
-        echo "[]" > "$BG_TASK_REGISTRY"
+    # Create registry if it doesn't exist. BG_TASK_REGISTRY defaults to a
+    # predictable path under the shared, world-writable /tmp — a local
+    # attacker could pre-plant a symlink there pointing at an arbitrary
+    # file. A plain `echo "[]" > "$BG_TASK_REGISTRY"` would silently follow
+    # that symlink and clobber whatever it points to (this installer often
+    # runs as root). Create it with O_CREAT|O_EXCL instead, which refuses
+    # to touch a path that already exists — symlink or not — rather than
+    # dereferencing it.
+    if [[ ! -e "$BG_TASK_REGISTRY" ]]; then
+        python3 - "$BG_TASK_REGISTRY" <<'PY'
+import os
+import sys
+
+registry_path = sys.argv[1]
+try:
+    fd = os.open(registry_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+except FileExistsError:
+    pass
+else:
+    with os.fdopen(fd, "w") as f:
+        f.write("[]")
+PY
     fi
-    
+
     # Add task to registry
     python3 - "$BG_TASK_REGISTRY" "$task_id" "$pid" "$description" "$log_file" <<'PY'
 import json

--- a/ods/tests/test-background-tasks-symlink-race.sh
+++ b/ods/tests/test-background-tasks-symlink-race.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# ============================================================================
+# Test: installers/lib/background-tasks.sh's bg_task_start() does not follow
+#       a pre-planted symlink at BG_TASK_REGISTRY to create/clobber an
+#       arbitrary file.
+# ============================================================================
+# Regression for: BG_TASK_REGISTRY defaults to a predictable path under the
+# shared, world-writable /tmp. bg_task_start() used to do:
+#     if [[ ! -f "$BG_TASK_REGISTRY" ]]; then echo "[]" > "$BG_TASK_REGISTRY"; fi
+# `-f` on a *dangling* symlink is false, so a local attacker who pre-plants
+# a dangling symlink at that path could get the installer (often running as
+# root) to create a new file at an attacker-chosen location — classic
+# CWE-59/CWE-367 symlink race.
+#
+# This test extracts the registry-creation block from the real file (both
+# pre-fix via `git show HEAD` and whatever is currently on disk) and runs
+# each against a dangling symlink pointing outside the intended registry
+# location, then checks whether the attacker-chosen target got created.
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB_FILE="$REPO_ROOT/installers/lib/background-tasks.sh"
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not available"; exit 0; }
+
+extract_current_block() {
+    sed -n '/# Create registry if it doesn'"'"'t exist\./,/^    fi$/p' "$LIB_FILE"
+}
+
+extract_prefix_block() {
+    local prefix
+    prefix="$(cd "$REPO_ROOT" && git rev-parse --show-prefix)"
+    (cd "$REPO_ROOT" && git show "HEAD:${prefix}installers/lib/background-tasks.sh") \
+        | sed -n '/# Create registry if it doesn'"'"'t exist$/,/^    fi$/p'
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+run_block() {
+    local block="$1" registry="$2"
+    (
+        BG_TASK_REGISTRY="$registry"
+        eval "$block"
+    )
+}
+
+echo "== Pre-fix block: dangling symlink escaping to an attacker-chosen path =="
+mkdir -p "$TMP_DIR/prefix/victim-dir"
+PREFIX_TARGET="$TMP_DIR/prefix/victim-dir/attacker-chosen-file.json"
+PREFIX_REGISTRY="$TMP_DIR/prefix/registry.json"
+ln -s "$PREFIX_TARGET" "$PREFIX_REGISTRY"
+PREFIX_BLOCK="$(extract_prefix_block)"
+run_block "$PREFIX_BLOCK" "$PREFIX_REGISTRY"
+check "pre-fix: following the symlink creates the attacker-chosen file (the bug)" \
+    "$([[ -e "$PREFIX_TARGET" ]] && echo yes || echo no)" "yes"
+
+echo "== Post-fix block: same dangling symlink =="
+mkdir -p "$TMP_DIR/postfix/victim-dir"
+POST_TARGET="$TMP_DIR/postfix/victim-dir/attacker-chosen-file.json"
+POST_REGISTRY="$TMP_DIR/postfix/registry.json"
+ln -s "$POST_TARGET" "$POST_REGISTRY"
+CURRENT_BLOCK="$(extract_current_block)"
+run_block "$CURRENT_BLOCK" "$POST_REGISTRY"
+check "post-fix: the symlink is never followed to create the attacker-chosen file" \
+    "$([[ -e "$POST_TARGET" ]] && echo yes || echo no)" "no"
+
+echo "== Post-fix block: normal case, no symlink involved =="
+NORMAL_REGISTRY="$TMP_DIR/normal-registry.json"
+run_block "$CURRENT_BLOCK" "$NORMAL_REGISTRY"
+check "post-fix: a plain, non-existent path still gets created normally" \
+    "$([[ -f "$NORMAL_REGISTRY" ]] && echo yes || echo no)" "yes"
+check "post-fix: freshly created registry starts as an empty JSON array" \
+    "$(cat "$NORMAL_REGISTRY")" "[]"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`bg_task_start()` creates its registry file (`BG_TASK_REGISTRY`, defaulting to `/tmp/ods-bg-tasks.json` — a predictable path under the shared, world-writable `/tmp`) like this:

```bash
if [[ ! -f "$BG_TASK_REGISTRY" ]]; then
    echo "[]" > "$BG_TASK_REGISTRY"
fi
```

`[[ -f ]]` on a *dangling* symlink is false. A local attacker who pre-plants a dangling symlink at `/tmp/ods-bg-tasks.json` pointing at some other path can get this code to follow it and create a new file at that attacker-chosen location the first time the installer runs — classic CWE-59/CWE-367 symlink race, and this installer frequently runs as root.

The later append path (`tempfile.mkstemp()` + `os.replace()`, already in the file) is already symlink-safe — `os.replace()` replaces the symlink entry itself rather than following it. This PR closes the one remaining gap: the initial creation.

Fix: create the registry with `O_CREAT|O_EXCL`, which fails if anything already exists at that path — symlink or not — instead of silently dereferencing it.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this. Verified directly (in WSL, since this needs real symlinks and python3): extracted the registry-creation block from both the pre-fix file (`git show HEAD`) and the current one, ran each against a dangling symlink pointing at an "attacker-chosen" path outside the registry location. Confirmed the pre-fix block creates the attacker-chosen file; the post-fix block never touches it. Also verified the normal, no-symlink case still creates a fresh `[]` registry correctly.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Installer / bootstrap / lifecycle

## Risk And Validation
- Risk level: Low (touches only the one-time initial-creation branch; the existing read/append/status logic is untouched)
- Validation: `bash -n`, plus a new test run under WSL that reproduces the symlink-follow directly against pre-fix code and confirms the fix blocks it.

```text
bash -n installers/lib/background-tasks.sh tests/test-background-tasks-symlink-race.sh

bash tests/test-background-tasks-symlink-race.sh   # (run under WSL/Linux — needs real symlinks + python3)
  # 4/4 PASS — pre-fix block follows the symlink (reproduces the bug),
  # post-fix block does not; normal creation path unaffected.
```

## Operational Change Check
- [x] Operational change; validation above.
