### PR TITLE
fix(installer): verify the compose failure report was actually written

### DIFF
--- a/ods/installers/lib/compose-failure-report.sh
+++ b/ods/installers/lib/compose-failure-report.sh
@@ -178,10 +178,26 @@ write_compose_failure_report() {
         fi
     } > "$report" 2>&1
 
-    if command -v ai_warn >/dev/null 2>&1; then
-        ai_warn "Compose failure report saved: $report"
+    # This function always runs as the first stage of a pipeline at every
+    # call site (`write_compose_failure_report ... | tail -n 1`), and bash's
+    # `set -e` is suspended for every command in a pipeline except the last
+    # — so a failed mkdir/redirect above (e.g. $install_dir unwritable)
+    # would NOT abort here. Explicitly verify the report actually landed on
+    # disk before claiming success; otherwise the caller would get back a
+    # path to a file that doesn't exist while believing the report saved.
+    if [[ -s "$report" ]]; then
+        if command -v ai_warn >/dev/null 2>&1; then
+            ai_warn "Compose failure report saved: $report"
+        else
+            echo "Compose failure report saved: $report"
+        fi
+        printf '%s\n' "$report"
     else
-        echo "Compose failure report saved: $report"
+        if command -v ai_bad >/dev/null 2>&1; then
+            ai_bad "Could not write compose failure report to $report"
+        else
+            echo "Could not write compose failure report to $report" >&2
+        fi
+        return 1
     fi
-    printf '%s\n' "$report"
 }

--- a/ods/tests/test-compose-failure-report-write-verify.sh
+++ b/ods/tests/test-compose-failure-report-write-verify.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# ============================================================================
+# Test: write_compose_failure_report() does not claim success when the
+#       report file was never actually written.
+# ============================================================================
+# Regression: this function always runs as the first stage of a pipeline at
+# every call site (`write_compose_failure_report ... | tail -n 1`). Bash's
+# `set -e` is suspended for every command in a pipeline except the last, so
+# when `{ ...report body... } > "$report" 2>&1` failed to open $report (e.g.
+# install_dir unwritable/nonexistent), the function did NOT abort — it fell
+# through to unconditionally printing "Compose failure report saved: $report"
+# and echoing that path back to the caller, even though nothing was written.
+#
+# This test sources the real library (both pre-fix via `git show HEAD` and
+# the current file) and calls write_compose_failure_report with an
+# install_dir that cannot be created, exactly as it's called at every real
+# call site: as the first stage of a pipeline.
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB_FILE="$REPO_ROOT/installers/lib/compose-failure-report.sh"
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+get_prefix_lib() {
+    local prefix
+    prefix="$(cd "$REPO_ROOT" && git rev-parse --show-prefix)"
+    (cd "$REPO_ROOT" && git show "HEAD:${prefix}installers/lib/compose-failure-report.sh")
+}
+
+run_with_lib() {
+    local lib_src="$1" install_dir="$2"
+    (
+        eval "$lib_src"
+        # Make $install_dir itself a file, not a directory — mkdir -p on it
+        # fails (already swallowed via `2>/dev/null || true`), and the
+        # subsequent report redirection then fails to open too, since a
+        # path component is a regular file, not a directory.
+        write_compose_failure_report \
+            "$install_dir" \
+            "test phase" \
+            "docker compose up" \
+            "" \
+            "unknown" \
+            "next step" | tail -n 1
+    )
+}
+
+echo "== Pre-fix library: install_dir cannot be created =="
+BLOCKED_PATH_PRE="$TMP_DIR/blocked-pre"
+: > "$BLOCKED_PATH_PRE"   # a plain file where the "directory" should be
+PREFIX_LIB="$(get_prefix_lib)"
+PREFIX_OUTPUT="$(run_with_lib "$PREFIX_LIB" "$BLOCKED_PATH_PRE/subdir")"
+check "pre-fix: claims a report path even though nothing was written (the bug)" \
+    "$([[ -n "$PREFIX_OUTPUT" ]] && echo yes || echo no)" "yes"
+check "pre-fix: the claimed report path does not actually exist" \
+    "$([[ -f "$PREFIX_OUTPUT" ]] && echo yes || echo no)" "no"
+
+echo "== Post-fix library: install_dir cannot be created =="
+BLOCKED_PATH_POST="$TMP_DIR/blocked-post"
+: > "$BLOCKED_PATH_POST"
+CURRENT_LIB="$(cat "$LIB_FILE")"
+POST_OUTPUT="$(run_with_lib "$CURRENT_LIB" "$BLOCKED_PATH_POST/subdir")"
+check "post-fix: no report path is emitted when nothing was written" \
+    "$([[ -z "$POST_OUTPUT" ]] && echo yes || echo no)" "yes"
+
+echo "== Post-fix library: normal writable install_dir still works =="
+OK_INSTALL_DIR="$TMP_DIR/ok-install"
+OK_OUTPUT="$(run_with_lib "$CURRENT_LIB" "$OK_INSTALL_DIR")"
+check "post-fix: a real report path is emitted on the success path" \
+    "$([[ -n "$OK_OUTPUT" ]] && echo yes || echo no)" "yes"
+check "post-fix: the emitted report path actually exists and is non-empty" \
+    "$([[ -s "$OK_OUTPUT" ]] && echo yes || echo no)" "yes"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`write_compose_failure_report()` always runs as the first stage of a pipeline at every call site (`write_compose_failure_report ... | tail -n 1`, used in `installers/phases/11-services.sh` and `installers/macos/install-macos.sh`). Bash's `set -e` is suspended for every command in a pipeline except the last one — so when the report body's `{ ... } > "$report" 2>&1` redirection failed to open (e.g. an unwritable/nonexistent `install_dir`), the function did **not** abort. It fell straight through to unconditionally printing `"Compose failure report saved: $report"` and echoing that path back to the caller — even though nothing was ever written to disk.

Every call site does check `[[ -n "${report_path:-}" ]]` before telling the operator the report was saved, but that guard is useless here because the function still emits a non-empty (just nonexistent) path.

Fix: explicitly verify the report file landed on disk (non-empty) before claiming success. On failure, report it and return non-zero, so the existing `[[ -n "$report_path" ]]` guards at call sites now work as they were clearly intended to.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this. This one took real investigation to pin down: I first assumed `set -e` inside the sourcing script would already catch a failed redirect, and confirmed empirically it does when the function is called directly — but every real call site invokes it as `func ... | tail -n 1`, and I reproduced with an isolated bash script that `set -e` is specifically suspended for non-last pipeline stages, which is exactly why the bug survives in practice. Verified the fix directly: sourced both the pre-fix library (`git show HEAD`) and the current one, called `write_compose_failure_report` through the identical `| tail -n 1` pattern with an install_dir that can't be created. Confirmed the pre-fix version still emits a path to a file that was never created; the post-fix version emits nothing. Also confirmed the existing `tests/test-compose-failure-report.sh` (success path) still passes unmodified.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Installer / bootstrap / lifecycle

## Risk And Validation
- Risk level: Low (adds a post-write existence check only; the report body and all existing successful-write behavior are unchanged)
- Validation: `bash -n`, the existing `tests/test-compose-failure-report.sh` (still 13/13 green), plus a new test reproducing the exact pipeline-based call pattern used at every real call site.

```text
bash -n installers/lib/compose-failure-report.sh tests/test-compose-failure-report-write-verify.sh

bash tests/test-compose-failure-report.sh
  # 13/13 PASS (unchanged, no regression)

bash tests/test-compose-failure-report-write-verify.sh
  # 5/5 PASS — pre-fix library claims a report path to a nonexistent file
  # (reproduces the bug); post-fix library emits nothing on failure and
  # a real, non-empty path on success.
```

## Operational Change Check
- [x] Operational change; validation above.
