### PR TITLE
fix(cold-storage): stop reporting a failed model archive as successful

### DIFF
--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -119,15 +119,28 @@ do_archive() {
         if (( idle_days >= MAX_IDLE_DAYS )); then
             if [[ "$dry_run" == "true" ]]; then
                 log "WOULD ARCHIVE: $name ($size, idle ${idle_days}d)"
+                ((archived++))
             else
                 log "ARCHIVING: $name ($size, idle ${idle_days}d)"
-                # Move to cold storage
-                mv "$model_dir" "$COLD_DIR/$name"
+                # Move to cold storage. This script runs under `set -uo
+                # pipefail` (no `-e`), so a failed mv here would otherwise
+                # fall straight through to the unconditional "ARCHIVED" log
+                # line and count() below — reporting success on a model
+                # that was never moved.
+                if ! mv "$model_dir" "$COLD_DIR/$name"; then
+                    log "ERROR: Failed to move $name to $COLD_DIR/$name — left in place, not counted as archived"
+                    ((skipped++))
+                    continue
+                fi
                 # Create symlink so HF cache still resolves
-                ln -s "$COLD_DIR/$name" "${model_dir%/}"
+                if ! ln -s "$COLD_DIR/$name" "${model_dir%/}"; then
+                    log "ERROR: Moved $name to $COLD_DIR/$name but failed to symlink it back at $model_dir — HF cache will show it as missing until you run: ln -s '$COLD_DIR/$name' '${model_dir%/}'"
+                    ((archived++))
+                    continue
+                fi
                 log "ARCHIVED: $name -> $COLD_DIR/$name"
+                ((archived++))
             fi
-            ((archived++))
         else
             log "SKIP (recent, ${idle_days}d): $name ($size)"
             ((skipped++))

--- a/ods/tests/test-llm-cold-storage-archive-failure.sh
+++ b/ods/tests/test-llm-cold-storage-archive-failure.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# ============================================================================
+# Test: scripts/llm-cold-storage.sh's do_archive() does not report a failed
+#       mv as a successful archive.
+# ============================================================================
+# Regression: this script runs under `set -uo pipefail` (no `-e`), and the
+# real archive step was:
+#     mv "$model_dir" "$COLD_DIR/$name"
+#     ln -s "$COLD_DIR/$name" "${model_dir%/}"
+#     log "ARCHIVED: $name -> $COLD_DIR/$name"
+# with no exit-status check on either command. If `mv` failed (destination
+# already exists as a non-empty directory, disk full, permission error,
+# etc.), the script still unconditionally logged "ARCHIVED" and counted the
+# model as archived, and would then create a symlink pointing at a
+# nonexistent cold-storage path — corrupting the HF cache entry while
+# leaving the model exactly where it was (no space freed at all).
+#
+# This runs the real script (both pre-fix via `git show HEAD` and the
+# current one) as a subprocess against a forced mv failure: pre-creating a
+# non-empty directory at the destination path, which makes `mv` fail
+# deterministically regardless of privilege level.
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CURRENT_SCRIPT="$REPO_ROOT/scripts/llm-cold-storage.sh"
+
+command -v bc >/dev/null 2>&1 || { echo "SKIP: bc not available (required by get_last_access_days)"; exit 0; }
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+get_prefix_script() {
+    local prefix
+    prefix="$(cd "$REPO_ROOT" && git rev-parse --show-prefix)"
+    (cd "$REPO_ROOT" && git show "HEAD:${prefix}scripts/llm-cold-storage.sh")
+}
+
+setup_fixture() {
+    local base="$1"
+    local hf_cache="$base/hf-cache"
+    local cold_dir="$base/cold"
+    local model_dir="$hf_cache/models--Fake--IdleModel"
+    mkdir -p "$model_dir"
+    echo "fake weights" > "$model_dir/model.bin"
+    # Old atime so get_last_access_days reports well past MAX_IDLE_DAYS (7).
+    touch -a -t 202001010000 "$model_dir/model.bin" "$model_dir"
+    mkdir -p "$cold_dir"
+    printf '%s\n' "$hf_cache" "$cold_dir"
+}
+
+# Force `mv "$model_dir" "$COLD_DIR/$name"` to fail: pre-create a plain
+# *file* at the destination path. `mv` moving a directory onto an existing
+# non-directory refuses ("cannot overwrite non-directory with directory"),
+# deterministically and regardless of privilege level — unlike an existing
+# directory target, which mv would just move the source inside instead.
+force_mv_failure() {
+    local cold_dir="$1"
+    : > "$cold_dir/models--Fake--IdleModel"
+}
+
+echo "== Pre-fix script: mv destination pre-blocked =="
+PREFIX_SCRIPT_SRC="$(get_prefix_script)"
+PREFIX_SCRIPT_FILE="$TMP_DIR/prefix-llm-cold-storage.sh"
+printf '%s\n' "$PREFIX_SCRIPT_SRC" > "$PREFIX_SCRIPT_FILE"
+chmod +x "$PREFIX_SCRIPT_FILE"
+
+mapfile -t PRE_FIXTURE < <(setup_fixture "$TMP_DIR/prefix-fixture")
+PRE_HF_CACHE="${PRE_FIXTURE[0]}"
+PRE_COLD_DIR="${PRE_FIXTURE[1]}"
+force_mv_failure "$PRE_COLD_DIR"
+PRE_LOG="$TMP_DIR/prefix.log"
+HF_CACHE="$PRE_HF_CACHE" COLD_DIR="$PRE_COLD_DIR" LOG_FILE="$PRE_LOG" \
+    bash "$PREFIX_SCRIPT_FILE" --execute > /dev/null 2>&1
+
+check "pre-fix: log falsely claims ARCHIVED despite the blocked mv (the bug)" \
+    "$(grep -c 'ARCHIVED: models--Fake--IdleModel ->' "$PRE_LOG" 2>/dev/null)" "1"
+check "pre-fix: model directory was never actually moved out of HF_CACHE" \
+    "$([[ -d "$PRE_HF_CACHE/models--Fake--IdleModel" && ! -L "$PRE_HF_CACHE/models--Fake--IdleModel" ]] && echo yes || echo no)" "yes"
+
+echo "== Post-fix script: mv destination pre-blocked =="
+mapfile -t POST_FIXTURE < <(setup_fixture "$TMP_DIR/postfix-fixture")
+POST_HF_CACHE="${POST_FIXTURE[0]}"
+POST_COLD_DIR="${POST_FIXTURE[1]}"
+force_mv_failure "$POST_COLD_DIR"
+POST_LOG="$TMP_DIR/postfix.log"
+HF_CACHE="$POST_HF_CACHE" COLD_DIR="$POST_COLD_DIR" LOG_FILE="$POST_LOG" \
+    bash "$CURRENT_SCRIPT" --execute > /dev/null 2>&1
+
+check "post-fix: log reports an ERROR instead of a false ARCHIVED" \
+    "$(grep -c 'ERROR: Failed to move models--Fake--IdleModel' "$POST_LOG" 2>/dev/null)" "1"
+check "post-fix: no false ARCHIVED line for the blocked model" \
+    "$(grep -c 'ARCHIVED: models--Fake--IdleModel ->' "$POST_LOG" 2>/dev/null)" "0"
+check "post-fix: model directory is still a real directory in HF_CACHE, not touched" \
+    "$([[ -d "$POST_HF_CACHE/models--Fake--IdleModel" && ! -L "$POST_HF_CACHE/models--Fake--IdleModel" ]] && echo yes || echo no)" "yes"
+
+echo "== Post-fix script: normal successful archive (no regression) =="
+mapfile -t OK_FIXTURE < <(setup_fixture "$TMP_DIR/ok-fixture")
+OK_HF_CACHE="${OK_FIXTURE[0]}"
+OK_COLD_DIR="${OK_FIXTURE[1]}"
+OK_LOG="$TMP_DIR/ok.log"
+HF_CACHE="$OK_HF_CACHE" COLD_DIR="$OK_COLD_DIR" LOG_FILE="$OK_LOG" \
+    bash "$CURRENT_SCRIPT" --execute > /dev/null 2>&1
+
+check "post-fix success path: ARCHIVED is logged" \
+    "$(grep -c 'ARCHIVED: models--Fake--IdleModel ->' "$OK_LOG" 2>/dev/null || echo 0)" "1"
+check "post-fix success path: model dir is now a symlink into cold storage" \
+    "$([[ -L "$OK_HF_CACHE/models--Fake--IdleModel" ]] && echo yes || echo no)" "yes"
+check "post-fix success path: cold storage actually holds the moved files" \
+    "$([[ -f "$OK_COLD_DIR/models--Fake--IdleModel/model.bin" ]] && echo yes || echo no)" "yes"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`llm-cold-storage.sh` runs under `set -uo pipefail` (no `-e`). The real archive step in `do_archive()` was:

```bash
log "ARCHIVING: $name ($size, idle ${idle_days}d)"
mv "$model_dir" "$COLD_DIR/$name"
ln -s "$COLD_DIR/$name" "${model_dir%/}"
log "ARCHIVED: $name -> $COLD_DIR/$name"
```

with no exit-status check on either `mv` or `ln -s`. If `mv` failed (destination conflict, disk full, permission error), the script still unconditionally logged `"ARCHIVED: ..."` and counted the model as archived — and would then go on to create a symlink pointing at a cold-storage path that was never actually populated, corrupting the HF cache entry while freeing zero NVMe space, with the log claiming success the whole time.

Fix: check both commands explicitly.
- Failed `mv` → log an error, leave the model in place, don't count it as archived.
- Successful `mv` but failed `ln -s` → log an error with the manual recovery command (the model *did* move, but the cache symlink is missing).

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this. Verified directly: extracted the real script from both the pre-fix version (`git show HEAD`) and the current one, ran each as a subprocess against a fixture where the `mv` destination is deliberately blocked (pre-created as a plain file, so `mv` refuses to overwrite a non-directory with a directory — deterministic regardless of privilege level). Confirmed the pre-fix script logs a false "ARCHIVED" line while the model never actually left the cache; the post-fix script logs an "ERROR" instead and leaves the model untouched. Also verified the normal successful-archive path (move + symlink + correct log line) is unaffected.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] CLI / scripts

## Risk And Validation
- Risk level: Low (adds explicit status checks only; the move/symlink mechanics and normal success path are unchanged)
- Validation: `bash -n`, plus a new test (run under WSL — the script needs GNU `stat`/`bc`) exercising the forced-failure and success paths against both pre-fix and post-fix code.

```text
bash -n scripts/llm-cold-storage.sh tests/test-llm-cold-storage-archive-failure.sh

bash tests/test-llm-cold-storage-archive-failure.sh   # (run under WSL/Linux)
  # 8/8 PASS — pre-fix script falsely logs ARCHIVED on a blocked mv
  # (reproduces the bug); post-fix logs an ERROR and leaves the model
  # untouched; normal successful archive path is unaffected.
```

## Operational Change Check
- [x] Operational change; validation above.
