### PR TITLE
fix(token-spy): make the always_keep_last_n safety check actually restore messages

### DIFF
--- a/ods/extensions/services/token-spy/filters.py
+++ b/ods/extensions/services/token-spy/filters.py
@@ -238,6 +238,7 @@ def _filter_history(body: dict, cfg: dict, result: FilterResult,
     # An atomic unit is: [user msg, assistant reply, tool_call/tool result chain]
     # We must not split these or the API contract breaks.
     units = _group_into_units(conv_msgs)
+    original_units = units  # kept for the Step 7 restoration below
 
     # Step 3: Apply max_pairs — keep only the N most recent units
     if max_pairs and len(units) > max_pairs:
@@ -287,14 +288,25 @@ def _filter_history(body: dict, cfg: dict, result: FilterResult,
     # from the original conversation are present (protects in-flight tool chains)
     if always_keep_last_n and conv_msgs:
         tail = conv_msgs[-always_keep_last_n:]
-        # Check if tail messages are already in filtered_conv
-        # by comparing the last N messages
         tail_ids = {id(m) for m in tail}
-        existing_ids = {id(m) for m in filtered_conv[-always_keep_last_n:]} if filtered_conv else set()
-        if not tail_ids.issubset(existing_ids):
-            # Ensure tail messages are present — they may have been modified by
-            # truncation but should still be in the list since we keep recent units
-            pass  # Units-based approach already preserves recent messages
+        existing_ids = {id(m) for m in filtered_conv}
+        missing_ids = tail_ids - existing_ids
+        if missing_ids:
+            # max_pairs/drop_old_tool_calls above dropped a unit that held one
+            # of the guaranteed tail messages. Restore whichever original
+            # units still hold a missing message, in original order, ahead of
+            # what survived filtering — units are atomic (user/assistant/tool
+            # chains), so we restore whole units rather than splicing
+            # individual messages back in and risking a broken tool_call/
+            # tool_result pairing.
+            restored = []
+            for unit in original_units:
+                unit_ids = {id(m) for m in unit}
+                if unit_ids & missing_ids and not unit_ids & existing_ids:
+                    restored.extend(unit)
+                    result.messages_removed -= len(unit)
+                    existing_ids |= unit_ids
+            filtered_conv = restored + filtered_conv
 
     result.messages_kept = len(system_msgs) + len(filtered_conv)
 

--- a/ods/extensions/services/token-spy/tests/test_filters_always_keep_last_n.py
+++ b/ods/extensions/services/token-spy/tests/test_filters_always_keep_last_n.py
@@ -1,0 +1,116 @@
+"""Regression: `always_keep_last_n` in _filter_history() must actually restore
+messages that max_pairs trimming dropped, not just check-and-ignore them.
+
+Bug: Step 7 of _filter_history() computed whether the guaranteed tail
+messages were missing from the filtered output, then did nothing about it
+(`pass`) when they were. A caller relying on always_keep_last_n to protect
+an in-flight tool call chain from being dropped by max_pairs could silently
+lose those messages, breaking the tool_call/tool_result pairing contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = TOKEN_SPY_DIR.parents[3]
+FILTERS_REL_PATH = "ods/extensions/services/token-spy/filters.py"
+
+
+def _load_from_path(path: Path, prefix: str):
+    spec = importlib.util.spec_from_file_location(f"{prefix}_{uuid4().hex}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_prefix_module(tmp_path: Path):
+    """Load the pre-fix filters.py straight from git HEAD, for comparison."""
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "show", f"HEAD:{FILTERS_REL_PATH}"],
+        capture_output=True, text=True, check=True,
+    )
+    prefix_file = tmp_path / "filters_prefix.py"
+    prefix_file.write_text(result.stdout, encoding="utf-8")
+    return _load_from_path(prefix_file, "filters_prefix")
+
+
+def _build_units(n_units: int) -> list[dict]:
+    """n_units atomic [user, assistant] units, oldest first."""
+    messages = []
+    for i in range(n_units):
+        messages.append({"role": "user", "content": f"user turn {i}"})
+        messages.append({"role": "assistant", "content": f"assistant reply {i}"})
+    return messages
+
+
+def _run_filter_history(module, messages: list[dict], cfg: dict):
+    body = {"messages": messages}
+    result = module.FilterResult()
+    body, result = module._filter_history(body, cfg, result, False)
+    return body["messages"], result
+
+
+def test_prefix_drops_guaranteed_tail_messages(tmp_path):
+    """Reproduces the bug directly against the pre-fix module."""
+    module = _load_prefix_module(tmp_path)
+    messages = _build_units(5)  # 5 units x 2 msgs = 10 messages
+    cfg = {"always_keep_last_n": 4, "max_pairs": 1}
+
+    filtered, _result = _run_filter_history(module, messages, cfg)
+
+    # Tail should be the last 4 raw messages (units 4 and 5), but max_pairs=1
+    # only keeps unit 5 (last 2 messages) — the pre-fix no-op safety check
+    # does not restore the missing unit 4 messages.
+    assert len(filtered) == 2, (
+        "pre-fix: expected the no-op safety check to leave only the "
+        f"max_pairs-trimmed unit (2 messages), got {len(filtered)}"
+    )
+    filtered_contents = {m["content"] for m in filtered}
+    assert "user turn 3" not in filtered_contents  # part of the dropped unit 4
+    assert "assistant reply 3" not in filtered_contents
+
+
+def test_postfix_restores_guaranteed_tail_messages():
+    """The fix: missing tail units must be restored."""
+    module = _load_from_path(TOKEN_SPY_DIR / "filters.py", "filters_current")
+    messages = _build_units(5)
+    cfg = {"always_keep_last_n": 4, "max_pairs": 1}
+
+    filtered, result = _run_filter_history(module, messages, cfg)
+
+    filtered_contents = [m["content"] for m in filtered]
+    assert "user turn 3" in filtered_contents, "unit 4's user message must be restored"
+    assert "assistant reply 3" in filtered_contents, "unit 4's assistant message must be restored"
+    assert "user turn 4" in filtered_contents, "unit 5 (kept by max_pairs) must still be present"
+    assert "assistant reply 4" in filtered_contents
+
+    # Restored unit must come before the max_pairs-kept unit, preserving order.
+    assert filtered_contents.index("user turn 3") < filtered_contents.index("user turn 4")
+
+    # max_pairs=1 drops units 1-4 (8 messages) in Step 3; Step 7 must restore
+    # unit 4 (2 messages) since it holds guaranteed tail messages, leaving
+    # units 1-3 (6 messages) as the only messages legitimately dropped.
+    assert result.messages_removed == 6
+
+
+def test_postfix_no_restoration_needed_when_tail_already_present():
+    """No-op path: max_pairs keeps enough units that the tail is already whole."""
+    module = _load_from_path(TOKEN_SPY_DIR / "filters.py", "filters_current")
+    messages = _build_units(5)
+    cfg = {"always_keep_last_n": 4, "max_pairs": 3}  # keeps units 3,4,5 (6 msgs)
+
+    filtered, result = _run_filter_history(module, messages, cfg)
+
+    assert len(filtered) == 6
+    assert result.messages_removed == 4  # units 1 and 2 legitimately dropped
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

`_filter_history()` in Token Spy's request filter is supposed to guarantee that the last `always_keep_last_n` raw conversation messages survive filtering — the comment says it "protects in-flight tool chains" from being cut off by `max_pairs`/`drop_old_tool_calls` trimming. Step 7 correctly *detects* when a guaranteed message is missing from the filtered output, but then does nothing about it:

```python
if not tail_ids.issubset(existing_ids):
    # Ensure tail messages are present — they may have been modified by
    # truncation but should still be in the list since we keep recent units
    pass  # Units-based approach already preserves recent messages
```

The comment's claim is wrong: `max_pairs` (Step 3) can and does drop whole atomic units that hold guaranteed tail messages. When that happens the safety check silently does nothing, and a caller relying on `always_keep_last_n` can lose part of an in-flight tool_call/tool_result chain — which is exactly the failure mode the setting exists to prevent.

Fix: actually restore whichever original atomic units still hold a missing tail message, in original order, ahead of what survived filtering. Units are restored whole (not spliced message-by-message) so a tool_call/tool_result pairing can't be broken by a partial restore.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this. Verified directly with pytest: built a 5-unit (10-message) conversation, set `max_pairs=1` (keeps only the newest unit) and `always_keep_last_n=4` (which spans the newest *two* units), and ran it through both the pre-fix module (loaded straight from `git show HEAD`) and the current one. Confirmed the pre-fix module drops the second-newest unit's messages entirely despite the guarantee; the post-fix module restores them, in the correct order, and adjusts `messages_removed` accordingly. Also verified the no-restoration-needed case (tail already fully covered by `max_pairs`) is unaffected.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Model routing / Hermes / capabilities (Token Spy sits in the LLM request path and filters conversation history before it reaches the model)

## Risk And Validation
- Risk level: Low-medium (changes actual filtering output for the specific case where `max_pairs`/`drop_old_tool_calls` would otherwise cut into the guaranteed tail — this is the intended behavior of the setting, previously silently broken; the common case where the tail is already covered is unaffected)
- Validation: new pytest file covering the bug (against pre-fix code loaded from git), the fix, and the no-op case.

```text
python -m pytest extensions/services/token-spy/tests/test_filters_always_keep_last_n.py -v
  # 3 passed
```

## Operational Change Check
- [x] This is an operational change and validation is intentionally deferred for: this touches model routing's request-filtering path, but the change is pure Python logic (unit-restoration inside one function) with no infra/network/service-startup surface. Covered by the pytest suite above; I don't have a running Token Spy + live LLM traffic to fleet-validate against, flagging for a maintainer to smoke-test with real conversation traffic before release.
