### PR TITLE
fix(tailscale): add missing no-new-privileges security_opt

### DIFF
--- a/ods/extensions/services/tailscale/compose.yaml
+++ b/ods/extensions/services/tailscale/compose.yaml
@@ -3,6 +3,8 @@ services:
     image: tailscale/tailscale:v1.96.5
     container_name: ods-tailscale
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     # network_mode: host puts the Tailscale daemon in the host's network
     # namespace so the device's tailnet IP (100.x.y.z) is the host
     # itself. **It does NOT make loopback-bound services reachable

--- a/ods/tests/test_tailscale_compose_no_new_privileges.py
+++ b/ods/tests/test_tailscale_compose_no_new_privileges.py
@@ -1,0 +1,66 @@
+"""Regression: extensions/services/tailscale/compose.yaml must set
+security_opt: no-new-privileges:true, matching the convention already used
+by every other ODS extension service compose file.
+
+`no-new-privileges` is fully compatible with `cap_add` — it blocks a
+process from gaining privileges beyond what it starts with (via setuid/
+setgid binaries or file capabilities), it does not strip capabilities
+already granted at container creation. Tailscale needs NET_ADMIN/NET_RAW
+(already granted via cap_add) and nothing more, so this is a pure
+hardening no-op for normal operation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_REL_PATH = "ods/extensions/services/tailscale/compose.yaml"
+COMPOSE_PATH = REPO_ROOT / "ods" / "extensions" / "services" / "tailscale" / "compose.yaml"
+
+
+def _load_prefix_yaml() -> dict:
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "show", f"HEAD:{COMPOSE_REL_PATH}"],
+        capture_output=True, text=True, check=True, encoding="utf-8",
+    )
+    return yaml.safe_load(result.stdout)
+
+
+def test_prefix_was_missing_no_new_privileges():
+    """Confirms the gap existed before this fix."""
+    doc = _load_prefix_yaml()
+    security_opt = doc["services"]["tailscale"].get("security_opt", [])
+    assert "no-new-privileges:true" not in security_opt
+
+
+def test_postfix_sets_no_new_privileges():
+    doc = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    security_opt = doc["services"]["tailscale"].get("security_opt", [])
+    assert "no-new-privileges:true" in security_opt
+
+
+def test_postfix_still_has_required_capabilities():
+    """No regression: NET_ADMIN/NET_RAW (Tailscale's mesh networking and NAT
+    traversal) must still be present — no-new-privileges must not have been
+    used as a substitute for the capabilities Tailscale actually needs."""
+    doc = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    cap_add = doc["services"]["tailscale"].get("cap_add", [])
+    assert "NET_ADMIN" in cap_add
+    assert "NET_RAW" in cap_add
+
+
+def test_postfix_compose_yaml_still_parses_as_valid_structure():
+    doc = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    svc = doc["services"]["tailscale"]
+    assert svc["network_mode"] == "host"
+    assert svc["devices"] == ["/dev/net/tun:/dev/net/tun"]
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

16 of the other 17 ODS extension service compose files set `security_opt: [no-new-privileges:true]`; `extensions/services/tailscale/compose.yaml` was the sole outlier (a second outlier, `comfyui`, exists too but is out of scope for this PR — flagged separately).

`no-new-privileges` blocks a process from gaining privileges beyond what it starts with (via setuid/setgid binaries or file capabilities). It does **not** strip capabilities already granted at container creation, so it's fully compatible with Tailscale's existing `cap_add: [NET_ADMIN, NET_RAW]` — a pure hardening no-op for normal operation.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this — noticed the convention while auditing service compose files (grepped for `no-new-privileges` across all 18 `extensions/services/*/compose.yaml` files; tailscale was one of two missing it). Verified with `docker compose -f extensions/services/tailscale/compose.yaml config` that the file still parses correctly and the new `security_opt` and existing `cap_add`/`network_mode`/`devices` all resolve as expected.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Docker Compose / service manifests

## Risk And Validation
- Risk level: Low (adds a standard hardening flag already used by every other service; does not touch capabilities, networking, or volumes)
- Validation: `docker compose config` on the real file, plus a new test comparing pre-fix (git HEAD) vs post-fix YAML and confirming `cap_add`/structure are unaffected.

```text
docker compose -f extensions/services/tailscale/compose.yaml config
  # parses cleanly; security_opt: [no-new-privileges:true] present alongside
  # the existing cap_add: [NET_ADMIN, NET_RAW]

python -m pytest tests/test_tailscale_compose_no_new_privileges.py -v
  # 4 passed
```

## Operational Change Check
- [x] Operational change; validation above (`docker compose config` against the real file).
