### PR TITLE
fix(compose): make llama-server image configurable on the Apple overlay

### DIFF
--- a/ods/docker-compose.apple.yml
+++ b/ods/docker-compose.apple.yml
@@ -9,7 +9,7 @@
 
 services:
   llama-server:
-    image: ghcr.io/ggml-org/llama.cpp:server-b8248
+    image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}
     platform: linux/arm64
     deploy:
       resources:

--- a/ods/tests/test-apple-llama-server-image-configurable.sh
+++ b/ods/tests/test-apple-llama-server-image-configurable.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS docker-compose.apple.yml — llama-server image configurability
+# ============================================================================
+# Every other GPU overlay (nvidia, cpu, intel, base) lets operators override
+# the llama-server image via LLAMA_SERVER_IMAGE. docker-compose.apple.yml
+# hardcoded it instead, so operators on Apple Silicon couldn't pin/swap the
+# image without editing the compose file directly.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APPLE_COMPOSE="$ROOT_DIR/docker-compose.apple.yml"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== docker-compose.apple.yml llama-server image tests ==="
+echo ""
+
+if grep -Fq 'image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}' "$APPLE_COMPOSE"; then
+    pass "llama-server image is overridable via LLAMA_SERVER_IMAGE with the original default preserved"
+else
+    fail "llama-server image is not using the \${LLAMA_SERVER_IMAGE:-...} pattern"
+fi
+
+if grep -Fxq 'image: ghcr.io/ggml-org/llama.cpp:server-b8248' "$APPLE_COMPOSE"; then
+    fail "llama-server image is still hardcoded with no override mechanism (the bug)"
+else
+    pass "llama-server image is no longer hardcoded"
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    RESOLVED_DEFAULT="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" -f "$APPLE_COMPOSE" config 2>/dev/null \
+        | grep -A0 "^    image: ghcr.io/ggml-org/llama.cpp" | head -n1 | sed 's/^ *image: //')"
+    if [[ "$RESOLVED_DEFAULT" == "ghcr.io/ggml-org/llama.cpp:server-b8248" ]]; then
+        pass "docker compose config resolves the default image unchanged when unset"
+    else
+        fail "docker compose config did not resolve the expected default image (got: '$RESOLVED_DEFAULT')"
+    fi
+
+    RESOLVED_OVERRIDE="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key LLAMA_SERVER_IMAGE="my-custom-image:tag" \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" -f "$APPLE_COMPOSE" config 2>/dev/null \
+        | grep -F "my-custom-image:tag" | head -n1)"
+    if [[ -n "$RESOLVED_OVERRIDE" ]]; then
+        pass "docker compose config honors a LLAMA_SERVER_IMAGE override"
+    else
+        fail "docker compose config did not honor a LLAMA_SERVER_IMAGE override"
+    fi
+else
+    echo "  SKIP: docker compose not available — skipping live config resolution checks"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`docker-compose.apple.yml` hardcoded `image: ghcr.io/ggml-org/llama.cpp:server-b8248` for llama-server. Every other overlay (`docker-compose.nvidia.yml`, `docker-compose.cpu.yml`, `docker-compose.intel.yml`) and the base compose file already support overriding the image via `LLAMA_SERVER_IMAGE` — already registered in `.env.schema.json` and documented in `.env.example`. Apple Silicon operators had no way to pin a specific build or swap images without editing the compose file directly.

Fix: switch to the same `${LLAMA_SERVER_IMAGE:-...}` pattern already used everywhere else, keeping the existing default tag unchanged.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this — grepped all `docker-compose*.yml` files for `image:.*llama` and found apple.yml was the only overlay hardcoding it (the AMD overlay builds locally instead of pulling an image, so it's not part of this pattern). Verified directly with real `docker compose config` (Docker Desktop, not mocked): confirmed the default image still resolves unchanged when `LLAMA_SERVER_IMAGE` is unset, and confirmed a `LLAMA_SERVER_IMAGE=my-custom-image:tag` override actually takes effect in the resolved config.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Docker Compose / service manifests

## Risk And Validation
- Risk level: Low (adds an override mechanism only; default behavior is byte-for-byte identical to before)
- Validation: real `docker compose config` runs (default + override), plus a new test.

```text
docker compose -f docker-compose.base.yml -f docker-compose.apple.yml config
  # (with WEBUI_SECRET/DASHBOARD_API_KEY set) resolves llama-server image
  # to ghcr.io/ggml-org/llama.cpp:server-b8248 unchanged when unset, and to
  # the override value when LLAMA_SERVER_IMAGE is set — confirmed both ways

bash tests/test-apple-llama-server-image-configurable.sh
  # 4/4 PASS
```

## Operational Change Check
- [x] Operational change; validation above (`docker compose config` against the real files).
