### PR TITLE
fix(compose): add missing group_add for dashboard-api's GPU devices on multi-GPU AMD

### DIFF
--- a/ods/docker-compose.multigpu-amd.yml
+++ b/ods/docker-compose.multigpu-amd.yml
@@ -45,6 +45,12 @@ services:
     devices:
       - /dev/kfd:/dev/kfd
       - /dev/dri:/dev/dri
+    # Without group membership, a non-root container process can't actually
+    # read these device nodes (video/render group ownership on the host) —
+    # same requirement as llama-server's group_add in docker-compose.amd.yml.
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-992}"
     environment:
       GPU_COUNT: "${GPU_COUNT:-1}"
       GPU_ASSIGNMENT_JSON_B64: "${GPU_ASSIGNMENT_JSON_B64:-}"

--- a/ods/tests/test-multigpu-amd-dashboard-api-group-add.sh
+++ b/ods/tests/test-multigpu-amd-dashboard-api-group-add.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS docker-compose.multigpu-amd.yml — dashboard-api GPU device group_add
+# ============================================================================
+# dashboard-api gets /dev/kfd and /dev/dri added for multi-GPU monitoring,
+# but without group_add (video/render group membership) a non-root
+# container process can't actually read those device nodes — the same
+# requirement llama-server already has via docker-compose.amd.yml's
+# group_add. Without it, "Dashboard-api gets all GPUs for monitoring" (this
+# file's own header comment) silently fails with permission errors.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MULTIGPU_AMD="$ROOT_DIR/docker-compose.multigpu-amd.yml"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== multigpu-amd dashboard-api group_add tests ==="
+echo ""
+
+# Extract just the dashboard-api service block for a targeted check.
+DASHBOARD_BLOCK="$(awk '/^  dashboard-api:/{flag=1} /^  [a-z]/{if ($0 != "  dashboard-api:") flag=0} flag' "$MULTIGPU_AMD")"
+
+if grep -Fq '/dev/kfd:/dev/kfd' <<< "$DASHBOARD_BLOCK" && grep -Fq '/dev/dri:/dev/dri' <<< "$DASHBOARD_BLOCK"; then
+    pass "dashboard-api still requests /dev/kfd and /dev/dri (no regression)"
+else
+    fail "dashboard-api is missing the expected GPU device mounts"
+fi
+
+if grep -Fq 'group_add:' <<< "$DASHBOARD_BLOCK" && grep -Fq 'VIDEO_GID' <<< "$DASHBOARD_BLOCK" && grep -Fq 'RENDER_GID' <<< "$DASHBOARD_BLOCK"; then
+    pass "dashboard-api sets group_add for the mounted GPU devices"
+else
+    fail "dashboard-api mounts GPU devices without group_add (the bug)"
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    RESOLVED="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" -f "$ROOT_DIR/docker-compose.amd.yml" -f "$MULTIGPU_AMD" \
+        config 2>/dev/null | awk '/^  dashboard-api:/{flag=1} /^  [a-z]/{if ($0 != "  dashboard-api:") flag=0} flag')"
+    if grep -A3 'group_add:' <<< "$RESOLVED" | grep -Fq '"44"' && grep -A3 'group_add:' <<< "$RESOLVED" | grep -Fq '"992"'; then
+        pass "docker compose config resolves group_add to the expected default GIDs (44, 992)"
+    else
+        fail "docker compose config did not resolve the expected group_add defaults"
+    fi
+else
+    echo "  SKIP: docker compose not available — skipping live config resolution check"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`docker-compose.multigpu-amd.yml` adds `/dev/kfd` and `/dev/dri` to `dashboard-api` for per-GPU monitoring across multiple AMD cards, but never grants group membership for them. Those device nodes are typically owned by the host's `video`/`render` groups with restrictive permissions — without `group_add`, a non-root container process can't actually read them.

`llama-server` in the same file already gets this right via `docker-compose.amd.yml`'s `group_add: [VIDEO_GID, RENDER_GID]`, and this file's own header comment even says "devices and group_add inherited from docker-compose.amd.yml" — but that only applies to `llama-server`; `dashboard-api`'s device mounts are added fresh in this overlay with no group_add, silently undermining "Dashboard-api gets all GPUs for monitoring" (also from this file's header comment).

Fix: add the same `group_add` (`VIDEO_GID`/`RENDER_GID`, defaults 44/992) to `dashboard-api`.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this — noticed the discrepancy between the file's own header comment describing llama-server's inherited group_add and dashboard-api's device block having none. Verified directly with real `docker compose config` (Docker Desktop, not mocked), layering `docker-compose.base.yml` + `docker-compose.amd.yml` + `docker-compose.multigpu-amd.yml`: confirmed `dashboard-api`'s resolved config now includes `group_add: ["44", "992"]` alongside the existing device mounts.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Docker Compose / service manifests

## Risk And Validation
- Risk level: Low (adds group membership only; the mounted devices, ports, and other config are unchanged — this is strictly additive access matching what llama-server already has for the identical devices)
- Validation: real layered `docker compose config` run, plus a new test.

```text
docker compose -f docker-compose.base.yml -f docker-compose.amd.yml -f docker-compose.multigpu-amd.yml config
  # (with WEBUI_SECRET/DASHBOARD_API_KEY set) resolves dashboard-api's
  # group_add to ["44", "992"] alongside the existing /dev/kfd, /dev/dri

bash tests/test-multigpu-amd-dashboard-api-group-add.sh
  # 3/3 PASS
```

## Operational Change Check
- [x] Operational change; validation above (`docker compose config` against the real, layered files).
