### PR TITLE
fix(compose): add missing CPU/memory reservations to nvidia.yml llama-server

### DIFF
--- a/ods/docker-compose.nvidia.yml
+++ b/ods/docker-compose.nvidia.yml
@@ -8,14 +8,16 @@ services:
     image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9014}
     deploy:
       resources:
+        limits:
+          cpus: '${LLAMA_CPU_LIMIT:-16.0}'
+          memory: ${LLAMA_SERVER_MEMORY_LIMIT:-64G}
         reservations:
+          cpus: '${LLAMA_CPU_RESERVATION:-2.0}'
+          memory: 4G
           devices:
             - driver: nvidia
               count: all
               capabilities: [gpu]
-        limits:
-          cpus: '${LLAMA_CPU_LIMIT:-16.0}'
-          memory: ${LLAMA_SERVER_MEMORY_LIMIT:-64G}
 
   dashboard-api:
     deploy:

--- a/ods/tests/test-nvidia-llama-server-cpu-memory-reservation.sh
+++ b/ods/tests/test-nvidia-llama-server-cpu-memory-reservation.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS docker-compose.nvidia.yml — llama-server CPU/memory reservations
+# ============================================================================
+# Every overlay that overrides llama-server's deploy.resources (apple, cpu,
+# intel) sets both limits AND reservations for cpus/memory. nvidia.yml only
+# set limits — its reservations block had only the GPU `devices` entry, with
+# no cpus/memory floor, unlike every sibling overlay.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+NVIDIA_COMPOSE="$ROOT_DIR/docker-compose.nvidia.yml"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== docker-compose.nvidia.yml llama-server reservation tests ==="
+echo ""
+
+LLAMA_BLOCK="$(awk '/^  llama-server:/{flag=1} /^  [a-z]/{if ($0 != "  llama-server:") flag=0} flag' "$NVIDIA_COMPOSE")"
+
+if grep -Fq 'LLAMA_CPU_RESERVATION' <<< "$LLAMA_BLOCK" && grep -A5 'reservations:' <<< "$LLAMA_BLOCK" | grep -Fq 'memory: 4G'; then
+    pass "llama-server declares a CPU and memory reservation"
+else
+    fail "llama-server is still missing CPU/memory reservations (the bug)"
+fi
+
+if grep -A10 'reservations:' <<< "$LLAMA_BLOCK" | grep -Fq 'driver: nvidia'; then
+    pass "the existing GPU device reservation is preserved (no regression)"
+else
+    fail "the GPU device reservation was lost"
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    RESOLVED="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" -f "$NVIDIA_COMPOSE" config 2>/dev/null \
+        | awk '/^  llama-server:/{flag=1} /^  [a-z]/{if ($0 != "  llama-server:") flag=0} flag')"
+    if grep -A3 'reservations:' <<< "$RESOLVED" | grep -Fq 'cpus: 2' \
+        && grep -A5 'reservations:' <<< "$RESOLVED" | grep -Fq '"4294967296"'; then
+        pass "docker compose config resolves the default CPU/memory reservation (2 cpus, 4G)"
+    else
+        fail "docker compose config did not resolve the expected reservation defaults"
+    fi
+    if grep -A10 'reservations:' <<< "$RESOLVED" | grep -Fq 'driver: nvidia'; then
+        pass "docker compose config still resolves the GPU device reservation"
+    else
+        fail "docker compose config lost the GPU device reservation"
+    fi
+else
+    echo "  SKIP: docker compose not available — skipping live config resolution checks"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Every overlay that overrides `llama-server`'s `deploy.resources` — `docker-compose.apple.yml`, `docker-compose.cpu.yml`, `docker-compose.intel.yml` — sets both `limits` and `reservations` for `cpus`/`memory`. `docker-compose.nvidia.yml` only set `limits`; its `reservations` block had just the GPU `devices` entry, with no `cpus`/`memory` floor. Under host resource pressure from other containers, `llama-server` on the NVIDIA backend had no guaranteed minimum CPU/memory the way every other backend already does.

Fix: add `cpus`/`memory` to the existing `reservations` block alongside the GPU device reservation (merged into the single `reservations:` key — a naive addition would otherwise create a duplicate YAML key at the same level, which I caught and corrected before committing), matching `intel.yml`'s reservation defaults (2.0 cpus, 4G) since both are GPU-backed overlays with a similarly large limit ceiling.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this — compared `deploy.resources` blocks across all four llama-server-overriding overlays and found nvidia.yml was the only one missing the reservation floor. First implementation attempt introduced a duplicate `reservations:` key under the same `resources:` mapping (invalid/ambiguous YAML) — caught by re-reading the file after editing, then corrected by merging into one `reservations:` block. Verified directly with real `docker compose config` (Docker Desktop, not mocked): confirmed the resolved config now shows `reservations: {cpus: 2, memory: "4294967296", devices: [...nvidia...]}` together, and that the full layered stack (`base.yml` + `nvidia.yml`) still validates cleanly.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Docker Compose / service manifests

## Risk And Validation
- Risk level: Low (adds a resource floor only; existing limits and the GPU device reservation are unchanged)
- Validation: real `docker compose config` run confirming the merged reservations block resolves correctly, plus a new test.

```text
docker compose -f docker-compose.base.yml -f docker-compose.nvidia.yml config
  # (with WEBUI_SECRET/DASHBOARD_API_KEY set) resolves llama-server's
  # deploy.resources.reservations to {cpus: 2, memory: 4G, devices: [nvidia
  # gpu, count: -1]} together — confirmed the merge is valid, not a
  # duplicate key silently dropping one or the other

bash tests/test-nvidia-llama-server-cpu-memory-reservation.sh
  # 4/4 PASS
```

## Operational Change Check
- [x] Operational change; validation above (`docker compose config` against the real, layered files).
