### PR TITLE
fix(schema): mark ODS_TALK_VISION_KEY as secret

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -187,6 +187,7 @@
     "ODS_TALK_VISION_KEY": {
       "type": "string",
       "description": "Optional bearer token for the ODS Talk vision backend.",
+      "secret": true,
       "default": ""
     },
     "ODS_TALK_VISION_MODEL": {

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1275,6 +1275,7 @@ def test_render_env_preserves_commented_key_absent_from_values(commented_example
         "AUDIO_STT_OPENAI_API_KEY",
         "AUDIO_TTS_OPENAI_API_KEY",
         "RAG_OPENAI_API_KEY",
+        "ODS_TALK_VISION_KEY",
     ],
 )
 def test_production_schema_marks_provider_api_keys_secret(key):


### PR DESCRIPTION
## Summary

`ODS_TALK_VISION_KEY` ("Optional bearer token for the ODS Talk vision backend") was missing `"secret": true` in `.env.schema.json`, unlike every other API-key/token field. The repo already has a regression-guard test (`test_production_schema_marks_provider_api_keys_secret`) specifically for this class of gap, whose own docstring explains why it matters: *"without the explicit flag, masking in both `ods config show` and `GET /api/settings/env` falls back to a name-pattern match. The schema should be the authoritative source."* — this credential just wasn't in that guarded list.

Fix: add `"secret": true` to the schema entry, and extend the existing parametrized test to cover this key so it can't silently regress.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this — found the gap by comparing `ODS_TALK_VISION_KEY`'s schema entry against sibling credential fields, then found the pre-existing test built exactly for this class of gap and extended it rather than writing a new one. Ran the extended parametrized test (now 9 cases) and the full `test_settings_env.py` suite to confirm no regressions.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Dashboard API / host agent

## Risk And Validation
- Risk level: Low (adds an explicit flag matching existing name-pattern-based masking behavior; no behavior change for values that were already being masked heuristically, only makes the masking authoritative)
- Validation: extended existing regression-guard test plus full `test_settings_env.py` suite.

```text
python -c "import json; json.load(open('.env.schema.json', encoding='utf-8'))"

cd extensions/services/dashboard-api
python -m pytest tests/test_settings_env.py -k test_production_schema_marks_provider_api_keys_secret -v
  # 9 passed (8 existing + ODS_TALK_VISION_KEY)

python -m pytest tests/test_settings_env.py -v
  # 77 passed — no regressions
```

## Operational Change Check
- [x] This is not an operational change — schema metadata + test coverage only.
