### PR TITLE
fix(compose): fail safe to GPU 0 when LLAMA_SERVER_GPU_INDICES is unset

### DIFF
--- a/ods/docker-compose.multigpu-amd.yml
+++ b/ods/docker-compose.multigpu-amd.yml
@@ -35,7 +35,14 @@ services:
       - /models
     environment:
       LEMONADE_LLAMACPP: "${LEMONADE_LLAMACPP:-auto}"
-      ROCR_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_INDICES:-}"
+      # LLAMA_SERVER_GPU_INDICES is normally computed by the installer from
+      # the detected GPU assignment (e.g. "0,1,2"). If it's ever unset — a
+      # failed assignment computation, or the overlay enabled manually — an
+      # empty ROCR_VISIBLE_DEVICES means zero GPUs visible to ROCm, not "all
+      # GPUs": llama-server would silently lose GPU acceleration entirely.
+      # Fail safe to GPU 0, matching every sibling multigpu-amd service
+      # (comfyui/embeddings/whisper all default their GPU index to 0).
+      ROCR_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_INDICES:-0}"
       # Tensor split ratio (e.g. "0.5,0.5") — passed via env var because it may
       # be empty (auto-split). Inherited by inner llama-server via fork()+execv().
       LLAMA_ARG_TENSOR_SPLIT: "${LLAMA_ARG_TENSOR_SPLIT:-}"

--- a/ods/tests/test-multigpu-amd-llama-server-rocr-default.sh
+++ b/ods/tests/test-multigpu-amd-llama-server-rocr-default.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS docker-compose.multigpu-amd.yml — llama-server ROCR_VISIBLE_DEVICES
+# default
+# ============================================================================
+# Every sibling multigpu-amd service (comfyui, embeddings, whisper) defaults
+# its ROCR_VISIBLE_DEVICES-driving var to "0" — a safe, always-valid GPU
+# index — if unset. llama-server defaulted LLAMA_SERVER_GPU_INDICES (which
+# feeds ROCR_VISIBLE_DEVICES) to an empty string instead. An explicitly
+# empty ROCR_VISIBLE_DEVICES means "zero GPUs visible" to ROCm, not "all
+# GPUs" — so if the installer's GPU assignment computation ever failed to
+# populate LLAMA_SERVER_GPU_INDICES, llama-server would silently lose GPU
+# acceleration entirely, worse than every sibling service's fail-safe.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MULTIGPU_AMD="$ROOT_DIR/docker-compose.multigpu-amd.yml"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== multigpu-amd llama-server ROCR_VISIBLE_DEVICES default tests ==="
+echo ""
+
+if grep -Fq 'ROCR_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_INDICES:-0}"' "$MULTIGPU_AMD"; then
+    pass "llama-server defaults ROCR_VISIBLE_DEVICES to GPU 0, matching sibling services"
+else
+    fail "llama-server does not default ROCR_VISIBLE_DEVICES to \"0\" (the bug, or a regression)"
+fi
+
+if grep -Fq 'ROCR_VISIBLE_DEVICES: "${LLAMA_SERVER_GPU_INDICES:-}"' "$MULTIGPU_AMD"; then
+    fail "llama-server still defaults ROCR_VISIBLE_DEVICES to an empty string (the bug)"
+else
+    pass "llama-server no longer defaults ROCR_VISIBLE_DEVICES to an empty string"
+fi
+
+for sibling in \
+    "extensions/services/comfyui/compose.multigpu-amd.yaml:COMFYUI_GPU_INDEX" \
+    "extensions/services/embeddings/compose.multigpu-amd.yaml:EMBEDDINGS_GPU_INDEX" \
+    "extensions/services/whisper/compose.multigpu-amd.yaml:WHISPER_GPU_INDEX"; do
+    file="${sibling%%:*}"
+    var="${sibling##*:}"
+    if grep -Fq "ROCR_VISIBLE_DEVICES: \"\${${var}:-0}\"" "$ROOT_DIR/$file"; then
+        pass "sibling $file still defaults to GPU 0 (confirms the convention being matched)"
+    else
+        fail "sibling $file no longer defaults to GPU 0 — convention check is stale"
+    fi
+done
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    RESOLVED_DEFAULT="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" -f "$ROOT_DIR/docker-compose.amd.yml" -f "$MULTIGPU_AMD" \
+        config 2>/dev/null | sed -n '/^  llama-server:/,/^  [a-z]/p' | grep -i 'ROCR_VISIBLE_DEVICES')"
+    if grep -Fq '"0"' <<< "$RESOLVED_DEFAULT"; then
+        pass "docker compose config resolves ROCR_VISIBLE_DEVICES to \"0\" when unset"
+    else
+        fail "docker compose config did not resolve the expected default (got: '$RESOLVED_DEFAULT')"
+    fi
+
+    RESOLVED_OVERRIDE="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key LLAMA_SERVER_GPU_INDICES="0,1,2" \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" -f "$ROOT_DIR/docker-compose.amd.yml" -f "$MULTIGPU_AMD" \
+        config 2>/dev/null | sed -n '/^  llama-server:/,/^  [a-z]/p' | grep -i 'ROCR_VISIBLE_DEVICES')"
+    if grep -Fq '0,1,2' <<< "$RESOLVED_OVERRIDE"; then
+        pass "docker compose config still honors a real multi-GPU assignment"
+    else
+        fail "docker compose config did not honor a LLAMA_SERVER_GPU_INDICES override"
+    fi
+else
+    echo "  SKIP: docker compose not available — skipping live config resolution checks"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Every sibling multigpu-amd service (`comfyui`, `embeddings`, `whisper`) defaults its `ROCR_VISIBLE_DEVICES`-driving var to `"0"` (a safe, always-valid GPU index) if unset. `docker-compose.multigpu-amd.yml`'s `llama-server` defaulted `LLAMA_SERVER_GPU_INDICES` (which feeds `ROCR_VISIBLE_DEVICES`) to an **empty string** instead.

`LLAMA_SERVER_GPU_INDICES` is normally computed by the installer from the detected GPU assignment (a real comma list like `"0,1,2"`, per `installers/phases/03-features.sh`) — but an explicitly empty `ROCR_VISIBLE_DEVICES` means "zero GPUs visible" to ROCm, not "all GPUs". If the installer's assignment computation ever failed to populate this var (or the overlay is enabled manually without it set), `llama-server` — the one service in this overlay that most needs GPU access — would silently lose GPU acceleration entirely, which is worse than every sibling service's fail-safe of at least GPU 0.

Fix: default to `"0"` instead, matching the established sibling convention.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this — compared `ROCR_VISIBLE_DEVICES` handling across all multigpu-amd compose files and found llama-server was the only one defaulting to empty instead of `"0"`. Traced `LLAMA_SERVER_GPU_INDICES` through `installers/phases/03-features.sh` and `06-directories.sh` to confirm it's meant to always be a real assignment, with the empty default only ever hit in a failure/manual-config edge case. Verified directly with real `docker compose config` (Docker Desktop, not mocked), layering `base.yml` + `amd.yml` + `multigpu-amd.yml`: confirmed the default now resolves to `ROCR_VISIBLE_DEVICES: "0"`, and a real `LLAMA_SERVER_GPU_INDICES=0,1,2` override still resolves correctly.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Docker Compose / service manifests

## Risk And Validation
- Risk level: Low (only changes the fallback used when the installer's GPU assignment computation didn't run/failed; normal installer-driven multi-GPU setups already set `LLAMA_SERVER_GPU_INDICES` explicitly and are unaffected)
- Validation: real layered `docker compose config` runs (default + override), plus a new test that also cross-checks the sibling convention it's matching.

```text
docker compose -f docker-compose.base.yml -f docker-compose.amd.yml -f docker-compose.multigpu-amd.yml config
  # (with WEBUI_SECRET/DASHBOARD_API_KEY set) resolves llama-server's
  # ROCR_VISIBLE_DEVICES to "0" when LLAMA_SERVER_GPU_INDICES is unset, and
  # to "0,1,2" when explicitly set — confirmed both ways

bash tests/test-multigpu-amd-llama-server-rocr-default.sh
  # 7/7 PASS
```

## Operational Change Check
- [x] Operational change; validation above (`docker compose config` against the real, layered files).
