### PR TITLE
fix(egress): implement LRU eviction for direct_http_clients (#2701)

### DIFF
--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -7,6 +7,7 @@ injects provider credentials from a private file at the final egress boundary.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -66,6 +67,10 @@ PROBE_TIMEOUT_SECONDS = float(
         str(DEFAULT_PROBE_TIMEOUT_SECONDS),
     )
 )
+MAX_DIRECT_CLIENTS = max(
+    1,
+    int(os.environ.get("ODS_REMOTE_PROVIDER_MAX_DIRECT_CLIENTS", "4")),
+)
 app = FastAPI(title="ODS Remote Provider Egress", docs_url=None, redoc_url=None, openapi_url=None)
 
 _HOP_BY_HOP_RESPONSE_HEADERS = {
@@ -104,9 +109,24 @@ def _http_client(connection_key: str = "") -> httpx.AsyncClient:
             clients = {}
             app.state.direct_http_clients = clients
         client = clients.get(connection_key)
-        if client is None or client.is_closed:
-            client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
-            clients[connection_key] = client
+        if client is not None and not client.is_closed:
+            # Refresh LRU ordering: move to end
+            clients[connection_key] = clients.pop(connection_key)
+            return client
+
+        # Evict oldest entries if at or exceeding capacity
+        while len(clients) >= MAX_DIRECT_CLIENTS:
+            old_key, old_client = next(iter(clients.items()))
+            del clients[old_key]
+            if old_client and not old_client.is_closed:
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(old_client.aclose())
+                except RuntimeError:
+                    pass
+
+        client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
+        clients[connection_key] = client
         return client
     client = getattr(app.state, "http", None)
     if client is None or client.is_closed:
@@ -431,8 +451,11 @@ async def _startup() -> None:
 
 @app.on_event("shutdown")
 async def _shutdown() -> None:
-    await app.state.http.aclose()
+    http_client = getattr(app.state, "http", None)
+    if http_client is not None and not http_client.is_closed:
+        await http_client.aclose()
     clients = getattr(app.state, "direct_http_clients", {})
-    for client in clients.values():
-        await client.aclose()
+    for client in list(clients.values()):
+        if not client.is_closed:
+            await client.aclose()
     clients.clear()

--- a/ods/extensions/services/remote-provider-egress/app/tests/test_direct_http_clients.py
+++ b/ods/extensions/services/remote-provider-egress/app/tests/test_direct_http_clients.py
@@ -1,0 +1,174 @@
+"""Regression tests for #2701 — direct_http_clients LRU eviction and bounded capacity.
+
+These tests verify that app.state.direct_http_clients does not grow without bound,
+evicts old clients when capacity is reached, and closes clients cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+
+APP_MAIN = Path(__file__).resolve().parent.parent / "main.py"
+
+
+def load_app_main():
+    import importlib.util
+    import sys
+    import types
+
+    # Inject stubs if not present
+    if "remote_provider.policy" not in sys.modules:
+        policy_mod = types.ModuleType("remote_provider.policy")
+        policy_mod.DEFAULT_POLICY_PATH = Path("/dev/null")
+        policy_mod.load_policy = lambda path=None: {}
+
+        class PolicyError(ValueError):
+            pass
+
+        policy_mod.PolicyError = PolicyError
+        sys.modules["remote_provider.policy"] = policy_mod
+
+    if "remote_provider.egress" not in sys.modules:
+        egress_mod = types.ModuleType("remote_provider.egress")
+        egress_mod.DEFAULT_MAX_BODY_BYTES = 4 * 1024 * 1024
+        egress_mod.DEFAULT_SECRET_PATH = Path("/dev/null")
+
+        class EgressError(Exception):
+            def __init__(self, status: int, code: str, message: str) -> None:
+                super().__init__(message)
+                self.status = status
+                self.code = code
+                self.message = message
+
+        egress_mod.EgressError = EgressError
+        egress_mod.load_route_state = lambda path: {}
+        egress_mod.prepare_upstream_request = lambda **kw: None
+        egress_mod.provider_secret_status = lambda path: {}
+        egress_mod.read_provider_secret = lambda path: ""
+        egress_mod.route_from_state = lambda state, policy=None: {}
+        egress_mod.validate_direct_provider_resolution = lambda route, **kw: []
+        sys.modules["remote_provider.egress"] = egress_mod
+
+    if "remote_provider.egress_probe" not in sys.modules:
+        egress_probe_mod = types.ModuleType("remote_provider.egress_probe")
+        egress_probe_mod.probe_route_response = lambda *args, **kw: {}
+        sys.modules["remote_provider.egress_probe"] = egress_probe_mod
+
+    if "remote_provider.probe" not in sys.modules:
+        probe_mod = types.ModuleType("remote_provider.probe")
+        probe_mod.DEFAULT_PROBE_TIMEOUT_SECONDS = 10.0
+
+        class ProbeError(Exception):
+            pass
+
+        probe_mod.ProbeError = ProbeError
+        sys.modules["remote_provider.probe"] = probe_mod
+
+    if "remote_provider.ssh_supervisor" not in sys.modules:
+        sys.modules["remote_provider.ssh_supervisor"] = types.ModuleType(
+            "remote_provider.ssh_supervisor"
+        )
+
+    spec = importlib.util.spec_from_file_location("egress_main_2701", APP_MAIN)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_http_client_caches_and_reuses_active_client():
+    """Requesting the same key returns the same active httpx.AsyncClient."""
+    mod = load_app_main()
+    mod.app.state.direct_http_clients = {}
+
+    client1 = mod._http_client("https://provider1.example.com:443")
+    assert isinstance(client1, httpx.AsyncClient)
+    assert not client1.is_closed
+
+    client2 = mod._http_client("https://provider1.example.com:443")
+    assert client2 is client1
+    assert "https://provider1.example.com:443" in mod.app.state.direct_http_clients
+
+    asyncio.run(client1.aclose())
+
+
+def test_http_client_evicts_oldest_when_capacity_exceeded(monkeypatch):
+    """Adding clients beyond MAX_DIRECT_CLIENTS evicts and closes the oldest client."""
+    monkeypatch.setattr("os.environ", {"ODS_REMOTE_PROVIDER_MAX_DIRECT_CLIENTS": "2"})
+    mod = load_app_main()
+    mod.MAX_DIRECT_CLIENTS = 2
+    mod.app.state.direct_http_clients = {}
+
+    async def scenario():
+        client_a = mod._http_client("https://a.com:443")
+        client_b = mod._http_client("https://b.com:443")
+
+        assert len(mod.app.state.direct_http_clients) == 2
+        assert "https://a.com:443" in mod.app.state.direct_http_clients
+        assert "https://b.com:443" in mod.app.state.direct_http_clients
+
+        # Adding c should evict a (oldest)
+        client_c = mod._http_client("https://c.com:443")
+
+        assert len(mod.app.state.direct_http_clients) == 2
+        assert "https://a.com:443" not in mod.app.state.direct_http_clients
+        assert "https://b.com:443" in mod.app.state.direct_http_clients
+        assert "https://c.com:443" in mod.app.state.direct_http_clients
+
+        # Yield to event loop to allow task aclose to run
+        await asyncio.sleep(0.01)
+        assert client_a.is_closed
+
+        # Clean up remaining
+        await client_b.aclose()
+        await client_c.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_http_client_refreshes_lru_order_on_access():
+    """Accessing an existing client moves it to the end of the LRU order."""
+    mod = load_app_main()
+    mod.MAX_DIRECT_CLIENTS = 2
+    mod.app.state.direct_http_clients = {}
+
+    async def scenario():
+        client_a = mod._http_client("https://a.com:443")
+        client_b = mod._http_client("https://b.com:443")
+
+        # Accessing A again moves A to most recently used
+        mod._http_client("https://a.com:443")
+
+        # Adding C now evicts B (which is now the oldest)
+        client_c = mod._http_client("https://c.com:443")
+
+        assert "https://b.com:443" not in mod.app.state.direct_http_clients
+        assert "https://a.com:443" in mod.app.state.direct_http_clients
+        assert "https://c.com:443" in mod.app.state.direct_http_clients
+
+        await asyncio.sleep(0.01)
+        assert client_b.is_closed
+
+        await client_a.aclose()
+        await client_c.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_closes_all_direct_http_clients():
+    """Calling _shutdown closes all remaining direct_http_clients and app.state.http."""
+    mod = load_app_main()
+    mod.app.state.http = httpx.AsyncClient(follow_redirects=False, trust_env=False)
+    mod.app.state.direct_http_clients = {}
+
+    client1 = mod._http_client("https://p1.com:443")
+    client2 = mod._http_client("https://p2.com:443")
+
+    asyncio.run(mod._shutdown())
+
+    assert mod.app.state.http.is_closed
+    assert client1.is_closed
+    assert client2.is_closed
+    assert len(mod.app.state.direct_http_clients) == 0


### PR DESCRIPTION
### Summary

Fixes **#2701** — `_http_client(connection_key)` stored `httpx.AsyncClient` instances in `app.state.direct_http_clients` without an eviction policy, causing the dictionary to grow without bound and leak idle HTTP connection pools when remote provider endpoints were rotated over time.

### Problem

In `ods/extensions/services/remote-provider-egress/app/main.py`, the egress service maintains direct HTTP client instances for direct-transport routes keyed by `connection_key` (derived from scheme, hostname, and port).

When an operator reconfigured or rotated remote provider endpoints over long-running deployments, a new `httpx.AsyncClient` was created and stored in `app.state.direct_http_clients` for each unique endpoint. However, old clients were never removed or closed during service operation. Over time:

* Stale `httpx.AsyncClient` instances accumulated indefinitely in memory.
* Idle TCP socket connection pools to retired provider endpoints remained open until container restart.

### Solution

1. **Configurable Bounded LRU Cache**

   * Introduced `MAX_DIRECT_CLIENTS = max(1, int(os.environ.get("ODS_REMOTE_PROVIDER_MAX_DIRECT_CLIENTS", "4")))` to enforce a hard capacity limit (default: 4 active direct client connections).

2. **LRU Eviction & Automatic Cleanup**

   * In `_http_client(connection_key)`:

     * Re-accessing an existing active key updates its position in `direct_http_clients` (moves to Most Recently Used).
     * When capacity is reached (`len(clients) >= MAX_DIRECT_CLIENTS`), the oldest/least recently used entry is popped from the dictionary and asynchronously closed (`old_client.aclose()`) on the active event loop.

3. **Safe Shutdown**

   * Updated `_shutdown()` to verify `is_closed` state before awaiting `aclose()` across all remaining clients.

### Changes

* **`ods/extensions/services/remote-provider-egress/app/main.py`**

  * Added `MAX_DIRECT_CLIENTS` configuration.
  * Implemented LRU eviction and background task closure in `_http_client`.
  * Updated `_shutdown()` lifecycle handler.

* **`ods/extensions/services/remote-provider-egress/app/tests/test_direct_http_clients.py`** *(new test suite)*

  * `test_http_client_caches_and_reuses_active_client`: verifies caching and reuse for active keys.
  * `test_http_client_evicts_oldest_when_capacity_exceeded`: verifies that exceeding capacity evicts the oldest client and closes its socket connection pool.
  * `test_http_client_refreshes_lru_order_on_access`: verifies LRU access re-ordering.
  * `test_shutdown_closes_all_direct_http_clients`: verifies `_shutdown()` cleans up all clients.

### Verification

Ran the test suite locally:

```bash
pytest ods/extensions/services/remote-provider-egress/app/tests/ -v
```
