### PR TITLE
fix(installer): resolve llama memory helper from install root

### DIFF
--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -45,7 +45,7 @@ if $DRY_RUN; then
     log "[DRY RUN] Would validate .env against schema"
 else
     # shellcheck source=../lib/llama-memory-budget.sh
-    source "$SCRIPT_DIR/lib/llama-memory-budget.sh"
+    source "$SCRIPT_DIR/installers/lib/llama-memory-budget.sh"
 
     _phase06_rootless=false
     if [[ -f "$SCRIPT_DIR/lib/rootless-ownership.sh" ]]; then

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -479,14 +479,6 @@ raise SystemExit(1)' 2>/dev/null && return 0
     fi
     TOKEN_SPY_API_KEY=$(_env_get TOKEN_SPY_API_KEY "$_token_spy_key_default")
     unset _token_spy_key_default
-    LLAMA_SERVER_MEMORY_LIMIT_VALUE=""
-    if [[ "$GPU_BACKEND" == "nvidia" && "$EXTERNAL_LLM_ACTIVE" != "true" && "${ODS_MODE:-local}" != "cloud" ]]; then
-        _docker_memory_gb="$(ods_docker_memory_gb 2>/dev/null || true)"
-        _effective_memory_gb="$(ods_effective_container_memory_gb "${RAM_GB:-0}" "$_docker_memory_gb")"
-        _llama_memory_default="$(ods_default_nvidia_llama_memory_limit "$_effective_memory_gb")"
-        LLAMA_SERVER_MEMORY_LIMIT_VALUE="$(_env_get LLAMA_SERVER_MEMORY_LIMIT "$_llama_memory_default")"
-        unset _docker_memory_gb _effective_memory_gb _llama_memory_default
-    fi
     OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
     SEARXNG_SECRET=$(_env_get SEARXNG_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
 
@@ -523,6 +515,14 @@ raise SystemExit(1)' 2>/dev/null && return 0
         fi
         EXTERNAL_LLM_ACTIVE=true
         LLM_MODEL="$EXTERNAL_SELECTED_MODEL"
+    fi
+    LLAMA_SERVER_MEMORY_LIMIT_VALUE=""
+    if [[ "$GPU_BACKEND" == "nvidia" && "$EXTERNAL_LLM_ACTIVE" != "true" && "${ODS_MODE:-local}" != "cloud" ]]; then
+        _docker_memory_gb="$(ods_docker_memory_gb 2>/dev/null || true)"
+        _effective_memory_gb="$(ods_effective_container_memory_gb "${RAM_GB:-0}" "$_docker_memory_gb")"
+        _llama_memory_default="$(ods_default_nvidia_llama_memory_limit "$_effective_memory_gb")"
+        LLAMA_SERVER_MEMORY_LIMIT_VALUE="$(_env_get LLAMA_SERVER_MEMORY_LIMIT "$_llama_memory_default")"
+        unset _docker_memory_gb _effective_memory_gb _llama_memory_default
     fi
     ODS_MODE_VALUE="$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo "local"; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "lemonade"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo "${ODS_MODE:-local}"; fi)"
     ODS_MODEL_SWITCHBOARD_VALUE=$(_env_get ODS_MODEL_SWITCHBOARD "${ODS_MODEL_SWITCHBOARD:-observe}")

--- a/ods/tests/test-llama-memory-budget.sh
+++ b/ods/tests/test-llama-memory-budget.sh
@@ -47,4 +47,14 @@ if grep -qF 'source "$SCRIPT_DIR/lib/llama-memory-budget.sh"' \
     exit 1
 fi
 
+external_active_line="$(grep -nF 'EXTERNAL_LLM_ACTIVE=false' \
+    "$ROOT_DIR/installers/phases/06-directories.sh" | head -1 | cut -d: -f1)"
+memory_budget_line="$(grep -nF 'LLAMA_SERVER_MEMORY_LIMIT_VALUE=""' \
+    "$ROOT_DIR/installers/phases/06-directories.sh" | head -1 | cut -d: -f1)"
+if [[ -z "$external_active_line" || -z "$memory_budget_line" \
+    || "$external_active_line" -ge "$memory_budget_line" ]]; then
+    printf '[FAIL] phase 06 evaluates the memory budget before external-LLM state is initialized\n' >&2
+    exit 1
+fi
+
 printf '[PASS] NVIDIA llama-server memory budget contract\n'

--- a/ods/tests/test-llama-memory-budget.sh
+++ b/ods/tests/test-llama-memory-budget.sh
@@ -37,4 +37,14 @@ grep -qF 'LLAMA_SERVER_MEMORY_LIMIT=${LLAMA_SERVER_MEMORY_LIMIT_VALUE}' \
 grep -qF 'memory: ${LLAMA_SERVER_MEMORY_LIMIT:-64G}' \
     "$ROOT_DIR/docker-compose.nvidia.yml"
 
+# install-core.sh defines SCRIPT_DIR as the ODS root, so phase 06 must resolve
+# the helper through the installed installers/lib tree.
+grep -qF 'source "$SCRIPT_DIR/installers/lib/llama-memory-budget.sh"' \
+    "$ROOT_DIR/installers/phases/06-directories.sh"
+if grep -qF 'source "$SCRIPT_DIR/lib/llama-memory-budget.sh"' \
+    "$ROOT_DIR/installers/phases/06-directories.sh"; then
+    printf '[FAIL] phase 06 resolves llama-memory-budget.sh outside installers/lib\n' >&2
+    exit 1
+fi
+
 printf '[PASS] NVIDIA llama-server memory budget contract\n'


### PR DESCRIPTION
## Summary

Fix two Linux fresh-install regressions introduced by #2295:

1. Resolve `llama-memory-budget.sh` from the installed `installers/lib` tree.
2. Initialize external-LLM state before the NVIDIA memory-budget branch reads it under `set -u`.

## Root cause

`install-core.sh` defines `SCRIPT_DIR` as the ODS repository/install root. Phase 06 incorrectly sourced `$SCRIPT_DIR/lib/llama-memory-budget.sh`, but the new helper is installed at `$SCRIPT_DIR/installers/lib/llama-memory-budget.sh`. Fresh installs therefore stopped before directory and `.env` generation.

The fleet reproduced the same failure on both `strix-halo` (Linux x86_64/AMD) and `spark` (Linux aarch64/NVIDIA):

```text
/home/michael/ods/installers/phases/06-directories.sh: line 48: /home/michael/ods/lib/llama-memory-budget.sh: No such file or directory
```

After that path was corrected, the NVIDIA/aarch64 host exposed a second deterministic failure: the memory-budget block read `EXTERNAL_LLM_ACTIVE` before the variable was initialized. AMD did not hit that branch, which is why both architectures were required to validate the fix.

## Changes

- Source the helper through `installers/lib`.
- Move NVIDIA memory-budget evaluation after external-LLM state initialization.
- Extend the memory-budget regression test to enforce both contracts.

## Validation

- `bash -n installers/phases/06-directories.sh tests/test-llama-memory-budget.sh`
- `bash tests/test-llama-memory-budget.sh` -> PASS
- `bash tests/test-linux-cloud-mode.sh` -> PASS
- GitHub Actions: all required checks passed, including ShellCheck, Linux integration smoke, macOS smoke, and the distro matrix.

### Exact-SHA fleet validation

Validated commit `e4e4e6d95104267392341f25d58b9d5babf11d18` with run `ods-pr2703-final-20260810T2122Z`:

- `strix-halo` (Linux x86_64, AMD): fresh install PASS; core 7/7; cloud, dashboard, Hermes, UI, and full-model capabilities PASS.
- `spark` (Linux aarch64, NVIDIA): fresh install PASS; core 7/7; cloud, dashboard, Hermes, UI, and full-model capabilities PASS.
- Full Qwen3.6-35B model download, verification, and live swap completed on both hosts with no deferred probes remaining.
- Lifecycle PASS on both hosts: idempotent reinstall/update, restart, and doctor.
- A complete post-lifecycle rerun passed all 17 permanent regression fixtures and all product/capability probes.

Windows fleet execution was also attempted. It reached ODS image startup but is blocked independently by the host's Docker Desktop credential helper rejecting public pulls from the remote session (`A specified logon session does not exist`); the same isolated `docker pull` fails outside ODS, so it is not attributable to this Linux-only patch.
