### PR TITLE
fix(talk): stop shipping the AMD-specific vision model default to every backend

### DIFF
--- a/ods/docker-compose.amd.yml
+++ b/ods/docker-compose.amd.yml
@@ -110,6 +110,10 @@ services:
       - AMD_INFERENCE_RUNTIME_MODE=${AMD_INFERENCE_RUNTIME_MODE:-linux-container}
       - AMD_INFERENCE_MANAGED=${AMD_INFERENCE_MANAGED:-true}
       - LLAMA_METRICS_PORT=8001
+      # Restores the Lemonade-specific default (user.* naming convention
+      # registered on AMD install) that docker-compose.base.yml no longer
+      # ships to every backend.
+      - ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-user.Qwen3.6-35B-A3B-Vision}
     volumes:
       - /sys/class/drm:/sys/class/drm:ro
       - /sys/class/hwmon:/sys/class/hwmon:ro

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -266,9 +266,13 @@ services:
       # with Hermes/LiteLLM long-model timeouts so Talk does not 502 while the
       # underlying agent is still working.
       - ODS_TALK_HERMES_TIMEOUT=${ODS_TALK_HERMES_TIMEOUT:-900}
-      # Model id of the vision-capable variant. Defaults to the user.*
-      # name we register on AMD install (Qwen3.6-35B-A3B + mmproj-F16).
-      - ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-user.Qwen3.6-35B-A3B-Vision}
+      # Model id of the vision-capable variant. No universal default: the
+      # user.* Lemonade naming convention (docker-compose.amd.yml sets
+      # user.Qwen3.6-35B-A3B-Vision there) only resolves on AMD/Lemonade
+      # hosts — shipping it as the default here made ODS Talk image
+      # attachments fail with a "model not found" error on every other
+      # backend unless the operator manually overrode it.
+      - ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-}
     volumes:
       - ./scripts:/ods/scripts:ro,z
       - ./config:/ods/config:ro,z

--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -127,9 +127,11 @@ async def _require_hermes_talk_compatible() -> dict[str, Any]:
 
 
 def _vision_model_name() -> str:
-    """Lemonade name of the vision-capable model. Defaults match the strix
-    user.* registration we ship; operators can override per-host via env."""
-    return os.environ.get("ODS_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
+    """Model id of the vision-capable variant. No built-in fallback here —
+    the user.* Lemonade naming convention only resolves on AMD/Lemonade
+    hosts, which set ODS_TALK_VISION_MODEL themselves in
+    docker-compose.amd.yml. Other backends must configure this explicitly."""
+    return os.environ.get("ODS_TALK_VISION_MODEL", "")
 
 
 def _vision_backend_base_url() -> str:
@@ -727,6 +729,11 @@ async def talk_attachment(
         raise HTTPException(status_code=413, detail="Caption is too long.")
 
     if kind == "image":
+        if not _vision_model_name():
+            raise HTTPException(
+                status_code=409,
+                detail="Image attachments require ODS_TALK_VISION_MODEL to be set for this backend.",
+            )
         data = await file.read(MAX_IMAGE_BYTES + 1)
         if len(data) > MAX_IMAGE_BYTES:
             raise HTTPException(status_code=413, detail=f"Image is too large (max {MAX_IMAGE_BYTES // (1024 * 1024)} MB).")

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1061,6 +1061,7 @@ def test_talk_attachment_image_routes_to_vision_endpoint_bypassing_hermes(talk_c
         yield _sse_event("complete", {"session_id": "vision", "text": "Red.", "status": "ok", "warning": None})
         yield _sse_event("done", {})
 
+    monkeypatch.setenv("ODS_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
     monkeypatch.setattr("hermes_bridge.stream_prompt", fake_hermes_stream)
     monkeypatch.setattr("routers.talk._stream_vision_chat", fake_vision_stream)
 
@@ -1093,6 +1094,7 @@ def test_talk_attachment_image_uses_filename_when_mobile_uploads_octet_stream(ta
         yield _sse_event("complete", {"session_id": "vision", "text": "Red.", "status": "ok", "warning": None})
         yield _sse_event("done", {})
 
+    monkeypatch.setenv("ODS_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
     monkeypatch.setattr("routers.talk._stream_vision_chat", fake_vision_stream)
 
     png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
@@ -1107,14 +1109,40 @@ def test_talk_attachment_image_uses_filename_when_mobile_uploads_octet_stream(ta
     assert any(f.get("type") == "complete" and f.get("text") == "Red." for f in frames)
 
 
-def test_talk_attachment_image_too_large_returns_413(talk_client):
+def test_talk_attachment_image_too_large_returns_413(talk_client, monkeypatch):
     """Image size cap is enforced at the multipart boundary."""
+    monkeypatch.setenv("ODS_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
     big = b"\x89PNG\r\n\x1a\n" + b"x" * (11 * 1024 * 1024)
     resp = talk_client.post(
         "/api/talk/attachment",
         files={"file": ("huge.png", big, "image/png")},
     )
     assert resp.status_code == 413
+
+
+def test_talk_attachment_image_without_vision_model_returns_409(talk_client, monkeypatch):
+    """docker-compose.base.yml no longer ships an AMD/Lemonade-specific
+    ODS_TALK_VISION_MODEL default to every backend (it only makes sense on
+    Lemonade hosts, which set it themselves in docker-compose.amd.yml). On a
+    backend where it's genuinely unset, image attachments must fail with a
+    clear, actionable error instead of silently sending an empty/wrong model
+    id upstream and surfacing a confusing provider error."""
+    monkeypatch.delenv("ODS_TALK_VISION_MODEL", raising=False)
+
+    async def fake_vision_stream(image_bytes, content_type, prompt_text):
+        raise AssertionError("must not attempt a vision request with no model configured")
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+    monkeypatch.setattr("routers.talk._stream_vision_chat", fake_vision_stream)
+
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    resp = talk_client.post(
+        "/api/talk/attachment",
+        files={"file": ("photo.png", png_bytes, "image/png")},
+        data={"text": "what color?"},
+    )
+    assert resp.status_code == 409
+    assert "ODS_TALK_VISION_MODEL" in resp.json()["detail"]
 
 
 def test_talk_vision_url_defaults_to_openai_v1(monkeypatch):

--- a/ods/tests/test-ods-talk-vision-model-backend-scoped.sh
+++ b/ods/tests/test-ods-talk-vision-model-backend-scoped.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS docker-compose.base.yml / docker-compose.amd.yml — ODS_TALK_VISION_MODEL
+# ============================================================================
+# docker-compose.base.yml used to default ODS_TALK_VISION_MODEL to the
+# Lemonade/AMD-specific "user.Qwen3.6-35B-A3B-Vision" model id for every
+# backend. That naming convention only resolves on AMD/Lemonade hosts —
+# NVIDIA/Apple/CPU/Intel users got a "model not found" error on any ODS Talk
+# image attachment unless they manually overrode it. The default now lives
+# only on the AMD overlay, where it belongs.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== ODS_TALK_VISION_MODEL backend-scoping tests ==="
+echo ""
+
+if grep -Fq 'ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-}' "$ROOT_DIR/docker-compose.base.yml"; then
+    pass "base.yml no longer defaults to the Lemonade-specific model id"
+else
+    fail "base.yml still ships an AMD-specific default to every backend (the bug, or a regression)"
+fi
+
+if grep -Fq 'ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-user.Qwen3.6-35B-A3B-Vision}' "$ROOT_DIR/docker-compose.amd.yml"; then
+    pass "amd.yml restores the Lemonade-specific default for AMD hosts"
+else
+    fail "amd.yml no longer restores the Lemonade-specific default"
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    BASE_ONLY="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" config 2>/dev/null | grep 'ODS_TALK_VISION_MODEL')"
+    if grep -Fq 'ODS_TALK_VISION_MODEL: ""' <<< "$BASE_ONLY"; then
+        pass "docker compose config resolves ODS_TALK_VISION_MODEL to empty on base.yml alone"
+    else
+        fail "docker compose config did not resolve an empty default on base.yml alone (got: '$BASE_ONLY')"
+    fi
+
+    WITH_AMD="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" -f "$ROOT_DIR/docker-compose.amd.yml" config 2>/dev/null \
+        | grep 'ODS_TALK_VISION_MODEL')"
+    if grep -Fq 'user.Qwen3.6-35B-A3B-Vision' <<< "$WITH_AMD"; then
+        pass "docker compose config restores the Lemonade default when the AMD overlay is layered in"
+    else
+        fail "docker compose config did not restore the Lemonade default with the AMD overlay (got: '$WITH_AMD')"
+    fi
+
+    OVERRIDE="$(WEBUI_SECRET=test-secret DASHBOARD_API_KEY=test-key ODS_TALK_VISION_MODEL="my-custom-vision-model" \
+        docker compose -f "$ROOT_DIR/docker-compose.base.yml" config 2>/dev/null | grep 'ODS_TALK_VISION_MODEL')"
+    if grep -Fq 'my-custom-vision-model' <<< "$OVERRIDE"; then
+        pass "operators can still override ODS_TALK_VISION_MODEL on non-AMD backends"
+    else
+        fail "an explicit ODS_TALK_VISION_MODEL override was not honored"
+    fi
+else
+    echo "  SKIP: docker compose not available — skipping live config resolution checks"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`docker-compose.base.yml` defaulted `ODS_TALK_VISION_MODEL` to `"user.Qwen3.6-35B-A3B-Vision"` for every backend. That's a Lemonade-specific `user.*` model registration name — `talk.py`'s own docstring said "Defaults match the strix user.\* registration we ship" (strix = AMD Strix Point/Halo APUs) — which only resolves on AMD/Lemonade hosts. NVIDIA/Apple/CPU/Intel installs inherited this same default from the shared base compose file, so any ODS Talk image attachment on those backends silently sent an unknown model id upstream and failed with a confusing provider error, unless the operator happened to know to override it manually.

Fix:
- Move the default out of `docker-compose.base.yml` (now `ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-}`, empty/unconfigured by default) and into `docker-compose.amd.yml`, which restores it for the backend it actually applies to.
- `talk.py`'s `_vision_model_name()` Python-level fallback was also hardcoded to the same AMD-only string — updated to match (empty default), since Compose always sets the container env var once listed, making the Python fallback the only place this mattered for non-Docker/unit-test contexts.
- Added a clear `409` guard in `talk_attachment()`: if no vision model is configured, fail fast with an actionable message instead of making a network call that was always going to fail with a confusing provider error.

Found via code review, not a filed GitHub issue.

## AI Assistance

Used an AI coding assistant to find and fix this — traced `ODS_TALK_VISION_MODEL`'s default through `docker-compose.base.yml` and `talk.py`'s own docstrings, which explicitly describe it as AMD/Lemonade-specific ("strix user.\* registration"). First test pass caught that I'd only fixed the compose-level default and missed `_vision_model_name()`'s own Python-level fallback still hardcoding the same string — a unit test reproduced this exactly (env var deleted via `monkeypatch.delenv`, the new 409 guard didn't trigger because the Python fallback kicked in) — fixed and reran. Also had to update three existing vision-attachment tests that were implicitly relying on the removed fallback to keep passing correctly. Verified directly: `test_talk.py` full file (40/40), the vision/attachment-scoped subset (10/10 including the new 409 test), and real `docker compose config` confirming `ODS_TALK_VISION_MODEL` resolves to empty on `base.yml` alone, to the Lemonade default when `amd.yml` is layered in, and still honors an explicit operator override.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Docker Compose / service manifests
- [x] Dashboard API / host agent

## Risk And Validation
- Risk level: Medium (behavior change: ODS Talk image attachments on non-AMD backends now fail fast with a clear 409 instead of an upstream provider error — an improvement, but a visible behavior change for anyone who had manually set `ODS_TALK_VISION_MODEL` incorrectly and was somehow depending on the old failure mode; AMD/Lemonade behavior is unchanged)
- Validation run:
  - [x] Focused tests listed below

```text
python -c "import ast,io; ast.parse(io.open('extensions/services/dashboard-api/routers/talk.py', encoding='utf-8').read())"

cd extensions/services/dashboard-api
python -m pytest tests/test_talk.py -v
  # 40 passed

python -m pytest tests/test_talk.py -k "vision or attachment" -v
  # 10 passed (includes the new 409 guard test)

docker compose -f docker-compose.base.yml config
  # (with WEBUI_SECRET/DASHBOARD_API_KEY set) resolves ODS_TALK_VISION_MODEL to ""

docker compose -f docker-compose.base.yml -f docker-compose.amd.yml config
  # resolves ODS_TALK_VISION_MODEL to "user.Qwen3.6-35B-A3B-Vision"

bash tests/test-ods-talk-vision-model-backend-scoped.sh
  # 5/5 PASS
```
- Not required because: full 2083-test dashboard-api suite was started for a broader regression pass but interrupted mid-run for time; the affected surface (talk.py + its tests) is fully covered above and unrelated modules aren't touched by this change.

## Operational Change Check
- [x] This is an operational change and validation is intentionally deferred for: touches dashboard-api control flow (a new 409 response path) and compose service manifests. Covered by the focused test suite and real `docker compose config` runs above; flagging for a maintainer to smoke-test ODS Talk image attachments on both an AMD host and a non-AMD host before release.
