### PR TITLE
fix(tts): cover Kokoro CPU cold starts

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -63,6 +63,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-overlay-map-coherence.sh
 	@bash tests/contracts/test-plist-log-paths.sh
 	@python3 tests/contracts/test-llama-runtime-tunables.py
+	@python3 tests/contracts/test-service-startup-budgets.py
 	@echo ""
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh

--- a/ods/extensions/services/tts/compose.yaml
+++ b/ods/extensions/services/tts/compose.yaml
@@ -24,7 +24,10 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      # Kokoro loads the model and warms its voice pipelines before FastAPI
+      # starts serving. A cached CPU cold start has been measured at ~255s;
+      # first boot and slower storage need additional headroom.
+      start_period: 600s
     logging:
       driver: "json-file"
       options:

--- a/ods/tests/contracts/test-service-startup-budgets.py
+++ b/ods/tests/contracts/test-service-startup-budgets.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Release contracts for model-service healthcheck startup budgets."""
+
+from pathlib import Path
+import re
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+_DURATION_RE = re.compile(r"^(\d+)([smh])$")
+_SECONDS_PER_UNIT = {"s": 1, "m": 60, "h": 3600}
+
+
+def duration_seconds(value: object) -> int:
+    """Parse the single-unit durations used by bundled Compose files."""
+    match = _DURATION_RE.fullmatch(str(value))
+    if match is None:
+        raise AssertionError(f"unsupported Compose duration: {value!r}")
+    amount, unit = match.groups()
+    return int(amount) * _SECONDS_PER_UNIT[unit]
+
+
+def test_tts_start_period_covers_measured_cpu_cold_start() -> None:
+    compose_path = ROOT / "extensions" / "services" / "tts" / "compose.yaml"
+    compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    healthcheck = compose["services"]["tts"]["healthcheck"]
+
+    # Kokoro has been measured taking ~255s to load and warm on a CPU host.
+    # Keep a practical margin so Docker does not advertise a false failure.
+    assert duration_seconds(healthcheck["start_period"]) >= 300
+
+
+if __name__ == "__main__":
+    test_tts_start_period_covers_measured_cpu_cold_start()
+    print("service startup budget contracts passed")


### PR DESCRIPTION
## Summary
- raise the Kokoro TTS healthcheck start period from 30s to 600s
- document the measured CPU initialization path directly beside the runtime setting
- add a release contract requiring the startup grace period to remain above the measured cold-start floor

## Why this matters
Kokoro loads its model and warms voice pipelines before FastAPI begins serving. Issue #2704 measured a cached CPU cold start at about 255 seconds, while the existing health policy marks the container unhealthy after roughly 120 seconds. That false failure is visible through `docker ps`, the dashboard, `ods doctor`, `docker compose up --wait`, and external monitoring even though the service recovers normally. A 600-second grace period matches the existing embeddings precedent and does not delay healthy reporting: Docker accepts the first successful probe immediately.

Closes #2704.

## Overlap check
Searched open and closed PRs for `2704`, `Kokoro healthcheck`, `tts start_period`, `start_period 600s`, and `extensions/services/tts/compose.yaml`. No PR covers the cold-start budget. Open PRs #2499 and #1613 appeared in the file-path search but their current diffs do not change this TTS compose file or its healthcheck, so this scope is independent.

## Test plan
- [x] `python ods/tests/contracts/test-service-startup-budgets.py`
- [x] `python -m py_compile ods/tests/contracts/test-service-startup-budgets.py`
- [x] `git diff --check`

Generated with Codex