### PR TITLE
fix(remote-provider): stream bounded peer responses

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -816,18 +816,36 @@ def _peer_model_action_path(model_id: str, action: str = "") -> str:
     return f"/api/models/{encoded}{suffix}"
 
 
-def _peer_response_json(response: httpx.Response, token: str) -> Any:
-    content = response.content
-    if len(content) > PEER_PROXY_RESPONSE_MAX_BYTES:
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "error": "remote_peer_response_too_large",
-                "message": "Remote ODS peer response exceeded the safety limit.",
-            },
-        )
+def _peer_response_too_large() -> HTTPException:
+    return HTTPException(
+        status_code=502,
+        detail={
+            "error": "remote_peer_response_too_large",
+            "message": "Remote ODS peer response exceeded the safety limit.",
+        },
+    )
+
+
+async def _read_peer_response(response: httpx.Response) -> bytes:
+    declared_length = response.headers.get("content-length")
+    if declared_length:
+        try:
+            if int(declared_length) > PEER_PROXY_RESPONSE_MAX_BYTES:
+                raise _peer_response_too_large()
+        except ValueError:
+            pass
+
+    content = bytearray()
+    async for chunk in response.aiter_bytes():
+        if len(content) + len(chunk) > PEER_PROXY_RESPONSE_MAX_BYTES:
+            raise _peer_response_too_large()
+        content.extend(chunk)
+    return bytes(content)
+
+
+def _peer_response_json(content: bytes, token: str) -> Any:
     try:
-        payload = response.json()
+        payload = json.loads(content)
     except ValueError as exc:
         raise HTTPException(
             status_code=502,
@@ -839,15 +857,15 @@ def _peer_response_json(response: httpx.Response, token: str) -> Any:
     return _redact_peer_secret(payload, token)
 
 
-def _peer_http_error(response: httpx.Response, token: str) -> HTTPException:
+def _peer_http_error(status_code: int, content: bytes, token: str) -> HTTPException:
     try:
-        detail = _redact_peer_secret(response.json(), token)
+        detail = _redact_peer_secret(json.loads(content), token)
     except ValueError:
         detail = {
             "error": "remote_peer_http_error",
-            "message": f"Remote ODS peer returned HTTP {response.status_code}.",
+            "message": f"Remote ODS peer returned HTTP {status_code}.",
         }
-    return HTTPException(status_code=response.status_code, detail=detail)
+    return HTTPException(status_code=status_code, detail=detail)
 
 
 async def _peer_model_json_request(
@@ -870,14 +888,25 @@ async def _peer_model_json_request(
     url = f"{base_url}{path}"
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.request(
+            async with client.stream(
                 method,
                 url,
                 headers={
                     "Authorization": f"Bearer {token}",
                     "Accept": "application/json",
                 },
-            )
+            ) as response:
+                status_code = response.status_code
+                if status_code in {401, 403}:
+                    raise HTTPException(
+                        status_code=502,
+                        detail={
+                            "error": "remote_peer_auth_rejected",
+                            "message": "Remote ODS peer rejected the configured peer token.",
+                            "status": status_code,
+                        },
+                    )
+                content = await _read_peer_response(response)
     except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as exc:
         raise HTTPException(
             status_code=503,
@@ -895,18 +924,9 @@ async def _peer_model_json_request(
             },
         ) from exc
 
-    if response.status_code in {401, 403}:
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "error": "remote_peer_auth_rejected",
-                "message": "Remote ODS peer rejected the configured peer token.",
-                "status": response.status_code,
-            },
-        )
-    if response.status_code >= 400:
-        raise _peer_http_error(response, token)
-    return _peer_response_json(response, token)
+    if status_code >= 400:
+        raise _peer_http_error(status_code, content, token)
+    return _peer_response_json(content, token)
 
 
 def _overall_status(route_state: Mapping[str, Any], egress: Mapping[str, Any]) -> str:

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -354,10 +354,16 @@ def test_remote_provider_peer_models_proxies_with_redacted_peer_token(
 
     class FakeResponse:
         status_code = 200
-        content = b'{"models":[{"id":"remote-qwen"}],"echo":"unit-test-peer-token"}'
+        headers = {}
 
-        def json(self):
-            return {"models": [{"id": "remote-qwen"}], "echo": "unit-test-peer-token"}
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def aiter_bytes(self):
+            yield b'{"models":[{"id":"remote-qwen"}],"echo":"unit-test-peer-token"}'
 
     class FakeAsyncClient:
         def __init__(self, *args, **kwargs):
@@ -369,7 +375,7 @@ def test_remote_provider_peer_models_proxies_with_redacted_peer_token(
         async def __aexit__(self, *_args):
             return False
 
-        async def request(self, method, url, headers):
+        def stream(self, method, url, headers):
             captured.update({"method": method, "url": url, "headers": headers})
             return FakeResponse()
 
@@ -418,10 +424,16 @@ def test_remote_provider_peer_model_load_uses_long_timeout_and_encoded_model_id(
 
     class FakeResponse:
         status_code = 200
-        content = b'{"status":"activated"}'
+        headers = {}
 
-        def json(self):
-            return {"status": "activated"}
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def aiter_bytes(self):
+            yield b'{"status":"activated"}'
 
     class FakeAsyncClient:
         def __init__(self, *args, **kwargs):
@@ -433,7 +445,7 @@ def test_remote_provider_peer_model_load_uses_long_timeout_and_encoded_model_id(
         async def __aexit__(self, *_args):
             return False
 
-        async def request(self, method, url, headers):
+        def stream(self, method, url, headers):
             captured.update({"method": method, "url": url, "headers": headers})
             return FakeResponse()
 
@@ -449,6 +461,135 @@ def test_remote_provider_peer_model_load_uses_long_timeout_and_encoded_model_id(
     assert captured["method"] == "POST"
     assert captured["url"] == "https://peer.example.test/api/models/Qwen%203.5-9B/load"
     assert captured["timeout"] == rps.PEER_PROXY_LOAD_TIMEOUT_SECONDS
+
+
+def test_remote_provider_peer_models_stop_streaming_at_response_limit(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    secret_dir = state_root / "secrets"
+    secret_dir.mkdir(parents=True)
+    (secret_dir / "peer-token").write_bytes(b"unit-test-peer-token\n")
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "https://peer.example.test",
+                    "transport": "direct",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(rps, "PEER_PROXY_RESPONSE_MAX_BYTES", 10)
+    chunks_read = []
+
+    class FakeResponse:
+        status_code = 200
+        headers = {}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def aiter_bytes(self):
+            for chunk in (b"123456", b"78901", b"must-not-be-read"):
+                chunks_read.append(chunk)
+                yield chunk
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def stream(self, method, url, headers):
+            return FakeResponse()
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.get(
+        "/api/remote-provider/peer/models",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["error"] == "remote_peer_response_too_large"
+    assert chunks_read == [b"123456", b"78901"]
+
+
+def test_remote_provider_peer_models_reject_declared_oversize_without_reading(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    state_root = tmp_path / "remote-provider"
+    secret_dir = state_root / "secrets"
+    secret_dir.mkdir(parents=True)
+    (secret_dir / "peer-token").write_bytes(b"unit-test-peer-token\n")
+    state_path = state_root / "routing-state.json"
+    state_path.write_text(
+        json.dumps(
+            _route_state(
+                peer={
+                    "controlBaseUrl": "https://peer.example.test",
+                    "transport": "direct",
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+    rps = _patch_state_path(monkeypatch, state_path)
+    monkeypatch.setattr(rps, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(rps, "PEER_PROXY_RESPONSE_MAX_BYTES", 10)
+
+    class FakeResponse:
+        status_code = 500
+        headers = {"content-length": "11"}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def aiter_bytes(self):
+            raise AssertionError("declared oversize response must not be read")
+            yield b""
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def stream(self, method, url, headers):
+            return FakeResponse()
+
+    monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = test_client.get(
+        "/api/remote-provider/peer/models",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["error"] == "remote_peer_response_too_large"
 
 
 def test_remote_provider_peer_models_fail_closed_without_peer_token(


### PR DESCRIPTION
## Summary
- stream remote ODS peer lifecycle responses instead of buffering them before enforcing the 2 MB cap
- reject oversized `Content-Length` values before reading and stop chunk consumption at the exact decoded-byte boundary
- apply the same bounded behavior to success and error payloads while preserving JSON validation and peer-token redaction

## Why this matters
The peer lifecycle proxy exposed a `PEER_PROXY_RESPONSE_MAX_BYTES` safety limit, but `httpx.AsyncClient.request()` had already buffered the entire response before the length check ran. A broken or compromised remote peer could therefore make dashboard-api consume arbitrarily large memory on model list/load/delete operations; oversized error bodies bypassed the limit entirely. Streaming makes the documented cap an actual resource boundary, including decoded chunks from compressed responses.

## Overlap check
Searched open and closed PRs for `remote peer response limit`, `peer proxy streaming body`, `PEER_PROXY_RESPONSE_MAX_BYTES`, `remote_provider_status response too large`, and PRs changing `ods/extensions/services/dashboard-api/routers/remote_provider_status.py`. No open or closed PR covers response streaming or bounded peer lifecycle bodies. PR #2708 changes the separate `remote-provider-egress` service's inbound request body boundary; this PR changes dashboard-api's outbound ODS-peer response boundary and has no shared production file or behavior.

## Regression tests
- `pytest tests/test_remote_provider_status.py -q` — 28 passed
  - public `/api/remote-provider/peer/models` endpoint stops consuming chunks as soon as the decoded response crosses the cap
  - a declared oversized error response is rejected without reading its body
  - existing peer model list/load proxy, token-redaction, auth, SSH, status, plan, probe, and apply contracts remain green
- `python -m py_compile routers/remote_provider_status.py tests/test_remote_provider_status.py`
- `git diff --check`