### PR TITLE
fix(remote-provider): serialize state transactions

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -175,6 +175,7 @@ _service_health_cache: tuple[float, dict | None] = (0.0, None)
 _windows_gpu_metrics_lock = threading.Lock()
 _windows_llm_status_lock = threading.Lock()
 _service_health_lock = threading.Lock()
+_remote_provider_state_lock = threading.Lock()
 WINDOWS_WHISPER_CUDA_MIN_DRIVER_MAJOR = 575
 # Always-on services defined in docker-compose.base.yml — never stoppable via API.
 # Distinct from CORE_SERVICE_IDS (which is the allowlist of known service IDs).
@@ -2366,21 +2367,22 @@ def _read_remote_provider_route_state_for_update() -> dict:
 
 def _record_remote_provider_egress_probe(payload: dict) -> dict:
     probe_receipt = _remote_provider_probe_receipt_from_egress(payload)
-    state = _read_remote_provider_route_state_for_update()
-    provider = state.get("provider") if isinstance(state.get("provider"), dict) else {}
-    payload_transport = _remote_provider_safe_text(payload.get("transport"), max_length=32)
-    active_transport = str(provider.get("transport") or "direct")
-    if payload_transport != active_transport:
-        raise RuntimeError("remote-provider proof transport does not match active route")
-    state["status"] = _remote_provider_route_status(
-        enabled=True,
-        probe_receipt=probe_receipt,
-    )
-    _atomic_write_text(
-        _remote_provider_route_state_path(),
-        json.dumps(state, indent=2, sort_keys=True) + "\n",
-        0o644,
-    )
+    with _remote_provider_state_lock:
+        state = _read_remote_provider_route_state_for_update()
+        provider = state.get("provider") if isinstance(state.get("provider"), dict) else {}
+        payload_transport = _remote_provider_safe_text(payload.get("transport"), max_length=32)
+        active_transport = str(provider.get("transport") or "direct")
+        if payload_transport != active_transport:
+            raise RuntimeError("remote-provider proof transport does not match active route")
+        state["status"] = _remote_provider_route_status(
+            enabled=True,
+            probe_receipt=probe_receipt,
+        )
+        _atomic_write_text(
+            _remote_provider_route_state_path(),
+            json.dumps(state, indent=2, sort_keys=True) + "\n",
+            0o644,
+        )
     return {
         "schema": _REMOTE_PROVIDER_PROOF_RECORD_SCHEMA,
         "recorded": True,
@@ -2567,40 +2569,41 @@ def _apply_remote_provider_lifecycle_operation(payload: dict, plan: dict) -> dic
         secret_values = {}
         mutation_paths = _remote_provider_mutation_paths(action)
 
-    snapshots: dict[Path, dict] = {}
-    mutation_started = False
-    try:
-        snapshots = {path: _snapshot_text_file(path) for path in mutation_paths}
-        if action == "configure":
-            for ref, secret in secret_values.items():
-                _write_remote_provider_secret(ref, secret)
+    with _remote_provider_state_lock:
+        snapshots: dict[Path, dict] = {}
+        mutation_started = False
+        try:
+            snapshots = {path: _snapshot_text_file(path) for path in mutation_paths}
+            if action == "configure":
+                for ref, secret in secret_values.items():
+                    _write_remote_provider_secret(ref, secret)
+                    mutation_started = True
+                _write_remote_provider_route_state(plan, probe_receipt=probe_receipt)
                 mutation_started = True
-            _write_remote_provider_route_state(plan, probe_receipt=probe_receipt)
-            mutation_started = True
-        elif action == "disable":
-            _write_remote_provider_route_state(plan)
-            mutation_started = True
-        elif action == "remove":
-            for path in mutation_paths:
-                _remove_remote_provider_file(path)
+            elif action == "disable":
+                _write_remote_provider_route_state(plan)
                 mutation_started = True
-    except Exception as exc:
-        rollback = {"attempted": False, "ok": None}
-        if mutation_started and snapshots:
-            rollback["attempted"] = True
-            try:
-                _restore_remote_provider_snapshots(snapshots)
-            except Exception as rollback_exc:
-                rollback["ok"] = False
-                raise _RemoteProviderApplyError(
-                    f"Remote provider apply failed: {exc}; rollback failed: {rollback_exc}",
-                    rollback,
-                ) from exc
-            rollback["ok"] = True
-        raise _RemoteProviderApplyError(
-            f"Remote provider apply failed: {exc}",
-            rollback,
-        ) from exc
+            elif action == "remove":
+                for path in mutation_paths:
+                    _remove_remote_provider_file(path)
+                    mutation_started = True
+        except Exception as exc:
+            rollback = {"attempted": False, "ok": None}
+            if mutation_started and snapshots:
+                rollback["attempted"] = True
+                try:
+                    _restore_remote_provider_snapshots(snapshots)
+                except Exception as rollback_exc:
+                    rollback["ok"] = False
+                    raise _RemoteProviderApplyError(
+                        f"Remote provider apply failed: {exc}; rollback failed: {rollback_exc}",
+                        rollback,
+                    ) from exc
+                rollback["ok"] = True
+            raise _RemoteProviderApplyError(
+                f"Remote provider apply failed: {exc}",
+                rollback,
+            ) from exc
 
     return result
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2581,6 +2581,91 @@ class TestRemoteProviderLifecycle:
         assert secret_path.read_text(encoding="utf-8") == "old-provider-token\n"
         assert "unit-test-provider-token" not in dumped
 
+    def test_concurrent_apply_rollback_cannot_erase_later_success(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+        first_payload = self._ssh_configure_payload()
+        first_payload["provider"]["model"] = "first/model"
+        first_payload["secrets"]["apiKey"] = "first-provider-token"
+        second_payload = self._ssh_configure_payload()
+        second_payload["provider"]["model"] = "second/model"
+        second_payload["secrets"]["apiKey"] = "second-provider-token"
+
+        first_secret_written = threading.Event()
+        second_apply_ready = threading.Event()
+        second_mutation_started = threading.Event()
+        release_first = threading.Event()
+        real_secret_values = _mod._remote_provider_secret_values
+        real_write_secret = _mod._write_remote_provider_secret
+        real_write_state = _mod._write_remote_provider_route_state
+
+        def controlled_secret_values(payload, plan):
+            values = real_secret_values(payload, plan)
+            if values.get("REMOTE_LLM_API_KEY") == "second-provider-token":
+                second_apply_ready.set()
+            return values
+
+        def controlled_secret_write(ref, value):
+            real_write_secret(ref, value)
+            if ref != "REMOTE_LLM_API_KEY":
+                return
+            if value == "first-provider-token":
+                first_secret_written.set()
+                if not release_first.wait(timeout=5):
+                    raise RuntimeError("timed out waiting to release first apply")
+            elif value == "second-provider-token":
+                second_mutation_started.set()
+
+        def fail_first_route_write(plan, *, probe_receipt=None):
+            model = plan["route"]["provider"]["model"]
+            if model == "first/model":
+                raise RuntimeError("simulated first route-state failure")
+            return real_write_state(plan, probe_receipt=probe_receipt)
+
+        monkeypatch.setattr(_mod, "_remote_provider_secret_values", controlled_secret_values)
+        monkeypatch.setattr(_mod, "_write_remote_provider_secret", controlled_secret_write)
+        monkeypatch.setattr(_mod, "_write_remote_provider_route_state", fail_first_route_write)
+        first_handler = _FakeHandler(json.dumps(first_payload).encode("utf-8"))
+        second_handler = _FakeHandler(json.dumps(second_payload).encode("utf-8"))
+        first_thread = threading.Thread(
+            target=_mod.AgentHandler._handle_remote_provider_apply,
+            args=(first_handler,),
+        )
+        second_thread = threading.Thread(
+            target=_mod.AgentHandler._handle_remote_provider_apply,
+            args=(second_handler,),
+        )
+
+        first_thread.start()
+        assert first_secret_written.wait(timeout=5)
+        second_thread.start()
+        try:
+            assert second_apply_ready.wait(timeout=5)
+            overlapped_mutation = second_mutation_started.wait(timeout=1)
+        finally:
+            release_first.set()
+        first_thread.join(timeout=5)
+        second_thread.join(timeout=5)
+
+        assert not first_thread.is_alive()
+        assert not second_thread.is_alive()
+        assert overlapped_mutation is False
+        assert first_handler.response_code == 500
+        assert first_handler.parse_response()["rollback"] == {
+            "attempted": True,
+            "ok": True,
+        }
+        assert second_handler.response_code == 200
+        root = tmp_path / "remote-provider"
+        state = json.loads((root / "routing-state.json").read_text(encoding="utf-8"))
+        assert state["provider"]["model"] == "second/model"
+        assert (root / "secrets" / "provider-api-key").read_text(
+            encoding="utf-8"
+        ) == "second-provider-token\n"
+
 
 class TestTailscaleStatus:
     """Direct host-agent tests for /v1/tailscale/status behavior."""


### PR DESCRIPTION
## Summary
- serialize remote-provider state/secrets snapshot, mutation, and rollback as one host-agent critical section
- use the same state lock when recording egress proof so proof read-modify-write cannot overwrite a concurrent lifecycle change
- keep direct network probes outside the lock so slow providers do not block state operations before mutation begins

## Why this matters
The host agent uses a threaded HTTP server, but configure, disable, remove, and proof requests all mutate the same `routing-state.json` and secret files without coordination. Two valid requests could interleave: request A snapshots old state and partially writes, request B commits successfully, then A fails and restores its old snapshot over B. The API would report B as successful even though its route and credentials were silently lost. Serializing the transaction preserves the existing rollback guarantee under real concurrent Dashboard/CLI traffic.

## Overlap check
Searched open and closed PRs for `remote provider concurrent lifecycle`, `remote provider state lock`, `routing state race rollback`, `remote-provider proof race`, and open PRs changing `ods/bin/ods-host-agent.py` for remote-provider behavior. No existing PR covers lifecycle/proof serialization or rollback lost updates. PRs #2700, #2702, #2708, and #2710 operate in the egress service or dashboard-api proxy boundaries; none changes host-owned route/secret transactions or shares this production behavior.

## Regression tests
- `pytest tests/test_host_agent.py -q` — 258 passed, 4 skipped
- `pytest tests/test_host_agent.py::TestRemoteProviderLifecycle -q` — 17 passed
  - runs two public `_handle_remote_provider_apply` handlers on separate threads
  - pauses request A after its first secret mutation, starts request B, and forces A's route write to fail
  - proves B cannot enter the mutation region early and its successful route/token survive A's rollback
- `python -m py_compile bin/ods-host-agent.py extensions/services/dashboard-api/tests/test_host_agent.py`
- `git diff --check`