### PR TITLE
fix(uninstall): refuse to delete an ODS source checkout

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -137,6 +137,9 @@ test: ## Run unit and contract tests
 	@echo "=== macOS uninstall LaunchAgent cleanup ==="
 	@bash tests/test-macos-uninstall-launchagents.sh
 	@echo ""
+	@echo "=== uninstall source-checkout guard ==="
+	@bash tests/test-uninstall-source-checkout-guard.sh
+	@echo ""
 	@echo "=== token-spy session manager active-id extraction ==="
 	@bash tests/test-token-spy-session-manager.sh
 	@echo ""

--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -95,6 +95,22 @@ if [[ -d "$SCRIPT_DIR" && -f "$SCRIPT_DIR/ods-cli" ]]; then
     INSTALL_DIR="$SCRIPT_DIR"
 fi
 
+# Guard against deleting an ODS source checkout. The auto-detect above keys off
+# ods-cli, which the git repo ships too, so running this (especially with
+# --force, which skips the confirmation prompt) from a development clone would
+# rm -rf the working tree. A deployed install always carries an
+# installer-generated .env at its root; the installer strips .git when copying
+# to ~/ods. So a git working tree with no installer .env is a source checkout,
+# not an install — refuse it. `git rev-parse` walks up to the repo root, so this
+# also fires when INSTALL_DIR is a subdirectory (e.g. the repo's ods/ dir).
+if [[ ! -f "$INSTALL_DIR/.env" ]] && \
+   git -C "$INSTALL_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    log_error "Refusing to uninstall '$INSTALL_DIR': it is a git working tree with no installer-generated .env."
+    log_error "This looks like an ODS source checkout, not a deployed install."
+    log_error "To remove a real install here, set INSTALL_DIR=<path> explicitly, or delete it manually."
+    exit 1
+fi
+
 if [[ ! -d "$INSTALL_DIR" ]]; then
     log_error "Install directory not found: $INSTALL_DIR"
     exit 1

--- a/ods/tests/test-uninstall-source-checkout-guard.sh
+++ b/ods/tests/test-uninstall-source-checkout-guard.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Regression check: ods-uninstall.sh must refuse to delete an ODS *source
+# checkout*. The install-dir auto-detect keys off ods-cli, which the git repo
+# ships too, so running the uninstaller (especially with --force) from a
+# development clone would rm -rf the working tree. A deployed install always
+# carries an installer-generated .env at its root; a git working tree without it
+# is a source checkout and must be refused.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/ods-uninstall.sh"
+TMP_DIR=""
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+# Minimal stubs so the "allow" case can complete a full uninstall without
+# touching the real system. git is intentionally NOT stubbed — the guard relies
+# on the real binary, and prepending this dir to PATH leaves git reachable.
+make_stub_bin() {
+    local stub_dir="$1"
+    local tool
+    for tool in docker systemctl sudo pgrep; do
+        cat > "$stub_dir/$tool" <<'EOF'
+#!/usr/bin/env bash
+# is-enabled / pgrep must report "nothing found" so the caller skips cleanup.
+case "${1:-}" in
+    is-enabled) exit 1 ;;
+esac
+exit 1
+EOF
+        chmod +x "$stub_dir/$tool"
+    done
+    # sudo must exec its argument (chown/rm), not exit 1.
+    cat > "$stub_dir/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+    chmod +x "$stub_dir/sudo"
+}
+
+# Lay out a directory that looks like whatever `ods-uninstall.sh` keys off:
+# a git working tree containing ods-cli and the uninstaller itself.
+make_checkout() {
+    local dir="$1"
+    mkdir -p "$dir/lib"
+    cp "$TARGET" "$dir/ods-uninstall.sh"
+    cp "$ROOT_DIR/lib/safe-env.sh" "$dir/lib/safe-env.sh"
+    touch "$dir/ods-cli"
+    git -C "$dir" init -q
+}
+
+main() {
+    [[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+    TMP_DIR="$(mktemp -d -t ods-uninstall-guard-XXXXXX)"
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
+    local stub_dir="$TMP_DIR/bin"
+    mkdir -p "$stub_dir"
+    make_stub_bin "$stub_dir"
+
+    # --- Case 1: source checkout (git tree, no .env) must be refused ---
+    local checkout="$TMP_DIR/checkout"
+    make_checkout "$checkout"
+
+    local out status
+    set +e
+    out="$(HOME="$TMP_DIR/home1" PATH="$stub_dir:$PATH" \
+        bash "$checkout/ods-uninstall.sh" --force 2>&1)"
+    status=$?
+    set -e
+
+    (( status != 0 )) || fail "uninstall must exit non-zero for a source checkout"
+    grep -qF 'Refusing to uninstall' <<<"$out" \
+        || fail "uninstall must print a refusal for a source checkout; got: $out"
+    [[ -d "$checkout" && -f "$checkout/ods-cli" ]] \
+        || fail "uninstall must NOT delete the source checkout"
+    pass "refuses to uninstall a git checkout with no installer .env"
+
+    # --- Case 2: real install (has .env) must NOT be blocked by the guard ---
+    local install="$TMP_DIR/install"
+    make_checkout "$install"                       # git tree ...
+    printf '%s\n' 'GPU_BACKEND=cpu' > "$install/.env"  # ... but a real install
+
+    set +e
+    out="$(HOME="$TMP_DIR/home2" PATH="$stub_dir:$PATH" \
+        bash "$install/ods-uninstall.sh" --force 2>&1)"
+    status=$?
+    set -e
+
+    if grep -qF 'Refusing to uninstall' <<<"$out"; then
+        fail "guard must not fire for an install carrying a .env; got: $out"
+    fi
+    (( status == 0 )) || fail "uninstall of a real install should succeed; got exit $status: $out"
+    pass "allows uninstall of a git checkout that carries an installer .env"
+
+    echo "[OK] source-checkout guard regression checks passed"
+}
+
+main "$@"


### PR DESCRIPTION
Fixes #2712.

## Problem

`ods-uninstall.sh` derives its target from **its own location** whenever that directory contains `ods-cli`:

```sh
if [[ -d "$SCRIPT_DIR" && -f "$SCRIPT_DIR/ods-cli" ]]; then
    INSTALL_DIR="$SCRIPT_DIR"
fi
```

The repo ships `ods/ods-cli`, so running the uninstaller from a clone sets `INSTALL_DIR` to the checkout, and the final `rm -rf "$INSTALL_DIR"` **deletes the working tree** — including uncommitted work. `--force` makes it worse by skipping the `Are you sure?` prompt. There is no guard distinguishing a source checkout from a deployed install.

Repro:

```sh
git clone https://github.com/Osmantic/ODS /tmp/ods-demo
cd /tmp/ods-demo/ods
./ods-uninstall.sh --force     # /tmp/ods-demo/ods is deleted
```

## Fix

Refuse when `INSTALL_DIR` is a git working tree **and** has no installer-generated `.env`. A deployed install always carries `.env` at its root (the installer strips `.git` when copying to `~/ods`), which makes this a precise discriminator:

- source checkout (git tree, no `.env`) → **refused**
- copied install (`.env`, no `.git`) → allowed
- in-place clone-to-`~/ods` install (`.git` + `.env`) → allowed

`git rev-parse --is-inside-work-tree` walks up to the repo root, so the guard also fires when `INSTALL_DIR` is the repo's `ods/` subdirectory. If `git` is absent the guard no-ops.

## Tests

- New `tests/test-uninstall-source-checkout-guard.sh` covers both the refuse and allow cases; wired into `make test`.
- Existing `tests/test-uninstall-compose-flags.sh` stays green (its fixture already writes a `.env`).
- `bash -n` and `shellcheck` clean; verified live that running the patched uninstaller from a checkout now exits 1 with a refusal instead of deleting the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
