### PR TITLE
fix(repo): normalize every tracked text file to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,23 @@
-# Force LF line endings for all shell scripts and Docker-mounted files.
-# Windows Git's core.autocrlf converts LF→CRLF on checkout, which breaks
-# shell shebangs inside Linux Docker containers (kernel reads #!/bin/sh\r
-# and fails with "no such file or directory").
-*.sh text eol=lf
-*.bash text eol=lf
-ods/ods-cli text eol=lf
-Dockerfile* text eol=lf
-docker-entrypoint* text eol=lf
-*.yaml text eol=lf
-*.yml text eol=lf
-*.json text eol=lf
-*.env text eol=lf
-*.shellcheckrc text eol=lf
+# Every tracked text file is LF in the index and checks out LF, on every
+# platform. Windows Git's core.autocrlf otherwise converts on checkout, and a
+# trailing \r breaks whatever parses the file on the Linux side:
+#   * the kernel reads `#!/bin/sh\r` and fails with "no such file or directory"
+#   * modprobe keeps the \r as part of an option value
+#   * sysctl rejects the key outright
+#   * the `$`-anchored grep contracts in ods/tests/ stop matching
+#
+# text=auto leaves binary content alone — git detects that itself, so the
+# icons and images under installer/ and dashboard/public/ are unaffected.
+* text=auto eol=lf
 
-# PowerShell scripts can use CRLF (native Windows)
+# Redundant under the rule above, kept deliberately: ods/ods-cli is
+# extensionless, was the original CRLF casualty, and
+# tests/contracts/test-installer-contracts.sh pins this exact line so the
+# regression cannot come back by way of an edit to the default.
+ods/ods-cli text eol=lf
+
+# PowerShell is the deliberate exception: these run on native Windows, where
+# CRLF is expected. LF in the index, CRLF in every working tree.
 *.ps1 text eol=crlf
 *.psm1 text eol=crlf
 *.psd1 text eol=crlf


### PR DESCRIPTION
## Summary

`.gitattributes` forces `eol=lf` for shell scripts and a hand-maintained list of
extensions, because `core.autocrlf` on a Windows checkout otherwise leaves a
`\r` that the loader treats as part of the shebang. That list is incomplete,
and the files it misses are still parsed on the Linux side by things that do
not strip the `\r`.

The concrete breakage is on the host, not in a container.
`installers/phases/10-amd-tuning.sh` copies `config/system-tuning/99-ods.conf`
into `/etc/sysctl.d/` and `amdgpu.conf` into `/etc/modprobe.d/`. `modprobe`
keeps the trailing `\r` as part of the option value and `sysctl` rejects the
key, so an AMD install driven from a Windows checkout applies neither tuning
file and reports nothing.

The same gap covers the two Caddyfiles bind-mounted into `ods-proxy` and
`hermes-proxy`, the nginx configs mounted into / copied into their images, the
Hermes config and persona templates, and the brave-search module copied into
its runtime image. It also breaks two of the repo's own contracts —
`test-hermes-proxy-caddyfile.sh` and `test-installer-context-parity.sh` both
grep with a `$` anchor and fail on a Windows working tree against files that
are correct in the index.

Rather than extend the list a third time, this sets the default:
`* text=auto eol=lf`, keeping the deliberate PowerShell `eol=crlf` overrides
and the AMD fixture `-whitespace` rule.

**No stored content changes.** Every tracked file is already LF in the index —
`git ls-files --eol` reports zero `i/crlf` and zero `i/mixed` — so this only
affects what lands in a Windows working tree. `text=auto` leaves the 16
detected binaries (icons and images) alone. On Linux and macOS the checkout is
byte-identical before and after, which is why CI is unaffected either way.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. A stable-lane user on Linux or macOS is unaffected, because
their checkout is already LF. The failure needs a Windows working tree.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

No installer code changed. The box is checked because the user-visible effect
is on installer-delivered host config (`/etc/sysctl.d`, `/etc/modprobe.d`) when
the install is driven from a Windows checkout.

## Risk And Validation

- Risk level: Low — the diff is repository metadata, and the resulting Linux
  and macOS checkouts are byte-identical to today's.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# No stored content changes: index has nothing to renormalize
$ git ls-files --eol | grep -c 'i/crlf'      -> 0
$ git ls-files --eol | grep -c 'i/mixed'     -> 0

# Working tree fully re-checked-out under the new attributes
$ git ls-files -z | xargs -0 rm -f && git checkout -- .
$ git status --short                          -> (empty, no content churn)
$ git ls-files --eol | grep -c 'w/crlf'       -> 37  (all .ps1/.psm1/.psd1)

$ git diff --check                            -> clean
$ make lint                                   -> All lint checks passed.

# The two CRLF-sensitive contracts, same WSL shell, Windows working tree
                                          origin/main   this branch
tests/test-hermes-proxy-caddyfile.sh         FAIL          PASS
tests/test-installer-context-parity.sh       FAIL          PASS

# make test advances strictly further with the change
$ make test   on origin/main  -> stops at Makefile:26 (context parity, CRLF)
$ make test   on this branch  -> stops at Makefile:43

# What Makefile:43 is, and why it is not this PR:
tests/test-linux-install-preflight.sh   origin/main FAIL   this branch FAIL
  ✗ JSON output contract validation failed
  ✗ ROOTLESS_SUBID should pass with a full 65536 range
  (needs /etc/subuid host state this machine does not have; byte-identical
   failure on both sides, so it is pre-existing and environment-dependent)

# The ods/ods-cli guardrail in tests/contracts/test-installer-contracts.sh
# pins its exact line, so that line is kept rather than folded into the
# default. Verified passing.
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Classified as operational because the sysctl/modprobe files it fixes are host
mutation, even though no installer code is in the diff. Release-grade fleet
validation is not proposed: on the fleet's Linux hosts the checkout is
unchanged by this PR, so there is nothing new for that lane to exercise. The
behavior difference exists only on a Windows working tree, which is covered by
the before/after table above.

## Notes For Reviewers

- Reviewing the effect rather than the diff is easiest with
  `git ls-files --eol` before and after — the point of the change is that the
  `attr/` column becomes `text eol=lf` while the `i/` column never moves.
- I dropped the per-extension list rather than adding `Caddyfile`, `*.conf`,
  `*.template`, `*.mjs`, and `*.py` to it. Happy to restore the explicit list
  if you would rather keep the policy enumerated; the effect is the same for
  every file currently tracked. `ods/ods-cli` is the one line I kept, because
  `test-installer-contracts.sh` pins it verbatim and I would rather not weaken
  an existing guardrail to make the file shorter.
- Rollback is reverting this commit plus a re-checkout; no history rewrite or
  renormalization commit is involved.
