### PR TITLE
fix(dashboard-api): reject service ids with a trailing newline

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -425,8 +425,8 @@ def _is_installable(ext_id: str) -> bool:
 
 def _validate_service_id(service_id: str) -> None:
     """Validate service_id format, raising 404 if invalid."""
-    if not _SERVICE_ID_RE.match(service_id):
-        raise HTTPException(status_code=404, detail=f"Invalid service_id: {service_id}")
+    if not _SERVICE_ID_RE.fullmatch(service_id):
+        raise HTTPException(status_code=404, detail="Invalid service_id")
 
 
 def _assert_not_core(service_id: str) -> None:
@@ -1047,7 +1047,7 @@ def _serialize_extension_operation(func):
     """Keep same-service portal mutations serialized through runtime proof."""
     @wraps(func)
     def wrapped(service_id: str, *args, **kwargs):
-        if not _SERVICE_ID_RE.match(service_id):
+        if not _SERVICE_ID_RE.fullmatch(service_id):
             return func(service_id, *args, **kwargs)
         with _extension_operation_lock(service_id):
             return func(service_id, *args, **kwargs)
@@ -1281,8 +1281,8 @@ async def extension_detail(
     api_key: str = Depends(verify_api_key),
 ):
     """Get detailed information for a single extension."""
-    if not _SERVICE_ID_RE.match(service_id):
-        raise HTTPException(status_code=404, detail=f"Invalid service_id: {service_id}")
+    if not _SERVICE_ID_RE.fullmatch(service_id):
+        raise HTTPException(status_code=404, detail="Invalid service_id")
 
     ext = next((e for e in EXTENSION_CATALOG if e["id"] == service_id), None)
     if not ext:
@@ -1375,8 +1375,8 @@ async def extension_logs(
     api_key: str = Depends(verify_api_key),
 ):
     """Get container logs for any service via the host agent."""
-    if not _SERVICE_ID_RE.match(service_id):
-        raise HTTPException(status_code=404, detail=f"Invalid service_id: {service_id}")
+    if not _SERVICE_ID_RE.fullmatch(service_id):
+        raise HTTPException(status_code=404, detail="Invalid service_id")
 
     try:
         body = await asyncio.to_thread(
@@ -2057,7 +2057,7 @@ def _parse_manifest_deps(manifest_path: Path) -> list[str]:
     depends_on = svc.get("depends_on", []) if isinstance(svc, dict) else []
     if not isinstance(depends_on, list):
         return []
-    return [d for d in depends_on if isinstance(d, str) and _SERVICE_ID_RE.match(d)]
+    return [d for d in depends_on if isinstance(d, str) and _SERVICE_ID_RE.fullmatch(d)]
 
 
 def _read_direct_deps(service_id: str) -> list[str]:
@@ -2476,8 +2476,8 @@ def purge_extension_data(
     api_key: str = Depends(verify_api_key),
 ):
     """Permanently delete service data directory."""
-    if not _SERVICE_ID_RE.match(service_id):
-        raise HTTPException(status_code=404, detail=f"Invalid service_id: {service_id}")
+    if not _SERVICE_ID_RE.fullmatch(service_id):
+        raise HTTPException(status_code=404, detail="Invalid service_id")
 
     if service_id in ALWAYS_ON_SERVICES:
         raise HTTPException(status_code=403, detail="Cannot purge always-on service data")

--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -184,7 +184,7 @@ async def service_resources(api_key: str = Depends(verify_api_key)):
 @router.post("/api/services/{service_id}/restart")
 async def restart_service(service_id: str, api_key: str = Depends(verify_api_key)):
     """Restart a single known ODS service via the host agent."""
-    if not _SERVICE_ID_RE.match(service_id):
+    if not _SERVICE_ID_RE.fullmatch(service_id):
         raise HTTPException(status_code=400, detail="Invalid service_id")
     if service_id not in SERVICES:
         raise HTTPException(status_code=404, detail=f"Service not found: {service_id}")

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -287,12 +287,18 @@ class TestExtensionDetail:
         """Regex validation rejects path traversal and invalid service IDs."""
         _patch_extensions_config(monkeypatch, [], tmp_path=tmp_path)
 
-        for bad_id in ["..etc", ".hidden", "UPPERCASE", "-starts-dash"]:
+        # "%0A" is a trailing newline: Python's `$` matches just before a final
+        # newline, so a `$`-anchored `.match()` lets "foo\n" through and the id
+        # reaches the 404 detail string and the logs verbatim.
+        for bad_id in ["..etc", ".hidden", "UPPERCASE", "-starts-dash", "foo%0A"]:
             resp = test_client.get(
                 f"/api/extensions/{bad_id}",
                 headers=test_client.auth_headers,
             )
             assert resp.status_code == 404, f"Expected 404 for: {bad_id}"
+            assert "\n" not in resp.json()["detail"], (
+                f"Rejected id leaked a newline into the error body: {bad_id}"
+            )
 
     def test_detail_path_traversal_with_slashes(self, test_client):
         """Path traversal with slashes never reaches the handler."""
@@ -1472,7 +1478,9 @@ class TestMutationPathTraversal:
         """Path traversal IDs are rejected on all mutation endpoints."""
         _patch_mutation_config(monkeypatch, tmp_path)
 
-        bad_ids = ["..etc", ".hidden", "UPPERCASE", "-starts-dash"]
+        # "%0A" decodes to a trailing newline, which a `$`-anchored `.match()`
+        # accepts. Every mutation endpoint must reject it on format alone.
+        bad_ids = ["..etc", ".hidden", "UPPERCASE", "-starts-dash", "foo%0A"]
         endpoints = [
             ("POST", "/api/extensions/{}/install"),
             ("POST", "/api/extensions/{}/enable"),
@@ -1500,6 +1508,14 @@ class TestMutationPathTraversal:
                     )
                 assert resp.status_code == 404, (
                     f"Expected 404 for {method} {url}, got {resp.status_code}"
+                )
+                # A 404 alone does not prove the format check ran — an id that
+                # slips through still 404s at the directory lookup. The error
+                # body is what distinguishes the two: only the format check
+                # rejects before the id is interpolated into a message.
+                detail = resp.json().get("detail", "")
+                assert "\n" not in str(detail), (
+                    f"Rejected id leaked a newline into {method} {url}: {detail!r}"
                 )
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -314,6 +314,26 @@ class TestServiceResources:
 
         assert resp.status_code == 404
 
+    def test_restart_service_rejects_trailing_newline(self, test_client, monkeypatch):
+        """A known id with a trailing newline is not the known id.
+
+        Python's `$` also matches just before a final newline, so a
+        `$`-anchored `.match()` accepts "ape\\n". The id must be rejected by
+        the format check rather than falling through to the catalog lookup.
+        """
+        monkeypatch.setattr("routers.resources.SERVICES", {
+            "ape": {"name": "APE", "container_name": "ods-ape"},
+        })
+
+        with patch("routers.resources._post_agent_json") as post_agent:
+            resp = test_client.post(
+                "/api/services/ape%0A/restart",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 400
+        post_agent.assert_not_called()
+
     def test_restart_service_rejects_non_docker_service(self, test_client, monkeypatch):
         """Restart endpoint rejects known services that do not map to Docker."""
         monkeypatch.setattr("routers.resources.SERVICES", {

--- a/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
@@ -1,7 +1,9 @@
 """Tests for user extension manifest scanner."""
 
+import os
 from pathlib import Path
 
+import pytest
 import yaml
 
 from user_extensions import (
@@ -41,6 +43,21 @@ class TestScanUserExtensions:
     def test_scan_nonexistent_dir(self, tmp_path):
         """Non-existent directory returns empty dict."""
         assert scan_user_extension_services(tmp_path / "nope") == {}
+
+    @pytest.mark.skipif(os.name == "nt", reason="Windows forbids \\n in a filename")
+    def test_scan_skips_directory_name_with_trailing_newline(self, tmp_path):
+        """A directory whose name ends in a newline is not a valid service id.
+
+        Python's `$` matches just before a final newline, so a `$`-anchored
+        `.match()` accepts "my-ext\\n" and the scanner would publish it as a
+        service id that no compose or manifest lookup can resolve.
+        """
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "my-ext\n"
+        _write_manifest(ext_dir, _make_manifest("my-ext"))
+        (ext_dir / "compose.yaml").write_text("services:\n  my-ext:\n    image: test\n")
+
+        assert scan_user_extension_services(user_dir) == {}
 
     def test_scan_enabled_extension(self, tmp_path):
         """Extension with compose.yaml + manifest returns correct config."""

--- a/ods/extensions/services/dashboard-api/user_extensions.py
+++ b/ods/extensions/services/dashboard-api/user_extensions.py
@@ -38,7 +38,7 @@ def scan_user_extension_services(
 
         service_id = item.name
 
-        if not _SERVICE_ID_RE.match(service_id):
+        if not _SERVICE_ID_RE.fullmatch(service_id):
             continue
 
         # Only enabled extensions (compose.yaml present, not .disabled)


### PR DESCRIPTION
## Summary

`_SERVICE_ID_RE` is `^[a-z0-9][a-z0-9_-]*$`, checked with `.match()`. In Python
`$` also matches immediately before a final newline, so `.match()` accepts
`"foo\n"` — the one input in this class that gets through:

```python
>>> r = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
>>> bool(r.match("foo\n")),  bool(r.fullmatch("foo\n"))
(True, False)
>>> bool(r.match("foo\r")),  bool(r.match("foo\nbar")),  bool(r.match("foo\x00"))
(False, False, False)
```

That is 8 call sites across three modules — `routers/extensions.py` (6),
`routers/resources.py` (1), and `user_extensions.py` (1). This switches all of
them to `.fullmatch()`. The `^`/`$` anchors are left in place: they are
redundant under `fullmatch` but keep the intent readable and keep partial
protection if anyone reaches for `.match()` again.

Two of the affected sites are more than cosmetic:

- `_serialize_extension_operation` uses the check to decide whether to take a
  lock. An id that slips through gets a real `sha256(id).lock` file created
  under `.extension-operation-locks/`, for a request that is going to 404 at
  the directory lookup a moment later. `fullmatch` keeps those out.
- `purge_extension_data` ("permanently delete service data directory") is
  behind the same guard.

The routes still 404 either way, so nothing was exploitable — but the id was
reaching the error body and the logs verbatim, newline included:

```text
{"detail":"Extension not found: foo\n"}
```

A newline in attacker-influenced text that lands in a log line is how a forged
log entry gets written, so the second half of this change is to stop echoing an
id that just failed validation. `routers/resources.py` and
`bin/ods-host-agent.py` already use a bare `"Invalid service_id"` with no
interpolation; `routers/extensions.py` was the only module echoing the value,
in 4 places. It now matches. "Extension not found: {service_id}" is left alone
— by that point the id has passed the format check, so it can only contain
`[a-z0-9_-]`.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. The affected routes already return 404 for these ids, so there
is no user-visible failure on stable to hot-fix. This is input-validation and
log-hygiene hardening.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — touches the shared validator on the extension and
  service-resource control paths. The change is strictly narrowing: every input
  accepted before is still accepted, except a trailing newline.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# The three new/extended tests were confirmed to fail on the unfixed source
# first, so they actually guard the behaviour:
$ git stash push -- <the three source files>
$ pytest -k 'newline or traversal'
  FAILED test_resources.py::...::test_restart_service_rejects_trailing_newline
  FAILED test_user_extensions.py::...::test_scan_skips_directory_name_with_trailing_newline
  FAILED test_extensions.py::...::test_detail_rejects_path_traversal
    E  AssertionError: Rejected id leaked a newline into the error body: foo%0A
    E  assert '\n' not in 'Extension not found: foo\n'
  3 failed, 6 passed

$ git stash pop        # fix restored
$ pytest -k 'newline or traversal'
  9 passed, 287 deselected

$ pytest tests/   -> 2117 passed, 3 skipped  (full dashboard-api suite)
$ make lint                      -> All lint checks passed.
$ git diff --check               -> clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Dashboard API control-plane input validation, so it is classified as
operational. Release-grade fleet validation is not proposed: the behaviour
difference is confined to one rejected input shape that already produced a 404,
and the full dashboard-api suite covers the routes involved.

## Notes For Reviewers

- `TestMutationPathTraversal` needed a stronger assertion than status code. An
  id that slips past the format check still 404s at the directory lookup, so
  `assert 404` passes either way — I added an assertion that the error body
  carries no newline, which is what actually distinguishes "rejected on format"
  from "rejected on lookup". Same reasoning in `TestExtensionDetail`.
- The scanner test creates a directory whose name ends in `\n`, which Windows
  forbids, so it is `skipif(os.name == "nt")`. CI runs this suite on
  ubuntu-latest, so it executes there.
- Three modules each define their own copy of `_SERVICE_ID_RE`. I deliberately
  did not consolidate them in this PR — that is a refactor with a wider blast
  radius than the fix, and it would obscure a diff that is otherwise one word
  per line. Happy to follow up if you want a shared constant.
