### PR TITLE
test(restore): give the safety-UX fixture the library it needs, and run it

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Health Check Tests
         run: bash tests/test-health-check.sh
 
+      - name: Restore Safety UX Tests
+        run: bash tests/test-restore-safety-ux.sh
+
       - name: QR Code Helper Tests
         run: bash tests/test-qrcode-helper.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -67,6 +67,9 @@ test: ## Run unit and contract tests
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
 	@echo ""
+	@echo "=== restore confirmation UX ==="
+	@bash tests/test-restore-safety-ux.sh
+	@echo ""
 	@echo "=== QR code helper LAN detection ==="
 	@bash tests/test-qrcode-helper.sh
 	@echo ""

--- a/ods/tests/test-restore-safety-ux.sh
+++ b/ods/tests/test-restore-safety-ux.sh
@@ -24,6 +24,12 @@ FAKE_ODS="$TMP/ods"
 mkdir -p "$FAKE_ODS/.backups"
 # minimal marker so 'is this a ODS dir' check passes
 mkdir -p "$FAKE_ODS/data"
+# ods-restore.sh sources lib/rsync.sh relative to ODS_DIR before it reaches
+# any of the confirmation logic below, so the fixture has to provide it —
+# same as test-backup-restore-roundtrip.sh. Without it the script exits 1 at
+# the source line and both assertions below pass over untested code.
+mkdir -p "$FAKE_ODS/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/"
 
 # Create a minimal backup (manifest only, no data dirs)
 BID="20260101-000000"


### PR DESCRIPTION
## Summary

`tests/test-restore-safety-ux.sh` has never tested either of the two things it
asserts.

`ods-restore.sh:29` sources `$ODS_DIR/lib/rsync.sh` unconditionally, at the top
of the script, long before any confirmation logic. The fixture builds a fake ODS
root containing only `.backups/` and `data/`, so the script exits 1 on that
source line and the test reports:

```text
ℹ Restore should cancel unless backup ID is typed
✗ Expected rc=0 on cancel, got 1
```

The failure looks like a restore bug. It is the fixture. This copies
`lib/rsync.sh` into the fake root, the same way
`tests/test-backup-restore-roundtrip.sh` already does for the same reason.

### The test was not just failing, it was blind

Both assertions now run and pass. To confirm they actually guard something
rather than passing vacuously, I inverted the confirmation check in
`ods-restore.sh` so that a blank answer proceeds instead of cancelling, and ran
the test both ways:

```text
mutation: `if [[ "$confirm" != "$backup_id" ]]` -> a condition that never fires

  fixed fixture + mutated restore    ✗ Expected 'Restore cancelled' message   (caught)
  old fixture   + mutated restore    ✗ Expected rc=0 on cancel, got 1         (not caught)
  old fixture   + correct restore    ✗ Expected rc=0 on cancel, got 1         (identical)
```

The old fixture produced the *same* failure whether the restore logic was
correct or completely broken, so the test carried no signal either way. The
mutation was reverted; `ods-restore.sh` is untouched in this PR.

### Wiring it up

The test is not referenced by `ods/Makefile` or by any workflow, which is how it
went stale without anyone noticing. Fixing the fixture alone would leave it
running nowhere, so this also adds it to `make test` and to the
`integration-smoke` job in `test-linux.yml`. No backup or restore test currently
runs in CI at all; this is the first.

The test needs only `bash`, `mktemp` and `cp` — it passed in an environment
without Docker, and `ods-restore.sh` guards its `docker compose ls` call behind
`2>/dev/null` inside a conditional.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. No shipped behaviour changes; this repairs a test fixture and
adds the test to CI.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

Plus one CI workflow step and one `make test` line. No product code is modified.

## Risk And Validation

- Risk level: Low — test fixture and test wiring only. `ods-restore.sh` and
  every other shipped file are untouched.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash tests/test-restore-safety-ux.sh          # before
  ✗ Expected rc=0 on cancel, got 1                                 exit 1

$ bash tests/test-restore-safety-ux.sh          # after
  ✓ Restore cancels if confirmation doesn't match backup id
  ✓ Forced restore runs without interactive confirmation           exit 0

# mutation check described above — the fixed test catches an inverted
# confirmation, the old one does not

$ shellcheck --exclude=SC1091,SC2034 --severity=warning --format=gcc \
      ods/tests/test-restore-safety-ux.sh        -> clean
$ make lint                                      -> All lint checks passed.
$ git diff --check                               -> clean
$ python -c "yaml.safe_load(test-linux.yml)"     -> parses; step lands in
                                                    integration-smoke
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

No installer, compose, lifecycle, API or host-mutation code is touched.

## Notes For Reviewers

- Happy to split the CI/Makefile wiring into its own PR if you would rather keep
  this to the fixture. I kept them together because a repaired test that nothing
  executes is the same failure mode one release later.
- I put the CI step in `integration-smoke` next to the other `bash tests/*.sh`
  steps. Say the word if a different job is a better home.
- The wider issue is that roughly 107 of the 170 scripts in `ods/tests/` are not
  referenced by the Makefile or any workflow. Many of those legitimately need
  Docker or hardware. This PR only claims the one that does not, and that was
  silently broken. Worth a separate pass to sort the rest into "runs in CI",
  "needs hardware", or "delete".
