### PR TITLE
fix(model-router): require the internal key on the forward route

### DIFF
--- a/ods/config/litellm/switchboard.yaml
+++ b/ods/config/litellm/switchboard.yaml
@@ -3,19 +3,19 @@ model_list:
     litellm_params:
       model: openai/ods/current
       api_base: http://model-router:9099/v1
-      api_key: no-key
+      api_key: os.environ/ODS_ROUTER_INTERNAL_KEY
 
   - model_name: local
     litellm_params:
       model: openai/ods/current
       api_base: http://model-router:9099/v1
-      api_key: no-key
+      api_key: os.environ/ODS_ROUTER_INTERNAL_KEY
 
   - model_name: default
     litellm_params:
       model: openai/ods/current
       api_base: http://model-router:9099/v1
-      api_key: no-key
+      api_key: os.environ/ODS_ROUTER_INTERNAL_KEY
 
   - model_name: cloud
     litellm_params:
@@ -38,7 +38,7 @@ model_list:
     litellm_params:
       model: openai/ods/current
       api_base: http://model-router:9099/v1
-      api_key: no-key
+      api_key: os.environ/ODS_ROUTER_INTERNAL_KEY
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/ods/extensions/services/litellm/compose.yaml
+++ b/ods/extensions/services/litellm/compose.yaml
@@ -16,6 +16,11 @@ services:
       - ODS_MODEL_SWITCHBOARD=${ODS_MODEL_SWITCHBOARD:-observe}
       - TOKEN_SPY_URL=${TOKEN_SPY_URL:-http://token-spy:8080}
       - TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}
+      # Presented to model-router on the switchboard route. Mirrors the
+      # router's own resolution order (app/main.py: ODS_ROUTER_INTERNAL_KEY
+      # first, DASHBOARD_API_KEY second) so both sides land on the same value
+      # without introducing a new generated secret.
+      - ODS_ROUTER_INTERNAL_KEY=${ODS_ROUTER_INTERNAL_KEY:-${DASHBOARD_API_KEY:-}}
     volumes:
       - ./config/litellm/${ODS_MODE:-local}.yaml:/app/config.yaml:ro,z
       - ./config/litellm/switchboard.yaml:/app/switchboard.yaml:ro,z

--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import time
 import uuid
 from collections import OrderedDict
@@ -844,10 +845,29 @@ async def list_models() -> dict[str, Any]:
     return {"object": "list", "data": data, "ods": metadata}
 
 
+def _internal_key_authorized(request: Request) -> bool:
+    """Constant-time check of the caller's internal Bearer key.
+
+    Compared as UTF-8 bytes so a non-ASCII presented token is a clean mismatch
+    rather than a TypeError on the pre-auth path — the same shape as
+    dashboard-api's verify_api_key, token-spy and privacy-shield.
+
+    Returns False when no key is configured: the router must not serve a
+    protected route just because the deployment forgot to set one.
+    """
+    if not INTERNAL_KEY:
+        return False
+    provided = request.headers.get("authorization", "")
+    if not provided.startswith("Bearer "):
+        return False
+    return secrets.compare_digest(
+        provided[len("Bearer "):].encode("utf-8"), INTERNAL_KEY.encode("utf-8")
+    )
+
+
 @app.get("/internal/route-evidence/{probe_id}")
 async def route_evidence(probe_id: str, request: Request) -> Response:
-    provided = request.headers.get("authorization", "")
-    if not INTERNAL_KEY or provided != f"Bearer {INTERNAL_KEY}":
+    if not _internal_key_authorized(request):
         return JSONResponse({"error": "unauthorized"}, status_code=401)
     record = _evidence.get(probe_id)
     if record is None or time.monotonic() - record["storedAt"] > EVIDENCE_TTL_SECONDS:
@@ -859,6 +879,11 @@ async def route_evidence(probe_id: str, request: Request) -> Response:
 @app.api_route("/{full_path:path}", methods=["GET", "POST", "PUT", "DELETE",
                                              "PATCH", "HEAD", "OPTIONS", "CONNECT"])
 async def forward(full_path: str, request: Request) -> Response:
+    # The router is `expose:`d on the shared ods-network, so reachability is
+    # not a caller credential. Authenticate before revealing which paths are
+    # served, and before spending any local inference capacity.
+    if not _internal_key_authorized(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
     path = "/" + full_path
     method = FORWARD_PATHS.get(path)
     if method is None or request.method != method:

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -95,7 +95,10 @@ def router(tmp_path, monkeypatch):
         state_path.write_text(json.dumps(doc), encoding="utf-8")
         mod._state_cache["mtime"] = None
 
-    client = TestClient(mod.app)
+    # The forward route requires the internal key, so the default client
+    # presents it — that is what LiteLLM does on the switchboard route.
+    # Tests that assert the unauthenticated behaviour build their own client.
+    client = TestClient(mod.app, headers={"Authorization": "Bearer internal-secret"})
     client.__enter__()
     mod.app.state.http = httpx.AsyncClient(
         transport=httpx.MockTransport(upstream_handler)
@@ -275,15 +278,22 @@ class TestForwarding:
         assert b"Concrete.gguf" not in raw
 
     def test_client_authorization_stripped_and_backend_key_injected(self, router):
+        """The caller's key authenticates to the router and stops there.
+
+        The caller now presents the internal key rather than an arbitrary
+        bearer, so this also pins that the internal key is never forwarded to
+        the model backend — the upstream must see the endpoint's own key.
+        """
         mod, client, write_state, calls = router
         import os
         os.environ["KEYED_API_KEY"] = "backend-secret"
         write_state(endpoint="keyed")
         resp = client.post("/v1/chat/completions",
-                           headers={"Authorization": "Bearer client-secret"},
+                           headers={"Authorization": "Bearer internal-secret"},
                            json={"model": "ods/current", "messages": []})
         assert resp.status_code == 200
         assert calls[-1]["auth"] == "Bearer backend-secret"
+        assert "internal-secret" not in str(calls[-1]["auth"])
 
     def test_unknown_path_rejected(self, router):
         mod, client, write_state, calls = router
@@ -596,10 +606,68 @@ class TestModelsAndEvidence:
 
     def test_evidence_requires_bearer(self, router):
         mod, client, write_state, calls = router
-        assert client.get("/internal/route-evidence/x").status_code == 401
+        anon = TestClient(mod.app)
+        assert anon.get("/internal/route-evidence/x").status_code == 401
         wrong = client.get("/internal/route-evidence/x",
                            headers={"Authorization": "Bearer nope"})
         assert wrong.status_code == 401
+
+    def test_forward_requires_bearer(self, router):
+        """A shared-network peer with no key cannot spend inference capacity.
+
+        The router is `expose:`d on ods-network, so every container can reach
+        it. Reachability is not a credential.
+        """
+        mod, client, write_state, calls = router
+        write_state()
+        anon = TestClient(mod.app)
+        body = {"model": "ods/current", "messages": [{"role": "user", "content": "hi"}]}
+
+        resp = anon.post("/v1/chat/completions", json=body)
+        assert resp.status_code == 401
+        assert resp.json() == {"error": "unauthorized"}
+        assert calls == [], "unauthenticated request must not reach the upstream"
+
+        wrong = client.post("/v1/chat/completions", json=body,
+                            headers={"Authorization": "Bearer nope"})
+        assert wrong.status_code == 401
+        assert calls == []
+
+        ok = client.post("/v1/chat/completions", json=body)
+        assert ok.status_code == 200
+        assert len(calls) == 1
+
+    def test_forward_rejects_before_disclosing_served_paths(self, router):
+        """An unserved path returns 401, not 404, to an anonymous caller.
+
+        Authenticating first keeps FORWARD_PATHS from being enumerable by a
+        caller that cannot use any of them.
+        """
+        mod, client, write_state, calls = router
+        write_state()
+        anon = TestClient(mod.app)
+        assert anon.post("/v1/not-a-route", json={}).status_code == 401
+        # An authenticated caller still gets the ordinary 404.
+        assert client.post("/v1/not-a-route", json={}).status_code == 404
+
+    def test_forward_denies_when_no_key_is_configured(self, router):
+        """No configured key means deny, never allow-all.
+
+        Matches the pre-existing /internal/route-evidence behaviour rather
+        than failing open on the data plane.
+        """
+        mod, client, write_state, calls = router
+        write_state()
+        monkey = TestClient(mod.app)
+        original = mod.INTERNAL_KEY
+        try:
+            mod.INTERNAL_KEY = ""
+            body = {"model": "ods/current",
+                    "messages": [{"role": "user", "content": "hi"}]}
+            assert monkey.post("/v1/chat/completions", json=body).status_code == 401
+            assert calls == []
+        finally:
+            mod.INTERNAL_KEY = original
 
     def test_health_reports_route_presence(self, router):
         mod, client, write_state, calls = router

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -506,7 +506,7 @@ def render_litellm_switchboard(inputs: RenderInputs) -> RenderedFile:
     local_route = """    litellm_params:
       model: openai/ods/current
       api_base: http://model-router:9099/v1
-      api_key: no-key
+      api_key: os.environ/ODS_ROUTER_INTERNAL_KEY
 """
     routes = []
     for name in ("ods/current", "local", "default"):


### PR DESCRIPTION
## Summary

Part of #2718.

`model-router` is `expose:`d on 9099 and joins the default `ods-network`, so
every container in the stack can reach it. Its wildcard `forward()` handler —
which serves `/v1/chat/completions`, `/v1/completions` and `/v1/responses` —
had no caller check, so reachability was the only thing standing between any
container and the local inference capacity.

The service already has the right primitive and already applies it to
`/internal/route-evidence`. This extends it to the forward route.

### Router side

The inline check in `route_evidence` is lifted into `_internal_key_authorized()`
and used by both routes. Two small changes came with the extraction:

- `secrets.compare_digest` over UTF-8 bytes instead of `!=`, matching
  `dashboard-api/security.py`, `token-spy/main.py` and
  `privacy-shield/proxy.py`. Constant-time, and a non-ASCII presented token is
  a clean mismatch rather than a `TypeError` on the pre-auth path.
- The check runs *before* the `FORWARD_PATHS` lookup, so an anonymous caller
  cannot enumerate which paths are served. An authenticated caller still gets
  the ordinary 404.

`/health` stays anonymous — the compose healthcheck depends on it.
`/v1/models` also stays anonymous; it returns alias metadata, spends nothing,
and locking it is a separate call I did not want to bundle in here.

No configured key means deny, matching the existing `route_evidence`
behaviour rather than failing open on the data plane.

### Caller side

The only in-stack caller of the forward route is LiteLLM, and only in
switchboard mode — `select-config.sh` picks `switchboard.yaml` only when
`ODS_MODEL_SWITCHBOARD=enabled` and mode is not `cloud`. That config carried
`api_key: no-key`; it now sends `os.environ/ODS_ROUTER_INTERNAL_KEY`, in the
same form already used for `ANTHROPIC_API_KEY` and `MINIMAX_API_KEY`.
`scripts/render-runtime-configs.py` owns the enabled-mode copy of that YAML and
got the same change.

`dashboard-api` is the only other consumer and it calls
`/internal/route-evidence`, which was already authenticated.

**No new secret, and no migration.** The router resolves
`ODS_ROUTER_INTERNAL_KEY` then falls back to `DASHBOARD_API_KEY`
(`app/main.py:51-53`). LiteLLM's compose entry mirrors that exact order with a
nested default, so both sides land on the same value on an existing install
without anyone regenerating anything:

```yaml
- ODS_ROUTER_INTERNAL_KEY=${ODS_ROUTER_INTERNAL_KEY:-${DASHBOARD_API_KEY:-}}
```

Nested defaults are already used this way in
`extensions/services/perplexica/compose.yaml:14`. `DASHBOARD_API_KEY` is
generated by `installers/phases/06-directories.sh:460` and carries
`minLength: 10` in `.env.schema.json`, so it is present on every install.

This deliberately does not introduce `ODS_ROUTER_INTERNAL_KEY` as a generated
secret. Whether these services should get dedicated keys is one of the open
questions in #2718, and reusing the resolution order that already ships keeps
this PR from pre-empting that answer.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. Happy to backport if triage wants it on the stable lane; the
change is self-contained and needs no .env migration, but it does touch the
inference data path in switchboard mode, so I would rather it bake on main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High by the change map — model routing plus an auth boundary on
  the inference path. Blast radius is limited to switchboard mode, since that
  is the only configuration where LiteLLM routes through model-router.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# Unit suite — 48 before, 51 now (3 added)
$ pytest ods/extensions/services/model-router/tests/ -q
  51 passed

# Live container, real image, real uvicorn
$ docker build -t ods-model-router:authtest .
$ docker run -e ODS_ROUTER_INTERNAL_KEY=real-internal-key ...

  GET  /health                                  -> 200   (healthcheck intact)
  POST /v1/chat/completions  (no header)        -> 401   {"error":"unauthorized"}
  POST /v1/chat/completions  (Bearer wrong)     -> 401   {"error":"unauthorized"}
  POST /v1/chat/completions  (Bearer correct)   -> 503   no_active_route

  The 503 is the routing layer with a deliberately dead upstream — it proves
  the request got past auth rather than being rejected by it.

# Both sides resolve to the same key with only DASHBOARD_API_KEY set,
# rendered by docker compose itself rather than by inspection:
$ DASHBOARD_API_KEY=dash-abc123 docker compose -f extensions/services/litellm/compose.yaml config
    ODS_ROUTER_INTERNAL_KEY: dash-abc123
$ DASHBOARD_API_KEY=dash-abc123 docker compose -f docker-compose.base.yml config
    model-router ODS_ROUTER_INTERNAL_KEY = ''
    model-router DASHBOARD_API_KEY       = 'dash-abc123'
    -> router resolves INTERNAL_KEY to 'dash-abc123'   (same value)

$ python3 tests/test-render-runtime-configs.py            PASS
$ python3 tests/test-runtime-config-wiring.py             PASS
$ python3 tests/contracts/test-network-exposure-contracts.py  PASS
$ make lint                                               All lint checks passed.
$ ruff check ods/ --select E,F,W --ignore ...             All checks passed!
$ git diff --check                                        clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

This adds an auth boundary on the inference path, so it is operational. What I
could not do here is run a real LiteLLM against a real model-router — I have
verified the key resolution with `docker compose config` and the router's
behaviour in a live container, but the LiteLLM leg is verified by
configuration, not by traffic. A switchboard-mode fleet run is the right gate
before release, and I would rather that be stated than implied.

## Notes For Reviewers

- The one existing test I changed the semantics of is
  `test_client_authorization_stripped_and_backend_key_injected`. It used to
  send an arbitrary `Bearer client-secret`, which is now rejected. It sends the
  internal key instead, and I added an assertion that the internal key is *not*
  what the upstream sees — the endpoint's own key is. That is a stronger
  property than the test had before: the router's own credential must not leak
  to the model backend.
- The shared fixture client now presents the internal key by default, because
  that is what LiteLLM does. The two tests that assert unauthenticated
  behaviour build their own bare `TestClient`.
- `tests/test-generated-config-contracts.sh` fails in my environment both on
  this branch and on `origin/main` — it shells out to `docker compose` and my
  WSL docker shim cannot reach the daemon. It should run normally on the
  ubuntu runner.
