### PR TITLE
fix(restore): refuse symlinked backup entries as restore sources

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Compose Failure Report Tests
         run: bash tests/test-compose-failure-report.sh
 
+      - name: Restore Archive Member Safety Tests
+        run: bash tests/test-restore-symlink-rejection.sh
+
       - name: Uninstall Compose Flags Tests
         run: bash tests/test-uninstall-compose-flags.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -80,6 +80,9 @@ test: ## Run unit and contract tests
 	@echo "=== config migration (version check under set -e) ==="
 	@bash tests/test-migrate-config.sh
 	@echo ""
+	@echo "=== restore rejects symlinked archive members ==="
+	@bash tests/test-restore-symlink-rejection.sh
+	@echo ""
 	@echo "=== atomic .env writes ==="
 	@bash tests/test-atomic-env-writes.sh
 	@echo ""

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -396,6 +396,30 @@ stop_containers() {
     fi
 }
 
+# Refuse to treat a symlinked backup entry as a restore source.
+#
+# A backup archive is untrusted input: it can arrive from anywhere, and
+# extract_backup() only proves that member *names* are contained. A symlink
+# member's name can be perfectly ordinary while its target names any path on
+# the host. `[[ -f ]]` and `[[ -d ]]` both follow symlinks, so such a member
+# passes the guards below, and `cp`'s source operand is dereferenced too — so
+# the copy pulls whatever the link addresses into $ODS_DIR.
+#
+# Only the source *operand* is rejected. Symlinks nested inside a restored
+# tree are left alone, because `cp -r` and `rsync -a` recreate those as links
+# rather than following them — which is what a legitimate backup of a tree
+# containing symlinks (a models/ directory on another disk, say) relies on.
+assert_not_symlink() {
+    local path="$1"
+    local label="$2"
+    if [[ -L "$path" ]]; then
+        log_error "Backup entry '$label' is a symlink to: $(readlink "$path")"
+        log_error "Refusing to restore — backup archives are untrusted input."
+        return 1
+    fi
+    return 0
+}
+
 # Restore user data
 restore_user_data() {
     local backup_dir="$1"
@@ -405,6 +429,7 @@ restore_user_data() {
 
     local restored_any=false
     for dir in "${data_dirs[@]}"; do
+        assert_not_symlink "$backup_dir/$dir" "$dir" || return 1
         if [[ -d "$backup_dir/$dir" ]]; then
             restored_any=true
             mkdir -p "$ODS_DIR/$(dirname "$dir")"
@@ -431,6 +456,7 @@ restore_config() {
 
     # Dynamically discover config files (dotfiles + compose overlays + scripts)
     for file in "$backup_dir"/.env "$backup_dir"/.version "$backup_dir"/docker-compose*.y*ml "$backup_dir"/ods-*.sh; do
+        assert_not_symlink "$file" "$(basename "$file")" || return 1
         if [[ -f "$file" ]]; then
             restored_any=true
             cp "$file" "$ODS_DIR/"
@@ -438,6 +464,7 @@ restore_config() {
         fi
     done
 
+    assert_not_symlink "$backup_dir/config" "config/" || return 1
     if [[ -d "$backup_dir/config" ]]; then
         restored_any=true
         if [[ -d "$ODS_DIR/config" ]]; then

--- a/ods/tests/test-restore-symlink-rejection.sh
+++ b/ods/tests/test-restore-symlink-rejection.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# A backup archive is untrusted input. Its member *names* can be perfectly
+# ordinary while a member is a symlink whose target names any path on the
+# host — `[[ -f ]]`, `[[ -d ]]` and `cp`'s source operand all follow it.
+#
+# These tests pin that a symlinked restore source is refused, and that an
+# ordinary backup containing a nested symlink still restores.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_RESTORE="$SCRIPT_DIR/../ods-restore.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; exit 1; }
+info() { echo -e "${BLUE}ℹ${NC} $1"; }
+
+[[ -x "$ODS_RESTORE" ]] || fail "ods-restore.sh not found or not executable"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required to build the fixtures"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BID="20260101-000000"
+
+# Build a fake ODS root. ods-restore.sh sources lib/rsync.sh relative to
+# ODS_DIR before anything else runs.
+new_ods_root() {
+    local root="$1"
+    mkdir -p "$root/data" "$root/.backups" "$root/lib"
+    cp "$SCRIPT_DIR/../lib/rsync.sh" "$root/lib/"
+    printf 'compose\n' > "$root/docker-compose.yml"
+}
+
+# Write a backup archive whose single interesting member is a symlink.
+write_symlink_archive() {
+    local archive="$1" member="$2" target="$3"
+    python3 - "$archive" "$member" "$target" <<'PY'
+import io
+import sys
+import tarfile
+
+archive, member, target = sys.argv[1:]
+with tarfile.open(archive, "w:gz") as tf:
+    root = tarfile.TarInfo("20260101-000000")
+    root.type = tarfile.DIRTYPE
+    tf.addfile(root)
+    manifest = (b'{"manifest_version":"1.0","backup_date":"2026-01-01T00:00:00Z",'
+                b'"backup_id":"20260101-000000","backup_type":"config",'
+                b'"ods_version":"test"}\n')
+    info = tarfile.TarInfo(f"20260101-000000/manifest.json")
+    info.size = len(manifest)
+    tf.addfile(info, io.BytesIO(manifest))
+    link = tarfile.TarInfo(f"20260101-000000/{member}")
+    link.type = tarfile.SYMTYPE
+    link.linkname = target
+    tf.addfile(link)
+PY
+}
+
+run_restore() {
+    local root="$1"
+    set +e
+    ODS_DIR="$root" bash "$ODS_RESTORE" --config-only --skip-verify -f "$BID" \
+        > "$TMP/restore.out" 2>&1
+    local rc=$?
+    set -e
+    echo "$rc"
+}
+
+# --- a symlinked config/ directory must not be followed --------------------
+
+info "Symlinked config/ entry is refused"
+ODS_A="$TMP/a"
+new_ods_root "$ODS_A"
+mkdir -p "$TMP/outside-a/config"
+printf 'outside-canary\n' > "$TMP/outside-a/config/secret.txt"
+write_symlink_archive "$ODS_A/.backups/$BID.tar.gz" "config" "$TMP/outside-a/config"
+
+rc="$(run_restore "$ODS_A")"
+[[ "$rc" -ne 0 ]] || fail "Expected a nonzero exit for a symlinked config/ entry, got $rc"
+[[ ! -e "$ODS_A/config/secret.txt" ]] \
+    || fail "Outside file was copied into the ODS tree"
+grep -q "is a symlink to" "$TMP/restore.out" \
+    || fail "Expected the error to name the symlink; got: $(cat "$TMP/restore.out")"
+pass "Symlinked config/ is refused and nothing outside the backup is copied"
+
+# --- a symlinked .env must not be followed either --------------------------
+
+info "Symlinked .env entry is refused"
+ODS_B="$TMP/b"
+new_ods_root "$ODS_B"
+printf 'SECRET-OUTSIDE-CONTENT\n' > "$TMP/host-secret"
+write_symlink_archive "$ODS_B/.backups/$BID.tar.gz" ".env" "$TMP/host-secret"
+
+rc="$(run_restore "$ODS_B")"
+[[ "$rc" -ne 0 ]] || fail "Expected a nonzero exit for a symlinked .env entry, got $rc"
+if [[ -f "$ODS_B/.env" ]] && grep -q "SECRET-OUTSIDE-CONTENT" "$ODS_B/.env"; then
+    fail "Contents of a host file outside the backup were written into .env"
+fi
+pass "Symlinked .env is refused and no host file contents are pulled in"
+
+# --- an ordinary backup with a nested symlink still restores ---------------
+# `cp -r` recreates nested symlinks as links rather than following them, so
+# rejecting the source operand must not reject a legitimate tree that merely
+# contains one. Guards against over-blocking.
+
+info "Ordinary backup containing a nested symlink still restores"
+ODS_C="$TMP/c"
+new_ods_root "$ODS_C"
+STAGE="$TMP/stage/$BID"
+mkdir -p "$STAGE/config"
+cat > "$STAGE/manifest.json" <<'JSON'
+{
+  "manifest_version": "1.0",
+  "backup_date": "2026-01-01T00:00:00Z",
+  "backup_id": "20260101-000000",
+  "backup_type": "config",
+  "ods_version": "test"
+}
+JSON
+printf 'real-config\n' > "$STAGE/config/settings.json"
+ln -s "settings.json" "$STAGE/config/alias.json"
+tar czf "$ODS_C/.backups/$BID.tar.gz" -C "$TMP/stage" "$BID"
+
+rc="$(run_restore "$ODS_C")"
+[[ "$rc" -eq 0 ]] || fail "Ordinary backup should restore, got rc=$rc: $(cat "$TMP/restore.out")"
+[[ -f "$ODS_C/config/settings.json" ]] || fail "Expected config/settings.json to be restored"
+[[ -L "$ODS_C/config/alias.json" ]] \
+    || fail "Nested symlink should be restored as a symlink, not dereferenced"
+pass "Legitimate backup with a nested symlink restores unchanged"

--- a/ods/tests/test-restore-symlink-rejection.sh
+++ b/ods/tests/test-restore-symlink-rejection.sh
@@ -49,15 +49,23 @@ archive, member, target = sys.argv[1:]
 with tarfile.open(archive, "w:gz") as tf:
     root = tarfile.TarInfo("20260101-000000")
     root.type = tarfile.DIRTYPE
+    # TarInfo defaults to 0o644. On a directory that leaves no traversal bit,
+    # so a non-root extractor cannot read manifest.json inside it and the
+    # restore fails during validation instead of at the symlink guard this
+    # test exists to exercise. Root ignores the bit, so the difference only
+    # shows up off a root shell.
+    root.mode = 0o755
     tf.addfile(root)
     manifest = (b'{"manifest_version":"1.0","backup_date":"2026-01-01T00:00:00Z",'
                 b'"backup_id":"20260101-000000","backup_type":"config",'
                 b'"ods_version":"test"}\n')
-    info = tarfile.TarInfo(f"20260101-000000/manifest.json")
+    info = tarfile.TarInfo("20260101-000000/manifest.json")
+    info.mode = 0o644
     info.size = len(manifest)
     tf.addfile(info, io.BytesIO(manifest))
     link = tarfile.TarInfo(f"20260101-000000/{member}")
     link.type = tarfile.SYMTYPE
+    link.mode = 0o777
     link.linkname = target
     tf.addfile(link)
 PY


### PR DESCRIPTION
## Summary

`extract_backup()` rejects archive members whose names are absolute or contain
`../`, which proves a member *name* is contained. It does not prove anything
about a member's *type*. A symlink member's name can be perfectly ordinary
while its target names any path on the host, and every consumer downstream
follows it:

- `[[ -f "$file" ]]` and `[[ -d "$backup_dir/config" ]]` both follow symlinks,
  so the guards pass.
- `cp`'s source operand is dereferenced, so the copy pulls in whatever the
  link addresses.

Two concrete shapes, both reproduced against `main` with a disposable archive
and a temporary directory:

```text
member: 20260101-000000/config  -> <a directory outside the backup>
  main:        restore_rc=0, outside file present at $ODS_DIR/config/secret.txt
  this branch: restore_rc=1, refused, nothing copied

member: 20260101-000000/.env    -> <a file outside the backup>
  main:        restore_rc=0, that file's *contents* written to $ODS_DIR/.env
  this branch: restore_rc=1, refused, nothing copied
```

The `.env` case is the sharper of the two: whatever the link points at becomes
the environment file the whole stack subsequently reads.

## What this changes

An `assert_not_symlink` guard on the three restore *source operands* —
the `data/*` directories in `restore_user_data`, the `.env` / `.version` /
`docker-compose*` / `ods-*.sh` loop in `restore_config`, and `config/`.

Deliberately narrow: only the source operand is rejected, not symlinks found
anywhere in the tree. `cp -r` and `rsync -a` recreate nested symlinks as links
rather than following them, so nested links never pull outside data in — and
rejecting them wholesale would break a legitimate backup of a tree that
contains one. `ods-backup.sh` uses `rsync -a`, which preserves symlinks, so
that is a real case rather than a hypothetical: a `models/` directory living
on another disk is the obvious one. There is a test for exactly that.

The guard sits at the consumption sites rather than in `extract_backup()`,
which also covers the branch where `.backups/<id>/` already exists as a
directory — that path returns early today and performs no archive validation
at all.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Mainline by default, but this one is a reasonable backport candidate — the
change is small, additive, and needs no migration. Triage's call.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — `ods-restore.sh` is a lifecycle surface, but the change
  is additive and only ever turns a would-be copy into a refusal. No existing
  restore that succeeds today stops succeeding, unless the thing it was
  restoring was a symlinked source operand.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# New test, run against both trees. It fails on main, which is the point.
$ bash tests/test-restore-symlink-rejection.sh
  on origin/main   ✗ Expected a nonzero exit for a symlinked config/ entry, got 0
  on this branch   ✓ Symlinked config/ is refused and nothing outside is copied
                   ✓ Symlinked .env is refused and no host file contents pulled in
                   ✓ Legitimate backup with a nested symlink restores unchanged

# Neighbouring backup/restore coverage, this branch
tests/test-backup-restore-cli.sh      PASS
tests/test-backup-integrity.sh        PASS
tests/test-update-script-backup.sh    PASS
tests/test-restore-safety-ux.sh       FAIL  <- pre-existing, see below

# Re-run as a NON-ROOT user in a clean ubuntu:24.04 container. The first CI
# run caught a fixture bug my local shell could not: tarfile.TarInfo defaults
# to mode 0o644, which on the DIRTYPE entry leaves no traversal bit, so a
# non-root extractor failed at manifest validation rather than at the symlink
# guard. Root ignores the bit. Fixed in 88dcc74; the assertion that the error
# actually names the symlink is what caught it.
  on origin/main   x Expected a nonzero exit ... got 0   (still catches the bug)
  on this branch   v all three cases pass                 NONROOT_EXIT=0

$ shellcheck --exclude=SC1091,SC2034 --severity=warning --format=gcc \
      ods/ods-restore.sh ods/tests/test-restore-symlink-rejection.sh   clean
$ make lint                                        All lint checks passed.
$ git diff --check                                 clean
```

`test-restore-safety-ux.sh` fails identically on this branch and on
`origin/main` — its fixture omits `lib/rsync.sh`, so `ods-restore.sh` exits at
the `source` line before reaching any assertion. That is #2717, not this
change. Once #2717 lands, that test starts exercising the same code path this
PR touches.

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Restore is host mutation, so it is operational. Release-grade fleet validation
is not proposed: the change adds a refusal on one input shape and the
before/after is covered by a test that fails without it. What is *not* covered
is a real end-to-end restore of a full production backup on real hardware — if
triage wants that before release, this is a reasonable candidate for it.

## Notes For Reviewers

- The new test is wired into `make test` and into the `integration-smoke` job.
  I placed both entries away from the ones #2717 adds so the two PRs do not
  conflict textually in whichever order they merge.
- I considered rejecting symlinks across the whole extracted tree, and decided
  against it: `ods-backup.sh` uses `rsync -a`, which preserves symlinks, so
  a legitimate backup can contain them and a blanket rule would refuse to
  restore it. If you would rather have the stricter rule and accept that
  trade, say so and I will switch it — the test for the legitimate case makes
  the difference easy to see.
- Hardlink, device and FIFO members are not addressed here. `tar` will recreate
  them, but none of them dereference to an outside path the way a symlink
  source operand does, so they are a separate and much narrower question.
