### PR TITLE
fix(installers): guard INSTALL_DIR cd calls in ods-macos.sh

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -695,7 +695,7 @@ stop_native_llama() {
 
 cmd_status() {
     test_install
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
     resolve_cli_llm_route
 
     local flags
@@ -768,7 +768,7 @@ cmd_status() {
 cmd_start() {
     local service="${1:-}"
     test_install
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
     ensure_llama_cpu_budget
 
     # Start native llama-server first
@@ -809,7 +809,7 @@ cmd_start() {
 cmd_stop() {
     local service="${1:-}"
     test_install
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
 
     local flags
     flags=$(get_compose_flags)
@@ -838,7 +838,7 @@ cmd_stop() {
 cmd_restart() {
     local service="${1:-}"
     test_install
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
     ensure_llama_cpu_budget
 
     local flags
@@ -903,7 +903,7 @@ cmd_logs() {
     fi
 
     test_install
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
 
     local flags
     flags=$(get_compose_flags)
@@ -990,7 +990,7 @@ cmd_chat() {
 
 cmd_update() {
     test_install
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
     ensure_llama_cpu_budget
 
     # Upsert SHIELD_API_KEY when missing (pre-PR-#1069 upgrade path).


### PR DESCRIPTION
## Summary
- `cmd_status`, `cmd_start`, `cmd_stop`, `cmd_restart`, the log viewer, and `cmd_update` in `installers/macos/ods-macos.sh` all `cd "$INSTALL_DIR"` without checking the result, unlike the guarded `cd "$INSTALL_DIR" || exit 1` already used at line 653.
- If `INSTALL_DIR` is missing or unreadable, these commands silently continue running in the wrong working directory instead of failing clearly.

## Test plan
- [x] `bash -n installers/macos/ods-macos.sh` passes
- [x] Diff only adds `|| exit 1` to the 6 unguarded sites, no behavior change on the happy path