### PR TITLE
fix(installers): guard INSTALL_DIR cd in install-macos.sh

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1925,7 +1925,7 @@ if $DRY_RUN; then
     ai "[DRY RUN] Would run: docker compose up -d --remove-orphans --no-build --pull never"
 else
     # Change to install directory for docker compose
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
 
     # ── Bootstrap fast-start ──────────────────────────────────────────────
     _BOOTSTRAP_ACTIVE=false


### PR DESCRIPTION
## Summary
- The docker-compose bootstrap branch of `install-macos.sh` does `cd "$INSTALL_DIR"` without checking success, unlike similar guarded calls elsewhere in the macOS installer.
- A missing/unreadable `INSTALL_DIR` would otherwise let the script continue in the wrong working directory instead of failing loudly.

## Test plan
- [x] `bash -n installers/macos/install-macos.sh` passes
- [x] Single-line change, no behavior change on the happy path