### PR TITLE
fix(scripts): guard SCRIPT_DIR cd in ods-preflight.sh

### DIFF
--- a/ods/scripts/ods-preflight.sh
+++ b/ods/scripts/ods-preflight.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR" || { echo "ERROR: cannot cd to $SCRIPT_DIR" >&2; exit 1; }
 
 # Source service registry
 . "$SCRIPT_DIR/lib/service-registry.sh"


### PR DESCRIPTION
## Summary
- `cd "$SCRIPT_DIR"` in `ods-preflight.sh` relies on `set -euo pipefail` to abort on failure, but produces no diagnostic message telling the user why the script stopped.
- Adds an explicit error message so a broken/moved checkout fails with a clear cause instead of a silent abort.

## Test plan
- [x] `bash -n scripts/ods-preflight.sh` passes
- [x] No behavior change on the happy path