### PR TITLE
fix(scripts): guard ROOT_DIR cd in release-gate.sh

### DIFF
--- a/ods/scripts/release-gate.sh
+++ b/ods/scripts/release-gate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
+cd "$ROOT_DIR" || { echo "ERROR: cannot cd to $ROOT_DIR" >&2; exit 1; }
 
 PYTHON_CMD="python3"
 if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then


### PR DESCRIPTION
## Summary
- `cd "$ROOT_DIR"` in `release-gate.sh` relies on `set -euo pipefail` to abort silently on failure.
- Adds an explicit error message so a broken checkout fails with a clear cause instead of a bare abort.

## Test plan
- [x] `bash -n scripts/release-gate.sh` passes
- [x] No behavior change on the happy path