### PR TITLE
fix(scripts): guard ROOT_DIR cd in simulate-installers.sh

### DIFF
--- a/ods/scripts/simulate-installers.sh
+++ b/ods/scripts/simulate-installers.sh
@@ -25,7 +25,7 @@ exit 0
 EOF
 chmod +x "${FAKEBIN}/curl"
 
-cd "$ROOT_DIR"
+cd "$ROOT_DIR" || { echo "ERROR: cannot cd to $ROOT_DIR" >&2; exit 1; }
 
 # 1) Linux installer dry-run simulation
 LINUX_EXIT=0


### PR DESCRIPTION
## Summary
- `cd "$ROOT_DIR"` in `simulate-installers.sh` relies on `set -euo pipefail` to abort silently on failure.
- Adds an explicit error message so a broken checkout fails with a clear cause.

## Test plan
- [x] `bash -n scripts/simulate-installers.sh` passes
- [x] No behavior change on the happy path