### PR TITLE
fix(scripts): guard PROJECT_DIR cd in validate.sh

### DIFF
--- a/ods/scripts/validate.sh
+++ b/ods/scripts/validate.sh
@@ -11,7 +11,7 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-cd "$PROJECT_DIR"
+cd "$PROJECT_DIR" || { echo "ERROR: cannot cd to $PROJECT_DIR" >&2; exit 1; }
 
 # Source service registry
 export SCRIPT_DIR="$PROJECT_DIR"


### PR DESCRIPTION
## Summary
- `cd "$PROJECT_DIR"` in `validate.sh` relies on `set -euo pipefail` to abort silently on failure.
- Adds an explicit error message so a broken checkout fails with a clear cause.

## Test plan
- [x] `bash -n scripts/validate.sh` passes
- [x] No behavior change on the happy path