### PR TITLE
fix(dashboard): use current hostname instead of hardcoded localhost in SuccessValidation

### DIFF
--- a/ods/extensions/services/dashboard/src/components/SuccessValidation.jsx
+++ b/ods/extensions/services/dashboard/src/components/SuccessValidation.jsx
@@ -23,7 +23,7 @@ export function SuccessValidation({ status, onAllPassed }) {
         icon: MessageSquare,
         status: serviceMap['llama-server (LLM Inference)'] === 'healthy' ? 'passed' : 'pending',
         service: 'llama-server (LLM Inference)',
-        action: 'Try chatting at localhost:3000',
+        action: `Try chatting at ${window.location.hostname}:3000`,
         testUrl: '/api/test/llm'
       },
       {
@@ -55,7 +55,7 @@ export function SuccessValidation({ status, onAllPassed }) {
         icon: Zap,
         status: serviceMap['n8n (Workflows)'] === 'healthy' ? 'passed' : 'pending',
         service: 'n8n (Workflows)',
-        action: 'Visit localhost:5678',
+        action: `Visit ${window.location.hostname}:5678`,
         testUrl: '/api/test/workflows'
       }
     ])


### PR DESCRIPTION
## Summary
- `SuccessValidation.jsx` hardcodes `localhost:3000` (Open WebUI) and `localhost:5678` (n8n) as the suggested URLs.
- When the dashboard is opened from another device on the LAN (e.g. `http://<host-ip>:PORT`), these links are wrong — "localhost" resolves to the client, not the ODS host.
- Uses `window.location.hostname` (already used elsewhere in `App.jsx`) so the suggested link always points at the actual server.

## Test plan
- [x] Reviewed with `npx eslint` on the changed file — no new errors
- [x] Change is isolated to the two hardcoded strings, no other behavior touched